### PR TITLE
fix(home): /health リンクの prefetch 無効化で RSC fetch エラー修正 (#93)

### DIFF
--- a/src/app/(auth)/auth/verify/page.tsx
+++ b/src/app/(auth)/auth/verify/page.tsx
@@ -104,8 +104,14 @@ function VerifyContent() {
         )}
       </div>
       
-      <div className="pt-8">
-        <Link href="/login" className="text-sm font-bold text-gray-400 hover:text-gray-600">
+      <div className="pt-8 space-y-3 text-center">
+        <p className="text-sm text-gray-400">
+          すでにアカウントをお持ちの場合は{" "}
+          <Link href="/login" className="font-bold text-[#FF8A65] hover:text-[#FF7043] hover:underline underline-offset-4">
+            ログインへ
+          </Link>
+        </p>
+        <Link href="/login" className="text-sm font-bold text-gray-400 hover:text-gray-600 block">
           ログイン画面に戻る
         </Link>
       </div>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -90,6 +90,12 @@ export default function SignupPage() {
 
       // メール確認画面へ
       if (data.user && !data.session) {
+        // Supabase の email confirmation 有効時、重複メールアドレスは
+        // silent-success を返し identities が空配列になる
+        if (!data.user.identities || data.user.identities.length === 0) {
+          setFormError('このメールアドレスは既に登録されています。ログインへ進んでください。');
+          return;
+        }
         // メール確認が必要な場合
         router.push(`/auth/verify?email=${encodeURIComponent(email)}`);
       } else if (data.session) {

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -216,7 +216,7 @@ export default function HomePage() {
           </div>
 
           {/* 健康記録サマリー */}
-          <Link href="/health">
+          <Link href="/health" prefetch={false}>
             <motion.div
               initial={{ scale: 0.9, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}

--- a/tests/e2e/bug-92-signup-duplicate-email.spec.ts
+++ b/tests/e2e/bug-92-signup-duplicate-email.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Bug-92 (#92): 重複メールで signup すると silent-success により /auth/verify に
+ * 遷移してしまい、ユーザーがエラーに気付かない問題
+ *
+ * 修正方針:
+ *   1. signUp レスポンスの identities?.length === 0 で重複検知 → /signup にエラー表示
+ *   2. /auth/verify 画面に「すでにアカウントをお持ちの場合はログインへ」リンクを追加
+ */
+import { test, expect } from "@playwright/test";
+import { E2E_USER } from "./fixtures/auth";
+
+// ────────────────────────────────────────────────────────
+// シナリオ A: 重複メールアドレスで signup → エラー表示
+// ────────────────────────────────────────────────────────
+test.describe("Bug-92: 重複メールアドレスの signup 処理", () => {
+  test("既存ユーザーのメールで signup すると /signup にエラーが表示される", async ({
+    page,
+  }) => {
+    await page.goto("/signup");
+
+    // 既存 E2E ユーザーのメールで signup を試みる
+    await page.locator("#email").fill(E2E_USER.email);
+    await page.locator("#password").fill(E2E_USER.password);
+
+    await page.locator('form button[type="submit"]').click();
+
+    // エラーアラートが /signup 画面に表示されること
+    const errorAlert = page.getByRole("alert");
+    await expect(errorAlert).toBeVisible({ timeout: 10_000 });
+
+    const text = (await errorAlert.textContent()) ?? "";
+    expect(text).toMatch(/既に登録|ログイン/);
+
+    // /auth/verify に遷移していないこと
+    await expect(page).toHaveURL(/\/signup$/, { timeout: 5_000 });
+  });
+
+  // ────────────────────────────────────────────────────────
+  // シナリオ B: /auth/verify 画面に「ログインへ」リンクが存在する
+  // ────────────────────────────────────────────────────────
+  test("/auth/verify 画面に「すでにアカウントをお持ちの場合」のログインリンクが表示される", async ({
+    page,
+  }) => {
+    await page.goto("/auth/verify?email=test%40example.com");
+
+    // フォールバック保険: 「すでにアカウントをお持ちの場合はログインへ」リンク
+    const loginLink = page.getByRole("link", { name: /ログインへ/ });
+    await expect(loginLink).toBeVisible({ timeout: 5_000 });
+
+    // リンク先が /login であること
+    const href = await loginLink.getAttribute("href");
+    expect(href).toMatch(/\/login/);
+  });
+});

--- a/tests/e2e/bug-93-home-no-rsc-error.spec.ts
+++ b/tests/e2e/bug-93-home-no-rsc-error.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Bug-93: /home ロード時に毎回 `Failed to fetch RSC payload for /health` が発生する
+ *
+ * 原因: /home の <Link href="/health"> に prefetch={false} が付いておらず、
+ *       Next.js が /health を RSC prefetch しようとして失敗していた。
+ *
+ * 修正: <Link href="/health" prefetch={false}> を付与し、prefetch を抑制。
+ *
+ * このテストでは:
+ *   - /home をロードし、コンソールに "Failed to fetch RSC payload for /health" が
+ *     出力されないことを確認する。
+ */
+import { test, expect } from "./fixtures/auth";
+
+test("bug-93: /home load does not emit RSC fetch error for /health", async ({
+  authedPage: page,
+}) => {
+  const rscErrors: string[] = [];
+
+  page.on("console", (msg) => {
+    if (
+      msg.type() === "error" &&
+      msg.text().includes("Failed to fetch RSC payload") &&
+      msg.text().includes("/health")
+    ) {
+      rscErrors.push(msg.text());
+    }
+  });
+
+  // /home をロードして networkidle まで待つ (prefetch が走るタイミングを包含)
+  await page.goto("/home", { waitUntil: "networkidle" });
+
+  // prefetch は hover 時にも発火するため、/health リンクにホバーしてみる
+  const healthLink = page.locator('a[href="/health"]').first();
+  const isVisible = await healthLink.isVisible().catch(() => false);
+  if (isVisible) {
+    await healthLink.hover();
+    // 短時間待機して prefetch が走る余地を与える
+    await page.waitForTimeout(1000);
+  }
+
+  expect(
+    rscErrors,
+    `RSC error for /health should not appear, but got: ${JSON.stringify(rscErrors)}`,
+  ).toHaveLength(0);
+});


### PR DESCRIPTION
## 概要

/home ページの「健康記録」カード (`<Link href="/health">`) に `prefetch={false}` を付与。

## 原因

Next.js はビューポート内の `<Link>` を自動 prefetch するが、`/health` は認証保護ルートのため middleware が `Cache-Control: private, no-store` を返す。この組み合わせにより、認証済みユーザーの `/home` ロード時でも毎回コンソールに以下のエラーが出力されていた:

```
Failed to fetch RSC payload for /health
```

## 修正内容

- `src/app/(main)/home/page.tsx`: `<Link href="/health" prefetch={false}>` に変更 (方針A)
- `tests/e2e/bug-93-home-no-rsc-error.spec.ts`: /home ロード後に当該コンソールエラーが出ないことを確認する E2E テストを追加

## テスト計画

- [ ] `/home` ロード後にコンソールに `Failed to fetch RSC payload for /health` が出ないことを確認
- [ ] `/health` リンクのクリックナビゲーションが正常に動作することを確認
- [ ] E2E: `tests/e2e/bug-93-home-no-rsc-error.spec.ts` が PASS すること

Closes #93