### PR TITLE
fix(recipes): /api/recipes 全ユーザー500エラー修正 — recipes↔user_profiles FK追加 (#211)

### DIFF
--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -210,7 +210,7 @@ export default function AdminDashboard() {
                       borderRadius: '8px',
                       boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
                     }}
-                    formatter={(value: number) => [value, '完了数']}
+                    formatter={(value: number | undefined) => [value ?? 0, '完了数']}
                   />
                   <Line
                     type="monotone"
@@ -238,7 +238,7 @@ export default function AdminDashboard() {
               <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
                   <Pie
-                    data={modeDistribution}
+                    data={modeDistribution as unknown as Record<string, unknown>[]}
                     dataKey="value"
                     nameKey="name"
                     cx="50%"
@@ -262,7 +262,7 @@ export default function AdminDashboard() {
                       border: '1px solid #e5e7eb',
                       borderRadius: '8px',
                     }}
-                    formatter={(value: number) => [value.toLocaleString(), '件']}
+                    formatter={(value: number | undefined) => [(value ?? 0).toLocaleString(), '件']}
                   />
                   <Legend />
                 </PieChart>

--- a/supabase/migrations/20260430150000_recipes_user_profiles_fk.sql
+++ b/supabase/migrations/20260430150000_recipes_user_profiles_fk.sql
@@ -1,0 +1,19 @@
+-- Issue #211: /api/recipes が全ユーザーに 500 を返す問題を修正
+-- 原因: recipes.user_id は auth.users(id) を参照しているが、
+--       Supabase クエリで user_profiles(nickname) の JOIN を使う際に
+--       recipes → user_profiles の FK がスキーマキャッシュに存在せず 500 になる。
+--
+-- 解決策: recipes.user_id → user_profiles(id) の FK を追加する。
+-- user_profiles が存在しないユーザーのレシピを守るため NOT VALID で追加し、
+-- 既存データへのバックフィルは不要（プロファイル未作成ユーザーは authorName が '匿名' にフォールバック）。
+
+ALTER TABLE recipes
+  ADD CONSTRAINT recipes_user_id_fkey
+  FOREIGN KEY (user_id)
+  REFERENCES user_profiles(id)
+  ON DELETE SET NULL
+  NOT VALID;
+
+-- スキーマキャッシュへ即時反映させるため VALIDATE は省略（NOT VALID のまま）。
+-- Supabase の PostgREST はスキーマキャッシュをリロードすることで FK を認識し、
+-- recipes (..., user_profiles (...)) の JOIN が正常に動作するようになる。


### PR DESCRIPTION
## Summary

- **原因**: `recipes.user_id` が `auth.users(id)` のみを参照しており、PostgREST のスキーマキャッシュが `user_profiles` との FK を認識できなかった。`route.ts` の `.select('*, user_profiles(nickname), ...')` クエリが FK 解決に失敗し、全ユーザーに 500 を返していた。
- **修正**: `ALTER TABLE recipes ADD CONSTRAINT recipes_user_id_fkey FOREIGN KEY (user_id) REFERENCES user_profiles(id) ON DELETE SET NULL NOT VALID` を migration で追加。`NOT VALID` により既存データへの整合性チェックをスキップしつつ、PostgREST のスキーマキャッシュには FK が登録され JOIN が解決される。
- **副次修正**: `src/app/(admin)/admin/page.tsx` の pre-existing TypeScript エラー (recharts `Formatter<number>` 型) も同時修正。

## Migration

`supabase/migrations/20260430150000_recipes_user_profiles_fk.sql`

```sql
ALTER TABLE recipes
  ADD CONSTRAINT recipes_user_id_fkey
  FOREIGN KEY (user_id)
  REFERENCES user_profiles(id)
  ON DELETE SET NULL
  NOT VALID;
```

## Test plan

- [ ] migration apply 後に `curl https://homegohan-app.vercel.app/api/recipes` で 200 確認
- [ ] `npm run build` で TypeScript エラーなし (ローカル確認済み)
- [ ] プロファイル未作成ユーザーのレシピは `authorName: '匿名'` にフォールバックされること

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)