### PR TITLE
fix(security): CRON_SECRET 認証バイパス修正 + env 管理不備解消 (#196 #206)

### DIFF
--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -11,10 +11,15 @@
    - `NEXT_PUBLIC_SUPABASE_ANON_KEY` - Supabaseの匿名キー
    - `SUPABASE_SERVICE_ROLE_KEY` - Supabaseのサービスロールキー（サーバーサイドのみ）
 
-2. **Google AI (Gemini) 関連**
+2. **Cron / スケジューラ関連**
+   - `CRON_SECRET` - Vercel Cron からのリクエストを認証するシークレット（未設定の場合、cron エンドポイントは 503 を返す）
+     - Vercel Dashboard → Settings → Environment Variables に設定
+     - ランダムな英数字 32 文字以上を推奨
+
+4. **Google AI (Gemini) 関連**
    - `GOOGLE_AI_STUDIO_API_KEY` または `GOOGLE_GEN_AI_API_KEY` - Google AI APIキー
 
-3. **OpenAI関連**（既存機能用）
+5. **OpenAI関連**（既存機能用）
    - `OPENAI_API_KEY` - OpenAI APIキー
 
 ---
@@ -62,6 +67,9 @@ touch .env.local
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+
+# Cron Secret (Vercel Cron 認証用)
+CRON_SECRET=your_cron_secret_here
 
 # Google AI (Gemini)
 GOOGLE_AI_STUDIO_API_KEY=your_google_ai_api_key

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,16 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf8'));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  env: {
+    NEXT_PUBLIC_APP_VERSION: process.env.NEXT_PUBLIC_APP_VERSION ?? `v${pkg.version}`,
+    NEXT_PUBLIC_BUILD_DATE: process.env.NEXT_PUBLIC_BUILD_DATE ?? new Date().toISOString().slice(0, 10).replace(/-/g, ''),
+  },
   async headers() {
     return [
       {

--- a/src/app/api/ai/menu/day/regenerate/route.ts
+++ b/src/app/api/ai/menu/day/regenerate/route.ts
@@ -101,7 +101,7 @@ export async function POST(request: Request) {
 
     // 6. Edge Functionを呼び出し（V5/V4をfeature flagで切り替え）
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const supabaseServiceKey = process.env.SERVICE_ROLE_JWT || process.env.SUPABASE_SERVICE_ROLE_KEY!;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
     const generator = useV5 ? callGenerateMenuV5WithRetry : callGenerateMenuV4WithRetry;
     const edgeFunctionPromise = generator({

--- a/src/app/api/ai/menu/meal/generate/route.ts
+++ b/src/app/api/ai/menu/meal/generate/route.ts
@@ -103,7 +103,7 @@ export async function POST(request: Request) {
 
     // 5. Edge Function generate-menu-v4 を非同期で呼び出し
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const supabaseServiceKey = process.env.SERVICE_ROLE_JWT || process.env.SUPABASE_SERVICE_ROLE_KEY!;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
     const generator = useV5Wrapped ? callGenerateMenuV5WithRetry : callGenerateMenuV4WithRetry;
     const targetLabel = useV5Wrapped ? 'generate-menu-v5' : 'generate-menu-v4';
 

--- a/src/app/api/ai/menu/meal/regenerate/route.ts
+++ b/src/app/api/ai/menu/meal/regenerate/route.ts
@@ -69,7 +69,7 @@ export async function POST(request: Request) {
 
     // 5. Edge Function generate-menu-v4 を非同期で呼び出し
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const supabaseServiceKey = process.env.SERVICE_ROLE_JWT || process.env.SUPABASE_SERVICE_ROLE_KEY!;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
     const generator = useV5Wrapped ? callGenerateMenuV5WithRetry : callGenerateMenuV4WithRetry;
     const targetLabel = useV5Wrapped ? 'generate-menu-v5' : 'generate-menu-v4';
 

--- a/src/app/api/ai/menu/v4/generate/route.ts
+++ b/src/app/api/ai/menu/v4/generate/route.ts
@@ -306,7 +306,7 @@ export async function POST(request: Request) {
 
     // 11. Call Edge Function in background
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const supabaseServiceKey = process.env.SERVICE_ROLE_JWT || process.env.SUPABASE_SERVICE_ROLE_KEY!;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
     
     const generator = useV5Direct ? callGenerateMenuV5WithRetry : callGenerateMenuV4WithRetry;
     const targetLabel = useV5Direct ? 'generate-menu-v5' : 'generate-menu-v4';

--- a/src/app/api/ai/menu/weekly/request/route.ts
+++ b/src/app/api/ai/menu/weekly/request/route.ts
@@ -223,7 +223,7 @@ export async function POST(request: Request) {
 
     // 5. Edge Function generate-menu-v4 をバックグラウンドで呼び出し
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const supabaseServiceKey = process.env.SERVICE_ROLE_JWT || process.env.SUPABASE_SERVICE_ROLE_KEY!;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
     const generator = useV5Wrapped ? callGenerateMenuV5WithRetry : callGenerateMenuV4WithRetry;
     const targetLabel = useV5Wrapped ? 'generate-menu-v5' : 'generate-menu-v4';
     console.log(`🚀 Calling Edge Function ${targetLabel}...`);

--- a/src/app/api/ai/nutrition-analysis/route.ts
+++ b/src/app/api/ai/nutrition-analysis/route.ts
@@ -356,7 +356,7 @@ export async function POST(request: Request) {
 
     // generate-menu-v4を呼び出す（同期呼び出し）
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const serviceRoleKey = process.env.SERVICE_ROLE_JWT || process.env.SUPABASE_SERVICE_ROLE_KEY!;
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
     // リクエストを作成
     const targetSlots = [{ date: targetDate, mealType: targetMealType, plannedMealId: meal.id }];

--- a/src/app/api/cron/process-menu-queue/route.ts
+++ b/src/app/api/cron/process-menu-queue/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 
 export const runtime = 'edge';
@@ -5,13 +6,18 @@ export const maxDuration = 60; // Vercel Pro: 60s OK
 
 export async function GET(req: Request) {
   // CRON 認証 (Vercel Cron の Authorization header をチェック)
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    console.error('[cron] CRON_SECRET not set');
+    return NextResponse.json({ error: 'cron_disabled' }, { status: 503 });
+  }
   const auth = req.headers.get('authorization');
-  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return new Response('Unauthorized', { status: 401 });
+  if (auth !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SERVICE_ROLE_JWT!;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
   const supabase = createClient(supabaseUrl, serviceRoleKey);
   const workerId = crypto.randomUUID();

--- a/src/app/api/shopping-list/regenerate/route.ts
+++ b/src/app/api/shopping-list/regenerate/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
 
     // Edge Functionを非同期で呼び出し（fire-and-forget）
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const supabaseServiceKey = process.env.SERVICE_ROLE_JWT || process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
     if (!supabaseUrl || !supabaseServiceKey) {
       throw new Error('Missing Supabase configuration');


### PR DESCRIPTION
## Summary

- **#196 [high]** `CRON_SECRET` が未設定の場合に `Bearer undefined` との文字列照合で認証がバイパスされる問題を修正。未設定時は 503 を返すガードを追加
- **#206 [medium]** `SERVICE_ROLE_JWT` デッドエイリアスを 8 ファイルで `SUPABASE_SERVICE_ROLE_KEY` に統一、`NEXT_PUBLIC_APP_VERSION`/`BUILD_DATE` を `next.config.mjs` 経由で動的注入、`ENV_SETUP.md` に `CRON_SECRET` の説明を追記

## Changed files

| ファイル | 変更内容 |
|---|---|
| `src/app/api/cron/process-menu-queue/route.ts` | CRON_SECRET ガード追加、SERVICE_ROLE_JWT 削除 |
| `src/app/api/ai/menu/day/regenerate/route.ts` | SERVICE_ROLE_JWT → SUPABASE_SERVICE_ROLE_KEY |
| `src/app/api/ai/menu/meal/generate/route.ts` | 同上 |
| `src/app/api/ai/menu/meal/regenerate/route.ts` | 同上 |
| `src/app/api/ai/menu/v4/generate/route.ts` | 同上 |
| `src/app/api/ai/menu/weekly/request/route.ts` | 同上 |
| `src/app/api/ai/nutrition-analysis/route.ts` | 同上 |
| `src/app/api/shopping-list/regenerate/route.ts` | 同上 |
| `next.config.mjs` | APP_VERSION/BUILD_DATE を package.json から動的注入 |
| `ENV_SETUP.md` | CRON_SECRET の説明を追記 |

## Test plan

- [ ] `npm run build` でコンパイルエラーがないことを確認（admin/page.tsx の既存 TS エラーは別 PR fix/admin-chart-typescript-error で対応済み）
- [ ] CRON_SECRET 未設定時に `/api/cron/process-menu-queue` が 503 を返すことを確認
- [ ] CRON_SECRET 設定済み・正しい Bearer トークンで 200 系が返ることを確認
- [ ] SERVICE_ROLE_JWT を削除した各 API エンドポイントが正常に動作することを確認

Closes #196
Closes #206