### PR TITLE
fix(misc): Wave2/F8 misc backend 5件修正 (#135 #139 #143 #144 #136)

### DIFF
--- a/src/app/(main)/MainLayout.tsx
+++ b/src/app/(main)/MainLayout.tsx
@@ -144,8 +144,12 @@ export default function MainLayout({
           </div>
         )}
 
-        <div className="p-4 border-t border-gray-100">
-           <Link href="/settings" className="flex items-center gap-4 px-4 py-3 text-gray-400 hover:text-gray-600 hover:bg-gray-50 rounded-xl transition-colors">
+        <div className="p-4 border-t border-gray-100 space-y-1">
+           <Link href="/pantry" className={`flex items-center gap-4 px-4 py-3 rounded-xl transition-colors ${pathname === '/pantry' ? 'bg-orange-50 text-accent font-bold' : 'text-gray-400 hover:text-gray-600 hover:bg-gray-50'}`}>
+             <Icons.ShoppingBag className="w-5 h-5" />
+             <span>食材管理</span>
+           </Link>
+           <Link href="/settings" className={`flex items-center gap-4 px-4 py-3 rounded-xl transition-colors ${pathname === '/settings' ? 'bg-orange-50 text-accent font-bold' : 'text-gray-400 hover:text-gray-600 hover:bg-gray-50'}`}>
              <Icons.Settings className="w-5 h-5" />
              <span>設定</span>
            </Link>

--- a/src/app/(main)/health/graphs/page.tsx
+++ b/src/app/(main)/health/graphs/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { formatLocalDate } from "@/lib/date-utils";
+import { createClient } from "@/lib/supabase/client";
 import {
   ArrowLeft, Scale, Heart, Moon, TrendingUp, TrendingDown,
   Calendar, ChevronLeft, ChevronRight, Target
@@ -47,6 +48,7 @@ export default function HealthGraphsPage() {
   const [period, setPeriod] = useState<Period>('month');
   const [metric, setMetric] = useState<Metric>('weight');
   const [targetWeight, setTargetWeight] = useState<number | null>(null);
+  const channelRef = useRef<ReturnType<ReturnType<typeof createClient>['channel']> | null>(null);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -80,6 +82,31 @@ export default function HealthGraphsPage() {
 
   useEffect(() => {
     void fetchData();
+  }, [fetchData]);
+
+  // Realtime subscription for health_records
+  useEffect(() => {
+    const supabase = createClient();
+
+    const channel = supabase
+      .channel('health-graphs-realtime')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'health_records' },
+        () => { void fetchData(); }
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'health_checkups' },
+        () => { void fetchData(); }
+      )
+      .subscribe();
+
+    channelRef.current = channel;
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
   }, [fetchData]);
 
   // グラフデータを生成

--- a/src/app/(main)/pantry/page.tsx
+++ b/src/app/(main)/pantry/page.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { motion, AnimatePresence } from "framer-motion";
+import { createClient } from "@/lib/supabase/client";
+import { ArrowLeft, Camera, Plus, Trash2, RefreshCw, Package, AlertCircle } from "lucide-react";
+
+const colors = {
+  bg: "#FAF9F7",
+  card: "#FFFFFF",
+  text: "#1A1A1A",
+  textLight: "#4A4A4A",
+  textMuted: "#9A9A9A",
+  accent: "#E07A5F",
+  accentLight: "#FDF0ED",
+  border: "#EEEEEE",
+  success: "#4CAF50",
+  successLight: "#E8F5E9",
+  error: "#F44336",
+};
+
+interface PantryItem {
+  id: string;
+  name: string;
+  amount: string | null;
+  category: string;
+  expirationDate: string | null;
+  addedAt: string;
+}
+
+interface AnalysisResult {
+  detailedIngredients: {
+    name: string;
+    quantity?: string;
+    category?: string;
+    freshness?: string;
+    daysRemaining?: number;
+  }[];
+  summary: string;
+  suggestions: string[];
+}
+
+export default function PantryPage() {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [items, setItems] = useState<PantryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [analyzing, setAnalyzing] = useState(false);
+  const [analysisResult, setAnalysisResult] = useState<AnalysisResult | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const fetchItems = useCallback(async () => {
+    try {
+      const res = await fetch("/api/pantry");
+      if (res.ok) {
+        const data = await res.json();
+        setItems(data.items || []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch pantry items:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchItems();
+  }, [fetchItems]);
+
+  const handlePhotoSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // プレビュー表示
+    const objectUrl = URL.createObjectURL(file);
+    setPreviewUrl(objectUrl);
+    setAnalysisResult(null);
+    setError(null);
+    setAnalyzing(true);
+
+    try {
+      // Base64に変換してAPIへ送信
+      const arrayBuffer = await file.arrayBuffer();
+      const base64 = btoa(
+        new Uint8Array(arrayBuffer).reduce((acc, byte) => acc + String.fromCharCode(byte), "")
+      );
+
+      const res = await fetch("/api/ai/analyze-fridge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          imageBase64: base64,
+          mimeType: file.type || "image/jpeg",
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "解析に失敗しました");
+      }
+
+      const data = await res.json();
+      setAnalysisResult({
+        detailedIngredients: data.detailedIngredients || [],
+        summary: data.summary || "",
+        suggestions: data.suggestions || [],
+      });
+    } catch (err: any) {
+      setError(err.message || "解析中にエラーが発生しました");
+    } finally {
+      setAnalyzing(false);
+      // reset file input
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const handleSaveIngredients = async (mode: "append" | "replace") => {
+    if (!analysisResult) return;
+    setSaving(true);
+    setError(null);
+
+    try {
+      const ingredients = analysisResult.detailedIngredients.map((item) => ({
+        name: item.name,
+        amount: item.quantity || null,
+        category: item.category || undefined,
+        daysRemaining: item.daysRemaining,
+        freshness: item.freshness,
+      }));
+
+      const res = await fetch("/api/pantry/from-photo", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ingredients, mode }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || "保存に失敗しました");
+      }
+
+      setAnalysisResult(null);
+      setPreviewUrl(null);
+      await fetchItems();
+    } catch (err: any) {
+      setError(err.message || "保存中にエラーが発生しました");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      const res = await fetch(`/api/pantry/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        setItems((prev) => prev.filter((item) => item.id !== id));
+      }
+    } catch (err) {
+      console.error("Delete failed:", err);
+    }
+  };
+
+  const categoryLabel: Record<string, string> = {
+    vegetable: "野菜",
+    meat: "肉類",
+    fish: "魚介",
+    dairy: "乳製品・卵",
+    other: "その他",
+  };
+
+  const isExpiringSoon = (dateStr: string | null): boolean => {
+    if (!dateStr) return false;
+    const diff = (new Date(dateStr).getTime() - Date.now()) / (1000 * 60 * 60 * 24);
+    return diff >= 0 && diff <= 3;
+  };
+
+  return (
+    <div className="min-h-screen pb-24" style={{ backgroundColor: colors.bg }}>
+      {/* ヘッダー */}
+      <div className="sticky top-0 z-10 px-4 py-4 flex items-center justify-between" style={{ backgroundColor: colors.bg }}>
+        <div className="flex items-center gap-2">
+          <button onClick={() => router.back()} className="p-2 -ml-2">
+            <ArrowLeft size={24} style={{ color: colors.text }} />
+          </button>
+          <h1 className="font-bold" style={{ color: colors.text }}>食材管理</h1>
+        </div>
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium"
+          style={{ backgroundColor: colors.accent, color: "white" }}
+        >
+          <Camera size={16} />
+          写真で追加
+        </button>
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={handlePhotoSelect}
+      />
+
+      {/* エラー表示 */}
+      <AnimatePresence>
+        {error && (
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            className="mx-4 mb-4 p-3 rounded-xl flex items-center gap-2"
+            style={{ backgroundColor: "#FFEBEE" }}
+          >
+            <AlertCircle size={18} style={{ color: colors.error }} />
+            <p className="text-sm" style={{ color: colors.error }}>{error}</p>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* 解析中 */}
+      {analyzing && (
+        <div className="mx-4 mb-4 p-4 rounded-2xl" style={{ backgroundColor: colors.card }}>
+          {previewUrl && (
+            <img src={previewUrl} alt="解析中の写真" className="w-full h-48 object-cover rounded-xl mb-3" />
+          )}
+          <div className="flex items-center gap-3">
+            <RefreshCw size={20} className="animate-spin" style={{ color: colors.accent }} />
+            <p className="text-sm font-medium" style={{ color: colors.textLight }}>
+              冷蔵庫の食材を解析中…
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* 解析結果 */}
+      <AnimatePresence>
+        {analysisResult && !analyzing && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+            className="mx-4 mb-4 p-4 rounded-2xl"
+            style={{ backgroundColor: colors.card }}
+          >
+            {previewUrl && (
+              <img src={previewUrl} alt="解析した写真" className="w-full h-48 object-cover rounded-xl mb-3" />
+            )}
+            <p className="text-sm font-medium mb-2" style={{ color: colors.text }}>
+              解析結果: {analysisResult.detailedIngredients.length}品目を検出
+            </p>
+            {analysisResult.summary && (
+              <p className="text-sm mb-3" style={{ color: colors.textLight }}>{analysisResult.summary}</p>
+            )}
+
+            {/* 検出された食材リスト */}
+            <div className="space-y-1 mb-3 max-h-40 overflow-y-auto">
+              {analysisResult.detailedIngredients.map((item, i) => (
+                <div key={i} className="flex items-center justify-between py-1">
+                  <span className="text-sm" style={{ color: colors.text }}>{item.name}</span>
+                  {item.quantity && (
+                    <span className="text-xs" style={{ color: colors.textMuted }}>{item.quantity}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            {/* 提案料理 */}
+            {analysisResult.suggestions.length > 0 && (
+              <div className="mb-3 p-3 rounded-xl" style={{ backgroundColor: colors.accentLight }}>
+                <p className="text-xs font-medium mb-1" style={{ color: colors.accent }}>おすすめレシピ</p>
+                {analysisResult.suggestions.map((s, i) => (
+                  <p key={i} className="text-sm" style={{ color: colors.textLight }}>・{s}</p>
+                ))}
+              </div>
+            )}
+
+            {/* 保存ボタン */}
+            <div className="flex gap-2">
+              <button
+                onClick={() => handleSaveIngredients("append")}
+                disabled={saving}
+                className="flex-1 py-2 rounded-xl text-sm font-medium"
+                style={{ backgroundColor: colors.accent, color: "white" }}
+              >
+                {saving ? "保存中…" : "追加保存"}
+              </button>
+              <button
+                onClick={() => handleSaveIngredients("replace")}
+                disabled={saving}
+                className="flex-1 py-2 rounded-xl text-sm font-medium"
+                style={{ backgroundColor: colors.card, color: colors.accent, border: `1px solid ${colors.accent}` }}
+              >
+                全て置き換え
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* 食材一覧 */}
+      <div className="px-4">
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <RefreshCw size={24} className="animate-spin" style={{ color: colors.accent }} />
+          </div>
+        ) : items.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 gap-4">
+            <Package size={48} style={{ color: colors.textMuted }} />
+            <p className="text-sm" style={{ color: colors.textMuted }}>食材がありません</p>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="flex items-center gap-2 px-6 py-3 rounded-full text-sm font-medium"
+              style={{ backgroundColor: colors.accent, color: "white" }}
+            >
+              <Camera size={16} />
+              冷蔵庫を撮影して追加
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {items.map((item) => (
+              <motion.div
+                key={item.id}
+                layout
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, x: -20 }}
+                className="flex items-center justify-between p-4 rounded-2xl"
+                style={{ backgroundColor: colors.card }}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="font-medium truncate" style={{ color: colors.text }}>{item.name}</p>
+                    {item.expirationDate && isExpiringSoon(item.expirationDate) && (
+                      <span className="text-xs px-2 py-0.5 rounded-full" style={{ backgroundColor: "#FFEBEE", color: colors.error }}>
+                        期限間近
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 mt-0.5">
+                    <span className="text-xs" style={{ color: colors.textMuted }}>
+                      {categoryLabel[item.category] || item.category}
+                    </span>
+                    {item.amount && (
+                      <span className="text-xs" style={{ color: colors.textMuted }}>・{item.amount}</span>
+                    )}
+                    {item.expirationDate && (
+                      <span
+                        className="text-xs"
+                        style={{ color: isExpiringSoon(item.expirationDate) ? colors.error : colors.textMuted }}
+                      >
+                        ・{item.expirationDate}まで
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleDelete(item.id)}
+                  className="ml-3 p-2 rounded-full"
+                  style={{ color: colors.textMuted }}
+                >
+                  <Trash2 size={16} />
+                </button>
+              </motion.div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/ai/hint/route.ts
+++ b/src/app/api/ai/hint/route.ts
@@ -1,9 +1,8 @@
 import { createClient } from '@/lib/supabase/server';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 export async function POST(request: Request) {
-  const supabase = createClient(cookies());
+  const supabase = await createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
   if (userError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 

--- a/src/app/api/ai/image/generate/route.ts
+++ b/src/app/api/ai/image/generate/route.ts
@@ -1,5 +1,4 @@
 import { createClient } from '@/lib/supabase/server';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { GoogleGenAI, createUserContent } from '@google/genai';
 
@@ -41,7 +40,7 @@ function getQuotaErrorMessage(rawError: string): string {
 }
 
 export async function POST(request: Request) {
-  const supabase = createClient(cookies());
+  const supabase = await createClient();
 
   try {
     const { prompt, images } = await request.json();

--- a/src/app/api/announcements/route.ts
+++ b/src/app/api/announcements/route.ts
@@ -1,9 +1,8 @@
 import { createClient } from '@/lib/supabase/server';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 export async function GET(request: Request) {
-  const supabase = createClient(cookies());
+  const supabase = await createClient();
   const { searchParams } = new URL(request.url);
   const mode = searchParams.get('mode'); // 'admin' | 'public'
 
@@ -40,7 +39,7 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
-  const supabase = createClient(cookies());
+  const supabase = await createClient();
 
   try {
     // 1. 権限チェック

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,6 +1,55 @@
 import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 
+async function sendAdminNotification(inquiry: {
+  id: string;
+  inquiry_type: string;
+  email: string;
+  subject: string;
+  message: string;
+}): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const adminEmail = process.env.ADMIN_NOTIFICATION_EMAIL;
+
+  if (!apiKey || !adminEmail) {
+    console.error('Admin notification skipped: RESEND_API_KEY or ADMIN_NOTIFICATION_EMAIL not set');
+    return;
+  }
+
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: 'homegohan <noreply@homegohan.app>',
+        to: [adminEmail],
+        subject: `[お問い合わせ] ${inquiry.subject}`,
+        text: [
+          `新しいお問い合わせが届きました。`,
+          ``,
+          `ID: ${inquiry.id}`,
+          `種別: ${inquiry.inquiry_type}`,
+          `送信者: ${inquiry.email}`,
+          `件名: ${inquiry.subject}`,
+          ``,
+          `--- 内容 ---`,
+          inquiry.message,
+        ].join('\n'),
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      console.error('Admin notification failed:', res.status, body);
+    }
+  } catch (err) {
+    console.error('Admin notification error:', err);
+  }
+}
+
 export async function POST(request: Request) {
   const supabase = await createClient();
   
@@ -51,8 +100,8 @@ export async function POST(request: Request) {
       );
     }
 
-    // TODO: メール通知を送信（管理者へ）
-    // await sendAdminNotification(data);
+    // 管理者へメール通知（env未設定時はsilent succeed）
+    await sendAdminNotification(data);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/notification-preferences/route.ts
+++ b/src/app/api/notification-preferences/route.ts
@@ -69,27 +69,15 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ error: 'No valid fields provided' }, { status: 400 });
   }
 
-  const { data: existing } = await supabase
+  // upsertでselect→分岐を1クエリに集約し、並列アクセス時の競合とレイテンシを解消
+  const result = await supabase
     .from('notification_preferences')
-    .select('id')
-    .eq('user_id', user.id)
-    .maybeSingle();
-
-  let result;
-  if (existing) {
-    result = await supabase
-      .from('notification_preferences')
-      .update({ ...patch, updated_at: new Date().toISOString() })
-      .eq('id', existing.id)
-      .select('notifications_enabled, auto_analyze_enabled, data_share_enabled')
-      .single();
-  } else {
-    result = await supabase
-      .from('notification_preferences')
-      .insert({ user_id: user.id, ...patch })
-      .select('notifications_enabled, auto_analyze_enabled, data_share_enabled')
-      .single();
-  }
+    .upsert(
+      { user_id: user.id, ...patch, updated_at: new Date().toISOString() },
+      { onConflict: 'user_id' }
+    )
+    .select('notifications_enabled, auto_analyze_enabled, data_share_enabled')
+    .single();
 
   if (result.error) {
     return NextResponse.json({ error: result.error.message }, { status: 500 });

--- a/src/app/api/pantry/[id]/route.ts
+++ b/src/app/api/pantry/[id]/route.ts
@@ -1,12 +1,11 @@
 import { createClient } from '@/lib/supabase/server';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 export async function PATCH(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  const supabase = createClient(cookies());
+  const supabase = await createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
   if (userError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
@@ -49,7 +48,7 @@ export async function DELETE(
   request: Request,
   { params }: { params: { id: string } }
 ) {
-  const supabase = createClient(cookies());
+  const supabase = await createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
   if (userError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 

--- a/src/app/api/pantry/route.ts
+++ b/src/app/api/pantry/route.ts
@@ -1,9 +1,8 @@
 import { createClient } from '@/lib/supabase/server';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 export async function GET(request: Request) {
-  const supabase = createClient(cookies());
+  const supabase = await createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
   if (userError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
@@ -29,7 +28,7 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
-  const supabase = createClient(cookies());
+  const supabase = await createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
   if (userError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 

--- a/src/app/api/shopping-list/regenerate/status/route.ts
+++ b/src/app/api/shopping-list/regenerate/status/route.ts
@@ -1,12 +1,11 @@
 import { createClient } from '@/lib/supabase/server';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 /**
  * 買い物リスト再生成リクエストのステータス確認API
  */
 export async function GET(request: Request) {
-  const supabase = createClient(cookies());
+  const supabase = await createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
   if (userError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { cookies } from "next/headers";
 
 export async function POST(request: Request) {
-  const supabase = createClient(cookies());
+  const supabase = await createClient();
   
   try {
     const { data: { user }, error: userError } = await supabase.auth.getUser();

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -129,4 +129,9 @@ export const Icons = {
       <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
   ),
+  ShoppingBag: ({ className }: IconProps) => (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
+    </svg>
+  ),
 };


### PR DESCRIPTION
## Summary

- **#135** `src/app/api/contact/route.ts`: 管理者メール通知TODOをResend API fetch直接呼び出しで実装。`RESEND_API_KEY`/`ADMIN_NOTIFICATION_EMAIL` 未設定時はconsole.errorのみのsilent succeed
- **#139** `createClient(cookies())`旧パターンをawait createClient()に一括統一(announcements/pantry/upload/hint/ai-image-generate/shopping-list-statusの計7ファイル)
- **#143** `/health/graphs/page.tsx`: Supabase Realtimeで`health_records`と`health_checkups`テーブルの変更を購読し自動再fetch
- **#144** `/api/notification-preferences` PATCH: select+分岐2クエリをupsert1クエリに変更、並列アクセス時の競合とレイテンシを解消
- **#136** `/pantry/page.tsx`新規作成: 写真で追加ボタン→`/api/ai/analyze-fridge`呼び出し、追加保存/全置き換えモード、期限間近ハイライト。サイドバーに食材管理リンクとIcons.ShoppingBagを追加

## Test plan

- [ ] `/contact` からお問い合わせ送信 → DB保存成功、RESEND_API_KEY設定時はメール送信確認
- [ ] `/api/announcements` GET/POST が正常動作することを確認
- [ ] `/health/graphs` で健康記録を追加すると自動でグラフ更新
- [ ] `/settings` でnotification-preferences PATCH を並列実行しても20s以内に完了
- [ ] `/pantry` にアクセスし写真を選択→解析→保存が正常動作

Closes #135, #139, #143, #144, #136