### PR TITLE
fix(security): Edge Function 認証穴を一括修正

### DIFF
--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,0 +1,86 @@
+/**
+ * 認証ヘルパー - Edge Functions用
+ *
+ * requireAuth:        ユーザー向け関数 — Supabase JWT を検証し userId を返す
+ * requireServiceRole: バッチ向け関数  — CRON_SECRET / SERVICE_ROLE_SECRET を検証する
+ */
+
+import { createClient } from "@supabase/supabase-js";
+
+// -------------------------------------------------------
+// ユーザー認証（JWT）
+// -------------------------------------------------------
+
+export type AuthOk = { userId: string };
+
+/**
+ * Authorization: Bearer <jwt> を検証し、成功時は { userId } を返す。
+ * 失敗時は 401 Response を返す（呼び出し元は early return すること）。
+ *
+ * @example
+ * const authResult = await requireAuth(req);
+ * if (authResult instanceof Response) return authResult;
+ * const { userId } = authResult;
+ */
+export async function requireAuth(req: Request): Promise<AuthOk | Response> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return new Response(
+      JSON.stringify({ error: "Authorization header required" }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
+  const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
+
+  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data: { user }, error } = await supabase.auth.getUser();
+  if (error || !user) {
+    return new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  return { userId: user.id };
+}
+
+// -------------------------------------------------------
+// サービスロール認証（CRON_SECRET）
+// -------------------------------------------------------
+
+/**
+ * Authorization: Bearer <secret> を CRON_SECRET / SERVICE_ROLE_SECRET と比較する。
+ * 一致すれば null を返す（認証成功）。
+ * 失敗すれば 401 / 503 Response を返す（呼び出し元は early return すること）。
+ *
+ * @example
+ * const authErr = requireServiceRole(req);
+ * if (authErr) return authErr;
+ */
+export function requireServiceRole(req: Request): Response | null {
+  const secret =
+    Deno.env.get("CRON_SECRET") ?? Deno.env.get("SERVICE_ROLE_SECRET");
+
+  if (!secret) {
+    return new Response(
+      JSON.stringify({ error: "Service not configured" }),
+      { status: 503, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const authHeader = req.headers.get("authorization");
+  if (authHeader !== `Bearer ${secret}`) {
+    return new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  return null;
+}

--- a/supabase/functions/_shared/catalog/import-runner.ts
+++ b/supabase/functions/_shared/catalog/import-runner.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import { corsHeaders } from "../cors.ts";
 import { createLogger, generateRequestId } from "../db-logger.ts";
+import { requireServiceRole } from "../auth.ts";
 import { firecrawlScrapeStructured } from "../firecrawl-client.ts";
 import {
   cleanupCatalogExtract,
@@ -92,6 +93,15 @@ const DETAIL_SCHEMA: Record<string, unknown> = {
 export async function handleCatalogImportRequest(req: Request, options: HandlerOptions) {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
+  }
+
+  // バッチ専用: CRON_SECRET 認証（Firecrawl / LLM コスト保護）
+  const authErr = requireServiceRole(req);
+  if (authErr) {
+    return new Response(authErr.body, {
+      status: authErr.status,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
   }
 
   const requestId = generateRequestId();

--- a/supabase/functions/aggregate-org-stats/index.ts
+++ b/supabase/functions/aggregate-org-stats/index.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import { corsHeaders } from '../_shared/cors.ts';
+import { requireServiceRole } from '../_shared/auth.ts';
 
 const supabaseAdmin = createClient(
   Deno.env.get('SUPABASE_URL') ?? '',
@@ -9,6 +10,15 @@ const supabaseAdmin = createClient(
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
+  }
+
+  // バッチ専用: CRON_SECRET 認証
+  const authErr = requireServiceRole(req);
+  if (authErr) {
+    return new Response(authErr.body, {
+      status: authErr.status,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
   }
 
   try {

--- a/supabase/functions/analyze-fridge/index.ts
+++ b/supabase/functions/analyze-fridge/index.ts
@@ -1,13 +1,27 @@
-import { serve } from 'https://deno.land/std@0.178.0/http/server.ts';
 import { corsHeaders } from '../_shared/cors.ts';
-import { createFastLLMClient, getFastLLMModel } from "../_shared/fast-llm.ts";
+import { createFastLLMClient, getFastLLMModel } from '../_shared/fast-llm.ts';
+import { requireAuth } from '../_shared/auth.ts';
+import { createLogger, generateRequestId } from '../_shared/db-logger.ts';
 
 const openai = createFastLLMClient();
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }
+
+  // JWT 認証
+  const authResult = await requireAuth(req);
+  if (authResult instanceof Response) {
+    return new Response(authResult.body, {
+      status: authResult.status,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+  const { userId } = authResult;
+
+  const requestId = generateRequestId();
+  const logger = createLogger('analyze-fridge', requestId).withUser(userId);
 
   try {
     const { imageUrl } = await req.json();
@@ -19,23 +33,25 @@ serve(async (req) => {
       });
     }
 
-    // Grok Vision API
+    logger.info('Analyzing fridge image', { imageUrl: imageUrl.slice(0, 80) });
+
+    // Vision API
     const response = await openai.chat.completions.create({
       model: getFastLLMModel(),
       messages: [
         {
           role: 'user',
           content: [
-            { 
-              type: 'text', 
+            {
+              type: 'text',
               text: `この画像（冷蔵庫の中身や食材）に写っている食材をリストアップしてください。
                      また、見た目から判断して「使いかけ」や「鮮度が落ちていそう」なものがあれば、それを優先消費候補 (expiringSoon) としてマークしてください。
                      結果は以下のJSON形式のみで出力してください。余計な説明は不要です。
-                     
+
                      {
                        "ingredients": ["キャベツ", "卵", "牛乳"],
                        "expiringSoon": ["キャベツ (使いかけ)", "牛乳"]
-                     }` 
+                     }`,
             },
             {
               type: 'image_url',
@@ -47,18 +63,18 @@ serve(async (req) => {
         },
       ],
       max_tokens: 500,
-      response_format: { type: "json_object" },
+      response_format: { type: 'json_object' },
     } as any);
 
     const result = JSON.parse(response.choices[0].message.content || '{}');
+    logger.info('Fridge analysis complete', { ingredientCount: result.ingredients?.length ?? 0 });
 
     return new Response(JSON.stringify(result), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       status: 200,
     });
-
   } catch (error: any) {
-    console.error('Error analyzing fridge:', error);
+    logger.error('Error analyzing fridge', error);
     return new Response(JSON.stringify({ error: error.message }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       status: 500,

--- a/supabase/functions/calculate-segment-stats/index.ts
+++ b/supabase/functions/calculate-segment-stats/index.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import { corsHeaders } from '../_shared/cors.ts';
+import { requireServiceRole } from '../_shared/auth.ts';
 
 const supabaseAdmin = createClient(
   Deno.env.get('SUPABASE_URL') ?? '',
@@ -13,6 +14,15 @@ const supabaseAdmin = createClient(
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
+  }
+
+  // バッチ専用: CRON_SECRET 認証
+  const authErr = requireServiceRole(req);
+  if (authErr) {
+    return new Response(authErr.body, {
+      status: authErr.status,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
   }
 
   try {

--- a/supabase/functions/generate-hint/index.ts
+++ b/supabase/functions/generate-hint/index.ts
@@ -1,0 +1,152 @@
+/**
+ * generate-hint Edge Function
+ *
+ * ユーザーの食事データを受け取り、AI がパーソナライズされたヒントを生成する。
+ * 生成結果は user_hints テーブルに保存される（既存なら上書き）。
+ *
+ * 認証: Supabase JWT (Authorization: Bearer <token>)
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { corsHeaders } from "../_shared/cors.ts";
+import { requireAuth } from "../_shared/auth.ts";
+import { createLogger, generateRequestId } from "../_shared/db-logger.ts";
+import { createFastLLMClient, getFastLLMModel } from "../_shared/fast-llm.ts";
+
+const openai = createFastLLMClient();
+
+interface HintRequest {
+  userId?: string;
+  cookRate?: number;
+  avgCal?: number;
+  cookCount?: number;
+  buyCount?: number;
+  outCount?: number;
+  expiringItems?: string[];
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  // JWT 認証
+  const authResult = await requireAuth(req);
+  if (authResult instanceof Response) {
+    return new Response(authResult.body, {
+      status: authResult.status,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+  const { userId } = authResult;
+
+  const requestId = generateRequestId();
+  const logger = createLogger("generate-hint", requestId).withUser(userId);
+
+  try {
+    const body = (await req.json().catch(() => ({}))) as HintRequest;
+
+    const cookRate = typeof body.cookRate === "number" ? body.cookRate : 0;
+    const avgCal = typeof body.avgCal === "number" ? body.avgCal : 0;
+    const cookCount = typeof body.cookCount === "number" ? body.cookCount : 0;
+    const buyCount = typeof body.buyCount === "number" ? body.buyCount : 0;
+    const outCount = typeof body.outCount === "number" ? body.outCount : 0;
+    const expiringItems = Array.isArray(body.expiringItems) ? body.expiringItems : [];
+
+    logger.info("Generating hint", {
+      cookRate,
+      avgCal,
+      cookCount,
+      buyCount,
+      outCount,
+      expiringCount: expiringItems.length,
+    });
+
+    const expiringText = expiringItems.length > 0
+      ? `期限間近の食材: ${expiringItems.slice(0, 5).join("、")}`
+      : "期限間近の食材: なし";
+
+    const prompt = `あなたは健康的な食生活をサポートするアドバイザーです。
+以下のユーザーの食事データを見て、短く（1〜2文）励ましと具体的なアドバイスを日本語で提供してください。
+
+【今週の食事データ】
+- 自炊率: ${cookRate}%
+- 平均カロリー: ${avgCal > 0 ? `${avgCal}kcal/日` : "記録なし"}
+- 自炊回数: ${cookCount}回
+- 買い弁当/テイクアウト回数: ${buyCount}回
+- 外食回数: ${outCount}回
+- ${expiringText}
+
+ヒントはポジティブなトーンで、具体的で実践しやすい内容にしてください。
+JSON形式で {"hint": "..."} のみ出力してください。`;
+
+    const response = await openai.chat.completions.create({
+      model: getFastLLMModel(),
+      messages: [{ role: "user", content: prompt }],
+      max_tokens: 150,
+      response_format: { type: "json_object" },
+    } as any);
+
+    const result = JSON.parse(response.choices[0].message.content || '{"hint": ""}');
+    const hint = typeof result.hint === "string" && result.hint.trim()
+      ? result.hint.trim()
+      : getFallbackHint(cookRate, avgCal, expiringItems);
+
+    // user_hints テーブルへ保存（テーブルが存在する場合のみ）
+    try {
+      const supabaseAdmin = createClient(
+        Deno.env.get("SUPABASE_URL") ?? "",
+        Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? Deno.env.get("SERVICE_ROLE_JWT") ?? "",
+        { auth: { persistSession: false, autoRefreshToken: false } },
+      );
+
+      await supabaseAdmin
+        .from("user_hints")
+        .upsert(
+          {
+            user_id: userId,
+            hint,
+            generated_at: new Date().toISOString(),
+            metadata_json: {
+              cookRate,
+              avgCal,
+              cookCount,
+              buyCount,
+              outCount,
+              expiringItemCount: expiringItems.length,
+            },
+          },
+          { onConflict: "user_id" },
+        );
+    } catch (dbErr) {
+      // DB 保存失敗はログのみ（レスポンスには影響しない）
+      logger.warn("Failed to save hint to DB", { error: String(dbErr) });
+    }
+
+    logger.info("Hint generated successfully");
+
+    return new Response(JSON.stringify({ hint }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 200,
+    });
+  } catch (error: any) {
+    logger.error("Error generating hint", error);
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 500,
+      },
+    );
+  }
+});
+
+function getFallbackHint(cookRate: number, avgCal: number, expiringItems: string[]): string {
+  if (expiringItems.length > 0) {
+    return `${expiringItems.slice(0, 2).join("・")}が期限間近です。今日の献立に取り入れてみましょう！`;
+  }
+  if (cookRate >= 80) return "自炊率80%以上！素晴らしいですね。引き続き健康的な食生活を続けましょう。";
+  if (cookRate >= 60) return `自炊率${cookRate}%、好調です！週末の作り置きでさらに楽になりますよ。`;
+  if (avgCal > 2500) return "カロリーが少し高めです。野菜を一品追加してバランスを整えましょう。";
+  return "今週も健康的な食事を心がけましょう！小さな積み重ねが大切です。";
+}


### PR DESCRIPTION
## Summary

- **#179** `analyze-fridge`: `serve` → `Deno.serve` 移行、Supabase JWT 認証追加、`db-logger` 統合
- **#181** `aggregate-org-stats` / `calculate-segment-stats`: `requireServiceRole()` で `CRON_SECRET` 必須化（バッチ専用）
- **#185** `import-*-catalog` 6関数: `import-runner.ts` に `requireServiceRole()` を追加し Firecrawl/LLM コスト無制限消費を防止
- **#189** `generate-hint` Edge Function を新規作成: JWT 認証・LLM ヒント生成・`user_hints` 保存

### 新規追加: `_shared/auth.ts`

| 関数 | 用途 | 失敗時 |
|------|------|--------|
| `requireAuth(req)` | ユーザー向け — Supabase JWT 検証 → `{ userId }` | 401 Response |
| `requireServiceRole(req)` | バッチ向け — `CRON_SECRET` 比較 → `null` (成功) | 401 / 503 Response |

## Test plan

- [ ] `analyze-fridge`: 認証なしリクエストが 401 を返すことを確認
- [ ] `analyze-fridge`: 有効な JWT で正常に画像解析が実行されることを確認
- [ ] `aggregate-org-stats` / `calculate-segment-stats`: `CRON_SECRET` なしで 401 を返すことを確認
- [ ] `import-*-catalog` 各関数: `CRON_SECRET` なしで 401 を返すことを確認
- [ ] `generate-hint`: JWT 認証付きリクエストでヒントが返ることを確認

Closes #179, #181, #185, #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)