### PR TITLE
Switch image generation to Nano Banana 2

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -200,11 +200,10 @@
 - `temperature`: 0.4
 - `maxOutputTokens`: 4096
 
-### 3.3 Google Gemini 3 Pro Image Preview (画像生成 / Nano Banana Pro)
+### 3.3 Google Gemini 3.1 Flash Image Preview (画像生成 / Nano Banana 2)
 
 **使用箇所:**
-- `generate-weekly-menu` Edge Function
-- `generate-single-meal` Edge Function
+- `src/app/api/ai/image/generate/route.ts`
 
 **プロンプト:**
 ```
@@ -213,8 +212,8 @@ Natural lighting, high resolution, minimalist plating, Japanese cuisine style.
 ```
 
 **パラメータ:**
-- `model`: gemini-3-pro-image-preview
-- `responseModalities`: ['IMAGE']
+- `model`: gemini-3.1-flash-image-preview
+- `responseModalities`: ['TEXT', 'IMAGE']
 - `imageConfig`: { aspectRatio: '1:1' }
 
 ---
@@ -2484,11 +2483,11 @@ GOOGLE_GEN_AI_API_KEY=xxx
 
 ### オプション
 ```env
-# 画像生成モデル（デフォルト: gemini-3-pro-image-preview）
-GEMINI_IMAGE_MODEL=gemini-3-pro-image-preview
+# 画像生成モデル（デフォルト: gemini-3.1-flash-image-preview / Nano Banana 2）
+GEMINI_IMAGE_MODEL=gemini-3.1-flash-image-preview
 
-# 分析モデル（デフォルト: gemini-2.0-flash）
-GEMINI_ANALYSIS_MODEL=gemini-2.0-flash
+# 画像認識・構造化抽出モデル（デフォルト: gemini-3-pro-preview）
+GEMINI_VISION_MODEL=gemini-3-pro-preview
 ```
 
 ---
@@ -2685,4 +2684,3 @@ homegohan/
 
 **更新日:** 2026年1月3日
 **バージョン:** 0.3.0 (V4汎用献立生成エンジン追加)
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@google/generative-ai": "^0.24.1",
+        "@google/genai": "^1.44.0",
         "@supabase/ssr": "^0.1.0",
         "@supabase/supabase-js": "^2.78.0",
         "@vercel/functions": "^3.3.4",
@@ -4146,13 +4146,27 @@
         "excpretty": "build/cli.js"
       }
     },
