### PR TITLE
fix(a11y): Wave2/F19 高優先度 WCAG 違反 5件一括修正 (#199 #204 #207 #209 #210)

### DIFF
--- a/src/app/(main)/badges/page.tsx
+++ b/src/app/(main)/badges/page.tsx
@@ -99,8 +99,19 @@ export default function BadgesPage() {
     fetchBadges();
   }, []);
 
+  // #210: Escape キーでバッジ詳細モーダルを閉じる
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && selectedBadge) {
+        setSelectedBadge(null);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [selectedBadge]);
+
   // ランク計算
-  const currentRankIndex = RANKS.findIndex((r, i) => 
+  const currentRankIndex = RANKS.findIndex((r, i) =>
     earnedCount >= r.min && (i === RANKS.length - 1 || earnedCount < RANKS[i+1].min)
   );
   const currentRank = RANKS[currentRankIndex] || RANKS[0];

--- a/src/app/(main)/health/record/page.tsx
+++ b/src/app/(main)/health/record/page.tsx
@@ -254,8 +254,9 @@ export default function HealthRecordPage() {
           {expandedSections.body && (
             <div className="px-4 pb-4 space-y-4">
               <div>
-                <label className="block text-sm mb-1" style={{ color: colors.textLight }}>体重 (kg)</label>
+                <label htmlFor="health-weight" className="block text-sm mb-1" style={{ color: colors.textLight }}>体重 (kg)</label>
                 <input
+                  id="health-weight"
                   type="number"
                   step="0.1"
                   value={formData.weight}
@@ -266,8 +267,9 @@ export default function HealthRecordPage() {
                 />
               </div>
               <div>
-                <label className="block text-sm mb-1" style={{ color: colors.textLight }}>体脂肪率 (%)</label>
+                <label htmlFor="health-body-fat" className="block text-sm mb-1" style={{ color: colors.textLight }}>体脂肪率 (%)</label>
                 <input
+                  id="health-body-fat"
                   type="number"
                   step="0.1"
                   value={formData.body_fat_percentage}
@@ -305,22 +307,24 @@ export default function HealthRecordPage() {
             <div className="px-4 pb-4 space-y-4">
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm mb-1" style={{ color: colors.textLight }}>収縮期血圧</label>
+                  <label htmlFor="health-systolic-bp" className="block text-sm mb-1" style={{ color: colors.textLight }}>収縮期血圧</label>
                   <input
                     type="number"
                     value={formData.systolic_bp}
-                    onChange={(e) => setFormData({ ...formData, systolic_bp: e.target.value })}
+                    id="health-systolic-bp"
+                  onChange={(e) => setFormData({ ...formData, systolic_bp: e.target.value })}
                     placeholder="120"
                     className="w-full p-3 rounded-xl"
                     style={{ backgroundColor: colors.bg, color: colors.text }}
                   />
                 </div>
                 <div>
-                  <label className="block text-sm mb-1" style={{ color: colors.textLight }}>拡張期血圧</label>
+                  <label htmlFor="health-diastolic-bp" className="block text-sm mb-1" style={{ color: colors.textLight }}>拡張期血圧</label>
                   <input
                     type="number"
                     value={formData.diastolic_bp}
-                    onChange={(e) => setFormData({ ...formData, diastolic_bp: e.target.value })}
+                    id="health-diastolic-bp"
+                  onChange={(e) => setFormData({ ...formData, diastolic_bp: e.target.value })}
                     placeholder="80"
                     className="w-full p-3 rounded-xl"
                     style={{ backgroundColor: colors.bg, color: colors.text }}
@@ -329,23 +333,25 @@ export default function HealthRecordPage() {
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm mb-1" style={{ color: colors.textLight }}>脈拍 (bpm)</label>
+                  <label htmlFor="health-heart-rate" className="block text-sm mb-1" style={{ color: colors.textLight }}>脈拍 (bpm)</label>
                   <input
                     type="number"
                     value={formData.heart_rate}
-                    onChange={(e) => setFormData({ ...formData, heart_rate: e.target.value })}
+                    id="health-heart-rate"
+                  onChange={(e) => setFormData({ ...formData, heart_rate: e.target.value })}
                     placeholder="70"
                     className="w-full p-3 rounded-xl"
                     style={{ backgroundColor: colors.bg, color: colors.text }}
                   />
                 </div>
                 <div>
-                  <label className="block text-sm mb-1" style={{ color: colors.textLight }}>体温 (℃)</label>
+                  <label htmlFor="health-body-temp" className="block text-sm mb-1" style={{ color: colors.textLight }}>体温 (℃)</label>
                   <input
                     type="number"
                     step="0.1"
                     value={formData.body_temp}
-                    onChange={(e) => setFormData({ ...formData, body_temp: e.target.value })}
+                    id="health-body-temp"
+                  onChange={(e) => setFormData({ ...formData, body_temp: e.target.value })}
                     placeholder="36.5"
                     className="w-full p-3 rounded-xl"
                     style={{ backgroundColor: colors.bg, color: colors.text }}
@@ -379,11 +385,12 @@ export default function HealthRecordPage() {
           {expandedSections.lifestyle && (
             <div className="px-4 pb-4 space-y-4">
               <div>
-                <label className="block text-sm mb-1" style={{ color: colors.textLight }}>睡眠時間 (時間)</label>
+                <label htmlFor="health-sleep-hours" className="block text-sm mb-1" style={{ color: colors.textLight }}>睡眠時間 (時間)</label>
                 <input
                   type="number"
                   step="0.5"
                   value={formData.sleep_hours}
+                  id="health-sleep-hours"
                   onChange={(e) => setFormData({ ...formData, sleep_hours: e.target.value })}
                   placeholder="7.0"
                   className="w-full p-3 rounded-xl"
@@ -400,23 +407,25 @@ export default function HealthRecordPage() {
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm mb-1" style={{ color: colors.textLight }}>水分摂取 (ml)</label>
+                  <label htmlFor="health-water-intake" className="block text-sm mb-1" style={{ color: colors.textLight }}>水分摂取 (ml)</label>
                   <input
                     type="number"
                     step="100"
                     value={formData.water_intake}
-                    onChange={(e) => setFormData({ ...formData, water_intake: e.target.value })}
+                    id="health-water-intake"
+                  onChange={(e) => setFormData({ ...formData, water_intake: e.target.value })}
                     placeholder="2000"
                     className="w-full p-3 rounded-xl"
                     style={{ backgroundColor: colors.bg, color: colors.text }}
                   />
                 </div>
                 <div>
-                  <label className="block text-sm mb-1" style={{ color: colors.textLight }}>歩数</label>
+                  <label htmlFor="health-step-count" className="block text-sm mb-1" style={{ color: colors.textLight }}>歩数</label>
                   <input
                     type="number"
                     value={formData.step_count}
-                    onChange={(e) => setFormData({ ...formData, step_count: e.target.value })}
+                    id="health-step-count"
+                  onChange={(e) => setFormData({ ...formData, step_count: e.target.value })}
                     placeholder="8000"
                     className="w-full p-3 rounded-xl"
                     style={{ backgroundColor: colors.bg, color: colors.text }}
@@ -424,10 +433,11 @@ export default function HealthRecordPage() {
                 </div>
               </div>
               <div>
-                <label className="block text-sm mb-1" style={{ color: colors.textLight }}>便通 (回)</label>
+                <label htmlFor="health-bowel-movement" className="block text-sm mb-1" style={{ color: colors.textLight }}>便通 (回)</label>
                 <input
                   type="number"
                   value={formData.bowel_movement}
+                  id="health-bowel-movement"
                   onChange={(e) => setFormData({ ...formData, bowel_movement: e.target.value })}
                   placeholder="1"
                   className="w-full p-3 rounded-xl"

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -112,6 +112,18 @@ export default function HomePage() {
   } = useHomeData();
 
   const [showWeeklyDetail, setShowWeeklyDetail] = useState(false);
+
+  // #199: Escape キーで週間統計モーダルを閉じる
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && showWeeklyDetail) {
+        setShowWeeklyDetail(false);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [showWeeklyDetail]);
+
   const [showCheckin, setShowCheckin] = useState(false);
   const [checkinSubmitting, setCheckinSubmitting] = useState(false);
   const [checkinFeedback, setCheckinFeedback] = useState<
@@ -1102,6 +1114,9 @@ export default function HomePage() {
               className="fixed inset-0 bg-black/60 z-[60] backdrop-blur-sm"
             />
             <motion.div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="weekly-stats-title"
               initial={{ y: "100%" }}
               animate={{ y: 0 }}
               exit={{ y: "100%" }}
@@ -1112,7 +1127,7 @@ export default function HomePage() {
                 <div className="w-12 h-1 bg-gray-200 rounded-full mx-auto mb-6 lg:hidden" />
                 
                 <div className="flex justify-between items-center mb-6">
-                  <h2 className="text-xl font-bold text-gray-900">今週の統計</h2>
+                  <h2 id="weekly-stats-title" className="text-xl font-bold text-gray-900">今週の統計</h2>
                   <button onClick={() => setShowWeeklyDetail(false)} className="p-2 bg-gray-100 rounded-full hover:bg-gray-200 transition-colors">
                     <X size={20} color={colors.textLight} />
                   </button>

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -9,9 +9,20 @@ import { clearUserScopedLocalStorage, broadcastSignOut } from "@/lib/user-storag
 
 type WeekStartDay = 'sunday' | 'monday';
 
-// スイッチコンポーネント
-const Switch = ({ checked, onChange }: { checked: boolean; onChange: () => void }) => (
+// スイッチコンポーネント (#207: role=switch / aria-checked / aria-label 追加)
+const Switch = ({
+  checked,
+  onChange,
+  label,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+}) => (
   <button
+    role="switch"
+    aria-checked={checked}
+    aria-label={label}
     onClick={onChange}
     className={`w-12 h-7 rounded-full p-1 transition-colors duration-300 ${checked ? 'bg-[#FF8A65]' : 'bg-gray-200'}`}
   >
@@ -174,7 +185,7 @@ export default function SettingsPage() {
                  <div className="w-8 h-8 rounded-lg bg-blue-50 flex items-center justify-center text-blue-500">🔔</div>
                  <span className="font-bold text-gray-700">通知</span>
                </div>
-               <Switch checked={settings.notifications} onChange={() => toggle('notifications')} />
+               <Switch checked={settings.notifications} onChange={() => toggle('notifications')} label="通知を有効化" />
              </div>
 
              <div className="flex items-center justify-between p-4 border-b border-gray-50">
@@ -182,7 +193,7 @@ export default function SettingsPage() {
                  <div className="w-8 h-8 rounded-lg bg-purple-50 flex items-center justify-center text-purple-500">🤖</div>
                  <span className="font-bold text-gray-700">自動解析</span>
                </div>
-               <Switch checked={settings.autoAnalyze} onChange={() => toggle('autoAnalyze')} />
+               <Switch checked={settings.autoAnalyze} onChange={() => toggle('autoAnalyze')} label="自動解析を有効化" />
              </div>
 
              <div className="flex items-center justify-between p-4">

--- a/src/components/AIChatBubble.tsx
+++ b/src/components/AIChatBubble.tsx
@@ -827,6 +827,7 @@ export default function AIChatBubble() {
                 </button>
                 <button
                   onClick={() => setIsOpen(false)}
+                  aria-label="AIチャットを閉じる"
                   className="p-2 rounded-full hover:bg-gray-100"
                 >
                   <X size={18} color={colors.textMuted} />
@@ -1225,6 +1226,7 @@ export default function AIChatBubble() {
                   <button
                     onClick={sendMessage}
                     disabled={!inputText.trim() || isSending || !currentSessionId}
+                    aria-label="メッセージを送信"
                     className="w-10 h-10 rounded-full flex items-center justify-center"
                     style={{
                       background: inputText.trim() ? colors.primary : colors.border,

--- a/tests/e2e/wave2-f19-a11y-fixes.spec.ts
+++ b/tests/e2e/wave2-f19-a11y-fixes.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * Wave 2 / F19: A11y high 違反 一括修正 検証テスト
+ *
+ * #199: ホーム週間統計モーダル role=dialog / aria-labelledby / Escape キー
+ * #204: AIChatBubble SVG ボタン aria-label (open / close / send)
+ * #207: 設定トグルスイッチ role=switch / aria-checked / aria-label
+ * #209: 健康記録 体重・体脂肪率 input label 関連付け
+ * #210: バッジモーダル Escape キーで閉じる
+ *
+ * 対象環境: ローカル dev / https://homegohan-app.vercel.app/
+ */
+import { test, expect } from "./fixtures/auth";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #199: 週間統計モーダル role=dialog
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe("#199 週間統計モーダル ARIA", () => {
+  test("role=dialog / aria-modal / aria-labelledby が付与されている", async ({ page }) => {
+    await page.goto("/home");
+    await page.waitForLoadState("networkidle");
+
+    // 週間グラフをクリックしてモーダルを開く
+    const weeklyGraph = page.locator("text=今週の自炊率").first();
+    await weeklyGraph.click();
+
+    const dialog = page.locator('[role="dialog"]').first();
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute("aria-modal", "true");
+    await expect(dialog).toHaveAttribute("aria-labelledby", "weekly-stats-title");
+
+    // labelledby が指す見出しが存在する
+    const title = page.locator("#weekly-stats-title");
+    await expect(title).toBeVisible();
+    await expect(title).toContainText("今週の統計");
+  });
+
+  test("Escape キーでモーダルが閉じる", async ({ page }) => {
+    await page.goto("/home");
+    await page.waitForLoadState("networkidle");
+
+    const weeklyGraph = page.locator("text=今週の自炊率").first();
+    await weeklyGraph.click();
+
+    const dialog = page.locator('[role="dialog"]').first();
+    await expect(dialog).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible({ timeout: 3000 });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #204: AIChatBubble SVG ボタン aria-label
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe("#204 AIChatBubble ボタン aria-label", () => {
+  test("AI チャットを開くボタンに aria-label がある", async ({ page }) => {
+    await page.goto("/home");
+    await page.waitForLoadState("networkidle");
+
+    const openBtn = page.locator('[data-testid="ai-chat-floating-button"]');
+    await expect(openBtn).toBeVisible();
+    await expect(openBtn).toHaveAttribute("aria-label", "AIアドバイザーを開く");
+  });
+
+  test("AI チャットを閉じるボタンに aria-label がある", async ({ page }) => {
+    await page.goto("/home");
+    await page.waitForLoadState("networkidle");
+
+    // チャットを開く
+    const openBtn = page.locator('[data-testid="ai-chat-floating-button"]');
+    await openBtn.click();
+
+    // 閉じるボタン
+    const closeBtn = page.locator('button[aria-label="AIチャットを閉じる"]');
+    await expect(closeBtn).toBeVisible();
+  });
+
+  test("メッセージ送信ボタンに aria-label がある", async ({ page }) => {
+    await page.goto("/home");
+    await page.waitForLoadState("networkidle");
+
+    const openBtn = page.locator('[data-testid="ai-chat-floating-button"]');
+    await openBtn.click();
+
+    const sendBtn = page.locator('button[aria-label="メッセージを送信"]');
+    await expect(sendBtn).toBeVisible();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #207: 設定トグルスイッチ role=switch / aria-checked / aria-label
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe("#207 設定トグルスイッチ ARIA", () => {
+  test("通知スイッチに role=switch / aria-checked / aria-label がある", async ({ page }) => {
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const notifSwitch = page.locator('[role="switch"][aria-label="通知を有効化"]');
+    await expect(notifSwitch).toBeVisible();
+
+    const checked = await notifSwitch.getAttribute("aria-checked");
+    expect(["true", "false"]).toContain(checked);
+  });
+
+  test("自動解析スイッチに role=switch / aria-checked / aria-label がある", async ({ page }) => {
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const analyzeSwitch = page.locator('[role="switch"][aria-label="自動解析を有効化"]');
+    await expect(analyzeSwitch).toBeVisible();
+
+    const checked = await analyzeSwitch.getAttribute("aria-checked");
+    expect(["true", "false"]).toContain(checked);
+  });
+
+  test("スイッチをクリックすると aria-checked が反転する", async ({ page }) => {
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const notifSwitch = page.locator('[role="switch"][aria-label="通知を有効化"]');
+    const before = await notifSwitch.getAttribute("aria-checked");
+
+    await notifSwitch.click();
+    await page.waitForTimeout(500);
+
+    const after = await notifSwitch.getAttribute("aria-checked");
+    expect(after).not.toBe(before);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #209: 健康記録 input label 関連付け
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe("#209 健康記録 input label", () => {
+  test("体重 input が label と htmlFor/id で関連付けられている", async ({ page }) => {
+    await page.goto("/health/record");
+    await page.waitForLoadState("networkidle");
+
+    // label をクリックすると input にフォーカスが当たる
+    const weightLabel = page.locator('label[for="health-weight"]');
+    await expect(weightLabel).toBeVisible();
+
+    const weightInput = page.locator('input#health-weight');
+    await expect(weightInput).toBeVisible();
+
+    // label クリックで input にフォーカス
+    await weightLabel.click();
+    await expect(weightInput).toBeFocused();
+  });
+
+  test("体脂肪率 input が label と htmlFor/id で関連付けられている", async ({ page }) => {
+    await page.goto("/health/record");
+    await page.waitForLoadState("networkidle");
+
+    const fatLabel = page.locator('label[for="health-body-fat"]');
+    await expect(fatLabel).toBeVisible();
+
+    const fatInput = page.locator('input#health-body-fat');
+    await expect(fatInput).toBeVisible();
+
+    await fatLabel.click();
+    await expect(fatInput).toBeFocused();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #210: バッジモーダル Escape キーで閉じる
+// ─────────────────────────────────────────────────────────────────────────────
+test.describe("#210 バッジモーダル Escape キー", () => {
+  test("バッジカードをクリックするとモーダルが開く", async ({ page }) => {
+    await page.goto("/badges");
+    await page.waitForLoadState("networkidle");
+
+    const badgeCard = page.locator('[data-testid="badge-card"]').first();
+    await badgeCard.click();
+
+    const modal = page.locator('[data-testid="badge-detail-modal"]');
+    await expect(modal).toBeVisible();
+  });
+
+  test("Escape キーでバッジモーダルが閉じる", async ({ page }) => {
+    await page.goto("/badges");
+    await page.waitForLoadState("networkidle");
+
+    const badgeCard = page.locator('[data-testid="badge-card"]').first();
+    await badgeCard.click();
+
+    const modal = page.locator('[data-testid="badge-detail-modal"]');
+    await expect(modal).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(modal).not.toBeVisible({ timeout: 3000 });
+  });
+
+  test("バッジモーダルに role=dialog / aria-modal / aria-labelledby がある", async ({ page }) => {
+    await page.goto("/badges");
+    await page.waitForLoadState("networkidle");
+
+    const badgeCard = page.locator('[data-testid="badge-card"]').first();
+    await badgeCard.click();
+
+    const modal = page.locator('[data-testid="badge-detail-modal"]');
+    await expect(modal).toHaveAttribute("role", "dialog");
+    await expect(modal).toHaveAttribute("aria-modal", "true");
+    await expect(modal).toHaveAttribute("aria-labelledby", "badge-detail-title");
+  });
+});


### PR DESCRIPTION
## Summary

- **#199** ホーム週間統計モーダルに `role=dialog` / `aria-modal="true"` / `aria-labelledby="weekly-stats-title"` を付与、見出し `h2` に `id` を追加、Escape キーで閉じる keydown ハンドラを追加 (WCAG 4.1.2 A)
- **#204** `AIChatBubble` の SVG-only ボタン 3件に `aria-label` を付与: 開く「AIアドバイザーを開く」(既存確認)・閉じる「AIチャットを閉じる」・送信「メッセージを送信」
- **#207** 設定ページの `Switch` コンポーネントに `role="switch"` / `aria-checked={checked}` / `aria-label` prop を追加 (WCAG 4.1.2 A)
- **#209** 健康記録ページの全 input 要素 (体重・体脂肪率・血圧 2件・脈拍・体温・睡眠時間・水分摂取・歩数・便通) に `htmlFor` / `id` を付与して `<label>` と正しく関連付け (WCAG 1.3.1 A)
- **#210** バッジ詳細モーダルに Escape キーで `setSelectedBadge(null)` を呼ぶ `keydown` ハンドラを追加 (WCAG 2.1.2 A)

## Test plan

- [ ] `tests/e2e/wave2-f19-a11y-fixes.spec.ts` を追加 (新規ファイル)
  - #199: `role=dialog` / `aria-modal` / `aria-labelledby` 検証、Escape キーでモーダルが閉じる
  - #204: 各ボタンの `aria-label` 存在検証
  - #207: `role=switch` / `aria-checked` 存在検証、クリックで `aria-checked` 反転を検証
  - #209: `label[for]` クリックで対応 `input` にフォーカス
  - #210: バッジカードクリックでモーダル表示、Escape で閉じる
- [ ] ローカル `npm run build` で TypeScript エラーなし確認済み (既存の admin/page.tsx 型エラーは本 PR と無関係)

Closes #199, #204, #207, #209, #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)