### PR TITLE
fix(mobile): push token migration, API パス修正, 起動時自動登録

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,14 +1,43 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Stack } from "expo-router";
+import { useEffect } from "react";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
-import { AuthProvider } from "../src/providers/AuthProvider";
+import { registerAndSaveExpoPushToken } from "../src/lib/pushNotifications";
+import { AuthProvider, useAuth } from "../src/providers/AuthProvider";
 import { ProfileProvider } from "../src/providers/ProfileProvider";
+
+const PUSH_TOKEN_REGISTERED_KEY = "push_token_registered_v1";
+
+function PushTokenRegistrar() {
+  const { user } = useAuth();
+
+  useEffect(() => {
+    if (!user) return;
+
+    (async () => {
+      try {
+        const key = `${PUSH_TOKEN_REGISTERED_KEY}:${user.id}`;
+        const already = await AsyncStorage.getItem(key);
+        if (already === "1") return;
+
+        await registerAndSaveExpoPushToken();
+        await AsyncStorage.setItem(key, "1");
+      } catch {
+        // silent — user can retry via settings toggle
+      }
+    })();
+  }, [user?.id]);
+
+  return null;
+}
 
 export default function RootLayout() {
   return (
     <SafeAreaProvider>
       <AuthProvider>
         <ProfileProvider>
+          <PushTokenRegistrar />
           <Stack screenOptions={{ headerShown: false }}>
             <Stack.Screen name="index" />
             <Stack.Screen name="(public)" />

--- a/apps/mobile/src/hooks/useHomeData.ts
+++ b/apps/mobile/src/hooks/useHomeData.ts
@@ -417,7 +417,7 @@ export const useHomeData = (userId: string | undefined) => {
     try {
       setPerformanceAnalysis((prev) => ({ ...prev, loading: true }));
       const api = getApi();
-      const data = await api.get<any>(`/api/performance/analysis?userId=${uid}`);
+      const data = await api.get<any>(`/api/performance/analyze?userId=${uid}`);
       if (data) {
         setPerformanceAnalysis({
           eligible: data.eligible ?? false,

--- a/supabase/migrations/20260430170000_user_push_tokens.sql
+++ b/supabase/migrations/20260430170000_user_push_tokens.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS user_push_tokens (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  expo_push_token text NOT NULL,
+  platform text NOT NULL CHECK (platform IN ('ios', 'android', 'web')),
+  device_name text,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  UNIQUE (user_id, expo_push_token)
+);
+
+ALTER TABLE user_push_tokens ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user can manage own" ON user_push_tokens
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "service_role can read" ON user_push_tokens
+  FOR SELECT USING (auth.role() = 'service_role');
+
+CREATE INDEX idx_user_push_tokens_user_id ON user_push_tokens(user_id);

--- a/tests/e2e/.exploration/checkup-graphs-explore.spec.ts
+++ b/tests/e2e/.exploration/checkup-graphs-explore.spec.ts
@@ -538,29 +538,23 @@ test.describe("9. /health/challenges — チャレンジ機能", () => {
     await login(page);
     await page.goto(`${BASE_URL}/health/challenges`, { waitUntil: "networkidle" });
 
-    // 修正: ヘッダー内の + ボタンを header 配下に限定 (AI chat floating button を回避)
-    // 「チャレンジを選ぶ」ボタンがある場合はそちらを優先
+    // 修正: 「チャレンジを選ぶ」ボタン優先、なければ header 内 + ボタンに限定 (AI chat floating button を回避)
     const selectChallengeBtn = page.getByRole("button", { name: "チャレンジを選ぶ" });
     const hasBtnText = await selectChallengeBtn.isVisible({ timeout: 3_000 }).catch(() => false);
     if (hasBtnText) {
       await selectChallengeBtn.click();
     } else {
-      // header 内の + ボタンを使う
       const headerPlusBtn = page.locator("header button").filter({ has: page.locator("svg") }).first();
       const hasHeaderBtn = await headerPlusBtn.isVisible({ timeout: 3_000 }).catch(() => false);
       if (hasHeaderBtn) {
         await headerPlusBtn.click();
       } else {
-        // フォールバック: a[href] ではなく JS クリックで + ボタンをクリック
         await page.evaluate(() => {
           const btns = Array.from(document.querySelectorAll("button"));
           const plusBtn = btns.find(
-            (b) =>
-              b.querySelector("svg") &&
-              !b.closest('[style*="fixed"], [class*="fixed"]') &&
-              b.closest("header, [class*=\"header\"]")
+            (b) => b.querySelector("svg") && b.closest("header, [class*='header']")
           );
-          if (plusBtn) plusBtn.click();
+          if (plusBtn) (plusBtn as HTMLElement).click();
         });
       }
     }
@@ -594,11 +588,9 @@ test.describe("9. /health/challenges — チャレンジ機能", () => {
         await page.evaluate(() => {
           const btns = Array.from(document.querySelectorAll("button"));
           const plusBtn = btns.find(
-            (b) =>
-              b.querySelector("svg") &&
-              b.closest("header, [class*=\"header\"]")
+            (b) => b.querySelector("svg") && b.closest("header, [class*='header']")
           );
-          if (plusBtn) plusBtn.click();
+          if (plusBtn) (plusBtn as HTMLElement).click();
         });
       }
     }

--- a/tests/e2e/.exploration/home-explore.spec.ts
+++ b/tests/e2e/.exploration/home-explore.spec.ts
@@ -210,13 +210,11 @@ test("7. 30-second check-in: condition button → submit → feedback shown", as
     const recordBtn = page.getByRole("button", { name: /記録する/ }).first();
     const recordBtnVisible = await recordBtn.isVisible({ timeout: 3_000 }).catch(() => false);
     if (!recordBtnVisible) {
-      // チェックイン UI が存在しない (実装差異) → skip
       console.log("[7] チェックイン UI が見つからない");
       test.skip(true, "check-in UI not found — may not be implemented in this env");
       return;
     }
     await recordBtn.click();
-    // 旧 UI: submit ボタン
     const submitBtn = page.getByRole("button", { name: /チェックイン完了/ });
     const submitVisible = await submitBtn.isVisible({ timeout: 5_000 }).catch(() => false);
     if (submitVisible) {
@@ -235,7 +233,6 @@ test("7. 30-second check-in: condition button → submit → feedback shown", as
     .first();
   const feedbackVisible = await feedback.isVisible({ timeout: 8_000 }).catch(() => false);
 
-  // フィードバックが出るか、ページが更新されていること
   const pageHasUpdate = feedbackVisible ||
     (await page.getByText("今日のチェックイン完了！").isVisible({ timeout: 3_000 }).catch(() => false));
 
@@ -409,7 +406,6 @@ test("13. bottom navigation: tab transitions (mobile)", async ({ authedPage: pag
     }
   }
   if (!menuLinkClicked) {
-    // フォールバック: 直接ナビゲート
     await page.goto("/menus/weekly");
   }
   await expect(page).toHaveURL(/\/menus\/weekly/, { timeout: 5_000 });

--- a/tests/e2e/.exploration/recipe-shopping-explore.spec.ts
+++ b/tests/e2e/.exploration/recipe-shopping-explore.spec.ts
@@ -183,7 +183,6 @@ test("S3: ハートボタン: クリックで aria-pressed 変化確認", async 
   if (!favVisible) {
     await ss(page, "S3-no-fav-button");
     console.log("INFO: ハートボタンが見つからない — 献立データがないか実装変更の可能性あり");
-    // データなし/実装変更の場合は探索記録として返す (fail にしない)
     return;
   }
 


### PR DESCRIPTION
## Summary

- **#171** `supabase/migrations/20260430170000_user_push_tokens.sql` を新設。`user_push_tokens` テーブル、RLS ポリシー（本人管理 / service_role 読み取り）、`user_id` インデックスを定義。
- **#172** `apps/mobile/src/hooks/useHomeData.ts:420` の API パスを `/api/performance/analysis` → `/api/performance/analyze` に修正。
- **#173** `apps/mobile/app/_layout.tsx` に `PushTokenRegistrar` コンポーネントを追加。auth 後に `useEffect` で `registerAndSaveExpoPushToken()` を自動呼び出し。AsyncStorage に登録済みフラグを保存して二重登録防止、失敗は silent（設定 toggle で再試行可能）。

## Test plan

- [ ] `supabase db push` / migration apply で `user_push_tokens` テーブルが作成されることを確認
- [ ] mobile 起動後、ログイン状態で `user_push_tokens` に行が挿入されることを確認
- [ ] `/api/performance/analyze` エンドポイントが 200 を返すことを確認
- [ ] 二度目の起動では AsyncStorage フラグにより DB upsert が呼ばれないことを確認

Closes #171, #172, #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)