-    "node_modules/@google/generative-ai": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
-      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+    "node_modules/@google/genai": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.44.0.tgz",
+      "integrity": "sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "node_modules/@homegohan/core": {
@@ -4776,6 +4790,70 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.0.0",
@@ -6335,6 +6413,12 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -7004,6 +7088,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/aggregate-error": {
@@ -7764,6 +7857,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bplist-creator": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
@@ -7888,6 +7990,12 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
       "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-fill": {
       "version": "1.0.0",
@@ -8786,6 +8894,15 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -9131,6 +9248,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -10552,6 +10678,29 @@
       "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
       "license": "MIT"
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fetch-retry": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-4.1.1.tgz",
@@ -10745,6 +10894,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/framer-motion": {
       "version": "12.23.24",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.24.tgz",
@@ -10874,6 +11035,68 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gaxios/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/generator-function": {
@@ -11113,6 +11336,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.1.tgz",
+      "integrity": "sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "7.1.3",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -11335,6 +11584,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -12492,6 +12754,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -12555,6 +12826,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -13036,6 +13328,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -14794,6 +15092,26 @@
         "node": ">= 0.10.5"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -15323,6 +15641,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -15782,6 +16113,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/pump": {
@@ -16645,6 +17000,15 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/reusify": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "mobile:android": "npm --workspace apps/mobile run android"
   },
   "dependencies": {
-    "@google/generative-ai": "^0.24.1",
+    "@google/genai": "^1.44.0",
     "@supabase/ssr": "^0.1.0",
     "@supabase/supabase-js": "^2.78.0",
     "@vercel/functions": "^3.3.4",

--- a/src/app/api/ai/image/generate/route.ts
+++ b/src/app/api/ai/image/generate/route.ts
@@ -1,196 +1,190 @@
 import { createClient } from '@/lib/supabase/server';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
-import { GoogleGenerativeAI } from '@google/generative-ai';
+import { GoogleGenAI, createUserContent } from '@google/genai';
+
+interface ReferenceImageInput {
+  base64: string;
+  mimeType?: string;
+}
+
+const DEFAULT_IMAGE_GENERATION_MODEL = 'gemini-3.1-flash-image-preview';
+
+function normalizeReferenceImages(raw: unknown): ReferenceImageInput[] {
+  if (!Array.isArray(raw)) return [];
+
+  return raw
+    .map<ReferenceImageInput | null>((item) => {
+      const image = typeof item === 'object' && item !== null ? item as Record<string, unknown> : {};
+      const base64 = typeof image.base64 === 'string' && image.base64.trim() ? image.base64.trim() : null;
+      if (!base64) return null;
+
+      return {
+        base64: base64.replace(/^data:image\/\w+;base64,/, ''),
+        mimeType: typeof image.mimeType === 'string' && image.mimeType.trim() ? image.mimeType.trim() : 'image/png',
+      };
+    })
+    .filter((image): image is ReferenceImageInput => image !== null);
+}
+
+function getQuotaErrorMessage(rawError: string): string {
+  try {
+    const parsed = JSON.parse(rawError);
+    if (parsed.error?.message) {
+      return parsed.error.message;
+    }
+  } catch {
+    // ignore JSON parse failure
+  }
+
+  return '画像生成のクォータが超過しました。しばらく待ってから再度お試しください。';
+}
 
 export async function POST(request: Request) {
   const supabase = createClient(cookies());
 
   try {
-    const { prompt } = await request.json();
+    const { prompt, images } = await request.json();
 
-    if (!prompt) {
+    if (!prompt || typeof prompt !== 'string') {
       return NextResponse.json({ error: 'Prompt is required' }, { status: 400 });
     }
 
-    // 1. ユーザー認証
     const { data: { user }, error: userError } = await supabase.auth.getUser();
     if (userError || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    // 2. Google Generative AI (Nano Banana / Gemini) API 呼び出し
-    const API_KEY = process.env.GOOGLE_AI_STUDIO_API_KEY || process.env.GOOGLE_GEN_AI_API_KEY;
-    
-    if (!API_KEY) {
+    const apiKey = process.env.GOOGLE_AI_STUDIO_API_KEY || process.env.GOOGLE_GEN_AI_API_KEY;
+    if (!apiKey) {
       return NextResponse.json({ error: 'Google AI API Key is missing' }, { status: 500 });
     }
 
-    const genAI = new GoogleGenerativeAI(API_KEY);
-    
-    // 環境変数でモデルを切り替え可能
-    // 注意: 無料プランでは画像生成モデルのクォータが0の場合があります
-    // 有料プランが必要な場合:
-    // - Nano Banana: gemini-2.5-flash-image-preview
-    // - Nano Banana Pro: gemini-3-pro-image-preview
-    // 無料で利用可能なモデル: gemini-2.0-flash-exp (テキスト生成のみ、画像生成は未対応)
-    // 画像生成には有料プランが必要です
-    // デフォルトは Nano Banana Pro（高品質）
-    const modelName = process.env.GEMINI_IMAGE_MODEL || 'gemini-3-pro-image-preview';
-    
-    // プロンプトの構築（料理写真用に最適化）
-    const enhancedPrompt = `A delicious, appetizing, professional food photography shot of ${prompt}. Natural lighting, high resolution, minimalist plating, Japanese cuisine style.`;
+    const modelName = process.env.GEMINI_IMAGE_MODEL || DEFAULT_IMAGE_GENERATION_MODEL;
+    const ai = new GoogleGenAI({ apiKey });
+
+    const enhancedPrompt = `Create a delicious, appetizing, professional food photography shot of ${prompt}. Natural lighting, high resolution, minimalist plating, Japanese cuisine style.`;
+    const referenceImages = normalizeReferenceImages(images);
 
     let imageBase64 = '';
+    let textResponse = '';
 
     try {
-      // Gemini REST APIを直接呼び出し（画像生成モデル用）
-      const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${API_KEY}`;
-      
-      const response = await fetch(apiUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+      const response = await ai.models.generateContent({
+        model: modelName,
+        contents: createUserContent([
+          enhancedPrompt,
+          ...referenceImages.map((image) => ({
+            inlineData: {
+              mimeType: image.mimeType || 'image/png',
+              data: image.base64,
+            },
+          })),
+        ]),
+        config: {
+          responseModalities: ['TEXT', 'IMAGE'],
+          imageConfig: {
+            aspectRatio: '1:1',
+          },
         },
-        body: JSON.stringify({
-          contents: [{
-            parts: [{
-              text: enhancedPrompt
-            }]
-          }],
-          generationConfig: {
-            responseModalities: ['IMAGE'],
-            imageConfig: {
-              aspectRatio: '1:1'
-            }
-          }
-        })
       });
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error("Gemini API Error:", errorText);
-        
-        // 429エラー（クォータ超過）の場合は、より詳細なエラーメッセージを返す
-        if (response.status === 429) {
-          let errorMessage = '画像生成のクォータが超過しました。';
-          try {
-            const errorData = JSON.parse(errorText);
-            if (errorData.error?.message) {
-              errorMessage = errorData.error.message;
-              // リトライ可能な時間がある場合は追加情報を提供
-              if (errorData.error?.details) {
-                const retryInfo = errorData.error.details.find((d: any) => d.retryDelay);
-                if (retryInfo) {
-                  errorMessage += ` しばらく待ってから再度お試しください。`;
-                }
-              }
-            }
-          } catch (e) {
-            // JSON解析に失敗した場合はデフォルトメッセージを使用
-          }
-          return NextResponse.json({ 
-            error: errorMessage,
-            code: 'QUOTA_EXCEEDED',
-            suggestion: 'Google AI Studioでプランとクォータを確認してください: https://ai.dev/usage'
-          }, { status: 429 });
-        }
-        
-        throw new Error(`Gemini API returned ${response.status}: ${errorText}`);
-      }
-
-      const data = await response.json();
-      
-      // レスポンスから画像データを抽出
-      const parts = data.candidates?.[0]?.content?.parts || [];
-      
+      const parts = response.candidates?.[0]?.content?.parts || [];
       for (const part of parts) {
-        if (part.inlineData && part.inlineData.mimeType?.startsWith('image/')) {
+        if (part.text) {
+          textResponse += part.text;
+        }
+        if (part.inlineData?.mimeType?.startsWith('image/') && part.inlineData.data) {
           imageBase64 = part.inlineData.data;
           break;
         }
       }
 
       if (!imageBase64) {
-        console.error("Response structure:", JSON.stringify(data, null, 2));
         throw new Error('No image data in response. The model may not support image generation.');
       }
-
     } catch (genError: any) {
-      console.error("Gemini Generation Error:", genError);
-      throw new Error(`Failed to generate image: ${genError.message || 'Unknown error'}`);
+      console.error('Gemini Generation Error:', genError);
+
+      const status = genError?.status || genError?.code;
+      const rawMessage = typeof genError?.message === 'string' ? genError.message : '';
+      if (status === 429 || rawMessage.includes('429')) {
+        return NextResponse.json({
+          error: getQuotaErrorMessage(rawMessage),
+          code: 'QUOTA_EXCEEDED',
+          suggestion: 'Google AI Studioで Nano Banana 2 のクォータを確認してください: https://ai.google.dev/gemini-api/docs/image-generation',
+        }, { status: 429 });
+      }
+
+      throw new Error(`Failed to generate image: ${rawMessage || 'Unknown error'}`);
     }
 
     const buffer = Buffer.from(imageBase64, 'base64');
-
-    // 3. Supabase Storage へアップロード
-    // バケット名: 'fridge-images' または 'meal-images' など、プロジェクトに合わせて変更可能
     const bucketName = 'fridge-images';
     const fileName = `generated/${user.id}/${Date.now()}.png`;
-    
-    // バケットの存在確認とアップロード
-    // 注意: サーバーサイドのクライアントは匿名キーを使用しているため、
-    // StorageへのアクセスにはRLSポリシーが必要です
+
     const { error: uploadError } = await supabase.storage
       .from(bucketName)
       .upload(fileName, buffer, {
         contentType: 'image/png',
         upsert: true,
-        cacheControl: '3600'
+        cacheControl: '3600',
       });
 
     if (uploadError) {
-      console.error("Upload error:", uploadError);
-      console.error("Error details:", JSON.stringify(uploadError, null, 2));
-      
-      // エラーメッセージを取得
+      console.error('Upload error:', uploadError);
+
       const errorMessage = uploadError.message || String(uploadError);
       const errorStatus = (uploadError as any).statusCode || (uploadError as any).status;
-      
-      // バケットが見つからない場合
-      if (errorMessage.includes('Bucket not found') || 
-          errorMessage.includes('not found') ||
-          errorMessage.includes('does not exist') ||
-          errorStatus === 404) {
-        return NextResponse.json({ 
+
+      if (
+        errorMessage.includes('Bucket not found') ||
+        errorMessage.includes('not found') ||
+        errorMessage.includes('does not exist') ||
+        errorStatus === 404
+      ) {
+        return NextResponse.json({
           error: `Storage bucket '${bucketName}' not found.`,
           code: 'BUCKET_NOT_FOUND',
           details: errorMessage,
-          suggestion: `1. Go to Supabase Dashboard → Storage\n2. Verify bucket '${bucketName}' exists and is Public\n3. Check bucket name spelling (case-sensitive)`
+          suggestion: `1. Go to Supabase Dashboard → Storage\n2. Verify bucket '${bucketName}' exists and is Public\n3. Check bucket name spelling (case-sensitive)`,
         }, { status: 404 });
       }
-      
-      // 権限エラーの場合（RLSポリシーが不足）
-      if (errorMessage.includes('permission') || 
-          errorMessage.includes('policy') || 
-          errorMessage.includes('RLS') ||
-          errorMessage.includes('new row violates') ||
-          errorStatus === 403) {
-        return NextResponse.json({ 
+
+      if (
+        errorMessage.includes('permission') ||
+        errorMessage.includes('policy') ||
+        errorMessage.includes('RLS') ||
+        errorMessage.includes('new row violates') ||
+        errorStatus === 403
+      ) {
+        return NextResponse.json({
           error: `Permission denied for Storage bucket '${bucketName}'.`,
           code: 'PERMISSION_DENIED',
           details: errorMessage,
-          suggestion: `Set up Storage RLS policies:\n1. Go to Supabase Dashboard → Storage → ${bucketName}\n2. Click "Policies" tab\n3. Create policy:\n   - Policy name: "Allow authenticated users to upload"\n   - Allowed operation: INSERT\n   - Target roles: authenticated\n   - USING expression: auth.role() = 'authenticated'\n   - WITH CHECK expression: auth.role() = 'authenticated'`
+          suggestion: `Set up Storage RLS policies:\n1. Go to Supabase Dashboard → Storage → ${bucketName}\n2. Click "Policies" tab\n3. Create policy:\n   - Policy name: "Allow authenticated users to upload"\n   - Allowed operation: INSERT\n   - Target roles: authenticated\n   - USING expression: auth.role() = 'authenticated'\n   - WITH CHECK expression: auth.role() = 'authenticated'`,
         }, { status: 403 });
       }
-      
-      // その他のエラー
-      return NextResponse.json({ 
+
+      return NextResponse.json({
         error: `Failed to upload image: ${errorMessage}`,
         code: 'UPLOAD_ERROR',
-        details: errorMessage
+        details: errorMessage,
       }, { status: 500 });
     }
 
-    // 4. 公開URLの取得
     const { data: { publicUrl } } = supabase.storage
       .from(bucketName)
       .getPublicUrl(fileName);
 
-    return NextResponse.json({ imageUrl: publicUrl });
-
+    return NextResponse.json({
+      imageUrl: publicUrl,
+      modelUsed: modelName,
+      referenceImageCount: referenceImages.length,
+      text: textResponse.trim(),
+    });
   } catch (error: any) {
-    console.error("Image Gen Error:", error);
+    console.error('Image Gen Error:', error);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/src/app/api/pantry/from-photo/route.ts
+++ b/src/app/api/pantry/from-photo/route.ts
@@ -185,7 +185,7 @@ export async function POST(request: Request) {
           user_id: user.id,
           image_url: imageUrl || null,
           extracted_ingredients: ingredients,
-          model_used: process.env.GEMINI_IMAGE_MODEL || 'gemini-3-pro-preview',
+          model_used: process.env.GEMINI_VISION_MODEL || 'gemini-3-pro-preview',
         });
     }
 

--- a/src/lib/ai/gemini-json.ts
+++ b/src/lib/ai/gemini-json.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_GEMINI_IMAGE_MODEL } from './image-recognition';
+import { DEFAULT_GEMINI_VISION_MODEL } from './image-recognition';
 
 export interface GeminiImageInput {
   base64: string;
@@ -42,7 +42,7 @@ export async function generateGeminiJson<T>({
   images = [],
   temperature = 0.1,
   maxOutputTokens = 2048,
-  model = process.env.GEMINI_IMAGE_MODEL || DEFAULT_GEMINI_IMAGE_MODEL,
+  model = process.env.GEMINI_VISION_MODEL || DEFAULT_GEMINI_VISION_MODEL,
 }: GenerateGeminiJsonOptions): Promise<{ data: T; model: string; rawText: string }> {
   const apiKey = getGoogleAiApiKey();
   const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`, {

--- a/src/lib/ai/image-recognition.ts
+++ b/src/lib/ai/image-recognition.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_GEMINI_IMAGE_MODEL = 'gemini-3-pro-preview';
+export const DEFAULT_GEMINI_VISION_MODEL = 'gemini-3-pro-preview';
 export const AUTO_CLASSIFY_CONFIDENCE_THRESHOLD = 0.75;
 
 export type PhotoType = 'meal' | 'fridge' | 'health_checkup' | 'weight_scale' | 'unknown';

--- a/supabase/functions/_shared/gemini-json.ts
+++ b/supabase/functions/_shared/gemini-json.ts
@@ -12,7 +12,7 @@ interface GenerateGeminiJsonOptions {
   model?: string
 }
 
-export const DEFAULT_GEMINI_IMAGE_MODEL = 'gemini-3-pro-preview'
+export const DEFAULT_GEMINI_VISION_MODEL = 'gemini-3-pro-preview'
 
 export async function generateGeminiJson<T>({
   prompt,
@@ -20,7 +20,7 @@ export async function generateGeminiJson<T>({
   images = [],
   temperature = 0.1,
   maxOutputTokens = 2048,
-  model = Deno.env.get('GEMINI_IMAGE_MODEL') || DEFAULT_GEMINI_IMAGE_MODEL,
+  model = Deno.env.get('GEMINI_VISION_MODEL') || DEFAULT_GEMINI_VISION_MODEL,
 }: GenerateGeminiJsonOptions): Promise<{ data: T; model: string; rawText: string }> {
   const apiKey = Deno.env.get('GOOGLE_AI_STUDIO_API_KEY') || Deno.env.get('GOOGLE_GEN_AI_API_KEY')
   if (!apiKey) {

--- a/tests/image-route-contracts.test.ts
+++ b/tests/image-route-contracts.test.ts
@@ -2,12 +2,34 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetUser = vi.fn();
 const mockInvoke = vi.fn();
+const mockUpload = vi.fn();
+const mockGetPublicUrl = vi.fn();
+const mockGenerateContent = vi.fn();
 
 vi.mock('@/lib/supabase/server', () => ({
-  createClient: vi.fn(async () => ({
+  createClient: vi.fn(() => ({
     auth: { getUser: mockGetUser },
     functions: { invoke: mockInvoke },
+    storage: {
+      from: vi.fn(() => ({
+        upload: mockUpload,
+        getPublicUrl: mockGetPublicUrl,
+      })),
+    },
   })),
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => undefined),
+}));
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class {
+    models = {
+      generateContent: mockGenerateContent,
+    };
+  },
+  createUserContent: vi.fn((parts) => parts),
 }));
 
 describe('image route contracts', () => {
@@ -16,7 +38,12 @@ describe('image route contracts', () => {
     vi.restoreAllMocks();
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
     mockInvoke.mockReset();
+    mockUpload.mockResolvedValue({ error: null });
+    mockGetPublicUrl.mockReturnValue({ data: { publicUrl: 'https://example.com/generated.png' } });
+    mockGenerateContent.mockReset();
     process.env.GOOGLE_AI_STUDIO_API_KEY = 'test-key';
+    delete process.env.GEMINI_IMAGE_MODEL;
+    delete process.env.GEMINI_VISION_MODEL;
   });
 
   it('analyze-weight-scale reads the nested health-photo response shape', async () => {
@@ -86,6 +113,8 @@ describe('image route contracts', () => {
   });
 
   it('classify-photo accepts multiple images and returns normalized output', async () => {
+    process.env.GEMINI_IMAGE_MODEL = 'gemini-3.1-flash-image-preview';
+
     const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       candidates: [
         {
@@ -135,5 +164,52 @@ describe('image route contracts', () => {
     const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(requestBody.contents[0].parts).toHaveLength(3);
     expect(requestBody.generationConfig.responseMimeType).toBe('application/json');
+  });
+
+  it('image-generate uses Nano Banana 2 and accepts multiple reference images', async () => {
+    mockGenerateContent.mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [
+              { text: 'generated' },
+              {
+                inlineData: {
+                  mimeType: 'image/png',
+                  data: Buffer.from('png-data').toString('base64'),
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const { POST } = await import('../src/app/api/ai/image/generate/route');
+    const response = await POST(new Request('http://localhost/api/ai/image/generate', {
+      method: 'POST',
+      body: JSON.stringify({
+        prompt: 'banana curry',
+        images: [
+          { base64: 'abc', mimeType: 'image/jpeg' },
+          { base64: 'def', mimeType: 'image/png' },
+        ],
+      }),
+    }));
+
+    expect(mockGenerateContent).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'gemini-3.1-flash-image-preview',
+      config: expect.objectContaining({
+        responseModalities: ['TEXT', 'IMAGE'],
+      }),
+    }));
+
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      imageUrl: 'https://example.com/generated.png',
+      modelUsed: 'gemini-3.1-flash-image-preview',
+      referenceImageCount: 2,
+      text: 'generated',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- switch the image generation route to the official `@google/genai` SDK
- default image generation to `gemini-3.1-flash-image-preview` and allow multiple reference images
- separate generation and vision model env vars so recognition routes stay on the vision model
