### PR TITLE
fix(ai-chat): #125/#126/#128/#138 AI Chat/Consultation 4件バグ修正

### DIFF
--- a/src/app/api/ai/consultation/sessions/route.ts
+++ b/src/app/api/ai/consultation/sessions/route.ts
@@ -143,74 +143,11 @@ export async function POST(request: Request) {
 
     if (error) throw error;
 
-    // 過去のセッション要約を整形
-    const pastSessionsInfo = pastSessions && pastSessions.length > 0
-      ? `【過去の相談履歴（最新10件）】
-${pastSessions.map((s: any) => {
-  const keyFacts = s.context_snapshot?.key_facts || [];
-  const userInsights = s.context_snapshot?.user_insights || [];
-  return `
-■ ${s.title}（${s.summary_generated_at ? new Date(s.summary_generated_at).toLocaleDateString('ja-JP') : '日付不明'}）
-  概要: ${s.summary || '要約なし'}
-  トピック: ${(s.key_topics || []).join(', ') || 'なし'}
-  ${keyFacts.length > 0 ? `重要な事実:
-${keyFacts.map((f: any) => `    - [${f.category}] ${f.date ? f.date + ': ' : ''}${f.content}`).join('\n')}` : ''}
-  ${userInsights.length > 0 ? `判明したこと: ${userInsights.join(', ')}` : ''}`;
-}).join('\n')}`
-      : '';
+    // #138: セッション作成時のシステムメッセージDB書き込みを削除。
+    // システムプロンプトは messages/route.ts の buildSystemPrompt() で動的に構築され、
+    // DB には保存しない（二重管理の解消）。
 
-    // 重要メッセージを整形
-    const importantMessagesInfo = importantMessages && importantMessages.length > 0
-      ? `【ユーザーが重要とマークした過去の会話（最新20件）】
-${importantMessages.map((m: any) => `- ${m.content.substring(0, 150)}${m.content.length > 150 ? '...' : ''} ${m.importance_reason ? `(理由: ${m.importance_reason})` : ''}`).join('\n')}`
-      : '';
-
-    // システムメッセージを追加
-    await supabase
-      .from('ai_consultation_messages')
-      .insert({
-        session_id: data.id,
-        role: 'system',
-        content: `あなたは「ほめゴハン」のAI栄養アドバイザーです。
-ユーザーの食事や健康について相談に乗り、具体的なアドバイスを提供します。
-
-【重要な行動指針】
-1. まず褒める：ユーザーの努力や良い点を見つけて褒める
-2. 共感する：ユーザーの悩みや状況に寄り添う
-3. 具体的に提案：実行可能な具体的なアドバイスを提供
-4. アクション提案：必要に応じて献立の作成や変更を提案
-5. 過去の相談内容を踏まえて、一貫性のあるアドバイスを提供
-
-【ユーザー情報】
-${JSON.stringify(contextSnapshot.profile, null, 2)}
-
-【最近の食事傾向】
-${recentMeals?.length || 0}件の食事記録があります。
-
-${pastSessionsInfo}
-
-${importantMessagesInfo}
-
-あなたはユーザーの代わりに以下のアクションを実行できます：
-- generate_day_menu: 特定の日の献立を作成
-- generate_week_menu: 1週間の献立を作成
-- update_meal: 既存の献立を変更
-- add_to_shopping_list: 買い物リストに追加
-- suggest_recipe: レシピを提案
-
-アクションを提案する場合は、以下の形式でJSONを含めてください：
-\`\`\`action
-{
-  "type": "アクション種類",
-  "params": { ... }
-}
-\`\`\`
-
-【重要】過去の相談で判明したユーザーの好みや傾向、設定した目標を覚えておき、一貫性のあるアドバイスを心がけてください。`,
-        metadata: { isSystemPrompt: true },
-      });
-
-    return NextResponse.json({ 
+    return NextResponse.json({
       success: true, 
       session: {
         id: data.id,

--- a/src/components/AIChatBubble.tsx
+++ b/src/components/AIChatBubble.tsx
@@ -152,6 +152,7 @@ export default function AIChatBubble() {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
   const [showMessageMenu, setShowMessageMenu] = useState<string | null>(null);
   const [isClosingSession, setIsClosingSession] = useState(false);
+  const [isToggling, setIsToggling] = useState(false); // #125: 連続クリック防止フラグ
   const [showDayMenuModal, setShowDayMenuModal] = useState(false);
   // Bug-5 (#21): Default to the date currently displayed on the weekly menu
   // page (published via window.__weeklyCurrentDate). If unavailable, fall back
@@ -327,6 +328,7 @@ export default function AIChatBubble() {
   // チャットを開く
   // Bug-6: 隣接 UI からの誤クリックでチャットが意図せず開くのを防ぐため、
   // event を受け取って stopPropagation し、既にモーダルが開いている場合は無視する。
+  // #125: isToggling フラグで連続クリックによる二重表示を防止する。
   const openChat = async (e?: React.MouseEvent) => {
     if (e) {
       e.stopPropagation();
@@ -336,23 +338,31 @@ export default function AIChatBubble() {
       // 別のモーダルが開いている間はチャットを開かない
       return;
     }
+    // #125: transition 中の連続クリックを弾く
+    if (isToggling) return;
+    setIsToggling(true);
     setIsOpen(true);
     setHasUnread(false);
-    const authenticated = await fetchSessions();
-    
-    if (!authenticated) {
-      return; // 認証されていない場合は何もしない
-    }
-    
-    // 既存のアクティブセッションがあればそれを使う、なければ新規作成
-    if (sessions.length > 0 && !currentSessionId) {
-      const activeSession = sessions.find(s => s.messageCount > 0) || sessions[0];
-      setCurrentSessionId(activeSession.id);
-      await fetchMessages(activeSession.id);
-    } else if (!currentSessionId) {
-      await createNewSession();
-    } else {
-      await fetchMessages(currentSessionId);
+    try {
+      const authenticated = await fetchSessions();
+
+      if (!authenticated) {
+        return; // 認証されていない場合は何もしない
+      }
+
+      // 既存のアクティブセッションがあればそれを使う、なければ新規作成
+      if (sessions.length > 0 && !currentSessionId) {
+        const activeSession = sessions.find(s => s.messageCount > 0) || sessions[0];
+        setCurrentSessionId(activeSession.id);
+        await fetchMessages(activeSession.id);
+      } else if (!currentSessionId) {
+        await createNewSession();
+      } else {
+        await fetchMessages(currentSessionId);
+      }
+    } finally {
+      // #125: アニメーション完了まで少し待ってからフラグを解除
+      setTimeout(() => setIsToggling(false), 400);
     }
   };
 
@@ -498,6 +508,12 @@ export default function AIChatBubble() {
 
       // ストリーム完了後：メッセージを最終状態に更新
       if (finalData) {
+        // #126: コンテキスト切替後に空応答になるケースをフォールバック表示
+        const resolvedContent = accumulatedContent || finalData.aiMessage.content || '';
+        const displayContent = resolvedContent.trim()
+          ? resolvedContent
+          : '応答の取得中にコンテキストが切り替わりました。もう一度お試しください。';
+
         setMessages(prev => prev.map(m => {
           if (m.id === tempUserMsgId) {
             return {
@@ -510,7 +526,7 @@ export default function AIChatBubble() {
             return {
               ...m,
               id: finalData.aiMessage.id,
-              content: accumulatedContent || finalData.aiMessage.content,
+              content: displayContent,
               proposedActions: finalData.aiMessage.proposedActions ? {
                 ...finalData.aiMessage.proposedActions,
                 actionId: finalData.aiMessage.id,
@@ -538,9 +554,13 @@ export default function AIChatBubble() {
         }
       } else {
         // finalDataがない場合（フォールバック）
+        // #126: accumulatedContent が空の場合もエラー表示する
+        const fallbackContent = accumulatedContent.trim()
+          ? accumulatedContent
+          : '応答に失敗しました。再試行してください。';
         setMessages(prev => prev.map(m =>
           m.id === tempAiMsgId
-            ? { ...m, content: accumulatedContent, isStreaming: false }
+            ? { ...m, content: fallbackContent, isStreaming: false }
             : m
         ));
       }
@@ -774,7 +794,8 @@ export default function AIChatBubble() {
       </AnimatePresence>
 
       {/* チャットウィンドウ */}
-      <AnimatePresence>
+      {/* #125: mode='wait' でアニメーション完了を待ち、二重表示を防止 */}
+      <AnimatePresence mode="wait">
         {isOpen && (
           <motion.div
             initial={{ opacity: 0, y: 100, scale: 0.9 }}

--- a/tests/e2e/bug-125-126-ai-chat-cluster.spec.ts
+++ b/tests/e2e/bug-125-126-ai-chat-cluster.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Bug-125 (#125): AIフローティングボタン連続クリックでチャットウィンドウが二重表示される
+ * Bug-126 (#126): コンテキスト切替後の最終応答が空文字になる
+ *
+ * 検証:
+ *  #125:
+ *   1. フローティングボタンを素早く連続クリックしても、チャットウィンドウは1つしか表示されない
+ *   2. isToggling フラグが解除された後は再度クリックで正常に開閉できる
+ *
+ *  #126:
+ *   1. メッセージ送信後、AI応答バブルが空文字のままにならない
+ *   2. ストリーミング完了後も isStreaming カーソルが消えて、コンテンツが表示される
+ */
+import { test, expect } from "./fixtures/auth";
+
+test.describe("Bug-125: フローティングボタン連続クリック二重表示防止", () => {
+  test("連続クリックしてもチャットウィンドウが1つだけ表示される", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/home");
+
+    const floatingButton = authedPage.getByTestId("ai-chat-floating-button");
+    await expect(floatingButton).toBeVisible({ timeout: 10_000 });
+
+    // 素早く3回連続クリック（二重表示バグの再現）
+    await floatingButton.click();
+    await floatingButton.click({ force: true }).catch(() => {});
+    await floatingButton.click({ force: true }).catch(() => {});
+
+    // チャットウィンドウのヘッダーは常に1つだけ
+    const chatHeadings = authedPage.getByRole("heading", { name: /AIアドバイザー/ });
+    await expect(chatHeadings.first()).toBeVisible({ timeout: 8_000 });
+    // 2つ目のウィンドウが存在しないことを確認（count === 1）
+    await expect(chatHeadings).toHaveCount(1);
+  });
+
+  test("チャットを閉じて再度開いても正常に動作する", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/home");
+
+    const floatingButton = authedPage.getByTestId("ai-chat-floating-button");
+    await expect(floatingButton).toBeVisible({ timeout: 10_000 });
+
+    // 1回目: 開く
+    await floatingButton.click();
+    await expect(
+      authedPage.getByRole("heading", { name: /AIアドバイザー/ })
+    ).toBeVisible({ timeout: 8_000 });
+
+    // 閉じる
+    const closeButton = authedPage.locator('button[aria-label="閉じる"], button').filter({
+      has: authedPage.locator('svg'),
+    }).last();
+    // X ボタンを探してクリック（チャットヘッダー内の閉じるボタン）
+    await authedPage.locator('button').filter({ has: authedPage.locator('svg[data-lucide="x"], svg.lucide-x') }).last().click().catch(async () => {
+      // フォールバック: Escape キーで閉じる
+      await authedPage.keyboard.press("Escape");
+    });
+
+    // フローティングボタンが再表示される
+    await expect(floatingButton).toBeVisible({ timeout: 5_000 });
+
+    // 2回目: 再度開く（isToggling がリセットされていること）
+    await floatingButton.click();
+    await expect(
+      authedPage.getByRole("heading", { name: /AIアドバイザー/ })
+    ).toBeVisible({ timeout: 8_000 });
+  });
+});
+
+test.describe("Bug-126: コンテキスト切替後の空応答防止", () => {
+  test("メッセージ送信後 AI応答バブルが空文字にならない", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/menus/weekly");
+
+    const floatingButton = authedPage.getByTestId("ai-chat-floating-button");
+    await expect(floatingButton).toBeVisible({ timeout: 10_000 });
+    await floatingButton.click();
+
+    const chatHeading = authedPage.getByRole("heading", { name: /AIアドバイザー/ });
+    await expect(chatHeading).toBeVisible({ timeout: 10_000 });
+
+    const input = authedPage.getByPlaceholder(/メッセージを入力/);
+    await expect(input).toBeVisible({ timeout: 5_000 });
+    await input.fill("こんにちは");
+    await input.press("Enter");
+
+    // ユーザーメッセージが表示されるまで待つ
+    await expect(
+      authedPage.locator("text=こんにちは").first()
+    ).toBeVisible({ timeout: 5_000 });
+
+    // 30秒以内に空でない AI応答バブルが表示されること（#126 の修正確認）
+    const aiBubble = authedPage
+      .locator('[data-testid="ai-message-bubble"]')
+      .filter({ hasNotText: "" })
+      .first();
+    await expect(aiBubble).toBeVisible({ timeout: 30_000 });
+
+    // 応答テキストが空でないことを確認
+    const bubbleText = await aiBubble.textContent();
+    expect((bubbleText ?? "").trim().length).toBeGreaterThan(0);
+  });
+
+  test("ストリーミング完了後に isStreaming カーソルが消える", async ({
+    authedPage,
+  }) => {
+    await authedPage.goto("/menus/weekly");
+
+    const floatingButton = authedPage.getByTestId("ai-chat-floating-button");
+    await expect(floatingButton).toBeVisible({ timeout: 10_000 });
+    await floatingButton.click();
+
+    await expect(
+      authedPage.getByRole("heading", { name: /AIアドバイザー/ })
+    ).toBeVisible({ timeout: 10_000 });
+
+    const input = authedPage.getByPlaceholder(/メッセージを入力/);
+    await expect(input).toBeVisible({ timeout: 5_000 });
+    await input.fill("今日の献立を教えて");
+    await input.press("Enter");
+
+    // 30秒以内に streaming カーソルが消えた（非空）バブルが表示されること
+    await expect(
+      authedPage.locator('[data-testid="ai-message-bubble"]').filter({ hasNotText: "" }).first()
+    ).toBeVisible({ timeout: 30_000 });
+
+    // streaming-cursor が消えていること（isStreaming=false になっている）
+    const streamingCursor = authedPage.locator(".streaming-cursor");
+    await expect(streamingCursor).toHaveCount(0, { timeout: 5_000 });
+  });
+});


### PR DESCRIPTION
## 修正内容

### #125 [high] フローティングボタン連続クリック → チャットウィンドウ二重表示
- `AIChatBubble.tsx` に `isToggling` state を追加し、`openChat` が実行中は再クリックを弾く
- `try/finally` で 400ms 後にフラグを解除（Framer Motion のアニメーション完了を待つ）
- チャットウィンドウの `AnimatePresence` を `mode="wait"` に変更し、exit アニメーション完了前の re-mount を防止

### #126 [medium] コンテキスト切替後の最終応答が空文字
- ストリーミング完了時に `accumulatedContent` と `finalData.aiMessage.content` の両方が空の場合（コンテキスト切替タイミング）にフォールバックエラーメッセージを表示
- `finalData` がない場合も `accumulatedContent` が空なら「再試行してください」を表示し、AI バブルが永続的に空のままにならないようにする

### #128 [bug] execute エンドポイント未実装
- `/api/ai/consultation/actions/[actionId]/execute/route.ts` が既に完全実装済みであることを確認
- メッセージ ID による `message_id` フォールバック検索、全 action_type のハンドラを含む

### #138 [bug] AIプロンプト二重管理
- `sessions/route.ts` の POST handler 内で `ai_consultation_messages` に `role: 'system'` レコードを INSERT していた冗長処理を削除
- システムプロンプトは `messages/route.ts` の `buildSystemPrompt()` のみで一元管理（リクエストごとに動的構築）

## テスト

- `tests/e2e/bug-125-126-ai-chat-cluster.spec.ts` を新規追加
  - Bug-125: 連続クリックでウィンドウが1つだけ表示されること
  - Bug-125: 閉じて再度開いても正常動作すること
  - Bug-126: AI応答バブルが空文字にならないこと
  - Bug-126: ストリーミング完了後に streaming カーソルが消えること

## Close

Closes #125, #126, #128, #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)