### PR TITLE
fix: Issues #90 / #92 まとめて修正 (体重 validation + 重複メール silent-success)

### DIFF
--- a/src/app/(auth)/auth/verify/page.tsx
+++ b/src/app/(auth)/auth/verify/page.tsx
@@ -104,8 +104,14 @@ function VerifyContent() {
         )}
       </div>
       
-      <div className="pt-8">
-        <Link href="/login" className="text-sm font-bold text-gray-400 hover:text-gray-600">
+      <div className="pt-8 space-y-3 text-center">
+        <p className="text-sm text-gray-400">
+          すでにアカウントをお持ちの場合は{" "}
+          <Link href="/login" className="font-bold text-[#FF8A65] hover:text-[#FF7043] hover:underline underline-offset-4">
+            ログインへ
+          </Link>
+        </p>
+        <Link href="/login" className="text-sm font-bold text-gray-400 hover:text-gray-600 block">
           ログイン画面に戻る
         </Link>
       </div>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -90,6 +90,12 @@ export default function SignupPage() {
 
       // メール確認画面へ
       if (data.user && !data.session) {
+        // Supabase の email confirmation 有効時、重複メールアドレスは
+        // silent-success を返し identities が空配列になる
+        if (!data.user.identities || data.user.identities.length === 0) {
+          setFormError('このメールアドレスは既に登録されています。ログインへ進んでください。');
+          return;
+        }
         // メール確認が必要な場合
         router.push(`/auth/verify?email=${encodeURIComponent(email)}`);
       } else if (data.session) {

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -216,7 +216,7 @@ export default function HomePage() {
           </div>
 
           {/* 健康記録サマリー */}
-          <Link href="/health">
+          <Link href="/health" prefetch={false}>
             <motion.div
               initial={{ scale: 0.9, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}

--- a/src/lib/health-payloads.ts
+++ b/src/lib/health-payloads.ts
@@ -180,7 +180,7 @@ function parseNullableNumber(
   input: PlainObject,
   key: string,
   errors: string[],
-  opts: { integer?: boolean } = {},
+  opts: { integer?: boolean; min?: number; max?: number; label?: string } = {},
 ): number | null | undefined {
   if (!hasOwn(input, key)) return undefined;
 
@@ -201,6 +201,16 @@ function parseNullableNumber(
 
   if (opts.integer && !Number.isInteger(numeric)) {
     errors.push(`${key} must be an integer or null`);
+    return undefined;
+  }
+
+  const label = opts.label ?? key;
+  if (opts.min !== undefined && numeric < opts.min) {
+    errors.push(`${label} は ${opts.min} 以上の値を入力してください`);
+    return undefined;
+  }
+  if (opts.max !== undefined && numeric > opts.max) {
+    errors.push(`${label} は ${opts.max} 以下の値を入力してください`);
     return undefined;
   }
 
@@ -302,6 +312,13 @@ export function sanitizeHealthRecordPayload(
   return parseKnownFields(input, (body, errors) => {
     const data: Record<string, unknown> = {};
 
+    const numericFieldOpts: Record<string, { min?: number; max?: number; label?: string }> = {
+      weight: { min: 20, max: 300, label: '体重 (kg)' },
+      body_fat_percentage: { min: 1, max: 70, label: '体脂肪率 (%)' },
+      muscle_mass: { min: 5, max: 150, label: '筋肉量 (kg)' },
+      sleep_hours: { min: 0, max: 24, label: '睡眠時間 (h)' },
+      body_temp: { min: 30, max: 45, label: '体温 (°C)' },
+    };
     const numericFields = [
       'weight',
       'body_fat_percentage',
@@ -310,10 +327,23 @@ export function sanitizeHealthRecordPayload(
       'body_temp',
     ] as const;
     for (const field of numericFields) {
-      const value = parseNullableNumber(body, field, errors);
+      const value = parseNullableNumber(body, field, errors, numericFieldOpts[field] ?? {});
       if (value !== undefined) data[field] = value;
     }
 
+    const integerFieldOpts: Record<string, { min?: number; max?: number; label?: string }> = {
+      systolic_bp: { min: 30, max: 300, label: '収縮期血圧 (mmHg)' },
+      diastolic_bp: { min: 20, max: 200, label: '拡張期血圧 (mmHg)' },
+      heart_rate: { min: 20, max: 300, label: '心拍数 (bpm)' },
+      sleep_quality: { min: 1, max: 10, label: '睡眠の質 (1-10)' },
+      water_intake: { min: 0, max: 10000, label: '水分摂取量 (mL)' },
+      step_count: { min: 0, max: 100000, label: '歩数' },
+      bowel_movement: { min: 0, max: 20, label: '排便回数' },
+      overall_condition: { min: 1, max: 10, label: '全体的な体調 (1-10)' },
+      mood_score: { min: 1, max: 10, label: '気分スコア (1-10)' },
+      energy_level: { min: 1, max: 10, label: 'エネルギーレベル (1-10)' },
+      stress_level: { min: 1, max: 10, label: 'ストレスレベル (1-10)' },
+    };
     const integerFields = [
       'systolic_bp',
       'diastolic_bp',
@@ -328,7 +358,7 @@ export function sanitizeHealthRecordPayload(
       'stress_level',
     ] as const;
     for (const field of integerFields) {
-      const value = parseNullableNumber(body, field, errors, { integer: true });
+      const value = parseNullableNumber(body, field, errors, { integer: true, ...(integerFieldOpts[field] ?? {}) });
       if (value !== undefined) data[field] = value;
     }
 
@@ -386,6 +416,17 @@ export function sanitizeHealthCheckupPayload(input: unknown): ValidationResult<H
       if (value !== undefined) data[field] = value;
     }
 
+    const numericFieldOpts: Record<string, { min?: number; max?: number; label?: string }> = {
+      height: { min: 50, max: 250, label: '身長 (cm)' },
+      weight: { min: 20, max: 300, label: '体重 (kg)' },
+      bmi: { min: 10, max: 70, label: 'BMI' },
+      waist_circumference: { min: 30, max: 300, label: '腹囲 (cm)' },
+      hemoglobin: { min: 1, max: 25, label: 'ヘモグロビン (g/dL)' },
+      hba1c: { min: 3, max: 15, label: 'HbA1c (%)' },
+      creatinine: { min: 0.1, max: 30, label: 'クレアチニン (mg/dL)' },
+      egfr: { min: 0, max: 150, label: 'eGFR (mL/min/1.73m²)' },
+      uric_acid: { min: 0.5, max: 20, label: '尿酸 (mg/dL)' },
+    };
     const numericFields = [
       'height',
       'weight',
@@ -398,10 +439,22 @@ export function sanitizeHealthCheckupPayload(input: unknown): ValidationResult<H
       'uric_acid',
     ] as const;
     for (const field of numericFields) {
-      const value = parseNullableNumber(body, field, errors);
+      const value = parseNullableNumber(body, field, errors, numericFieldOpts[field] ?? {});
       if (value !== undefined) data[field] = value;
     }
 
+    const integerFieldOpts: Record<string, { min?: number; max?: number; label?: string }> = {
+      blood_pressure_systolic: { min: 30, max: 300, label: '収縮期血圧 (mmHg)' },
+      blood_pressure_diastolic: { min: 20, max: 200, label: '拡張期血圧 (mmHg)' },
+      fasting_glucose: { min: 20, max: 700, label: '空腹時血糖 (mg/dL)' },
+      total_cholesterol: { min: 50, max: 1000, label: '総コレステロール (mg/dL)' },
+      ldl_cholesterol: { min: 10, max: 700, label: 'LDLコレステロール (mg/dL)' },
+      hdl_cholesterol: { min: 5, max: 200, label: 'HDLコレステロール (mg/dL)' },
+      triglycerides: { min: 10, max: 5000, label: '中性脂肪 (mg/dL)' },
+      ast: { min: 1, max: 5000, label: 'AST (U/L)' },
+      alt: { min: 1, max: 5000, label: 'ALT (U/L)' },
+      gamma_gtp: { min: 1, max: 5000, label: 'γ-GTP (U/L)' },
+    };
     const integerFields = [
       'blood_pressure_systolic',
       'blood_pressure_diastolic',
@@ -415,7 +468,7 @@ export function sanitizeHealthCheckupPayload(input: unknown): ValidationResult<H
       'gamma_gtp',
     ] as const;
     for (const field of integerFields) {
-      const value = parseNullableNumber(body, field, errors, { integer: true });
+      const value = parseNullableNumber(body, field, errors, { integer: true, ...(integerFieldOpts[field] ?? {}) });
       if (value !== undefined) data[field] = value;
     }
 
@@ -436,12 +489,30 @@ export function sanitizeBloodTestPayload(input: unknown): ValidationResult<Blood
       if (value !== undefined) data[field] = value;
     }
 
+    const numericFieldOpts: Record<string, { min?: number; max?: number; label?: string }> = {
+      hba1c: { min: 3, max: 15, label: 'HbA1c (%)' },
+      creatinine: { min: 0.1, max: 30, label: 'クレアチニン (mg/dL)' },
+      egfr: { min: 0, max: 150, label: 'eGFR (mL/min/1.73m²)' },
+      uric_acid: { min: 0.5, max: 20, label: '尿酸 (mg/dL)' },
+      bun: { min: 1, max: 200, label: 'BUN (mg/dL)' },
+      hemoglobin: { min: 1, max: 25, label: 'ヘモグロビン (g/dL)' },
+    };
     const numericFields = ['hba1c', 'creatinine', 'egfr', 'uric_acid', 'bun', 'hemoglobin'] as const;
     for (const field of numericFields) {
-      const value = parseNullableNumber(body, field, errors);
+      const value = parseNullableNumber(body, field, errors, numericFieldOpts[field] ?? {});
       if (value !== undefined) data[field] = value;
     }
 
+    const integerFieldOpts: Record<string, { min?: number; max?: number; label?: string }> = {
+      total_cholesterol: { min: 50, max: 1000, label: '総コレステロール (mg/dL)' },
+      ldl_cholesterol: { min: 10, max: 700, label: 'LDLコレステロール (mg/dL)' },
+      hdl_cholesterol: { min: 5, max: 200, label: 'HDLコレステロール (mg/dL)' },
+      triglycerides: { min: 10, max: 5000, label: '中性脂肪 (mg/dL)' },
+      fasting_glucose: { min: 20, max: 700, label: '空腹時血糖 (mg/dL)' },
+      ast: { min: 1, max: 5000, label: 'AST (U/L)' },
+      alt: { min: 1, max: 5000, label: 'ALT (U/L)' },
+      gamma_gtp: { min: 1, max: 5000, label: 'γ-GTP (U/L)' },
+    };
     const integerFields = [
       'total_cholesterol',
       'ldl_cholesterol',
@@ -453,7 +524,7 @@ export function sanitizeBloodTestPayload(input: unknown): ValidationResult<Blood
       'gamma_gtp',
     ] as const;
     for (const field of integerFields) {
-      const value = parseNullableNumber(body, field, errors, { integer: true });
+      const value = parseNullableNumber(body, field, errors, { integer: true, ...(integerFieldOpts[field] ?? {}) });
       if (value !== undefined) data[field] = value;
     }
 

--- a/tests/e2e/bug-90-health-validation.spec.ts
+++ b/tests/e2e/bug-90-health-validation.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Bug-90: 体重フィールドにサーバー側バリデーションなし
+ *
+ * 確認:
+ *   1. weight に -1 を POST → 400 が返り DB に書かれない
+ *   2. weight に 0 を POST → 400 が返り DB に書かれない
+ *   3. weight に 999999 を POST → 400 が返り DB に書かれない
+ *   4. weight に有効値 (65) を POST → 200/201 が返る
+ *
+ * テスト戦略:
+ *   - ローカル dev server ではログイン後 cookie を使って直接 API を叩く
+ *   - 本番 (PLAYWRIGHT_BASE_URL=https://...) の場合も同様
+ */
+import { test, expect } from "./fixtures/auth";
+
+const RECORD_DATE = "2000-01-01"; // 過去の固定日付でテスト用レコードを使用
+
+/**
+ * 認証済みページのコンテキストを使って health/records/quick エンドポイントを直接 fetch する
+ * (authedPage は Playwright の Page オブジェクト。evaluate 経由でブラウザ内 fetch を実行する)
+ */
+async function postQuickRecord(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  authedPage: any,
+  body: Record<string, unknown>,
+): Promise<{ status: number; json: unknown }> {
+  return authedPage.evaluate(
+    async ({ url, payload }: { url: string; payload: Record<string, unknown> }) => {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        credentials: "include",
+      });
+      let json: unknown;
+      try {
+        json = await res.json();
+      } catch {
+        json = null;
+      }
+      return { status: res.status, json };
+    },
+    { url: "/api/health/records/quick", payload: body },
+  );
+}
+
+test.describe("Bug-90: health records weight server-side validation", () => {
+  test("weight=-1 は 400 を返し DB に保存されない", async ({ authedPage }) => {
+    const { status, json } = await postQuickRecord(authedPage, {
+      weight: -1,
+      record_date: RECORD_DATE,
+    });
+
+    expect(status, `期待 400 だが ${status} が返った: ${JSON.stringify(json)}`).toBe(400);
+
+    // error メッセージに体重に関するバリデーション文言が含まれることを確認
+    const errorMsg = (json as { error?: string })?.error ?? "";
+    expect(errorMsg).toMatch(/体重|weight/i);
+  });
+
+  test("weight=0 は 400 を返し DB に保存されない", async ({ authedPage }) => {
+    const { status, json } = await postQuickRecord(authedPage, {
+      weight: 0,
+      record_date: RECORD_DATE,
+    });
+
+    expect(status, `期待 400 だが ${status} が返った: ${JSON.stringify(json)}`).toBe(400);
+
+    const errorMsg = (json as { error?: string })?.error ?? "";
+    expect(errorMsg).toMatch(/体重|weight/i);
+  });
+
+  test("weight=999999 は 400 を返し DB に保存されない", async ({ authedPage }) => {
+    const { status, json } = await postQuickRecord(authedPage, {
+      weight: 999999,
+      record_date: RECORD_DATE,
+    });
+
+    expect(status, `期待 400 だが ${status} が返った: ${JSON.stringify(json)}`).toBe(400);
+
+    const errorMsg = (json as { error?: string })?.error ?? "";
+    expect(errorMsg).toMatch(/体重|weight/i);
+  });
+
+  test("weight=65 (有効値) は 200 を返す", async ({ authedPage }) => {
+    const { status, json } = await postQuickRecord(authedPage, {
+      weight: 65,
+      record_date: RECORD_DATE,
+    });
+
+    // 200 または 201 を期待
+    expect([200, 201], `期待 200/201 だが ${status} が返った: ${JSON.stringify(json)}`).toContain(
+      status,
+    );
+  });
+});

--- a/tests/e2e/bug-92-signup-duplicate-email.spec.ts
+++ b/tests/e2e/bug-92-signup-duplicate-email.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Bug-92 (#92): 重複メールで signup すると silent-success により /auth/verify に
+ * 遷移してしまい、ユーザーがエラーに気付かない問題
+ *
+ * 修正方針:
+ *   1. signUp レスポンスの identities?.length === 0 で重複検知 → /signup にエラー表示
+ *   2. /auth/verify 画面に「すでにアカウントをお持ちの場合はログインへ」リンクを追加
+ */
+import { test, expect } from "@playwright/test";
+import { E2E_USER } from "./fixtures/auth";
+
+// ────────────────────────────────────────────────────────
+// シナリオ A: 重複メールアドレスで signup → エラー表示
+// ────────────────────────────────────────────────────────
+test.describe("Bug-92: 重複メールアドレスの signup 処理", () => {
+  test("既存ユーザーのメールで signup すると /signup にエラーが表示される", async ({
+    page,
+  }) => {
+    await page.goto("/signup");
+
+    // 既存 E2E ユーザーのメールで signup を試みる
+    await page.locator("#email").fill(E2E_USER.email);
+    await page.locator("#password").fill(E2E_USER.password);
+
+    await page.locator('form button[type="submit"]').click();
+
+    // エラーアラートが /signup 画面に表示されること
+    const errorAlert = page.getByRole("alert");
+    await expect(errorAlert).toBeVisible({ timeout: 10_000 });
+
+    const text = (await errorAlert.textContent()) ?? "";
+    expect(text).toMatch(/既に登録|ログイン/);
+
+    // /auth/verify に遷移していないこと
+    await expect(page).toHaveURL(/\/signup$/, { timeout: 5_000 });
+  });
+
+  // ────────────────────────────────────────────────────────
+  // シナリオ B: /auth/verify 画面に「ログインへ」リンクが存在する
+  // ────────────────────────────────────────────────────────
+  test("/auth/verify 画面に「すでにアカウントをお持ちの場合」のログインリンクが表示される", async ({
+    page,
+  }) => {
+    await page.goto("/auth/verify?email=test%40example.com");
+
+    // フォールバック保険: 「すでにアカウントをお持ちの場合はログインへ」リンク
+    const loginLink = page.getByRole("link", { name: /ログインへ/ });
+    await expect(loginLink).toBeVisible({ timeout: 5_000 });
+
+    // リンク先が /login であること
+    const href = await loginLink.getAttribute("href");
+    expect(href).toMatch(/\/login/);
+  });
+});

--- a/tests/e2e/bug-93-home-no-rsc-error.spec.ts
+++ b/tests/e2e/bug-93-home-no-rsc-error.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Bug-93: /home ロード時に毎回 `Failed to fetch RSC payload for /health` が発生する
+ *
+ * 原因: /home の <Link href="/health"> に prefetch={false} が付いておらず、
+ *       Next.js が /health を RSC prefetch しようとして失敗していた。
+ *
+ * 修正: <Link href="/health" prefetch={false}> を付与し、prefetch を抑制。
+ *
+ * このテストでは:
+ *   - /home をロードし、コンソールに "Failed to fetch RSC payload for /health" が
+ *     出力されないことを確認する。
+ */
+import { test, expect } from "./fixtures/auth";
+
+test("bug-93: /home load does not emit RSC fetch error for /health", async ({
+  authedPage: page,
+}) => {
+  const rscErrors: string[] = [];
+
+  page.on("console", (msg) => {
+    if (
+      msg.type() === "error" &&
+      msg.text().includes("Failed to fetch RSC payload") &&
+      msg.text().includes("/health")
+    ) {
+      rscErrors.push(msg.text());
+    }
+  });
+
+  // /home をロードして networkidle まで待つ (prefetch が走るタイミングを包含)
+  await page.goto("/home", { waitUntil: "networkidle" });
+
+  // prefetch は hover 時にも発火するため、/health リンクにホバーしてみる
+  const healthLink = page.locator('a[href="/health"]').first();
+  const isVisible = await healthLink.isVisible().catch(() => false);
+  if (isVisible) {
+    await healthLink.hover();
+    // 短時間待機して prefetch が走る余地を与える
+    await page.waitForTimeout(1000);
+  }
+
+  expect(
+    rscErrors,
+    `RSC error for /health should not appear, but got: ${JSON.stringify(rscErrors)}`,
+  ).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary

このブランチには PR #95 でマージ済みの #93 fix の上に、追加で2つの fix が積まれています。

- **Closes #90** - 体重・血圧・血糖値などにサーバー側 min/max validation を追加 (3aa50d9)
- **Closes #92** - 重複メールアドレスでの signup silent-success を修正 (5f8de7f)

## Test plan
- [ ] 体重 -1 / 0 / 999999 で 400 返る
- [ ] 既存メールで signup → エラー表示 + ログインリンク
- [ ] /auth/verify にフォールバック「ログインへ」リンク表示