### PR TITLE
fix: AI画像分類 多重フォールバック削除・1px除外・タイムアウト後DB書き込み防止

### DIFF
--- a/src/app/api/ai/analyze-meal-photo/route.ts
+++ b/src/app/api/ai/analyze-meal-photo/route.ts
@@ -60,6 +60,12 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Image is required' }, { status: 400 });
     }
 
+    // #121: タイムアウト後の DB 書き込み防止
+    // mealId がある非同期モードでは invokedAt を Edge Function に渡す。
+    // Edge Function 側はDB更新前に planned_meals.photo_analyzed_at と比較し、
+    // 自分より新しい書き込みが既にある場合は更新をスキップする（CAS パターン）。
+    const invokedAt = new Date().toISOString();
+
     const invokePromise = supabase.functions.invoke('analyze-meal-photo', {
       body: {
         images: imageDataArray,
@@ -67,6 +73,7 @@ export async function POST(request: Request) {
         mealType,
         prefetchedGeminiResult,
         userId: user.id,
+        invokedAt: mealId ? invokedAt : undefined,
       },
     });
 

--- a/src/app/api/ai/classify-photo/route.ts
+++ b/src/app/api/ai/classify-photo/route.ts
@@ -31,13 +31,6 @@ function recoverClassificationFromRawText(rawText: string): ClassifyPhotoResult 
   if (pair) {
     const recoveredType = pair[1] as PhotoType;
     const recoveredConf = Number(pair[2]);
-    // unknown かつ confidence が低い場合は文脈から meal を再推測
-    if (recoveredType === 'unknown' && recoveredConf < 0.5) {
-      const mealHints = /\b(food|meal|dish|plate|bowl|rice|soup|bento|定食|弁当|食事|料理|皿|茶碗|丼)\b/i;
-      if (mealHints.test(rawText)) {
-        return normalizeClassifyPhotoResult({ type: 'meal', confidence: 0.65 });
-      }
-    }
     return normalizeClassifyPhotoResult({
       type: recoveredType,
       confidence: recoveredConf,
@@ -46,19 +39,14 @@ function recoverClassificationFromRawText(rawText: string): ClassifyPhotoResult 
 
   const typeOnly = rawText.match(/"type"\s*:\s*"(meal|fridge|health_checkup|weight_scale|unknown)"/);
   if (!typeOnly) {
-    // 型が見当たらない場合は meal として回収（classify-failed を防ぐ）
-    return normalizeClassifyPhotoResult({ type: 'meal', confidence: 0.5 });
+    // 型が見当たらない場合は unknown を返す
+    return normalizeClassifyPhotoResult({ type: 'unknown', confidence: 0.0 });
   }
 
   const recoveredType = typeOnly[1] as PhotoType;
-  // unknown は meal にフォールバック（classify-failed を絶対に返さない）
-  if (recoveredType === 'unknown') {
-    return normalizeClassifyPhotoResult({ type: 'meal', confidence: 0.5 });
-  }
-
   return normalizeClassifyPhotoResult({
     type: recoveredType,
-    confidence: 0.7,
+    confidence: recoveredType === 'unknown' ? 0.0 : 0.7,
   });
 }
 
@@ -66,32 +54,30 @@ function buildPrompt(imageCount: number): string {
   const imageCountText = imageCount > 1 ? `${imageCount}枚の` : '';
   return `この${imageCountText}画像セットの主な用途を判別してください。
 
-【絶対禁止ルール】食事・料理の写真に対して "unknown" や "classify-failed" を返すことは厳禁です。
-器、皿、食材、食卓、トレイが写っている場合は必ず "meal" を返してください。
+まず「これは食事・料理の写真ですか？」を判断してください。
+明確に食事・料理だと判断できる場合のみ "meal" を返してください。
 
 以下の4つのカテゴリから最も適切なものを選んでください：
 
 1. "meal" - 食事・料理の写真
    【例】定食（米飯＋主菜＋副菜＋汁物）、単品料理、弁当、丼、ラーメン、
         パスタ、サラダ、ケーキ、カフェの飲み物、和食、洋食、中華。
-        器・トレイ・食材の盛り付けが写っていれば必ず "meal" を選んでください。
-        疑わしい場合は "meal" を選んでください。
+        料理が明確に写っている場合に選んでください。
 2. "fridge" - 冷蔵庫の中身や買い物食材の写真（冷蔵庫の内部が写っている場合）
 3. "health_checkup" - 健康診断結果や検査票など紙の書類のみ
 4. "weight_scale" - 体重計や体組成計のディスプレイ写真のみ
 
 判定ルール:
 - 複数枚ある場合は、画像全体を見て最も一貫したカテゴリを選んでください
-- 料理・食事の画像（器、盛り付け、食卓、弁当箱）は **絶対に "meal"** を選んでください
 - 体重計ディスプレイ写真は必ず "weight_scale" を最優先で判定してください
 - 紙の健康診断結果と体重計ディスプレイは厳密に区別してください
-- 食べ物・飲み物・料理が少しでも写っている場合は "meal" を返してください
-- "unknown" は本当に4カテゴリのどれにも一切当てはまらない場合のみ使用してください
-- 迷った場合は "meal" を選んでください（誤分類より未分類の方が問題です）
+- 料理・食事が明確に写っている場合は "meal" を返してください
+- 4カテゴリのどれにも当てはまらない場合や、画像が不鮮明・空白・テスト画像の場合は "unknown" を返してください
+- 判定に自信がない場合は confidence を低く設定してください
 
 JSON では次の2項目だけ返してください:
-- "type": 上記4カテゴリのいずれか（"meal" / "fridge" / "health_checkup" / "weight_scale"）
-- "confidence": 0.0 から 1.0 の小数
+- "type": 上記4カテゴリのいずれか（"meal" / "fridge" / "health_checkup" / "weight_scale" / "unknown"）
+- "confidence": 0.0 から 1.0 の小数（判定に自信がない場合は低い値を設定する）
 
 説明文や候補配列は返さないでください。`;
 }
@@ -152,6 +138,24 @@ function buildMealAnalysisPrompt(mealType?: string, imageCount: number = 1): str
 const CLASSIFY_CONFIDENCE_THRESHOLD = 0.5;
 const CLASSIFY_RETRY_TEMPERATURE = 0.4;
 
+// 画像の最小バイトサイズ（1px ブランク JPEG 等の極小画像を除外するための閾値）
+// 通常の 100x100px JPEG でも数 KB 以上になるため、1000 バイト未満は無効とみなす
+const MIN_IMAGE_BYTES = 1000;
+
+/**
+ * base64 画像が最低品質要件を満たしているか検証する。
+ * 極小・空白画像（例: 1px ブランク JPEG）は unknown を強制して AI 呼び出しをスキップする。
+ */
+function isImageSufficientQuality(images: ImageInput[]): boolean {
+  for (const image of images) {
+    if (!image.base64 || image.base64.length === 0) return false;
+    // base64 文字数からバイト数を近似 (実際のバイト数 ≈ base64 長 × 3/4)
+    const approxBytes = Math.floor(image.base64.length * 0.75);
+    if (approxBytes < MIN_IMAGE_BYTES) return false;
+  }
+  return true;
+}
+
 async function requestClassification(
   images: ImageInput[],
   temperature = 0.1,
@@ -211,14 +215,13 @@ async function requestClassificationWithRetry(
     return best;
   }
 
-  // すべてのリトライで unknown になった場合は meal にフォールバック
-  // （写真が存在する以上、何らかの食事関連コンテンツである可能性が最も高い）
-  console.warn('Photo Classification: all retries returned unknown, forcing meal fallback', {
+  // すべてのリトライで unknown になった場合は unknown を返す
+  console.warn('Photo Classification: all retries returned unknown, returning unknown', {
     firstConf: first.result.confidence,
     candidateCount: candidates.length,
   });
   return {
-    result: normalizeClassifyPhotoResult({ type: 'meal', confidence: 0.5 }),
+    result: normalizeClassifyPhotoResult({ type: 'unknown', confidence: first.result.confidence }),
     model: first.model,
   };
 }
@@ -262,9 +265,41 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Image Base64 is required' }, { status: 400 });
     }
 
+    // #151: 極小・空白画像（例: 1px ブランク JPEG）は AI に送らず unknown を返す
+    if (!isImageSufficientQuality(images)) {
+      console.warn('Photo Classification: image rejected due to insufficient quality (too small)', {
+        imageCount: images.length,
+        approxBytesFirst: images[0] ? Math.floor(images[0].base64.length * 0.75) : 0,
+      });
+      return NextResponse.json({
+        type: 'unknown',
+        confidence: 0.0,
+        description: '画像が小さすぎるか無効です',
+        modelUsed: CLASSIFY_MODEL,
+      });
+    }
+
     const classifyStartedAt = Date.now();
     const { result: initialResult, model } = await requestClassificationWithRetry(images);
     const classifyElapsedMs = Date.now() - classifyStartedAt;
+
+    // #151: confidence 閾値チェック — 低信頼度の分類は unknown として扱う
+    const FINAL_CONFIDENCE_THRESHOLD = 0.6;
+    if (initialResult.confidence < FINAL_CONFIDENCE_THRESHOLD && initialResult.type !== 'unknown') {
+      console.info('Photo Classification: confidence below threshold, treating as unknown', {
+        type: initialResult.type,
+        confidence: initialResult.confidence,
+        threshold: FINAL_CONFIDENCE_THRESHOLD,
+      });
+      // 信頼度が低すぎる場合は unknown として扱うが、元の型情報は candidates に保持する
+      const lowConfResult = normalizeClassifyPhotoResult({
+        type: 'unknown',
+        confidence: initialResult.confidence,
+        candidates: [{ type: initialResult.type, confidence: initialResult.confidence }],
+      });
+      return NextResponse.json({ ...lowConfResult, modelUsed: model });
+    }
+
     let result: ClassifyPhotoResult | ClassifyPhotoWithMealAnalysisResult = initialResult;
 
     if (images.length > 1 && !resolveClassifyPhotoType(initialResult).type) {

--- a/supabase/functions/analyze-meal-photo/index.ts
+++ b/supabase/functions/analyze-meal-photo/index.ts
@@ -46,13 +46,14 @@ Deno.serve(async (req) => {
     }
 
     const body = await req.json()
-    const { images, imageBase64, mimeType, mealId, mealType, prefetchedGeminiResult } = body as {
+    const { images, imageBase64, mimeType, mealId, mealType, prefetchedGeminiResult, invokedAt } = body as {
       images?: ImageInput[];
       imageBase64?: string;
       mimeType?: string;
       mealId?: string;
       mealType?: string;
       prefetchedGeminiResult?: GeminiAnalysisResult;
+      invokedAt?: string;
     }
 
     const imageDataArray: ImageInput[] =
@@ -106,13 +107,14 @@ Deno.serve(async (req) => {
     }
 
     // 非同期でバックグラウンドタスクを実行
-    analyzeMealPhotoBackgroundTask({ 
+    analyzeMealPhotoBackgroundTask({
       images: imageDataArray,
       mealId,
       mealType,
       prefetchedGeminiResult,
       userId: user.id,
-      authHeader
+      authHeader,
+      invokedAt,
     }).catch((error) => {
       console.error('Background task error:', error)
     })
@@ -132,13 +134,14 @@ Deno.serve(async (req) => {
   }
 })
 
-async function analyzeMealPhotoBackgroundTask({ 
+async function analyzeMealPhotoBackgroundTask({
   images,
   mealId,
   mealType,
   prefetchedGeminiResult,
   userId,
-  authHeader
+  authHeader,
+  invokedAt,
 }: {
   images: ImageInput[];
   mealId: string;
@@ -146,6 +149,7 @@ async function analyzeMealPhotoBackgroundTask({
   prefetchedGeminiResult?: GeminiAnalysisResult;
   userId: string;
   authHeader: string;
+  invokedAt?: string;
 }) {
   console.log(`Starting photo analysis v2 for mealId: ${mealId}, user: ${userId}`)
   
@@ -205,6 +209,31 @@ async function analyzeMealPhotoBackgroundTask({
     const photoDishes = buildPhotoDishList(dishes, imageUrl)
     const dishName = result.dishes.map(d => d.name).join('、')
     
+    // #121: CAS パターン — タイムアウト後の DB 書き込み防止
+    // invokedAt が渡されている場合、DB の updated_at がそれより新しければスキップする
+    if (invokedAt) {
+      const { data: currentMeal, error: fetchError } = await supabase
+        .from('planned_meals')
+        .select('updated_at')
+        .eq('id', mealId)
+        .single()
+
+      if (fetchError) {
+        console.warn('Failed to fetch planned_meal for CAS check:', fetchError.message)
+      } else if (currentMeal?.updated_at) {
+        const currentUpdatedAt = new Date(currentMeal.updated_at).getTime()
+        const invokedAtTime = new Date(invokedAt).getTime()
+        if (currentUpdatedAt > invokedAtTime) {
+          console.warn(`Photo analysis result discarded: DB was already updated after this job was invoked`, {
+            mealId,
+            invokedAt,
+            currentUpdatedAt: currentMeal.updated_at,
+          })
+          return
+        }
+      }
+    }
+
     // planned_mealsを更新（全栄養素）
     try {
       await cancelPendingMealImageJobs({

--- a/tests/image-route-contracts.test.ts
+++ b/tests/image-route-contracts.test.ts
@@ -335,13 +335,16 @@ describe('image route contracts', () => {
     }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
     vi.stubGlobal('fetch', fetchMock);
 
+    // MIN_IMAGE_BYTES (1000) を超えるよう十分な長さの base64 ダミー値を使用
+    const validBase64 = 'A'.repeat(2000);
+
     const { POST } = await import('../src/app/api/ai/classify-photo/route');
     const response = await POST(new Request('http://localhost/api/ai/classify-photo', {
       method: 'POST',
       body: JSON.stringify({
         images: [
-          { base64: 'abc', mimeType: 'image/jpeg' },
-          { base64: 'def', mimeType: 'image/png' },
+          { base64: validBase64, mimeType: 'image/jpeg' },
+          { base64: validBase64, mimeType: 'image/png' },
         ],
       }),
     }));
@@ -408,11 +411,13 @@ describe('image route contracts', () => {
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
     vi.stubGlobal('fetch', fetchMock);
 
+    const validBase64 = 'A'.repeat(2000);
+
     const { POST } = await import('../src/app/api/ai/classify-photo/route');
     const response = await POST(new Request('http://localhost/api/ai/classify-photo', {
       method: 'POST',
       body: JSON.stringify({
-        images: [{ base64: 'abc', mimeType: 'image/jpeg' }],
+        images: [{ base64: validBase64, mimeType: 'image/jpeg' }],
         includeMealAnalysis: true,
         mealType: 'dinner',
       }),
@@ -454,7 +459,25 @@ describe('image route contracts', () => {
   });
 
   it('classify-photo retries with higher temperature when the batch result is weak', async () => {
-    // 1回目: unknown (confidence 低い) → retry 2回 → meal が返る
+    // 1回目: unknown (confidence 低い) → 並列リトライ 3回 → meal が返る
+    // 計 1 + 3 = 4 回の fetch が発生する
+    const mealResponse = () => new Response(JSON.stringify({
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: JSON.stringify({
+                  type: 'meal',
+                  confidence: 0.81,
+                }),
+              },
+            ],
+          },
+        },
+      ],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(new Response(JSON.stringify({
         candidates: [
@@ -472,47 +495,20 @@ describe('image route contracts', () => {
           },
         ],
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({
-        candidates: [
-          {
-            content: {
-              parts: [
-                {
-                  text: JSON.stringify({
-                    type: 'meal',
-                    confidence: 0.81,
-                  }),
-                },
-              ],
-            },
-          },
-        ],
-      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({
-        candidates: [
-          {
-            content: {
-              parts: [
-                {
-                  text: JSON.stringify({
-                    type: 'meal',
-                    confidence: 0.74,
-                  }),
-                },
-              ],
-            },
-          },
-        ],
-      }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      .mockResolvedValueOnce(mealResponse())
+      .mockResolvedValueOnce(mealResponse())
+      .mockResolvedValueOnce(mealResponse());
     vi.stubGlobal('fetch', fetchMock);
+
+    const validBase64 = 'A'.repeat(2000);
 
     const { POST } = await import('../src/app/api/ai/classify-photo/route');
     const response = await POST(new Request('http://localhost/api/ai/classify-photo', {
       method: 'POST',
       body: JSON.stringify({
         images: [
-          { base64: 'abc', mimeType: 'image/jpeg' },
-          { base64: 'def', mimeType: 'image/jpeg' },
+          { base64: validBase64, mimeType: 'image/jpeg' },
+          { base64: validBase64, mimeType: 'image/jpeg' },
         ],
       }),
     }));
@@ -523,8 +519,8 @@ describe('image route contracts', () => {
       type: 'meal',
       confidence: 0.81,
     });
-    // 初回 1 回 + リトライ 2 回 = 3 回
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // 初回 1 回 + 並列リトライ 3 回 = 4 回
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   it('classify-photo recovers when Gemini returns malformed JSON', async () => {
@@ -557,11 +553,13 @@ describe('image route contracts', () => {
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
     vi.stubGlobal('fetch', fetchMock);
 
+    const validBase64 = 'A'.repeat(2000);
+
     const { POST } = await import('../src/app/api/ai/classify-photo/route');
     const response = await POST(new Request('http://localhost/api/ai/classify-photo', {
       method: 'POST',
       body: JSON.stringify({
-        images: [{ base64: 'abc', mimeType: 'image/jpeg' }],
+        images: [{ base64: validBase64, mimeType: 'image/jpeg' }],
       }),
     }));
 
@@ -647,5 +645,108 @@ describe('image route contracts', () => {
       success: true,
       meal: storedMeal,
     });
+  });
+
+  // #150: 多重フォールバックで非食品画像が meal に強制分類される問題の repro
+  it('#150: classify-photo returns unknown when all retries consistently return unknown (non-food image)', async () => {
+    // すべてのリトライで unknown が返る場合は meal にフォールバックせず unknown を返す
+    const unknownResponse = new Response(JSON.stringify({
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                text: JSON.stringify({
+                  type: 'unknown',
+                  confidence: 0.15,
+                }),
+              },
+            ],
+          },
+        },
+      ],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(unknownResponse)
+      .mockResolvedValueOnce(unknownResponse.clone())
+      .mockResolvedValueOnce(unknownResponse.clone())
+      .mockResolvedValueOnce(unknownResponse.clone());
+    vi.stubGlobal('fetch', fetchMock);
+
+    // 十分なサイズの base64 画像（MIN_IMAGE_BYTES を超えるよう長さを確保）
+    const validBase64 = 'A'.repeat(2000);
+
+    const { POST } = await import('../src/app/api/ai/classify-photo/route');
+    const response = await POST(new Request('http://localhost/api/ai/classify-photo', {
+      method: 'POST',
+      body: JSON.stringify({
+        images: [{ base64: validBase64, mimeType: 'image/jpeg' }],
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    // 非食品画像は unknown を返す（meal への強制変換が行われていないことを確認）
+    expect(payload.type).toBe('unknown');
+  });
+
+  // #151: 1px ブランク JPEG が type:meal, confidence:1.0 で誤判別される問題の repro
+  it('#151: classify-photo returns unknown for 1px blank JPEG without calling AI', async () => {
+    // 1px JPEG の base64 は非常に短い（実際の 1px JPEG は約 300 バイト程度）
+    // MIN_IMAGE_BYTES = 1000 バイト未満として判定
+    // base64 長 ≈ bytes × 4/3 なので、1000 バイト未満 → base64 長 < 1334
+    const tinyBase64 = 'A'.repeat(100); // 約 75 バイト相当
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('../src/app/api/ai/classify-photo/route');
+    const response = await POST(new Request('http://localhost/api/ai/classify-photo', {
+      method: 'POST',
+      body: JSON.stringify({
+        images: [{ base64: tinyBase64, mimeType: 'image/jpeg' }],
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    // AI を呼ばずに unknown を返す
+    expect(payload.type).toBe('unknown');
+    expect(payload.confidence).toBe(0);
+    // AI は一切呼ばれていない
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // #121: analyze-meal-photo が invokedAt を Edge Function に渡すことを確認
+  it('#121: analyze-meal-photo passes invokedAt to edge function for CAS timeout protection', async () => {
+    mockInvoke.mockResolvedValue({
+      data: { message: 'Photo analysis started in background' },
+      error: null,
+    });
+
+    const { POST } = await import('../src/app/api/ai/analyze-meal-photo/route');
+    const beforeInvoke = new Date().toISOString();
+    const response = await POST(new Request('http://localhost/api/ai/analyze-meal-photo', {
+      method: 'POST',
+      body: JSON.stringify({
+        images: [{ base64: 'A'.repeat(2000), mimeType: 'image/jpeg' }],
+        mealId: 'meal-123',
+        mealType: 'dinner',
+      }),
+    }));
+    const afterInvoke = new Date().toISOString();
+
+    expect(response.status).toBe(200);
+    expect(mockInvoke).toHaveBeenCalledWith('analyze-meal-photo', {
+      body: expect.objectContaining({
+        mealId: 'meal-123',
+        invokedAt: expect.any(String),
+      }),
+    });
+
+    // invokedAt が正しい時刻範囲内であることを確認
+    const calledBody = (mockInvoke.mock.calls[0][1] as any).body;
+    expect(calledBody.invokedAt >= beforeInvoke).toBe(true);
+    expect(calledBody.invokedAt <= afterInvoke).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- **#150** `recoverClassificationFromRawText()` の `unknown→meal` 強制変換を削除。`requestClassificationWithRetry()` が全リトライで `unknown` を返しても `meal` にフォールバックせず `unknown` を返すよう修正。非食品画像が `meal` に誤分類される根本原因を除去
- **#151** `isImageSufficientQuality()` を追加し、`MIN_IMAGE_BYTES=1000B` 未満の極小画像（1px ブランクJPEG等）はAI呼び出しをスキップして `unknown` を返す。また `FINAL_CONFIDENCE_THRESHOLD=0.6` 未満の分類も `unknown` に降格し、高信頼度の場合のみ分類結果を採用する
- **#152** `buildPrompt()` の「絶対禁止ルール（unknownを返すことは厳禁）」を削除し、`unknown` を正当な返答として許容するプロンプトに変更。「まず食事画像か判断して」というfirst-passアプローチに変更
- **#121** `analyze-meal-photo/route.ts` が `invokedAt` を Edge Function に送信。Edge Function 側が DB 更新前に `updated_at > invokedAt` を CAS チェックし、25秒タイムアウト後の古い解析結果がDBに書き込まれることを防止

## Test plan

- [x] `tests/image-route-contracts.test.ts` に `#150`/`#151`/`#121` の repro テストを追加 (14/14 pass)
- [x] `tests/image-recognition.test.ts` 既存テスト全て通過 (9/9 pass)
- [x] `tests/meal-image-photo-contracts.test.ts` 既存テスト全て通過 (3/3 pass)

## Closes

Closes #121, #150, #151, #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)