### PR TITLE
fix(security): SSRF / PostgREST injection / rate limit / CSP を一括修正 (#272 #273 #274 #275)

### DIFF
--- a/tests/e2e/bug-31-favorite-button.spec.ts
+++ b/tests/e2e/bug-31-favorite-button.spec.ts
@@ -116,14 +116,11 @@ test.describe("recipe modal favorite button (Bug-31)", () => {
     await favBtn.click();
     await expect(favBtn).toHaveAttribute("aria-pressed", "true");
 
-    // モーダルを閉じる (エスケープキーでも閉じられる)
-    const closed = await authedPage.getByRole("button", { name: /閉じる/ }).first().click()
-      .then(() => true)
-      .catch(() => false);
-    if (!closed) {
-      await authedPage.keyboard.press('Escape');
-      await authedPage.waitForTimeout(500);
-    }
+    // モーダルを閉じる: recipe モーダルの閉じるボタンはアイコンのみ (テキスト "閉じる" なし)
+    // getByRole('button', { name: /閉じる/ }) は別ボタンにヒットしてページ遷移を起こす (#240)
+    // Escape キーで確実にクローズする
+    await authedPage.keyboard.press('Escape');
+    await authedPage.waitForTimeout(500);
 
     // ページをリロード
     await authedPage.reload();

--- a/tests/e2e/bug-92-signup-duplicate-email.spec.ts
+++ b/tests/e2e/bug-92-signup-duplicate-email.spec.ts
@@ -25,11 +25,11 @@ test.describe("Bug-92: 重複メールアドレスの signup 処理", () => {
     await page.locator('form button[type="submit"]').click();
 
     // エラーアラートが /signup 画面に表示されること
-    const errorAlert = page.getByRole("alert");
+    // getByRole("alert") は passwordError の <p role="alert"> も含む可能性あり
+    // formError の <p role="alert"> を明示的に絞り込み、テキストが入るまで待つ (#244)
+    const errorAlert = page.locator('p[role="alert"]');
     await expect(errorAlert).toBeVisible({ timeout: 10_000 });
-
-    const text = (await errorAlert.textContent()) ?? "";
-    expect(text).toMatch(/既に登録|ログイン/);
+    await expect(errorAlert).toHaveText(/既に登録|ログイン/, { timeout: 10_000 });
 
     // /auth/verify に遷移していないこと
     await expect(page).toHaveURL(/\/signup$/, { timeout: 5_000 });

--- a/tests/e2e/w5-1-onboarding-adversarial.spec.ts
+++ b/tests/e2e/w5-1-onboarding-adversarial.spec.ts
@@ -1,0 +1,1564 @@
+/**
+ * W5-1: Onboarding 完全嫌がらせ E2E
+ *
+ * ユーザーが普通やらない狂った操作・順序・状態でオンボーディング全体を破壊しに行く。
+ * バグ発見時は Issue 起票済み (本ファイルの各テスト冒頭にコメントで記載)。
+ *
+ * カテゴリ:
+ *   A. 完了後の動作 (1–6)
+ *   B. 中断 / 再開 (7–13)
+ *   C. 異常入力 (14–20)
+ *   D. 並列 / 競合 (21–24)
+ *   E. 異常状態の DB (25–28)
+ *
+ * 実行方法:
+ *   PLAYWRIGHT_BASE_URL=https://homegohan-app.vercel.app npm run test:e2e -- w5-1-onboarding-adversarial
+ */
+
+import { test, expect, type Page, type BrowserContext } from "@playwright/test";
+import { login } from "./fixtures/auth";
+
+// ─── 定数 ────────────────────────────────────────────────────────────────────
+
+const BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+
+// ─── ヘルパー ─────────────────────────────────────────────────────────────────
+
+/**
+ * ログイン後にオンボーディング状態をリセットして not_started に戻す。
+ * page.evaluate 経由で session cookie を引き継いだ fetch を実行。
+ */
+async function resetOnboarding(page: Page): Promise<void> {
+  const res = await page.evaluate(async (url: string) => {
+    const r = await fetch(url, { method: "DELETE", credentials: "include" });
+    return r.status;
+  }, `${BASE_URL}/api/onboarding/status`);
+  // 200 or 401 (未ログイン) を許容
+  expect([200, 401]).toContain(res);
+}
+
+/**
+ * オンボーディング API 経由で onboarding_completed_at を設定し完了扱いにする。
+ */
+async function completeOnboardingViaApi(page: Page): Promise<void> {
+  const res = await page.evaluate(async (url: string) => {
+    const r = await fetch(url, { method: "POST", credentials: "include" });
+    return r.status;
+  }, `${BASE_URL}/api/onboarding/complete`);
+  expect([200]).toContain(res);
+}
+
+/**
+ * onboarding/questions ページで最初の質問 (nickname) に回答してフローを開始する。
+ * in_progress 状態を API 側に作るための最小手順。
+ */
+async function startOnboardingFlow(page: Page): Promise<void> {
+  await page.goto(`${BASE_URL}/onboarding/welcome`);
+  await page.waitForLoadState("networkidle");
+  const startLink = page.locator('a[href*="/onboarding/questions"]').first();
+  if (await startLink.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await startLink.click();
+    await page.waitForLoadState("networkidle");
+  }
+  // nickname テキスト入力があれば回答して in_progress を確定
+  const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
+  if (await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await nicknameInput.fill("テストユーザー");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(1_000); // saveProgress の非同期 fetch を待つ
+  }
+}
+
+/**
+ * API でオンボーディングステータスを取得して返す。
+ */
+async function getOnboardingStatus(
+  page: Page
+): Promise<{ status: string; progress?: any; nickname?: string }> {
+  const result = await page.evaluate(async (url: string) => {
+    const r = await fetch(url, { method: "GET", credentials: "include" });
+    return r.json();
+  }, `${BASE_URL}/api/onboarding/status`);
+  return result;
+}
+
+// ─── A. 完了後の動作 ──────────────────────────────────────────────────────────
+
+test.describe("A. 完了後の動作", () => {
+  /**
+   * A-1: 完了ユーザーが /onboarding に直接アクセス → /home に redirect されるか
+   *
+   * onboarding-routing.ts の resolveOnboardingRedirect は status===completed かつ
+   * onboardingPath の場合、/home を返す。ただし /onboarding/complete は除外。
+   * クライアント側の /onboarding/page.tsx も API 経由で completed を検知して /home に飛ぶ。
+   */
+  test("A-1: 完了済みユーザーが /onboarding に直アクセスすると /home に飛ぶ", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await completeOnboardingViaApi(page);
+
+    await page.goto(`${BASE_URL}/onboarding`);
+    await page.waitForURL(/\/home/, { timeout: 15_000 });
+    expect(page.url()).toMatch(/\/home/);
+  });
+
+  /**
+   * A-2: 完了直後に cookie 全削除して再ログイン → 中断扱いになっていないか
+   *
+   * onboarding_completed_at は DB 側に保存されるため、cookie を消してもステータスは
+   * completed のままになるはず。localStorage のみ依存実装だと中断扱いになる致命的バグ。
+   */
+  test("A-2: 完了後に cookie 全削除して再ログイン → completed のまま", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await completeOnboardingViaApi(page);
+
+    // cookie を全削除してセッションを破棄
+    await page.context().clearCookies();
+
+    // 再ログイン
+    await login(page);
+
+    // ステータスが completed であることを確認
+    const statusData = await getOnboardingStatus(page);
+    expect(statusData.status).toBe("completed");
+
+    // /onboarding に飛んでも /home にリダイレクトされる
+    await page.goto(`${BASE_URL}/onboarding`);
+    await page.waitForURL(/\/home/, { timeout: 15_000 });
+    expect(page.url()).toMatch(/\/home/);
+  });
+
+  /**
+   * A-3: 完了後に別ブラウザで signin → onboarding 出ないことを確認
+   *
+   * 新しいブラウザコンテキスト（= 別ブラウザ相当）でログインして completed を確認する。
+   */
+  test("A-3: 完了後に別コンテキストでログイン → onboarding は出ない", async ({
+    browser,
+  }) => {
+    // コンテキスト A で完了状態を作る
+    const ctxA = await browser.newContext();
+    const pageA = await ctxA.newPage();
+    await login(pageA);
+    await resetOnboarding(pageA);
+    await completeOnboardingViaApi(pageA);
+    await ctxA.close();
+
+    // コンテキスト B（別ブラウザ相当）でログイン
+    const ctxB = await browser.newContext();
+    const pageB = await ctxB.newPage();
+    await login(pageB);
+    await pageB.goto(`${BASE_URL}/onboarding`);
+    // completed なので /home に飛ぶはず
+    await pageB.waitForURL(/\/(home|onboarding\/complete)/, {
+      timeout: 15_000,
+    });
+    expect(pageB.url()).not.toMatch(/\/onboarding\/welcome/);
+    expect(pageB.url()).not.toMatch(/\/onboarding\/resume/);
+    await ctxB.close();
+  });
+
+  /**
+   * A-4: 完了後に /onboarding/welcome に直アクセス → /home に redirect されるか
+   *
+   * resolveOnboardingRedirect の completed branch: onboardingPath かつ
+   * /onboarding/complete でなければ /home を返す。
+   */
+  test("A-4: 完了済みユーザーが /onboarding/welcome に直アクセスすると /home に飛ぶ", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await completeOnboardingViaApi(page);
+
+    await page.goto(`${BASE_URL}/onboarding/welcome`);
+    await page.waitForURL(/\/(home|onboarding)/, { timeout: 15_000 });
+    // welcome に留まっていないこと（/home または /onboarding/complete が正）
+    expect(page.url()).not.toContain("/onboarding/welcome");
+  });
+
+  /**
+   * A-5: 完了後に /onboarding/questions に直アクセス → /home に redirect されるか
+   *
+   * 完了済みなら questions ページへのアクセスも /home にリダイレクトすべき。
+   * クライアント側の status fetch が completed を返すため /home に飛ぶ。
+   */
+  test("A-5: 完了済みユーザーが /onboarding/questions に直アクセスしても質問フローに入れない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await completeOnboardingViaApi(page);
+
+    await page.goto(`${BASE_URL}/onboarding/questions`);
+    await page.waitForLoadState("networkidle");
+
+    // questions ページのメイン質問バブルが表示されていないことを確認
+    // (完了済みならリダイレクトで /home に飛ぶか、questions ページ自体は status チェックをしないが
+    //  middleware が /home に飛ばすはず)
+    // NOTE: questions/page.tsx は status を直接確認しないため middleware 依存
+    // middleware がリダイレクトしない実装の場合はここで問題を検出できる
+    await page.waitForTimeout(3_000);
+    const url = page.url();
+    // /home にいるか、または questions が表示されていても完了済み状態が維持されていることを確認
+    if (!url.includes("/home")) {
+      // questions ページが表示されている場合、ステータスが corrupted されていないか確認
+      const statusAfter = await getOnboardingStatus(page);
+      expect(statusAfter.status).toBe("completed");
+    }
+  });
+
+  /**
+   * A-6: 完了後 30日経過 (システム時刻変化なし確認) → onboarding 強制出ないか
+   *
+   * 実際のクロック変更は E2E では困難なため、API レスポンスの onboarding_completed_at
+   * フィールドが過去日付でも completed ステータスが維持されることを確認する。
+   * （実装上、日付比較ロジックがなければ問題なし）
+   */
+  test("A-6: 完了後 30日後 (simulate) でも onboarding は強制表示されない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await completeOnboardingViaApi(page);
+
+    // システム時刻を30日後にシミュレート（Date をモック）
+    await page.addInitScript(() => {
+      const OriginalDate = Date;
+      const futureMs = 30 * 24 * 60 * 60 * 1000;
+      class MockDate extends OriginalDate {
+        constructor(...args: any[]) {
+          if (args.length === 0) {
+            super(OriginalDate.now() + futureMs);
+          } else {
+            // @ts-ignore
+            super(...args);
+          }
+        }
+        static now() {
+          return OriginalDate.now() + futureMs;
+        }
+      }
+      // @ts-ignore
+      globalThis.Date = MockDate;
+    });
+
+    await page.goto(`${BASE_URL}/onboarding`);
+    await page.waitForURL(/\/(home|onboarding)/, { timeout: 15_000 });
+    // 30日後でも welcome/resume が出ないこと
+    expect(page.url()).not.toContain("/onboarding/welcome");
+    expect(page.url()).not.toContain("/onboarding/resume");
+  });
+});
+
+// ─── B. 中断 / 再開 ───────────────────────────────────────────────────────────
+
+test.describe("B. 中断 / 再開", () => {
+  /**
+   * B-7: 質問 5 まで答えて閉じる → 再ログイン → 再開できるか
+   *
+   * questions/page.tsx の saveProgress が currentStep と answers を DB に保存し、
+   * 再開時に /api/onboarding/status から復元することを確認する。
+   */
+  test("B-7: 途中まで回答して離脱 → 再ログインで in_progress に戻る", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await startOnboardingFlow(page);
+
+    // ページを離れてから再ログイン
+    await page.goto(`${BASE_URL}/home`);
+    await page.context().clearCookies();
+    await login(page);
+
+    const statusData = await getOnboardingStatus(page);
+    // not_started または in_progress (途中で saveProgress が走っていれば in_progress)
+    // welcome 画面で「始める」を押していなければ not_started になる可能性もある
+    expect(["not_started", "in_progress"]).toContain(statusData.status);
+
+    if (statusData.status === "in_progress") {
+      // 再開ページが表示されること
+      await page.goto(`${BASE_URL}/onboarding`);
+      await page.waitForURL(/\/onboarding\/(resume|questions)/, {
+        timeout: 15_000,
+      });
+    }
+  });
+
+  /**
+   * B-8: 同じユーザーで 2 タブ同時に onboarding を開く → どちらの進捗が勝つか
+   *
+   * 2つのタブで onboarding/questions を開いて回答した場合、
+   * 後から保存された回答が DB に反映されることを確認する（last-write-wins）。
+   * 期待: エラーにならず、どちらか片方の回答が DB に残る。
+   */
+  test("B-8: 2タブで同時に onboarding を開いてもエラーにならない", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext();
+    const pageA = await ctx.newPage();
+    await login(pageA);
+    await resetOnboarding(pageA);
+
+    const pageB = await ctx.newPage();
+
+    // 両方のタブで questions ページを開く
+    await Promise.all([
+      pageA.goto(`${BASE_URL}/onboarding/questions`),
+      pageB.goto(`${BASE_URL}/onboarding/questions`),
+    ]);
+    await Promise.all([
+      pageA.waitForLoadState("networkidle"),
+      pageB.waitForLoadState("networkidle"),
+    ]);
+
+    // タブ A で nickname を入力
+    const nicknameA = pageA.locator('input[placeholder*="たろう"]').first();
+    if (await nicknameA.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await nicknameA.fill("タブAユーザー");
+      await pageA.keyboard.press("Enter");
+      await pageA.waitForTimeout(800);
+    }
+
+    // タブ B で nickname を入力（競合）
+    const nicknameB = pageB.locator('input[placeholder*="たろう"]').first();
+    if (await nicknameB.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await nicknameB.fill("タブBユーザー");
+      await pageB.keyboard.press("Enter");
+      await pageB.waitForTimeout(800);
+    }
+
+    // どちらかの値が DB に保存されている（エラーにはなっていない）
+    const status = await getOnboardingStatus(pageA);
+    expect(["not_started", "in_progress"]).toContain(status.status);
+
+    await ctx.close();
+  });
+
+  /**
+   * B-9: 回答の保存先確認 — localStorage のみ依存でないことを検証
+   *
+   * saveProgress が /api/onboarding/progress を呼び出し DB に保存することを
+   * ネットワークリクエストで確認する。localStorage には保存していないことも確認。
+   */
+  test("B-9: 回答は DB に保存され localStorage のみ依存ではない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    // API コールを監視
+    const progressRequests: string[] = [];
+    page.on("request", (req) => {
+      if (
+        req.method() === "POST" &&
+        req.url().includes("/api/onboarding/progress")
+      ) {
+        progressRequests.push(req.url());
+      }
+    });
+
+    await startOnboardingFlow(page);
+    await page.waitForTimeout(2_000); // 非同期 saveProgress を待つ
+
+    // /api/onboarding/progress への POST が発生したことを確認
+    expect(progressRequests.length).toBeGreaterThan(0);
+
+    // localStorage に onboarding データが保存されていないことを確認
+    const lsKeys = await page.evaluate(() => {
+      const keys: string[] = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const k = localStorage.key(i);
+        if (k && k.toLowerCase().includes("onboarding")) {
+          keys.push(k);
+        }
+      }
+      return keys;
+    });
+    // localStorage に onboarding 関連キーがないことが望ましい（あれば潜在的なバグ）
+    if (lsKeys.length > 0) {
+      console.warn(
+        `[B-9] localStorage に onboarding キーが存在します: ${lsKeys.join(", ")}`
+      );
+    }
+  });
+
+  /**
+   * B-10: 質問 30 個目 (最終) で × ボタン (スキップ全体) → どこまで保存される？
+   *
+   * ヘッダーの「スキップ」ボタンを押すと /api/onboarding/complete が呼ばれ
+   * 完了扱いになってから /menus/weekly に遷移する実装を確認する。
+   */
+  test("B-10: 最終付近でグローバルスキップボタンを押すと complete が呼ばれる", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await page.goto(`${BASE_URL}/onboarding/questions`);
+    await page.waitForLoadState("networkidle");
+
+    // complete API への POST を監視
+    let completeApiCalled = false;
+    page.on("request", (req) => {
+      if (
+        req.method() === "POST" &&
+        req.url().includes("/api/onboarding/complete")
+      ) {
+        completeApiCalled = true;
+      }
+    });
+
+    // 「スキップ」リンクが表示されるまで待つ
+    const skipButton = page
+      .locator('button:has-text("スキップ"), a:has-text("スキップ")')
+      .last();
+    if (await skipButton.isVisible({ timeout: 8_000 }).catch(() => false)) {
+      // confirm ダイアログをオートクリックで承認
+      page.on("dialog", (dialog) => dialog.accept());
+      await skipButton.click();
+      await page.waitForTimeout(3_000);
+
+      // complete API が呼ばれたこと、または menus にリダイレクトされたことを確認
+      const afterUrl = page.url();
+      const apiOrRedirect =
+        completeApiCalled || afterUrl.includes("/menus");
+      expect(apiOrRedirect).toBe(true);
+    } else {
+      test.skip();
+    }
+  });
+
+  /**
+   * B-11: 戻るボタン連打 → 整合性が保たれるか
+   *
+   * handleBack() は stepHistory を使ったスタックベース実装。
+   * 連打しても負インデックスにならないことを確認する。
+   */
+  test("B-11: 戻るボタンを連打しても画面がクラッシュしない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await page.goto(`${BASE_URL}/onboarding/questions`);
+    await page.waitForLoadState("networkidle");
+
+    // 最初の質問に回答して次に進む
+    const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
+    if (await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await nicknameInput.fill("テスト");
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(1_000);
+
+      // 戻るボタンを取得
+      const backButton = page.locator('button').filter({
+        has: page.locator('path[d*="M15 19l-7-7 7-7"]'),
+      }).first();
+
+      // 戻るボタンを 5 回連打
+      for (let i = 0; i < 5; i++) {
+        const isVisible = await backButton
+          .isVisible({ timeout: 1_000 })
+          .catch(() => false);
+        if (isVisible) {
+          await backButton.click();
+          await page.waitForTimeout(200);
+        }
+      }
+
+      // ページがクラッシュしていないことを確認
+      await expect(page.locator("body")).toBeVisible();
+    } else {
+      test.skip();
+    }
+  });
+
+  /**
+   * B-12: 質問入力 → ブラウザ強制終了 → 再開で復元されるか
+   *
+   * page.close() でタブを閉じて新しいタブで再開したとき、
+   * DB から進捗が復元されることを確認する。
+   */
+  test("B-12: タブを強制クローズして新タブで再開すると進捗が復元される", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext();
+    const page1 = await ctx.newPage();
+    await login(page1);
+    await resetOnboarding(page1);
+
+    // フローを開始して最初の質問に回答
+    await page1.goto(`${BASE_URL}/onboarding/questions`);
+    await page1.waitForLoadState("networkidle");
+    const nicknameInput = page1
+      .locator('input[placeholder*="たろう"]')
+      .first();
+    if (await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await nicknameInput.fill("強制終了テスト");
+      await page1.keyboard.press("Enter");
+      await page1.waitForTimeout(1_500); // saveProgress を待つ
+    }
+
+    // タブを「強制終了」
+    await page1.close();
+
+    // 新しいタブで再開
+    const page2 = await ctx.newPage();
+    const statusData = await page2.evaluate(async (url: string) => {
+      const r = await fetch(url, { credentials: "include" });
+      return r.json();
+    }, `${BASE_URL}/api/onboarding/status`);
+
+    // in_progress であること（saveProgress が走っていれば）
+    if (statusData.status === "in_progress") {
+      expect(statusData.progress?.currentStep).toBeGreaterThan(0);
+      // nickname が復元されているか
+      if (statusData.progress?.answers?.nickname) {
+        expect(statusData.progress.answers.nickname).toBe("強制終了テスト");
+      }
+    }
+    // not_started の場合はタイミング問題 (saveProgress が間に合わなかった)
+    // これも有効なケースとして許容
+
+    await ctx.close();
+  });
+
+  /**
+   * B-13: resume=true で開いた questions ページが DB から進捗を復元するか
+   *
+   * isResume=true の場合、useEffect で /api/onboarding/status を fetch して
+   * currentStep と answers をセットする実装を確認する。
+   */
+  test("B-13: questions?resume=true でアクセスすると進捗が DB から復元される", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    // in_progress 状態を作る
+    await page.evaluate(async (url: string) => {
+      await fetch(url, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          currentStep: 3,
+          answers: { nickname: "再開テスト", gender: "male" },
+          totalQuestions: 30,
+        }),
+      });
+    }, `${BASE_URL}/api/onboarding/progress`);
+
+    // resume=true で questions ページを開く
+    await page.goto(`${BASE_URL}/onboarding/questions?resume=true`);
+    await page.waitForLoadState("networkidle");
+
+    // ローディングスピナーが消えるまで待つ (isLoading=true → false)
+    await page.waitForTimeout(3_000);
+
+    // 「前回の進捗を読み込み中...」が消えていること
+    const loadingText = page.locator("text=前回の進捗を読み込み中");
+    await expect(loadingText).not.toBeVisible({ timeout: 5_000 });
+
+    // ページに質問が表示されていること（クラッシュしていない）
+    await expect(page.locator("body")).toBeVisible();
+  });
+});
+
+// ─── C. 異常入力 ──────────────────────────────────────────────────────────────
+
+test.describe("C. 異常入力", () => {
+  /**
+   * C-14a: 体重フィールドに -100 → 「次へ」が disabled になる
+   *
+   * custom_stats の体重フィールドは min=10 max=300 の HTML 制約と
+   * JS バリデーション (Number(answers.weight) < 10) を持つ。
+   */
+  test("C-14a: 体重に -100 を入力すると「次へ」が disabled になる", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await page.goto(`${BASE_URL}/onboarding/questions`);
+    await page.waitForLoadState("networkidle");
+
+    // nickname を入力して body_stats ステップへ進む
+    const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
+    if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+    await nicknameInput.fill("テスト");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(1_000);
+
+    // gender 選択 (choice型)
+    const maleButton = page.locator('button:has-text("男性")').first();
+    if (await maleButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await maleButton.click();
+      await page.waitForTimeout(1_000);
+    }
+
+    // body_stats ステップ
+    const weightInput = page.locator('input[placeholder="60"]').first();
+    if (!(await weightInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+
+    const heightInput = page.locator('input[placeholder="170"]').first();
+    const ageInput = page.locator('input[placeholder="25"]').first();
+    const nextButton = page.locator('button:has-text("次へ")').first();
+
+    // 正常値で他フィールドを埋める
+    if (await ageInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await ageInput.fill("25");
+    }
+    if (await heightInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await heightInput.fill("170");
+    }
+
+    // 体重に -100 を入力
+    await weightInput.fill("-100");
+    // 「次へ」が disabled であること
+    await expect(nextButton).toBeDisabled({ timeout: 3_000 });
+  });
+
+  /**
+   * C-14b: 体重フィールドに 999999 → 「次へ」が disabled になる
+   */
+  test("C-14b: 体重に 999999 を入力すると「次へ」が disabled になる", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await page.goto(`${BASE_URL}/onboarding/questions`);
+    await page.waitForLoadState("networkidle");
+
+    const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
+    if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+    await nicknameInput.fill("テスト");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(1_000);
+
+    const maleButton = page.locator('button:has-text("男性")').first();
+    if (await maleButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await maleButton.click();
+      await page.waitForTimeout(1_000);
+    }
+
+    const weightInput = page.locator('input[placeholder="60"]').first();
+    if (!(await weightInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+
+    const heightInput = page.locator('input[placeholder="170"]').first();
+    const ageInput = page.locator('input[placeholder="25"]').first();
+    const nextButton = page.locator('button:has-text("次へ")').first();
+
+    if (await ageInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await ageInput.fill("25");
+    }
+    if (await heightInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await heightInput.fill("170");
+    }
+
+    // 体重に 999999 を入力 (max=300 を超える)
+    await weightInput.fill("999999");
+    await expect(nextButton).toBeDisabled({ timeout: 3_000 });
+  });
+
+  /**
+   * C-14c: 体重フィールドに "abc" → 数値以外は入力できないか
+   *
+   * input type="number" のため "abc" は空になる。
+   * あるいは onChange で `setAnswers({...answers, weight: e.target.value})` に
+   * 文字列が入っても Number() が NaN になりバリデーション失敗するはず。
+   */
+  test("C-14c: 体重に 'abc' を入力しても「次へ」は disabled のまま", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await page.goto(`${BASE_URL}/onboarding/questions`);
+    await page.waitForLoadState("networkidle");
+
+    const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
+    if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+    await nicknameInput.fill("テスト");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(1_000);
+
+    const maleButton = page.locator('button:has-text("男性")').first();
+    if (await maleButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await maleButton.click();
+      await page.waitForTimeout(1_000);
+    }
+
+    const weightInput = page.locator('input[placeholder="60"]').first();
+    if (!(await weightInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+
+    const heightInput = page.locator('input[placeholder="170"]').first();
+    const ageInput = page.locator('input[placeholder="25"]').first();
+    const nextButton = page.locator('button:has-text("次へ")').first();
+
+    if (await ageInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await ageInput.fill("25");
+    }
+    if (await heightInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await heightInput.fill("170");
+    }
+
+    // "abc" を type (number input は弾くが念の為確認)
+    await weightInput.fill("abc");
+    await expect(nextButton).toBeDisabled({ timeout: 3_000 });
+  });
+
+  /**
+   * C-14d: 体重フィールドに XSS ペイロード → エスケープされるか
+   *
+   * input type="number" のため XSS は入らないはずだが、
+   * text型の nickname フィールドに XSS を入れた場合の挙動を確認する。
+   */
+  test("C-14d: nickname に XSS を入力してもスクリプトが実行されない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await page.goto(`${BASE_URL}/onboarding/questions`);
+    await page.waitForLoadState("networkidle");
+
+    const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
+    if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+
+    // XSS ペイロードを入力
+    let alertFired = false;
+    page.on("dialog", () => {
+      alertFired = true;
+    });
+
+    await nicknameInput.fill('<script>alert(1)</script>');
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(2_000);
+
+    // alert が発火していないこと
+    expect(alertFired).toBe(false);
+  });
+
+  /**
+   * C-15: 身長に絵文字 / 全角数字 → バリデーション失敗で「次へ」が disabled
+   */
+  test("C-15: 身長に絵文字を入力しても「次へ」は disabled のまま", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await page.goto(`${BASE_URL}/onboarding/questions`);
+    await page.waitForLoadState("networkidle");
+
+    const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
+    if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+    await nicknameInput.fill("テスト");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(1_000);
+
+    const maleButton = page.locator('button:has-text("男性")').first();
+    if (await maleButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await maleButton.click();
+      await page.waitForTimeout(1_000);
+    }
+
+    const heightInput = page.locator('input[placeholder="170"]').first();
+    if (!(await heightInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+
+    const nextButton = page.locator('button:has-text("次へ")').first();
+
+    // 絵文字を入力 (number input では無効)
+    await heightInput.fill("🏃");
+    await expect(nextButton).toBeDisabled({ timeout: 3_000 });
+  });
+
+  /**
+   * C-16: 食物アレルギーで 1000 文字のタグを入力
+   *
+   * tags フィールドはカスタム入力を許可しており、API への保存時に diet_flags に入る。
+   * 1000文字の文字列でサーバー側がエラーを返さないか、または適切にハンドリングするか確認。
+   */
+  test("C-16: アレルギーフィールドに 1000 文字のタグを入力しても画面がクラッシュしない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    // アレルギーステップに直接到達するには多くのステップを経由する必要があるため、
+    // API 経由で progress を設定してアレルギーステップに近いステップに移動する
+    // (questions の allergies は index 28 付近)
+    // ここでは API に直接大きなペイロードを送ってサーバーの挙動を確認する
+    const longString = "あ".repeat(1000);
+
+    const res = await page.evaluate(
+      async ({ url, payload }: { url: string; payload: any }) => {
+        const r = await fetch(url, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        return { status: r.status, body: await r.json().catch(() => null) };
+      },
+      {
+        url: `${BASE_URL}/api/onboarding/progress`,
+        payload: {
+          currentStep: 5,
+          answers: {
+            nickname: "テスト",
+            allergies: [longString],
+          },
+          totalQuestions: 30,
+        },
+      }
+    );
+
+    // サーバーが 500 を返さないこと
+    expect(res.status).not.toBe(500);
+  });
+
+  /**
+   * C-17: 好み欄に SQL injection ペイロード → DB エラーにならないか
+   *
+   * Supabase は prepared statement を使うため SQL injection は防がれるはずだが、
+   * API が 500 を返さないことを確認する。
+   */
+  test("C-17: SQL injection ペイロードを API に送っても 500 にならない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    const sqlInjection = "'; DROP TABLE users; --";
+
+    const res = await page.evaluate(
+      async ({ url, payload }: { url: string; payload: any }) => {
+        const r = await fetch(url, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        return { status: r.status };
+      },
+      {
+        url: `${BASE_URL}/api/onboarding/progress`,
+        payload: {
+          currentStep: 3,
+          answers: {
+            nickname: sqlInjection,
+            dislikes: [sqlInjection],
+          },
+          totalQuestions: 30,
+        },
+      }
+    );
+
+    expect(res.status).not.toBe(500);
+    expect(res.status).toBeLessThan(500);
+  });
+
+  /**
+   * C-18: ニックネームに XSS img タグ → API 保存後に再取得して実行されないか
+   *
+   * XSS ペイロードを nickname として保存し、resume ページで表示したときに
+   * onerror が発火しないことを確認する。
+   */
+  test("C-18: XSS img タグを nickname に保存して表示しても script 実行されない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    const xssPayload = '<img src=x onerror=alert(1)>';
+
+    // XSS ペイロードを progress API で保存
+    await page.evaluate(
+      async ({ url, payload }: { url: string; payload: any }) => {
+        await fetch(url, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      },
+      {
+        url: `${BASE_URL}/api/onboarding/progress`,
+        payload: {
+          currentStep: 2,
+          answers: { nickname: xssPayload },
+          totalQuestions: 30,
+        },
+      }
+    );
+
+    // alert が発火していないことを監視
+    let alertFired = false;
+    page.on("dialog", async (dialog) => {
+      alertFired = true;
+      await dialog.dismiss();
+    });
+
+    // resume ページで nickname が表示される
+    await page.goto(`${BASE_URL}/onboarding/resume`);
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(2_000);
+
+    expect(alertFired).toBe(false);
+  });
+
+  /**
+   * C-19: 数値フィールド (target_weight) に 0 を入力 → 「次へ」が disabled
+   *
+   * target_weight は min=30 max=200 のバリデーションを持つ。
+   * 0 は範囲外なので disabled になるはず。
+   */
+  test("C-19: target_weight に 0 を入力すると「次へ」が disabled", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    // nutrition_goal=lose_weight の状態で target_weight ステップを表示するために
+    // progress API で状態を設定
+    await page.evaluate(
+      async ({ url, payload }: { url: string; payload: any }) => {
+        await fetch(url, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      },
+      {
+        url: `${BASE_URL}/api/onboarding/progress`,
+        payload: {
+          currentStep: 4, // target_weight は index 4
+          answers: {
+            nickname: "テスト",
+            gender: "male",
+            body_stats: "completed",
+            nutrition_goal: "lose_weight",
+          },
+          totalQuestions: 30,
+        },
+      }
+    );
+
+    await page.goto(`${BASE_URL}/onboarding/questions?resume=true`);
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(3_000);
+
+    // target_weight 入力フィールドを探す
+    const targetWeightInput = page
+      .locator('input[type="number"]')
+      .first();
+    if (
+      await targetWeightInput.isVisible({ timeout: 5_000 }).catch(() => false)
+    ) {
+      await targetWeightInput.fill("0");
+      const nextOrSubmitBtn = page
+        .locator('button[type="submit"], button:has-text("次へ")')
+        .first();
+      if (await nextOrSubmitBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+        await expect(nextOrSubmitBtn).toBeDisabled({ timeout: 3_000 });
+      }
+    } else {
+      test.skip();
+    }
+  });
+
+  /**
+   * C-20: 必須選択肢を空のまま「次へ」連打 → 質問が飛ばされないか
+   *
+   * multi_choice の「次へ」は selectedMulti.length === 0 のとき disabled になる実装。
+   * 連打してもステップが進まないことを確認する。
+   */
+  test("C-20: multi_choice で選択なしに「次へ」連打してもステップが進まない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await page.goto(`${BASE_URL}/onboarding/questions`);
+    await page.waitForLoadState("networkidle");
+
+    // exercise_types ステップ (multi_choice) まで進む
+    const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
+    if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+    await nicknameInput.fill("テスト");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(1_000);
+
+    // multi_choice の「次へ」ボタンを見つけて連打
+    const nextButton = page
+      .locator('button:has-text("次へ")')
+      .first();
+    for (let i = 0; i < 10; i++) {
+      if (await nextButton.isVisible({ timeout: 500 }).catch(() => false)) {
+        await nextButton.click({ force: true }); // disabled でも force クリック
+        await page.waitForTimeout(100);
+      }
+    }
+
+    // ページがクラッシュしていないことを確認
+    await expect(page.locator("body")).toBeVisible();
+  });
+});
+
+// ─── D. 並列 / 競合 ───────────────────────────────────────────────────────────
+
+test.describe("D. 並列 / 競合", () => {
+  /**
+   * D-21: 同じユーザーが 2 タブで onboarding 同時進行 → 最後 submit でどうなる？
+   *
+   * 2タブで別々の nickname を入力して submit したとき、
+   * DB には後から来たリクエストの値が入る (last-write-wins)。
+   * エラーにならないことを確認する。
+   */
+  test("D-21: 2タブで同時に完了させてもエラーにならない", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext();
+    const pageA = await ctx.newPage();
+    await login(pageA);
+    await resetOnboarding(pageA);
+
+    const pageB = await ctx.newPage();
+
+    // 両タブで progress を設定
+    const progressPayload = {
+      currentStep: 10,
+      answers: { nickname: "テスト" },
+      totalQuestions: 30,
+    };
+
+    await pageA.evaluate(
+      async ({ url, payload }: { url: string; payload: any }) => {
+        await fetch(url, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      },
+      { url: `${BASE_URL}/api/onboarding/progress`, payload: progressPayload }
+    );
+
+    // 2タブで同時に complete を送信
+    const results = await Promise.all([
+      pageA.evaluate(async (url: string) => {
+        const r = await fetch(url, {
+          method: "POST",
+          credentials: "include",
+        });
+        return r.status;
+      }, `${BASE_URL}/api/onboarding/complete`),
+      pageB.evaluate(async (url: string) => {
+        const r = await fetch(url, {
+          method: "POST",
+          credentials: "include",
+        });
+        return r.status;
+      }, `${BASE_URL}/api/onboarding/complete`),
+    ]);
+
+    // 両方のリクエストが 500 にならないこと
+    for (const status of results) {
+      expect(status).toBeLessThan(500);
+    }
+
+    // 最終的に completed になっていること
+    const finalStatus = await getOnboardingStatus(pageA);
+    expect(finalStatus.status).toBe("completed");
+
+    await ctx.close();
+  });
+
+  /**
+   * D-22: タブ A で完了 → タブ B でまだ in_progress の questions を表示中 →
+   *        タブ B から next を押すと progress が上書きされるか？
+   *
+   * タブ B が古い状態を持ったまま次のステップへ進んでも、
+   * onboarding_completed_at は保持されるべき（progress 保存は completed を消さない）。
+   */
+  test("D-22: タブ A で完了後にタブ B で進んでも completed_at は消えない", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext();
+    const pageA = await ctx.newPage();
+    await login(pageA);
+    await resetOnboarding(pageA);
+    await startOnboardingFlow(pageA);
+
+    // タブ A で完了
+    await completeOnboardingViaApi(pageA);
+
+    // タブ B で progress を保存（古いクライアントが送ってくる状況）
+    const pageB = await ctx.newPage();
+    const res = await pageB.evaluate(
+      async ({ url, payload }: { url: string; payload: any }) => {
+        const r = await fetch(url, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        return r.status;
+      },
+      {
+        url: `${BASE_URL}/api/onboarding/progress`,
+        payload: {
+          currentStep: 15,
+          answers: { nickname: "競合テスト" },
+          totalQuestions: 30,
+        },
+      }
+    );
+
+    // progress の保存は成功する (completed_at は progress API では触らない)
+    expect(res).toBeLessThan(500);
+
+    // completed_at が消えていないこと
+    const statusAfter = await getOnboardingStatus(pageA);
+    expect(statusAfter.status).toBe("completed");
+
+    await ctx.close();
+  });
+
+  /**
+   * D-23: 1 秒間に 50 回「次へ」連打 → 質問が飛ばされないか
+   *
+   * choice ボタンは click のたびに handleAnswer を呼び出すが、
+   * isTyping=true 中は AnimatePresence で入力エリアが非表示になるため
+   * 物理的に連打できない。disabled にはなっていないが表示されていないことを確認する。
+   */
+  test("D-23: choice ボタンを連打してもステップが正しく進む", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await page.goto(`${BASE_URL}/onboarding/questions`);
+    await page.waitForLoadState("networkidle");
+
+    const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
+    if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+    await nicknameInput.fill("テスト");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(800);
+
+    // gender 選択の choice ボタンを 10 回連打
+    const maleButton = page.locator('button:has-text("男性")').first();
+    if (await maleButton.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      for (let i = 0; i < 10; i++) {
+        await maleButton.click({ force: true }).catch(() => {});
+        await page.waitForTimeout(50);
+      }
+      await page.waitForTimeout(1_500);
+
+      // ページがクラッシュしていないこと
+      await expect(page.locator("body")).toBeVisible();
+    } else {
+      test.skip();
+    }
+  });
+
+  /**
+   * D-24: ネットワーク切断 → saveProgress が失敗 → 再接続後に再開できるか
+   *
+   * オフライン中に progress API が失敗しても、
+   * その後オンラインに戻してから再開したとき最後に保存した進捗から再開できることを確認する。
+   */
+  test("D-24: ネットワーク切断中の saveProgress 失敗後、再接続で再開できる", async ({
+    page,
+    context,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    // まず一度オンラインで progress を保存する
+    await page.evaluate(
+      async ({ url, payload }: { url: string; payload: any }) => {
+        await fetch(url, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      },
+      {
+        url: `${BASE_URL}/api/onboarding/progress`,
+        payload: {
+          currentStep: 5,
+          answers: { nickname: "ネットワークテスト", gender: "male" },
+          totalQuestions: 30,
+        },
+      }
+    );
+
+    // オフラインにする
+    await context.setOffline(true);
+
+    // オフライン中に progress 保存を試みる（失敗するはず）
+    const offlineRes = await page
+      .evaluate(
+        async ({ url, payload }: { url: string; payload: any }) => {
+          try {
+            const r = await fetch(url, {
+              method: "POST",
+              credentials: "include",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(payload),
+            });
+            return { ok: true, status: r.status };
+          } catch {
+            return { ok: false, status: 0 };
+          }
+        },
+        {
+          url: `${BASE_URL}/api/onboarding/progress`,
+          payload: {
+            currentStep: 10,
+            answers: { nickname: "オフライン更新" },
+            totalQuestions: 30,
+          },
+        }
+      )
+      .catch(() => ({ ok: false, status: 0 }));
+
+    // オフラインなのでリクエストは失敗する
+    expect(offlineRes.ok).toBe(false);
+
+    // オンラインに戻す
+    await context.setOffline(false);
+    await page.waitForTimeout(1_000);
+
+    // 再接続後に status を確認
+    const statusAfter = await getOnboardingStatus(page);
+    // オフライン中の更新は飛んでいないので、最後の正常な保存が残っている
+    expect(["in_progress"]).toContain(statusAfter.status);
+    if (statusAfter.status === "in_progress") {
+      // currentStep が 5 のまま (オフライン時の 10 は保存されていない)
+      const savedStep = statusAfter.progress?.currentStep;
+      if (savedStep !== undefined) {
+        expect(savedStep).toBe(5);
+      }
+    }
+  });
+});
+
+// ─── E. 異常状態の DB ─────────────────────────────────────────────────────────
+
+test.describe("E. 異常状態の DB", () => {
+  /**
+   * E-25: user_profiles が存在しない状態でステータス API にアクセス
+   *
+   * status API は maybeSingle() を使っており、profile が null でも
+   * not_started を返す実装になっている。
+   * 認証済みだが profile が存在しない状態をシミュレートするために
+   * progress を削除した後の挙動を確認する。
+   */
+  test("E-25: onboarding リセット後は not_started が返る", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    const statusData = await getOnboardingStatus(page);
+    // not_started であること
+    expect(statusData.status).toBe("not_started");
+    // エラーが返ってきていないこと
+    expect(statusData).not.toHaveProperty("error");
+  });
+
+  /**
+   * E-26: onboarding_started_at のみが設定されている (roles は空) 状態でアクセス
+   *
+   * roles=[] の場合は admin ではないため通常のオンボーディングフローになる。
+   * resolveOnboardingRedirect で roles.includes('admin') が false になり、
+   * status=in_progress → /onboarding/resume に飛ぶはず。
+   */
+  test("E-26: roles 配列が空の状態でも in_progress フローが正常に動く", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    // in_progress 状態にする
+    await page.evaluate(
+      async ({ url, payload }: { url: string; payload: any }) => {
+        await fetch(url, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      },
+      {
+        url: `${BASE_URL}/api/onboarding/progress`,
+        payload: {
+          currentStep: 2,
+          answers: { nickname: "Roles空テスト" },
+          totalQuestions: 30,
+        },
+      }
+    );
+
+    const statusData = await getOnboardingStatus(page);
+    expect(statusData.status).toBe("in_progress");
+
+    // /onboarding に飛んで resume にリダイレクトされること
+    await page.goto(`${BASE_URL}/onboarding`);
+    await page.waitForURL(/\/onboarding\/(resume|questions)/, {
+      timeout: 15_000,
+    });
+  });
+
+  /**
+   * E-27: onboarding_started_at が未来日付になっている状態
+   *
+   * onboarding-routing.ts は started_at の値を確認するだけで日付比較はしない。
+   * 未来日付でも in_progress として扱われることを確認する。
+   */
+  test("E-27: onboarding_started_at が未来日付でも in_progress として扱われる", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    // 未来日付の started_at を持つ状態を progress API 経由で作る
+    // (progress API は started_at が null の場合のみセットするため、
+    //  実際に「未来日付」を注入するには DB 直接操作が必要だが、
+    //  ここでは「started_at がセットされている状態」として in_progress を確認する)
+    await page.evaluate(
+      async ({ url, payload }: { url: string; payload: any }) => {
+        await fetch(url, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+      },
+      {
+        url: `${BASE_URL}/api/onboarding/progress`,
+        payload: {
+          currentStep: 1,
+          answers: { nickname: "未来日付テスト" },
+          totalQuestions: 30,
+        },
+      }
+    );
+
+    const statusData = await getOnboardingStatus(page);
+    // in_progress として認識されていること
+    expect(statusData.status).toBe("in_progress");
+  });
+
+  /**
+   * E-28: progress に不正な JSON が入っている状態でステータスAPI が500を返さないか
+   *
+   * onboarding_progress が壊れた JSON の場合、
+   * API は onboarding_progress を読み取れないが graceful に処理すべき。
+   * ここでは不正な progress を送り込んだ後の status 確認を行う。
+   * (実際に壊れた JSON を DB に入れるのはSupabase操作が必要なため、
+   *  progress API が空/null の progress を受け取った場合の挙動を代替確認)
+   */
+  test("E-28: 不正な progress ペイロードを送っても status API は 500 を返さない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    // 不正なペイロードを progress API に送る
+    const res = await page.evaluate(async (url: string) => {
+      const r = await fetch(url, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: "invalid json{{{",
+      });
+      return r.status;
+    }, `${BASE_URL}/api/onboarding/progress`);
+
+    // 400 (Bad Request) が返るはず、500 ではないこと
+    expect(res).not.toBe(500);
+
+    // その後 status API が正常に動くこと
+    const statusData = await getOnboardingStatus(page);
+    expect(statusData).toHaveProperty("status");
+    expect(statusData).not.toHaveProperty("error");
+  });
+});
+
+// ─── 追加シナリオ ─────────────────────────────────────────────────────────────
+
+test.describe("F. 追加シナリオ (UI / UX の境界値)", () => {
+  /**
+   * F-29: /onboarding/complete に未完了状態でアクセスしてもクラッシュしない
+   *
+   * in_progress 状態で /onboarding/complete に直アクセスした場合、
+   * middleware の resolveOnboardingRedirect は in_progress + /onboarding/complete の組み合わせで
+   * null を返す（リダイレクトしない）実装。ページが表示できること。
+   */
+  test("F-29: in_progress 状態で /onboarding/complete に直アクセスしてもエラーにならない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+    await startOnboardingFlow(page);
+
+    // /onboarding/complete に直アクセス
+    await page.goto(`${BASE_URL}/onboarding/complete`);
+    await page.waitForLoadState("networkidle");
+
+    // 500 エラーページが出ていないこと
+    const pageTitle = await page.title();
+    expect(pageTitle).not.toContain("500");
+    expect(pageTitle).not.toContain("Error");
+
+    // body が表示されていること
+    await expect(page.locator("body")).toBeVisible();
+  });
+
+  /**
+   * F-30: progress API に currentStep が負の数値でも 500 にならない
+   */
+  test("F-30: progress API に負の currentStep を送っても 500 にならない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    const res = await page.evaluate(
+      async ({ url, payload }: { url: string; payload: any }) => {
+        const r = await fetch(url, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        return r.status;
+      },
+      {
+        url: `${BASE_URL}/api/onboarding/progress`,
+        payload: {
+          currentStep: -999,
+          answers: { nickname: "負のステップ" },
+          totalQuestions: -1,
+        },
+      }
+    );
+
+    expect(res).not.toBe(500);
+  });
+
+  /**
+   * F-31: complete API を 3 回連続で呼び出しても idempotent に動く
+   *
+   * onboarding_completed_at の UPDATE は idempotent（既に完了済みでも上書きするだけ）。
+   * 3回呼んでも全て 200 を返すはず。
+   */
+  test("F-31: complete API を 3 回連続で呼び出しても全て 200 を返す", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    const results = [];
+    for (let i = 0; i < 3; i++) {
+      const res = await page.evaluate(async (url: string) => {
+        const r = await fetch(url, {
+          method: "POST",
+          credentials: "include",
+        });
+        return r.status;
+      }, `${BASE_URL}/api/onboarding/complete`);
+      results.push(res);
+    }
+
+    for (const status of results) {
+      expect(status).toBeLessThan(500);
+    }
+
+    // 最終的に completed になっていること
+    const finalStatus = await getOnboardingStatus(page);
+    expect(finalStatus.status).toBe("completed");
+  });
+
+  /**
+   * F-32: progress API で answers に巨大なネストオブジェクトを送る
+   *
+   * DB の onboarding_progress カラムが JSONB で無制限（PostgreSQL の JSONB 上限は 1GB）なため
+   * 通常は問題ないが、極端に大きいオブジェクトで 500 にならないことを確認する。
+   */
+  test("F-32: 大きな answers オブジェクトを送っても 500 にならない", async ({
+    page,
+  }) => {
+    await login(page);
+    await resetOnboarding(page);
+
+    // 1000個のキーを持つ answers
+    const bigAnswers: Record<string, string> = {};
+    for (let i = 0; i < 100; i++) {
+      bigAnswers[`key_${i}`] = "x".repeat(100);
+    }
+
+    const res = await page.evaluate(
+      async ({ url, payload }: { url: string; payload: any }) => {
+        const r = await fetch(url, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        return r.status;
+      },
+      {
+        url: `${BASE_URL}/api/onboarding/progress`,
+        payload: {
+          currentStep: 1,
+          answers: bigAnswers,
+          totalQuestions: 30,
+        },
+      }
+    );
+
+    expect(res).not.toBe(500);
+  });
+});

--- a/tests/e2e/w5-3-menu-gen-adversarial.spec.ts
+++ b/tests/e2e/w5-3-menu-gen-adversarial.spec.ts
@@ -1,0 +1,1290 @@
+/**
+ * Wave 5 / W5-3: 献立生成 Queue 完全嫌がらせ E2E
+ *
+ * 3〜5分かかる週間献立生成プロセスを破壊的にテストする。
+ * 実際の LLM 呼び出しは行わず、API をモックして UI・Queue・cron の挙動を検証する。
+ *
+ * 実行方法:
+ *   PLAYWRIGHT_BASE_URL=https://homegohan-app.vercel.app npm run test:e2e -- w5-3-menu-gen-adversarial
+ *
+ * prefix: [menu-gen][adversarial]
+ */
+
+import { test, expect, type Page } from "./fixtures/auth";
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+function getThisMonday(): string {
+  const d = new Date();
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  return d.toISOString().slice(0, 10);
+}
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr);
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+const FAKE_REQUEST_ID = "00000000-dead-beef-cafe-000000000w53";
+const FAKE_REQUEST_ID_2 = "00000000-dead-beef-cafe-000000001w53";
+
+/** 共通ルートモック: cleanup は "nothing stuck", pending は false を返す */
+async function stubIdle(page: Page) {
+  await page.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await page.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ hasPending: false }),
+    });
+  });
+}
+
+/** モックした週次リクエスト API (POST /api/ai/menu/weekly/request) */
+async function stubWeeklyRequest(page: Page, requestId: string) {
+  await page.route("**/api/ai/menu/weekly/request", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "processing", message: "Generation started", requestId }),
+    });
+  });
+}
+
+// ─── A. 連打・重複 ──────────────────────────────────────────────────────────
+
+/**
+ * A-1: 「献立生成」ボタンを 50 連打 → debounce/guard が機能して
+ *      API リクエストが最大 1 件しか発行されないことを確認。
+ *
+ * 期待: POST /api/ai/menu/weekly/request が 0〜1 件のみ
+ */
+test("[menu-gen][adversarial] A-1: 生成ボタン50連打 → リクエストは最大1件", async ({
+  authedPage,
+}) => {
+  await stubIdle(authedPage);
+  await stubWeeklyRequest(authedPage, FAKE_REQUEST_ID);
+
+  // status: processing を返すことで UI がループしないようにする
+  await authedPage.route("**/api/ai/menu/weekly/status*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "processing", progress: null }),
+    });
+  });
+
+  const postCount = { value: 0 };
+  authedPage.on("request", (req) => {
+    if (req.method() === "POST" && req.url().includes("/api/ai/menu/weekly/request")) {
+      postCount.value++;
+    }
+  });
+
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("networkidle");
+
+  // 献立生成ボタンを探す（複数のセレクタを試みる）
+  const genBtn = authedPage
+    .locator("button")
+    .filter({ hasText: /今週の献立を生成|献立を生成|AI献立|生成する/ })
+    .first();
+
+  const isVisible = await genBtn.isVisible({ timeout: 8_000 }).catch(() => false);
+  if (!isVisible) {
+    test.skip(true, "Generate button not visible – UI layout may differ");
+    return;
+  }
+
+  // 50 連打（Promise.all で同時発火）
+  const clicks = Array.from({ length: 50 }, () => genBtn.click({ force: true }).catch(() => {}));
+  await Promise.all(clicks);
+  await authedPage.waitForTimeout(2_000);
+
+  expect(
+    postCount.value,
+    `[BUG] 50連打でリクエストが ${postCount.value} 件送信された（期待: 最大1件）`,
+  ).toBeLessThanOrEqual(1);
+});
+
+/**
+ * A-2: 生成中に同じ週を別タブで生成依頼 → 2 本目の POST が弾かれるか確認。
+ *
+ * 期待: 2 本目タブでも pending 検出により UI が生成中状態を引き継ぐ
+ *       or 生成ボタンが disabled になっている
+ */
+test("[menu-gen][adversarial] A-2: 生成中に別タブで同週リクエスト → ガード or 引き継ぎ", async ({
+  authedPage,
+  context,
+}) => {
+  // tab A でモックした生成中状態を作る
+  const weekStr = getThisMonday();
+
+  await authedPage.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        hasPending: true,
+        requestId: FAKE_REQUEST_ID,
+        status: "processing",
+        mode: "v5",
+        startDate: weekStr,
+      }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/status*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "processing", progress: null }),
+    });
+  });
+
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("networkidle");
+  await authedPage.waitForTimeout(2_000);
+
+  // tab B を開く
+  const tabB = await context.newPage();
+
+  // tab B でも同じモックを適用
+  await tabB.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await tabB.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        hasPending: true,
+        requestId: FAKE_REQUEST_ID,
+        status: "processing",
+        mode: "v5",
+        startDate: weekStr,
+      }),
+    });
+  });
+  await tabB.route("**/api/ai/menu/weekly/status*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "processing", progress: null }),
+    });
+  });
+
+  const tabBPostCount = { value: 0 };
+  tabB.on("request", (req) => {
+    if (req.method() === "POST" && req.url().includes("/api/ai/menu/weekly/request")) {
+      tabBPostCount.value++;
+    }
+  });
+
+  await tabB.goto("/menus/weekly");
+  await tabB.waitForLoadState("networkidle");
+  await tabB.waitForTimeout(2_000);
+
+  // tab B の生成ボタンが disabled か、または新規 POST が発行されていないことを確認
+  const genBtn = tabB
+    .locator("button")
+    .filter({ hasText: /今週の献立を生成|献立を生成|AI献立/ })
+    .first();
+
+  const isDisabled = await genBtn.isDisabled({ timeout: 5_000 }).catch(() => false);
+  const showsGenerating = await tabB.locator("text=/生成中|処理中/").first().isVisible({ timeout: 3_000 }).catch(() => false);
+
+  // 生成ボタンが無効化されているか、生成中表示があれば OK
+  const isProtected = isDisabled || showsGenerating || tabBPostCount.value === 0;
+  expect(
+    isProtected,
+    `[BUG] tab B で生成中の重複リクエストが保護されていない（tabBPostCount=${tabBPostCount.value}, disabled=${isDisabled}, showsGenerating=${showsGenerating}）`,
+  ).toBe(true);
+
+  await tabB.close();
+});
+
+/**
+ * A-3: 異なる7日間範囲を5連続でリクエスト (queue 詰まり)
+ *
+ * 期待: 各リクエストが requestId を持って返ること
+ *       (実際の DB への挿入は行わないがモックで検証)
+ */
+test("[menu-gen][adversarial] A-3: 異なる週を5連続リクエスト → 各 requestId 返却", async ({
+  authedPage,
+}) => {
+  const requestIds: string[] = [];
+  let callCount = 0;
+
+  await authedPage.route("**/api/ai/menu/weekly/request", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.continue();
+      return;
+    }
+    callCount++;
+    const id = `fake-id-${callCount.toString().padStart(4, "0")}`;
+    requestIds.push(id);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "processing", message: "Generation started", requestId: id }),
+    });
+  });
+
+  await authedPage.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ hasPending: false }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/status*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "processing", progress: null }),
+    });
+  });
+
+  // 5 つの異なる週を直接 POST
+  const monday = getThisMonday();
+  const responses: number[] = [];
+  for (let i = 0; i < 5; i++) {
+    const startDate = addDays(monday, i * 7);
+    const res = await authedPage.request.post("/api/ai/menu/weekly/request", {
+      data: { startDate },
+      headers: { "Content-Type": "application/json" },
+    });
+    responses.push(res.status());
+  }
+
+  // 認証済みユーザーとして呼んでいるので 200 が期待されるが、
+  // モックが使えない場合は 401/400/500 も許容（実際の API を叩く場合）
+  // 少なくとも 5 件すべてがレスポンスを返したことを確認
+  expect(responses).toHaveLength(5);
+  for (const status of responses) {
+    expect(
+      [200, 201, 400, 401, 500],
+      `予期しない HTTP ステータス: ${status}`,
+    ).toContain(status);
+  }
+});
+
+// ─── B. 中断・再開 ──────────────────────────────────────────────────────────
+
+/**
+ * B-5: 生成中にタブ閉じ → 再オープン → 進捗復元
+ *
+ * 期待: pending リクエストが検出されて UI が生成中状態を引き継ぐ
+ */
+test("[menu-gen][adversarial] B-5: 生成中タブ閉じ再オープン → 進捗復元", async ({
+  authedPage,
+}) => {
+  const weekStr = getThisMonday();
+
+  await authedPage.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        hasPending: true,
+        requestId: FAKE_REQUEST_ID,
+        status: "processing",
+        mode: "v5",
+        startDate: weekStr,
+      }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/status*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "processing", progress: null }),
+    });
+  });
+
+  // localStorage に生成中状態を仕込む（タブを閉じた後の状態を模倣）
+  await authedPage.addInitScript(
+    ([reqId, weekKey]: [string, string]) => {
+      localStorage.setItem(
+        "weeklyMenuGenerating",
+        JSON.stringify({ weekStartDate: weekKey, timestamp: Date.now(), requestId: reqId }),
+      );
+    },
+    [FAKE_REQUEST_ID, weekStr],
+  );
+
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("networkidle");
+  await authedPage.waitForTimeout(3_000);
+
+  // 生成中UI（progress bar / spinner / テキスト）が表示されているか確認
+  const generatingIndicator = authedPage
+    .locator("text=/生成中|処理中|AIが献立/")
+    .or(authedPage.locator("[data-testid='generation-progress']"))
+    .or(authedPage.locator("text=/step.*of|ステップ/i"))
+    .first();
+
+  const isVisible = await generatingIndicator.isVisible({ timeout: 8_000 }).catch(() => false);
+
+  expect(
+    isVisible,
+    "[BUG] タブ再オープン後に生成中状態が復元されなかった（進捗UIが表示されていない）",
+  ).toBe(true);
+});
+
+/**
+ * B-6: 生成中に signOut → queue が孤児化しない（stale timeout で failed に遷移）
+ *
+ * 期待: ログアウト後に再ログインしてページを開いたとき、
+ *       stale request が failed 扱いになって UI が生成中ループにならない
+ */
+test("[menu-gen][adversarial] B-6: 生成中にサインアウト → stale 処理で failed 確認", async ({
+  authedPage,
+}) => {
+  // stale なリクエスト（21分前に更新されたもの）をシミュレート
+  // status=processing で returned → stale 判定で failed 化
+  const staleUpdatedAt = new Date(Date.now() - 21 * 60 * 1000).toISOString();
+
+  await authedPage.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        hasPending: true,
+        requestId: FAKE_REQUEST_ID,
+        status: "processing",
+        mode: "v5",
+        startDate: getThisMonday(),
+      }),
+    });
+  });
+
+  // status API: stale なデータ（20分以上前の updated_at）
+  await authedPage.route("**/api/ai/menu/weekly/status*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "failed",
+        errorMessage: "stale_request_timeout",
+        updatedAt: staleUpdatedAt,
+      }),
+    });
+  });
+
+  await authedPage.addInitScript(
+    ([reqId, weekKey]: [string, string]) => {
+      localStorage.setItem(
+        "weeklyMenuGenerating",
+        JSON.stringify({
+          weekStartDate: weekKey,
+          timestamp: Date.now() - 25 * 60 * 1000, // 25分前
+          requestId: reqId,
+        }),
+      );
+    },
+    [FAKE_REQUEST_ID, getThisMonday()],
+  );
+
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("networkidle");
+  await authedPage.waitForTimeout(3_000);
+
+  // failed 状態のUIが表示されているか、または生成中ではないこと
+  const infiniteSpinner = authedPage
+    .locator("text=/生成中|処理中/")
+    .first();
+  const isStillGenerating = await infiniteSpinner.isVisible({ timeout: 3_000 }).catch(() => false);
+
+  // stale な request で永遠に生成中表示のままになっていたら BUG
+  expect(
+    isStillGenerating,
+    "[BUG] stale なリクエスト（21分以上前）で UI が永遠に生成中のまま（ループ）",
+  ).toBe(false);
+});
+
+/**
+ * B-7: 生成中に /home に navigate → 戻ったとき進捗が復元されること
+ *
+ * 期待: /menus/weekly → /home → /menus/weekly で生成中状態が引き継がれる
+ */
+test("[menu-gen][adversarial] B-7: 生成中に /home ナビゲート → 戻ると進捗復元", async ({
+  authedPage,
+}) => {
+  const weekStr = getThisMonday();
+
+  await authedPage.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        hasPending: true,
+        requestId: FAKE_REQUEST_ID,
+        status: "processing",
+        mode: "v5",
+        startDate: weekStr,
+      }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/status*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "processing", progress: null }),
+    });
+  });
+
+  await authedPage.addInitScript(
+    ([reqId, weekKey]: [string, string]) => {
+      localStorage.setItem(
+        "weeklyMenuGenerating",
+        JSON.stringify({ weekStartDate: weekKey, timestamp: Date.now(), requestId: reqId }),
+      );
+    },
+    [FAKE_REQUEST_ID, weekStr],
+  );
+
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("networkidle");
+  await authedPage.waitForTimeout(1_500);
+
+  // /home に遷移
+  await authedPage.goto("/");
+  await authedPage.waitForLoadState("networkidle");
+
+  // /menus/weekly に戻る
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("networkidle");
+  await authedPage.waitForTimeout(3_000);
+
+  // 生成中 UI の復元を確認
+  const generatingIndicator = authedPage
+    .locator("text=/生成中|処理中|AIが献立/")
+    .or(authedPage.locator("[data-testid='generation-progress']"))
+    .first();
+
+  const isRestored = await generatingIndicator.isVisible({ timeout: 8_000 }).catch(() => false);
+  expect(
+    isRestored,
+    "[BUG] /home → /menus/weekly 戻り後に生成中状態が復元されなかった",
+  ).toBe(true);
+});
+
+/**
+ * B-8: 生成中に週を切り替え → 別週を表示しても生成進捗UIが正しく扱われる
+ *
+ * 期待: 別週の生成中でも、pending check でstartDate が不一致なら「引き継ぎしない」
+ */
+test("[menu-gen][adversarial] B-8: 生成中に週切り替え → 別週はhasPending=falseで返す", async ({
+  authedPage,
+}) => {
+  const weekStr = getThisMonday();
+  const nextWeekStr = addDays(weekStr, 7);
+  let pendingCallDate = "";
+
+  await authedPage.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    const url = new URL(route.request().url());
+    pendingCallDate = url.searchParams.get("date") ?? "";
+    // pending リクエストのstart_dateが今週（weekStr）、でも別週（nextWeekStr）を見ている場合はhasPending=false
+    if (pendingCallDate === nextWeekStr) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ hasPending: false }),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          hasPending: true,
+          requestId: FAKE_REQUEST_ID,
+          status: "processing",
+          mode: "v5",
+          startDate: weekStr, // 今週の生成中
+        }),
+      });
+    }
+  });
+  await authedPage.route("**/api/ai/menu/weekly/status*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "processing", progress: null }),
+    });
+  });
+
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("networkidle");
+  await authedPage.waitForTimeout(2_000);
+
+  // 翌週ボタン（next week）を探してクリック
+  const nextWeekBtn = authedPage
+    .locator("button")
+    .filter({ hasText: /翌週|次週|来週|>|›/ })
+    .or(authedPage.locator("[aria-label*='next week'], [aria-label*='翌週']"))
+    .first();
+
+  const hasNextWeekBtn = await nextWeekBtn.isVisible({ timeout: 5_000 }).catch(() => false);
+  if (!hasNextWeekBtn) {
+    test.skip(true, "Next week navigation button not found – UI layout may differ");
+    return;
+  }
+
+  await nextWeekBtn.click();
+  await authedPage.waitForTimeout(2_000);
+
+  // 別週（nextWeekStr）では pending が false なので生成中UIが出ないことを確認
+  const generatingText = authedPage.locator("text=/生成中|処理中/").first();
+  // 別週を見ているので生成中UIは表示されない（または今週の生成を引き継がない）
+  // これは仕様確認テスト — 表示状態をログするだけ
+  const isGeneratingVisible = await generatingText.isVisible({ timeout: 3_000 }).catch(() => false);
+  // pending check で別週の date が渡されていれば仕様通り
+  if (pendingCallDate === nextWeekStr) {
+    // 別週でも pending=false が返ったのに生成中が表示されている → BUG
+    if (isGeneratingVisible) {
+      // startDate が今週だが別週を見ている場合のログ
+      console.warn(`[INFO] 別週（${nextWeekStr}）でも生成中UIが表示された。仕様確認必要。`);
+    }
+  }
+  // テスト自体は pending API の呼び出しがあったことを確認
+  expect(pendingCallDate).not.toBe("");
+});
+
+// ─── C. 異常入力 ──────────────────────────────────────────────────────────
+
+/**
+ * C-9: startDate = 1900-01-01 / 9999-12-31 でリクエスト
+ *
+ * 期待: 400 または 401（サーバーがクラッシュしない）
+ */
+test("[menu-gen][adversarial] C-9: 極端な日付 1900-01-01 でリクエスト → 400/401", async ({
+  authedPage,
+}) => {
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("domcontentloaded");
+
+  const res1 = await authedPage.request.post("/api/ai/menu/weekly/request", {
+    data: { startDate: "1900-01-01" },
+    headers: { "Content-Type": "application/json" },
+  });
+  const res2 = await authedPage.request.post("/api/ai/menu/weekly/request", {
+    data: { startDate: "9999-12-31" },
+    headers: { "Content-Type": "application/json" },
+  });
+
+  // サーバーがクラッシュ（5xx）していないことを確認
+  // 400（バリデーションエラー）、401（未認証）、200（受け付けた場合）は OK
+  expect(res1.status(), `1900-01-01 で 5xx が返った: ${res1.status()}`).not.toBeGreaterThanOrEqual(500);
+  expect(res2.status(), `9999-12-31 で 5xx が返った: ${res2.status()}`).not.toBeGreaterThanOrEqual(500);
+});
+
+/**
+ * C-10: 過去 10 年前の週を生成リクエスト → 拒否 or 受け付け確認
+ *
+ * 期待: 400（拒否）または 200（受け付けて処理）— 5xx ではない
+ */
+test("[menu-gen][adversarial] C-10: 過去10年前の週をリクエスト → 5xxなし", async ({
+  authedPage,
+}) => {
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("domcontentloaded");
+
+  const tenYearsAgo = new Date();
+  tenYearsAgo.setFullYear(tenYearsAgo.getFullYear() - 10);
+  const dateStr = tenYearsAgo.toISOString().slice(0, 10);
+
+  const res = await authedPage.request.post("/api/ai/menu/weekly/request", {
+    data: { startDate: dateStr },
+    headers: { "Content-Type": "application/json" },
+  });
+
+  expect(
+    res.status(),
+    `過去10年前の日付で 5xx が返った: ${res.status()}`,
+  ).not.toBeGreaterThanOrEqual(500);
+});
+
+/**
+ * C-11: 7日間範囲ではなく 1日 / 100日 の targetSlots を送付
+ *
+ * 期待: server がクラッシュしない（400 or 200 で処理）
+ */
+test("[menu-gen][adversarial] C-11: targetSlots が不正サイズ → サーバークラッシュなし", async ({
+  authedPage,
+}) => {
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("domcontentloaded");
+
+  const monday = getThisMonday();
+
+  // 1日分のみ
+  const res1 = await authedPage.request.post("/api/ai/menu/v4/generate", {
+    data: {
+      targetSlots: [{ date: monday, mealType: "dinner" }],
+      constraints: {},
+      note: "",
+      ultimateMode: false,
+    },
+    headers: { "Content-Type": "application/json" },
+  });
+
+  // 100日分（7×3×100/7 ≒ 300スロット）
+  const massiveSlots = Array.from({ length: 300 }, (_, i) => ({
+    date: addDays(monday, Math.floor(i / 3)),
+    mealType: ["breakfast", "lunch", "dinner"][i % 3],
+  }));
+  const res2 = await authedPage.request.post("/api/ai/menu/v4/generate", {
+    data: {
+      targetSlots: massiveSlots,
+      constraints: {},
+      note: "",
+      ultimateMode: false,
+    },
+    headers: { "Content-Type": "application/json" },
+  });
+
+  expect(res1.status(), `1スロットで 5xx: ${res1.status()}`).not.toBeGreaterThanOrEqual(500);
+  expect(res2.status(), `300スロットで 5xx: ${res2.status()}`).not.toBeGreaterThanOrEqual(500);
+});
+
+/**
+ * C-12: メモ欄に 10000 文字 / NULL byte / control chars
+ *
+ * 期待: サーバーがクラッシュしない（400 or 200）
+ */
+test("[menu-gen][adversarial] C-12: 異常メモ入力 → サーバークラッシュなし", async ({
+  authedPage,
+}) => {
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("domcontentloaded");
+
+  const monday = getThisMonday();
+  const cases = [
+    { name: "10000文字", note: "あ".repeat(10000) },
+    { name: "NULL byte", note: "test\x00injection" },
+    { name: "control chars", note: "test\x01\x02\x03\x1B[31m red\x1B[0m" },
+    { name: "Unicode emoji bomb", note: "💣".repeat(1000) },
+    { name: "SQL injection attempt", note: "'; DROP TABLE weekly_menu_requests; --" },
+    { name: "JSON injection", note: '{"__proto__": {"admin": true}}' },
+  ];
+
+  for (const c of cases) {
+    const res = await authedPage.request.post("/api/ai/menu/weekly/request", {
+      data: { startDate: monday, note: c.note },
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(
+      res.status(),
+      `[BUG] ${c.name} で 5xx クラッシュ: ${res.status()}`,
+    ).not.toBeGreaterThanOrEqual(500);
+  }
+});
+
+// ─── D. queue / cron ──────────────────────────────────────────────────────
+
+/**
+ * D-14: CRON_SECRET なしで /api/cron/process-menu-queue → 401 or 503
+ *
+ * 期待: 未認証アクセスは拒否される
+ */
+test("[menu-gen][adversarial] D-14: CRON_SECRETなしでcron → 401/503", async ({
+  authedPage,
+}) => {
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("domcontentloaded");
+
+  // Authorization ヘッダーなしで GET
+  const resNoAuth = await authedPage.request.get("/api/cron/process-menu-queue");
+  expect(
+    [401, 503],
+    `[BUG] CRON_SECRET なしで ${resNoAuth.status()} が返った（401 or 503 が期待）`,
+  ).toContain(resNoAuth.status());
+
+  // 間違った secret
+  const resWrongAuth = await authedPage.request.get("/api/cron/process-menu-queue", {
+    headers: { Authorization: "Bearer wrong-secret-12345" },
+  });
+  expect(
+    [401, 503],
+    `[BUG] 不正な CRON_SECRET で ${resWrongAuth.status()} が返った`,
+  ).toContain(resWrongAuth.status());
+});
+
+/**
+ * D-16: attempt_count >= 3 のリクエストが failed に変わること
+ *
+ * 期待: cleanup API で status=failed に遷移した response が返る
+ *       (UI では failed エラーが表示される)
+ */
+test("[menu-gen][adversarial] D-16: attempt_count >= 3 → UI が failed 状態を表示", async ({
+  authedPage,
+}) => {
+  const weekStr = getThisMonday();
+
+  await authedPage.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    // attempt_count 上限超えは status=failed で返ってくる
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ hasPending: false }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/status*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "failed",
+        errorMessage: "attempt_limit_exceeded",
+        updatedAt: new Date().toISOString(),
+      }),
+    });
+  });
+
+  // localStorage に attempt_limit_exceeded な failed request を仕込む
+  await authedPage.addInitScript(
+    ([reqId, weekKey]: [string, string]) => {
+      localStorage.setItem(
+        "weeklyMenuGenerating",
+        JSON.stringify({ weekStartDate: weekKey, timestamp: Date.now(), requestId: reqId }),
+      );
+    },
+    [FAKE_REQUEST_ID, weekStr],
+  );
+
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("networkidle");
+  await authedPage.waitForTimeout(3_000);
+
+  // failed 状態のとき UI がループ（生成中表示）にならないことを確認
+  const infiniteSpinner = authedPage.locator("text=/生成中|処理中/").first();
+  const isStuckGenerating = await infiniteSpinner.isVisible({ timeout: 3_000 }).catch(() => false);
+  expect(
+    isStuckGenerating,
+    "[BUG] attempt_limit_exceeded (failed) なのに生成中UIがループし続けている",
+  ).toBe(false);
+});
+
+/**
+ * D-17: cleanup API の status='queued' 対応 (#116)
+ *
+ * 期待: GET /api/ai/menu/weekly/cleanup が status 'queued' を含めて返す
+ */
+test("[menu-gen][adversarial] D-17: cleanup API が queued ステータスを認識", async ({
+  authedPage,
+}) => {
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("domcontentloaded");
+
+  // GET /api/ai/menu/weekly/cleanup を呼んで stuckRequests の status フィールドを確認
+  const res = await authedPage.request.get("/api/ai/menu/weekly/cleanup");
+  // 認証済みなので 200 が返るはず
+  if (res.status() === 401) {
+    test.skip(true, "Authentication required for cleanup API – skip");
+    return;
+  }
+  expect(res.status()).toBe(200);
+
+  const body = await res.json();
+  // レスポンスが stuckRequests 配列を持っているか確認
+  expect(body).toHaveProperty("stuckRequests");
+  expect(Array.isArray(body.stuckRequests)).toBe(true);
+
+  // もし queued/pending/processing が含まれていれば status フィールドが正しいか確認
+  for (const req of body.stuckRequests ?? []) {
+    expect(
+      ["queued", "pending", "processing"],
+      `[BUG] cleanup API の stuckRequests に想定外の status: ${req.status}`,
+    ).toContain(req.status);
+  }
+});
+
+// ─── E. failure シナリオ ──────────────────────────────────────────────────
+
+/**
+ * E-18: AI API timeout 後の status 整合性 (#122)
+ *
+ * 期待: Edge Function が 50秒 abort した後、cron worker が二重に status を書き込まない
+ *       → UI では failed が一度だけ表示されてループしない
+ */
+test("[menu-gen][adversarial] E-18: タイムアウト後の status 整合性 → ループなし", async ({
+  authedPage,
+}) => {
+  let statusCallCount = 0;
+
+  await authedPage.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        hasPending: true,
+        requestId: FAKE_REQUEST_ID,
+        status: "failed",
+        mode: "v5",
+        startDate: getThisMonday(),
+      }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/status*", async (route) => {
+    statusCallCount++;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "failed",
+        errorMessage: "Edge function timeout after 50s",
+        updatedAt: new Date().toISOString(),
+      }),
+    });
+  });
+
+  await authedPage.addInitScript(
+    ([reqId, weekKey]: [string, string]) => {
+      localStorage.setItem(
+        "weeklyMenuGenerating",
+        JSON.stringify({ weekStartDate: weekKey, timestamp: Date.now(), requestId: reqId }),
+      );
+    },
+    [FAKE_REQUEST_ID, getThisMonday()],
+  );
+
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("networkidle");
+  await authedPage.waitForTimeout(5_000);
+
+  // failed になった後にポーリングが停止していることを確認
+  // 5秒待って status API の呼び出し回数が過剰でない（ループしていない）
+  const callCountAfter5s = statusCallCount;
+  await authedPage.waitForTimeout(5_000);
+  const callCountAfter10s = statusCallCount;
+
+  // failed 確認後はポーリングが止まるはず → 後半5秒で 0〜2回程度しか呼ばれない
+  const additionalCalls = callCountAfter10s - callCountAfter5s;
+  expect(
+    additionalCalls,
+    `[BUG] failed 状態後もポーリングが続いている（後半5秒で ${additionalCalls} 回呼ばれた）`,
+  ).toBeLessThanOrEqual(3);
+});
+
+/**
+ * E-19: 生成失敗後の retry button → 新規 requestId が発行されること
+ *
+ * 期待: retry したとき同じ requestId が再利用されるのではなく新規 POST が発行される
+ */
+test("[menu-gen][adversarial] E-19: 生成失敗後のリトライ → 新規requestId", async ({
+  authedPage,
+}) => {
+  let newRequestId = "";
+  let postCallCount = 0;
+
+  await authedPage.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ hasPending: false }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/status*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "failed",
+        errorMessage: "generation failed",
+        updatedAt: new Date().toISOString(),
+      }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/request", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.continue();
+      return;
+    }
+    postCallCount++;
+    newRequestId = `retry-request-${postCallCount}`;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status: "processing", requestId: newRequestId }),
+    });
+  });
+
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("networkidle");
+  await authedPage.waitForTimeout(2_000);
+
+  // retry/再生成ボタンを探す
+  const retryBtn = authedPage
+    .locator("button")
+    .filter({ hasText: /再試行|もう一度|リトライ|再生成/ })
+    .first();
+
+  const hasRetryBtn = await retryBtn.isVisible({ timeout: 5_000 }).catch(() => false);
+  if (!hasRetryBtn) {
+    // 通常の生成ボタンでリトライ相当
+    const genBtn = authedPage
+      .locator("button")
+      .filter({ hasText: /今週の献立を生成|献立を生成|AI献立/ })
+      .first();
+    const hasGenBtn = await genBtn.isVisible({ timeout: 3_000 }).catch(() => false);
+    if (!hasGenBtn) {
+      test.skip(true, "Retry/Generate button not visible – UI may be in different state");
+      return;
+    }
+    await genBtn.click();
+  } else {
+    await retryBtn.click();
+  }
+
+  await authedPage.waitForTimeout(2_000);
+
+  // 新規 POST が発行されたことを確認
+  expect(postCallCount, "[BUG] retry 時に新規 POST が発行されなかった").toBeGreaterThanOrEqual(1);
+  expect(
+    newRequestId,
+    "[BUG] retry 時に requestId が生成されなかった",
+  ).not.toBe("");
+  expect(
+    newRequestId,
+    "[BUG] retry 時に古い requestId が再利用された",
+  ).not.toBe(FAKE_REQUEST_ID);
+});
+
+// ─── F. multi-tab realtime ───────────────────────────────────────────────
+
+/**
+ * F-22: tab A で生成完了 → tab B で Realtime 受信して UI 更新
+ *
+ * 期待: Supabase Realtime の postgres_changes が tab B に届き、
+ *       献立データが更新されること（最低限：生成中UIが消える）
+ */
+test("[menu-gen][adversarial] F-22: tabA生成完了 → tabBでリアルタイム更新", async ({
+  authedPage,
+  context,
+}) => {
+  const weekStr = getThisMonday();
+
+  // tab B を先に開いておく（Realtime 購読を開始させる）
+  const tabB = await context.newPage();
+
+  await tabB.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await tabB.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        hasPending: true,
+        requestId: FAKE_REQUEST_ID,
+        status: "processing",
+        mode: "v5",
+        startDate: weekStr,
+      }),
+    });
+  });
+
+  let tabBStatusCallCount = 0;
+  await tabB.route("**/api/ai/menu/weekly/status*", async (route) => {
+    tabBStatusCallCount++;
+    // 最初2回は processing、3回目以降は completed
+    const status = tabBStatusCallCount >= 3 ? "completed" : "processing";
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ status, progress: null }),
+    });
+  });
+
+  await tabB.addInitScript(
+    ([reqId, weekKey]: [string, string]) => {
+      localStorage.setItem(
+        "weeklyMenuGenerating",
+        JSON.stringify({ weekStartDate: weekKey, timestamp: Date.now(), requestId: reqId }),
+      );
+    },
+    [FAKE_REQUEST_ID, weekStr],
+  );
+
+  await tabB.goto("/menus/weekly");
+  await tabB.waitForLoadState("networkidle");
+  await tabB.waitForTimeout(2_000);
+
+  // tab B が生成中状態を引き継いでいることを確認
+  const generatingIndicator = tabB
+    .locator("text=/生成中|処理中|AIが献立/")
+    .first();
+  const isGenerating = await generatingIndicator.isVisible({ timeout: 5_000 }).catch(() => false);
+
+  // ポーリングが completed を受信した後、生成中UIが消えることを待つ（最大15秒）
+  await tabB.waitForTimeout(15_000);
+
+  const isStillGenerating = await generatingIndicator.isVisible({ timeout: 2_000 }).catch(() => false);
+
+  if (isGenerating) {
+    // 生成中が表示されていたなら、completed 後は消えているべき
+    expect(
+      isStillGenerating,
+      "[BUG] completed 後もtab Bで生成中UIが残り続けている（ポーリング/Realtime が機能していない）",
+    ).toBe(false);
+  }
+
+  await tabB.close();
+});
+
+/**
+ * F-23: 進捗 % が逆行しない (#119 Ultimate Mode 6 step)
+ *
+ * 期待: step 4 → step 5 → step 6 の順で progress % が増加のみ
+ */
+test("[menu-gen][adversarial] F-23: Ultimate Mode 6ステップの進捗%が逆行しない", async ({
+  authedPage,
+}) => {
+  const weekStr = getThisMonday();
+  let statusCallCount = 0;
+
+  // step 4 → 5 → 6 を順にシミュレート
+  const progressSequence = [
+    { currentStep: 4, totalSteps: 6, message: "栄養バランス分析中...", completedSlots: 2, totalSlots: 7 },
+    { currentStep: 5, totalSteps: 6, message: "献立を改善中...", completedSlots: 5, totalSlots: 7 },
+    { currentStep: 6, totalSteps: 6, message: "最終保存中...", completedSlots: 7, totalSlots: 7 },
+  ];
+
+  await authedPage.route("**/api/ai/menu/weekly/cleanup", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "No stuck requests found", cleaned: 0 }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/pending*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        hasPending: true,
+        requestId: FAKE_REQUEST_ID,
+        status: "processing",
+        mode: "v5",
+        startDate: weekStr,
+      }),
+    });
+  });
+  await authedPage.route("**/api/ai/menu/weekly/status*", async (route) => {
+    const idx = Math.min(statusCallCount, progressSequence.length - 1);
+    statusCallCount++;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "processing",
+        progress: progressSequence[idx],
+      }),
+    });
+  });
+
+  await authedPage.addInitScript(
+    ([reqId, weekKey]: [string, string]) => {
+      localStorage.setItem(
+        "weeklyMenuGenerating",
+        JSON.stringify({ weekStartDate: weekKey, timestamp: Date.now(), requestId: reqId }),
+      );
+    },
+    [FAKE_REQUEST_ID, weekStr],
+  );
+
+  const displayedPercentages: number[] = [];
+
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("networkidle");
+
+  // 進捗 % 表示を 10秒間サンプリング
+  for (let i = 0; i < 10; i++) {
+    await authedPage.waitForTimeout(1_000);
+    // progress bar や % テキストを探す
+    const percentText = await authedPage
+      .locator("text=/%/")
+      .first()
+      .textContent({ timeout: 500 })
+      .catch(() => null);
+    if (percentText) {
+      const match = percentText.match(/(\d+)%/);
+      if (match) {
+        displayedPercentages.push(parseInt(match[1]));
+      }
+    }
+  }
+
+  // サンプリングできた場合は単調増加を検証
+  if (displayedPercentages.length >= 2) {
+    for (let i = 1; i < displayedPercentages.length; i++) {
+      expect(
+        displayedPercentages[i],
+        `[BUG] 進捗%が逆行した: ${displayedPercentages[i - 1]}% → ${displayedPercentages[i]}%`,
+      ).toBeGreaterThanOrEqual(displayedPercentages[i - 1]);
+    }
+  }
+  // サンプリングできなくてもテスト自体は pass（進捗バーなしの UI 構成の可能性）
+});
+
+// ─── Security / CRON boundary ───────────────────────────────────────────
+
+/**
+ * Security: 任意ユーザーが他ユーザーの requestId で status を確認できない
+ *
+ * 期待: /api/ai/menu/weekly/status?requestId=<他人のID> → 404 or 403 or empty result
+ */
+test("[menu-gen][adversarial] Security: 他ユーザーのrequestIdでstatus確認不可", async ({
+  authedPage,
+}) => {
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("domcontentloaded");
+
+  // ランダムな UUID（他人の requestId を模倣）
+  const otherUsersRequestId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+  const res = await authedPage.request.get(
+    `/api/ai/menu/weekly/status?requestId=${otherUsersRequestId}`,
+  );
+
+  // 認証済みだが他人のリクエスト → 空 result（failed/not found）または 403
+  if (res.status() === 200) {
+    const body = await res.json().catch(() => ({}));
+    // user_id フィルタが効いていれば status=failed (not found)
+    expect(
+      body.status,
+      `[BUG] 他ユーザーの requestId で status が ${body.status} として返された（認可漏れの可能性）`,
+    ).toBe("failed");
+  } else {
+    expect([403, 404]).toContain(res.status());
+  }
+});
+
+/**
+ * Edge: 生成リクエストに JSON 以外のボディを送付
+ *
+ * 期待: 400 or 415（サーバーがクラッシュしない）
+ */
+test("[menu-gen][adversarial] Edge: 非JSONボディ送付 → クラッシュなし", async ({
+  authedPage,
+}) => {
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("domcontentloaded");
+
+  const res = await authedPage.request.post("/api/ai/menu/weekly/request", {
+    data: "this is not json at all <script>alert(1)</script>",
+    headers: { "Content-Type": "text/plain" },
+  });
+
+  expect(
+    res.status(),
+    `[BUG] 非JSON ボディで 5xx クラッシュ: ${res.status()}`,
+  ).not.toBeGreaterThanOrEqual(500);
+});
+
+/**
+ * Edge: 巨大な JSON ボディ（note フィールドに 1MB のテキスト）
+ *
+ * 期待: 400 or 413（ペイロード制限）または処理される — 5xx ではない
+ */
+test("[menu-gen][adversarial] Edge: 1MBのnoteフィールド → クラッシュなし", async ({
+  authedPage,
+}) => {
+  await authedPage.goto("/menus/weekly");
+  await authedPage.waitForLoadState("domcontentloaded");
+
+  const oneMBNote = "x".repeat(1024 * 1024);
+  const res = await authedPage.request.post("/api/ai/menu/weekly/request", {
+    data: { startDate: getThisMonday(), note: oneMBNote },
+    headers: { "Content-Type": "application/json" },
+  });
+
+  expect(
+    res.status(),
+    `[BUG] 1MB note で 5xx クラッシュ: ${res.status()}`,
+  ).not.toBeGreaterThanOrEqual(500);
+});

--- a/tests/e2e/w5-9-multitab-realtime-adversarial.spec.ts
+++ b/tests/e2e/w5-9-multitab-realtime-adversarial.spec.ts
@@ -1,0 +1,1540 @@
+/**
+ * Wave 5 / W5-9: Multi-tab / Multi-device / Realtime 完全嫌がらせ
+ *
+ * 目的: 複数タブ・別デバイス・realtime 同期を破壊的にテストし、
+ *       race condition / DB 不整合 / メモリリーク / セッション漏洩を検出する。
+ *
+ * グループ:
+ *   A. 同一ユーザー / 2 タブ (W5A-1 〜 W5A-6)
+ *   B. 同一ユーザー / 別デバイス (W5B-7 〜 W5B-10)
+ *   C. 同時編集 / collision (W5C-11 〜 W5C-15)
+ *   D. realtime subscription leak (W5D-16 〜 W5D-18)
+ *   E. session 同期 (W5E-19 〜 W5E-21)
+ *   F. localStorage / sessionStorage 同期 (W5F-22 〜 W5F-23)
+ *   G. 異常な device 状態 (W5G-24 〜 W5G-25)
+ *
+ * 実行:
+ *   PLAYWRIGHT_BASE_URL=https://homegohan-app.vercel.app npm run test:e2e -- w5-9
+ *
+ * バグ発見時 Issue prefix: [multi-tab][adversarial] or [realtime][adversarial]
+ */
+
+import { test, expect, type BrowserContext, type Page } from "@playwright/test";
+
+// ============================================================
+// 定数・ヘルパー
+// ============================================================
+
+const E2E_USER = {
+  email: process.env.E2E_USER_EMAIL ?? "claude-debug-1777477826@homegohan.local",
+  password: process.env.E2E_USER_PASSWORD ?? "ClaudeDebug2026!",
+};
+
+/** 指定コンテキストでログインする。最大 2 回リトライ。 */
+async function loginInContext(context: BrowserContext): Promise<Page> {
+  const page = await context.newPage();
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await page.goto("/login");
+      await page.locator("#email").fill(E2E_USER.email);
+      await page.locator("#password").fill(E2E_USER.password);
+      await Promise.all([
+        page.waitForURL(
+          (url) =>
+            !url.pathname.startsWith("/login") &&
+            !url.pathname.startsWith("/auth"),
+          { timeout: 35_000 }
+        ),
+        page.locator("button[type=submit]").click(),
+      ]);
+      await expect(page).not.toHaveURL(/\/login/);
+      return page;
+    } catch (err) {
+      if (attempt === 1) throw err;
+      await page.waitForTimeout(3_000);
+    }
+  }
+  throw new Error("loginInContext: should not reach here");
+}
+
+/** スクリーンショットを添付 */
+async function attach(page: Page, testInfo: any, name: string) {
+  const buf = await page.screenshot({ fullPage: false });
+  await testInfo.attach(name, { body: buf, contentType: "image/png" });
+}
+
+/** console.error を収集するリスナーを設定し、クリーナーを返す */
+function collectConsoleErrors(page: Page, label: string): () => string[] {
+  const errors: string[] = [];
+  const handler = (msg: any) => {
+    if (msg.type() === "error") errors.push(`[${label}] ${msg.text()}`);
+  };
+  page.on("console", handler);
+  return () => errors;
+}
+
+// ============================================================
+// A. 同一ユーザー / 2 タブ
+// ============================================================
+
+/**
+ * W5A-1: tab A で食事記録 (planned_meal を is_completed: true) →
+ *         tab B で /home リロード後に反映されること (#143 修正後確認)
+ */
+test("W5A-1: タブA で食事完了 toggle → タブB /home リロードで反映", async ({ browser }, testInfo) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctxA);
+    const pageB = await loginInContext(ctxB);
+
+    // タブ B: /home を開いて初期状態を記録
+    await pageB.goto("/home");
+    await pageB.waitForLoadState("networkidle");
+    await attach(pageB, testInfo, "W5A-1: タブB 初期 /home");
+
+    // タブ A: /home に移動してチェックボックスを探す
+    await pageA.goto("/home");
+    await pageA.waitForLoadState("networkidle");
+    await attach(pageA, testInfo, "W5A-1: タブA 初期 /home");
+
+    // 食事完了チェックボックスを探す
+    const checkbox = pageA
+      .locator('[data-testid="meal-checkbox"], input[type="checkbox"], button[role="checkbox"]')
+      .first();
+    const checkboxVisible = await checkbox.isVisible({ timeout: 5_000 }).catch(() => false);
+
+    if (!checkboxVisible) {
+      testInfo.annotations.push({
+        type: "skip-reason",
+        description: "W5A-1: 食事チェックボックスが見つからない (献立未生成の可能性)",
+      });
+      return;
+    }
+
+    // 初期状態を記録してトグル
+    const initialChecked = await checkbox.getAttribute("aria-checked").catch(() => null);
+
+    await Promise.race([
+      checkbox.click().then(() =>
+        pageA.waitForResponse(
+          (res) =>
+            res.url().includes("/api/") || res.url().includes("supabase"),
+          { timeout: 10_000 }
+        )
+      ),
+      new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
+    ]).catch(() => {});
+
+    await attach(pageA, testInfo, "W5A-1: タブA チェック後");
+
+    // タブ B: /home をリロードして反映確認
+    await pageB.reload();
+    await pageB.waitForLoadState("networkidle");
+    await attach(pageB, testInfo, "W5A-1: タブB リロード後");
+
+    // エラーが出ていないことを確認
+    const hasError = await pageB.locator("text=エラー").isVisible().catch(() => false);
+    expect(hasError, "タブB /home リロード後にエラーが表示されない").toBe(false);
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5A-1: 食事完了toggle後タブBリロード正常。初期checked=${initialChecked}`,
+    });
+  } finally {
+    await ctxA.close();
+    await ctxB.close();
+  }
+});
+
+/**
+ * W5A-2: tab A で signOut → tab B が BroadcastChannel 経由で即時 /login へリダイレクト (#145)
+ *         同一コンテキスト (= 同じ Cookie) で確認する。
+ */
+test("W5A-2: タブA signOut → タブB が BroadcastChannel で /login にリダイレクト", async ({ browser }, testInfo) => {
+  // 同一コンテキスト = 同一ブラウザセッション
+  const ctx = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctx);
+
+    // タブ B を同じコンテキストで開く (/home を表示)
+    const pageB = await ctx.newPage();
+    await pageB.goto("/home");
+    await pageB.waitForLoadState("networkidle");
+    await attach(pageB, testInfo, "W5A-2: タブB signOut前");
+
+    // BroadcastChannel の利用可能確認
+    const bcAvailableB = await pageB.evaluate(() => typeof BroadcastChannel !== "undefined");
+    expect(bcAvailableB, "タブB で BroadcastChannel が利用可能").toBe(true);
+
+    // タブ A: /settings からサインアウト
+    await pageA.goto("/settings");
+    await pageA.waitForLoadState("networkidle");
+
+    const logoutBtn = pageA
+      .getByRole("button", { name: /ログアウト/ })
+      .or(pageA.locator("button").filter({ hasText: /ログアウト/ }))
+      .first();
+
+    const logoutVisible = await logoutBtn.isVisible({ timeout: 8_000 }).catch(() => false);
+    if (!logoutVisible) {
+      // BroadcastChannel の実装確認だけ行う
+      const bcAvailableA = await pageA.evaluate(() => typeof BroadcastChannel !== "undefined");
+      expect(bcAvailableA, "BroadcastChannel が利用可能").toBe(true);
+      testInfo.annotations.push({
+        type: "skip-reason",
+        description: "W5A-2: ログアウトボタンが見つからないため、BroadcastChannel 存在確認のみ実施",
+      });
+      return;
+    }
+
+    pageA.on("dialog", (d) => d.accept());
+    await logoutBtn.click();
+
+    const confirmBtn = pageA.locator("button").filter({ hasText: /^ログアウト$/ }).last();
+    const confirmVisible = await confirmBtn.isVisible({ timeout: 3_000 }).catch(() => false);
+    if (confirmVisible) await confirmBtn.click();
+
+    // タブ A が /login にリダイレクト
+    await pageA.waitForURL((url) => url.pathname.startsWith("/login"), { timeout: 20_000 });
+    await attach(pageA, testInfo, "W5A-2: タブA signOut後 /login");
+
+    // タブ B: BroadcastChannel 経由で /login にリダイレクトされるか確認
+    const redirected = await pageB
+      .waitForURL((url) => url.pathname.startsWith("/login"), { timeout: 8_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    await attach(pageB, testInfo, "W5A-2: タブB BroadcastChannel後");
+
+    if (!redirected) {
+      testInfo.annotations.push({
+        type: "issue",
+        description: "[multi-tab][adversarial] W5A-2: タブA signOut後、タブBが /login にリダイレクトされなかった。BroadcastChannel の伝播不良の可能性",
+      });
+    } else {
+      expect(pageB.url()).toContain("/login");
+      testInfo.annotations.push({
+        type: "result",
+        description: "W5A-2: BroadcastChannel signOut 伝播 OK",
+      });
+    }
+  } finally {
+    await ctx.close();
+  }
+});
+
+/**
+ * W5A-3: tab A で設定の通知 toggle → tab B リロード後に反映
+ */
+test("W5A-3: タブA で通知 toggle → タブB リロードで設定同期", async ({ browser }, testInfo) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctxA);
+    const pageB = await loginInContext(ctxB);
+
+    // 両タブで /settings を開く
+    await Promise.all([pageA.goto("/settings"), pageB.goto("/settings")]);
+    await Promise.all([
+      pageA.waitForLoadState("networkidle"),
+      pageB.waitForLoadState("networkidle"),
+    ]);
+
+    // 通知スイッチを探す
+    const getSwitch = (page: Page) =>
+      page
+        .locator("div.flex.items-center.justify-between", {
+          has: page.locator("span", { hasText: "通知" }),
+        })
+        .first()
+        .locator("button")
+        .first();
+
+    const switchA = getSwitch(pageA);
+    const switchAVisible = await switchA.isVisible({ timeout: 8_000 }).catch(() => false);
+
+    if (!switchAVisible) {
+      testInfo.annotations.push({
+        type: "skip-reason",
+        description: "W5A-3: 通知スイッチが見つからないためスキップ",
+      });
+      return;
+    }
+
+    const getChecked = async (sw: any) => {
+      const cls = (await sw.getAttribute("class").catch(() => "")) ?? "";
+      return cls.includes("bg-[#FF8A65]") || cls.includes("bg-orange") || cls.includes("bg-accent");
+    };
+
+    const beforeA = await getChecked(switchA);
+    await attach(pageA, testInfo, "W5A-3: タブA toggle前");
+    await attach(pageB, testInfo, "W5A-3: タブB 変更前");
+
+    // タブ A で toggle (API レスポンスを待つ)
+    await Promise.race([
+      Promise.all([
+        pageA
+          .waitForResponse(
+            (res) =>
+              res.url().includes("/api/notification") && res.request().method() !== "GET",
+            { timeout: 20_000 }
+          )
+          .catch(() => {}),
+        switchA.click(),
+      ]),
+      new Promise((resolve) => setTimeout(resolve, 5_000)),
+    ]);
+
+    await attach(pageA, testInfo, "W5A-3: タブA toggle後");
+
+    // タブ B をリロード
+    await pageB.reload();
+    await pageB.waitForLoadState("networkidle");
+    await attach(pageB, testInfo, "W5A-3: タブB リロード後");
+
+    const switchBAfter = getSwitch(pageB);
+    const afterA = await getChecked(switchA);
+    const afterB = await getChecked(switchBAfter);
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5A-3: 変更前A=${beforeA} → 変更後A=${afterA}, リロード後B=${afterB}`,
+    });
+
+    if (afterA !== afterB) {
+      testInfo.annotations.push({
+        type: "issue",
+        description: `[multi-tab][adversarial] W5A-3: 通知設定がタブBに反映されていない。タブA=${afterA}, タブB=${afterB}`,
+      });
+    }
+
+    // クリーンアップ: 元に戻す
+    if (afterA !== beforeA) {
+      await switchA.click().catch(() => {});
+    }
+  } finally {
+    await ctxA.close();
+    await ctxB.close();
+  }
+});
+
+/**
+ * W5A-4: tab A で /menus/weekly AI 生成中 → tab B でも進捗状態の localStorage が存在する
+ *         (同一コンテキストの場合 localStorage 共有されるため)
+ */
+test("W5A-4: 同一コンテキストで /menus/weekly 生成中の localStorage が他タブでも見える", async ({ browser }, testInfo) => {
+  const ctx = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctx);
+
+    // タブ B を同一コンテキストで開く
+    const pageB = await ctx.newPage();
+    await pageB.goto("/menus/weekly");
+    await pageB.waitForLoadState("networkidle");
+
+    // タブ A: /menus/weekly を開く
+    await pageA.goto("/menus/weekly");
+    await pageA.waitForLoadState("networkidle");
+
+    // タブ A: localStorage に生成中状態をシミュレート
+    const fakeGeneratingState = JSON.stringify({
+      requestId: "test-req-id-12345",
+      timestamp: Date.now(),
+      totalSlots: 7,
+    });
+    await pageA.evaluate((val) => {
+      localStorage.setItem("v4MenuGenerating", val);
+    }, fakeGeneratingState);
+
+    // タブ B: 同一コンテキストなので同じ localStorage を読める
+    const tabBValue = await pageB.evaluate(() => localStorage.getItem("v4MenuGenerating"));
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5A-4: タブB で読んだ v4MenuGenerating = ${tabBValue}`,
+    });
+
+    if (tabBValue !== null) {
+      // 同一コンテキストなので共有されていることが正常
+      expect(tabBValue).toBe(fakeGeneratingState);
+      testInfo.annotations.push({
+        type: "info",
+        description: "W5A-4: 同一コンテキスト内でlocalStorage が共有されている (正常動作)",
+      });
+    } else {
+      testInfo.annotations.push({
+        type: "issue",
+        description: "[multi-tab][adversarial] W5A-4: 同一コンテキスト内なのに localStorage が共有されていない。予期しない動作",
+      });
+    }
+
+    // クリーンアップ
+    await pageA.evaluate(() => localStorage.removeItem("v4MenuGenerating"));
+  } finally {
+    await ctx.close();
+  }
+});
+
+/**
+ * W5A-5: tab A で /profile 編集 (ニックネーム保存) → tab B の /home リロードで反映
+ */
+test("W5A-5: タブA でプロフィール編集 → タブB /home リロードで反映", async ({ browser }, testInfo) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctxA);
+    const pageB = await loginInContext(ctxB);
+
+    // タブ B: /home を開く
+    await pageB.goto("/home");
+    await pageB.waitForLoadState("networkidle");
+    await attach(pageB, testInfo, "W5A-5: タブB /home 更新前");
+
+    // タブ A: /profile を開く
+    await pageA.goto("/profile");
+    await pageA.waitForLoadState("networkidle");
+    await attach(pageA, testInfo, "W5A-5: タブA /profile");
+
+    // ニックネーム入力フィールドを探す
+    const nicknameInput = pageA
+      .locator('input[name="nickname"], input[placeholder*="ニックネーム"], input[placeholder*="名前"]')
+      .first();
+    const inputVisible = await nicknameInput.isVisible({ timeout: 8_000 }).catch(() => false);
+
+    if (!inputVisible) {
+      testInfo.annotations.push({
+        type: "skip-reason",
+        description: "W5A-5: ニックネーム入力が見つからないためスキップ",
+      });
+      return;
+    }
+
+    // 一時的なニックネームを設定
+    const testNickname = `テストユーザー${Date.now().toString().slice(-4)}`;
+    await nicknameInput.fill(testNickname);
+    await attach(pageA, testInfo, "W5A-5: タブA ニックネーム入力後");
+
+    // 保存
+    const saveBtn = pageA.getByRole("button", { name: /保存|更新|save/i }).first();
+    const saveBtnVisible = await saveBtn.isVisible({ timeout: 5_000 }).catch(() => false);
+
+    if (saveBtnVisible) {
+      await Promise.race([
+        saveBtn.click().then(() =>
+          pageA
+            .waitForResponse(
+              (res) =>
+                (res.url().includes("/api/profile") || res.url().includes("user_profiles")) &&
+                res.request().method() !== "GET",
+              { timeout: 15_000 }
+            )
+            .catch(() => {})
+        ),
+        new Promise((resolve) => setTimeout(resolve, 8_000)),
+      ]);
+    }
+
+    await attach(pageA, testInfo, "W5A-5: タブA 保存後");
+
+    // タブ B: /home をリロード
+    await pageB.reload();
+    await pageB.waitForLoadState("networkidle");
+    await attach(pageB, testInfo, "W5A-5: タブB /home リロード後");
+
+    const hasError = await pageB.locator("text=エラー").isVisible().catch(() => false);
+    expect(hasError, "タブB /home リロード後にエラーが表示されない").toBe(false);
+
+    // ニックネームが /home に表示されているか確認
+    const nicknameOnHome = await pageB.locator(`text=${testNickname}`).isVisible({ timeout: 3_000 }).catch(() => false);
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5A-5: ニックネーム="${testNickname}" がタブB /home に表示=${nicknameOnHome}`,
+    });
+  } finally {
+    await ctxA.close();
+    await ctxB.close();
+  }
+});
+
+/**
+ * W5A-6: tab A でアカウント削除を開始 → tab B の挙動 (エラーなく /login にリダイレクト)
+ */
+test("W5A-6: タブA アカウント削除後 タブB が適切に処理される", async ({ browser }, testInfo) => {
+  // 注意: 実際のアカウント削除は行わない。削除確認モーダルまでのフローを確認する
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctxA);
+    const pageB = await loginInContext(ctxB);
+
+    // タブ B: /home を開く
+    await pageB.goto("/home");
+    await pageB.waitForLoadState("networkidle");
+
+    // タブ A: /settings → アカウント削除セクションを確認
+    await pageA.goto("/settings");
+    await pageA.waitForLoadState("networkidle");
+    await attach(pageA, testInfo, "W5A-6: タブA /settings");
+
+    // アカウント削除ボタンを探す (実際には押さない)
+    const deleteBtn = pageA
+      .locator("button")
+      .filter({ hasText: /アカウント.*(削除|退会)|退会|delete account/i })
+      .first();
+    const deleteBtnVisible = await deleteBtn.isVisible({ timeout: 5_000 }).catch(() => false);
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5A-6: アカウント削除ボタンが存在する=${deleteBtnVisible}`,
+    });
+
+    if (deleteBtnVisible) {
+      // ボタンが存在することを確認 (クリックはしない)
+      expect(deleteBtnVisible, "アカウント削除ボタンが /settings に存在する").toBe(true);
+      testInfo.annotations.push({
+        type: "info",
+        description: "W5A-6: アカウント削除ボタン確認済み。実際の削除はスキップ (破壊的操作のため)",
+      });
+    } else {
+      testInfo.annotations.push({
+        type: "info",
+        description: "W5A-6: アカウント削除ボタンが見つからない (権限外 or 別ページ)",
+      });
+    }
+
+    // タブ B がまだ正常に表示されていることを確認
+    const hasError = await pageB.locator("text=エラー").isVisible().catch(() => false);
+    expect(hasError, "タブB が影響を受けていない").toBe(false);
+  } finally {
+    await ctxA.close();
+    await ctxB.close();
+  }
+});
+
+// ============================================================
+// B. 同一ユーザー / 別デバイス (別コンテキストで模倣)
+// ============================================================
+
+/**
+ * W5B-7: モバイルサイズで signin → デスクトップ側で同じユーザーの状態確認
+ */
+test("W5B-7: モバイル viewport でサインイン → デスクトップ viewport で同一ユーザー状態確認", async ({ browser }, testInfo) => {
+  const ctxMobile = await browser.newContext({
+    viewport: { width: 390, height: 844 }, // iPhone 14
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+  });
+  const ctxDesktop = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+  });
+  try {
+    const pageMobile = await loginInContext(ctxMobile);
+    const pageDesktop = await loginInContext(ctxDesktop);
+
+    // モバイル: /home を開く
+    await pageMobile.goto("/home");
+    await pageMobile.waitForLoadState("networkidle");
+    await attach(pageMobile, testInfo, "W5B-7: モバイル /home");
+
+    // デスクトップ: /home を開く
+    await pageDesktop.goto("/home");
+    await pageDesktop.waitForLoadState("networkidle");
+    await attach(pageDesktop, testInfo, "W5B-7: デスクトップ /home");
+
+    // 両端でエラーが出ていないこと
+    const mobileError = await pageMobile.locator("text=エラー").isVisible().catch(() => false);
+    const desktopError = await pageDesktop.locator("text=エラー").isVisible().catch(() => false);
+
+    expect(mobileError, "モバイルでエラーが表示されない").toBe(false);
+    expect(desktopError, "デスクトップでエラーが表示されない").toBe(false);
+
+    // モバイルではボトムナビが表示されているか
+    const bottomNav = await pageMobile.locator(".fixed.bottom-4").isVisible({ timeout: 3_000 }).catch(() => false);
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5B-7: モバイルボトムナビ表示=${bottomNav}、両端でエラーなし`,
+    });
+  } finally {
+    await ctxMobile.close();
+    await ctxDesktop.close();
+  }
+});
+
+/**
+ * W5B-9: 別デバイス（コンテキスト A）で食事記録 → デバイス B で /home リロード後に反映
+ */
+test("W5B-9: 別デバイス(A)で食事記録 → デバイス(B) /home リロードで反映", async ({ browser }, testInfo) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctxA);
+    const pageB = await loginInContext(ctxB);
+
+    // デバイス B: /home の初期状態
+    await pageB.goto("/home");
+    await pageB.waitForLoadState("networkidle");
+    await attach(pageB, testInfo, "W5B-9: デバイスB 記録前");
+
+    // デバイス A: /home に移動して食事チェック
+    await pageA.goto("/home");
+    await pageA.waitForLoadState("networkidle");
+
+    const checkbox = pageA
+      .locator('[role="checkbox"], input[type="checkbox"]')
+      .first();
+    const checkboxVisible = await checkbox.isVisible({ timeout: 5_000 }).catch(() => false);
+
+    if (!checkboxVisible) {
+      testInfo.annotations.push({
+        type: "skip-reason",
+        description: "W5B-9: 食事チェックボックスが見つからないためスキップ",
+      });
+      return;
+    }
+
+    await checkbox.click().catch(() => {});
+    await pageA.waitForTimeout(2_000);
+    await attach(pageA, testInfo, "W5B-9: デバイスA チェック後");
+
+    // デバイス B: /home リロード
+    await pageB.reload();
+    await pageB.waitForLoadState("networkidle");
+    await attach(pageB, testInfo, "W5B-9: デバイスB リロード後");
+
+    const hasError = await pageB.locator("text=エラー").isVisible().catch(() => false);
+    expect(hasError, "デバイスBにエラーなし").toBe(false);
+
+    testInfo.annotations.push({
+      type: "result",
+      description: "W5B-9: 別コンテキストで食事記録後、デバイスBリロードで正常表示",
+    });
+  } finally {
+    await ctxA.close();
+    await ctxB.close();
+  }
+});
+
+// ============================================================
+// C. 同時編集 / collision
+// ============================================================
+
+/**
+ * W5C-11: tab A と tab B で同じ献立スロットを同時編集 → DB の最終状態が一貫している
+ */
+test("W5C-11: 2 タブで同じ献立スロットを同時編集 → 最後書き込みが勝つ (LWW 確認)", async ({ browser }, testInfo) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctxA);
+    const pageB = await loginInContext(ctxB);
+
+    // 両タブ: /menus/weekly を開く
+    await Promise.all([pageA.goto("/menus/weekly"), pageB.goto("/menus/weekly")]);
+    await Promise.all([
+      pageA.waitForLoadState("networkidle"),
+      pageB.waitForLoadState("networkidle"),
+    ]);
+
+    await attach(pageA, testInfo, "W5C-11: タブA 編集前");
+    await attach(pageB, testInfo, "W5C-11: タブB 編集前");
+
+    // 編集ボタンを探す
+    const editBtnA = pageA
+      .locator('[data-testid="meal-edit-btn"], button[aria-label*="編集"]')
+      .or(pageA.locator('button:has(.lucide-pencil)'))
+      .first();
+    const editBtnB = pageB
+      .locator('[data-testid="meal-edit-btn"], button[aria-label*="編集"]')
+      .or(pageB.locator('button:has(.lucide-pencil)'))
+      .first();
+
+    const [editAVisible, editBVisible] = await Promise.all([
+      editBtnA.isVisible({ timeout: 5_000 }).catch(() => false),
+      editBtnB.isVisible({ timeout: 5_000 }).catch(() => false),
+    ]);
+
+    if (!editAVisible || !editBVisible) {
+      testInfo.annotations.push({
+        type: "skip-reason",
+        description: "W5C-11: 編集ボタンが見つからない (献立未生成の可能性)",
+      });
+      return;
+    }
+
+    // 並列で両タブから編集開始
+    const [resA, resB] = await Promise.allSettled([
+      (async () => {
+        await editBtnA.click();
+        await pageA.waitForTimeout(300);
+        return "tabA-edit-opened";
+      })(),
+      (async () => {
+        await pageB.waitForTimeout(150); // 微小ずらして競合状態を作る
+        await editBtnB.click();
+        await pageB.waitForTimeout(300);
+        return "tabB-edit-opened";
+      })(),
+    ]);
+
+    await attach(pageA, testInfo, "W5C-11: タブA 編集後");
+    await attach(pageB, testInfo, "W5C-11: タブB 編集後");
+
+    // エラー表示の確認
+    const errorA = await pageA.locator("text=エラー").isVisible().catch(() => false);
+    const errorB = await pageB.locator("text=エラー").isVisible().catch(() => false);
+
+    if (errorA || errorB) {
+      testInfo.annotations.push({
+        type: "issue",
+        description: `[multi-tab][adversarial] W5C-11: 同時編集でエラー表示。タブA=${errorA}, タブB=${errorB}`,
+      });
+    }
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5C-11: 同時編集結果 - タブA=${resA.status}, タブB=${resB.status}, エラーA=${errorA}, エラーB=${errorB}`,
+    });
+  } finally {
+    await ctxA.close();
+    await ctxB.close();
+  }
+});
+
+/**
+ * W5C-12: お気に入り toggle を 2 タブで同時実行 → DB の状態が一貫していること
+ */
+test("W5C-12: 2 タブで同じお気に入りを同時 toggle → race condition 確認", async ({ browser }, testInfo) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctxA);
+    const pageB = await loginInContext(ctxB);
+
+    await Promise.all([pageA.goto("/menus/weekly"), pageB.goto("/menus/weekly")]);
+    await Promise.all([
+      pageA.waitForLoadState("networkidle"),
+      pageB.waitForLoadState("networkidle"),
+    ]);
+
+    // レシピボタンを探す
+    const recipeBtnA = pageA.locator("text=レシピを見る").first();
+    const hasRecipeA = await recipeBtnA.isVisible({ timeout: 5_000 }).catch(() => false);
+
+    if (!hasRecipeA) {
+      testInfo.annotations.push({
+        type: "skip-reason",
+        description: "W5C-12: レシピデータが見つからないためスキップ",
+      });
+      return;
+    }
+
+    await recipeBtnA.click();
+    const favBtnA = pageA.locator('[data-testid="favorite-button"]');
+    await expect(favBtnA).toBeVisible({ timeout: 8_000 });
+
+    const recipeBtnB = pageB.locator("text=レシピを見る").first();
+    const hasRecipeB = await recipeBtnB.isVisible({ timeout: 5_000 }).catch(() => false);
+    if (!hasRecipeB) {
+      testInfo.annotations.push({
+        type: "skip-reason",
+        description: "W5C-12: タブBでレシピが見つからないためスキップ",
+      });
+      return;
+    }
+
+    await recipeBtnB.click();
+    const favBtnB = pageB.locator('[data-testid="favorite-button"]');
+    await expect(favBtnB).toBeVisible({ timeout: 8_000 });
+
+    const pressedBeforeA = await favBtnA.getAttribute("aria-pressed").catch(() => "unknown");
+    await attach(pageA, testInfo, "W5C-12: タブA toggle前");
+    await attach(pageB, testInfo, "W5C-12: タブB toggle前");
+
+    // 同時 toggle
+    const [toggleA, toggleB] = await Promise.allSettled([
+      favBtnA.click(),
+      favBtnB.click(),
+    ]);
+
+    await Promise.all([pageA.waitForTimeout(2_000), pageB.waitForTimeout(2_000)]);
+
+    const pressedAfterA = await favBtnA.getAttribute("aria-pressed").catch(() => "unknown");
+    const pressedAfterB = await favBtnB.getAttribute("aria-pressed").catch(() => "unknown");
+
+    await attach(pageA, testInfo, "W5C-12: タブA toggle後");
+    await attach(pageB, testInfo, "W5C-12: タブB toggle後");
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5C-12: toggle前A=${pressedBeforeA}, toggle後A=${pressedAfterA}, toggle後B=${pressedAfterB}`,
+    });
+
+    if (pressedAfterA !== pressedAfterB) {
+      testInfo.annotations.push({
+        type: "issue",
+        description: `[multi-tab][adversarial] W5C-12: 同時お気に入りtoggle後の状態不一致。タブA=${pressedAfterA}, タブB=${pressedAfterB}。race conditionの可能性`,
+      });
+    }
+
+    // クリーンアップ
+    if (pressedAfterA === "true") {
+      await favBtnA.click().catch(() => {});
+    }
+  } finally {
+    await ctxA.close();
+    await ctxB.close();
+  }
+});
+
+/**
+ * W5C-13: 同じ日 / 同じ meal_type の食事記録を 2 タブで同時作成 → unique 制約確認
+ */
+test("W5C-13: 同日同 meal_type の食事記録を 2 タブで同時作成 → 重複エラーまたは upsert 確認", async ({ browser }, testInfo) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctxA);
+    const pageB = await loginInContext(ctxB);
+
+    const today = new Date().toISOString().split("T")[0];
+
+    // 両タブで /menus/weekly の「食事追加」UIを開く
+    await Promise.all([pageA.goto("/menus/weekly"), pageB.goto("/menus/weekly")]);
+    await Promise.all([
+      pageA.waitForLoadState("networkidle"),
+      pageB.waitForLoadState("networkidle"),
+    ]);
+
+    await attach(pageA, testInfo, "W5C-13: タブA 追加前");
+    await attach(pageB, testInfo, "W5C-13: タブB 追加前");
+
+    // 食事追加ボタンを探す
+    const addBtnA = pageA.locator("button").filter({ hasText: /追加|add/i }).first();
+    const addBtnB = pageB.locator("button").filter({ hasText: /追加|add/i }).first();
+
+    const addAVisible = await addBtnA.isVisible({ timeout: 5_000 }).catch(() => false);
+    const addBVisible = await addBtnB.isVisible({ timeout: 5_000 }).catch(() => false);
+
+    if (!addAVisible || !addBVisible) {
+      testInfo.annotations.push({
+        type: "skip-reason",
+        description: "W5C-13: 食事追加ボタンが見つからないためスキップ",
+      });
+      return;
+    }
+
+    // 並列で追加ボタンをクリック
+    const [resA, resB] = await Promise.allSettled([
+      addBtnA.click(),
+      addBtnB.click(),
+    ]);
+
+    await Promise.all([pageA.waitForTimeout(1_500), pageB.waitForTimeout(1_500)]);
+    await attach(pageA, testInfo, "W5C-13: タブA 追加クリック後");
+    await attach(pageB, testInfo, "W5C-13: タブB 追加クリック後");
+
+    // エラーダイアログまたはエラーメッセージの確認
+    const errorA = await pageA
+      .locator("text=/重複|既に存在|already exists|unique/i")
+      .isVisible({ timeout: 3_000 })
+      .catch(() => false);
+    const errorB = await pageB
+      .locator("text=/重複|既に存在|already exists|unique/i")
+      .isVisible({ timeout: 3_000 })
+      .catch(() => false);
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5C-13: 同時追加結果 - resA=${resA.status}, resB=${resB.status}, 重複エラーA=${errorA}, 重複エラーB=${errorB}`,
+    });
+
+    // どちらかでエラーが出る、または両方成功するが重複行は作られない
+    testInfo.annotations.push({
+      type: "info",
+      description: `W5C-13: 今日${today}の同時食事追加テスト完了。重複エラーが出なければupsertで一方が上書きされている`,
+    });
+  } finally {
+    await ctxA.close();
+    await ctxB.close();
+  }
+});
+
+/**
+ * W5C-14: 健康記録の同じ日付を 2 タブで同時作成 → DB の unique 制約 (user_id, record_date) 確認
+ */
+test("W5C-14: 健康記録を 2 タブで同日同時作成 → DB unique 制約 or upsert 動作確認", async ({ browser }, testInfo) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctxA);
+    const pageB = await loginInContext(ctxB);
+
+    // 両タブで /health/record を開く
+    await Promise.all([pageA.goto("/health/record"), pageB.goto("/health/record")]);
+    await Promise.all([
+      pageA.waitForLoadState("networkidle"),
+      pageB.waitForLoadState("networkidle"),
+    ]);
+
+    // 体重入力フィールドを探す
+    const weightA = pageA.locator('input[type="number"]').first().or(
+      pageA.locator('input[placeholder*="kg"]').first()
+    );
+    const weightB = pageB.locator('input[type="number"]').first().or(
+      pageB.locator('input[placeholder*="kg"]').first()
+    );
+
+    const [aVisible, bVisible] = await Promise.all([
+      weightA.isVisible({ timeout: 5_000 }).catch(() => false),
+      weightB.isVisible({ timeout: 5_000 }).catch(() => false),
+    ]);
+
+    if (!aVisible || !bVisible) {
+      testInfo.annotations.push({
+        type: "skip-reason",
+        description: "W5C-14: 健康記録入力フィールドが見つからないためスキップ",
+      });
+      return;
+    }
+
+    // 異なる値を入力して同時保存 (競合テスト)
+    await weightA.fill("70.1");
+    await weightB.fill("70.9");
+
+    const saveBtnA = pageA.getByRole("button", { name: /保存|記録/i }).first();
+    const saveBtnB = pageB.getByRole("button", { name: /保存|記録/i }).first();
+
+    await attach(pageA, testInfo, "W5C-14: タブA 入力後");
+    await attach(pageB, testInfo, "W5C-14: タブB 入力後");
+
+    // 並列で保存
+    const [saveA, saveB] = await Promise.allSettled([
+      saveBtnA.click().then(() =>
+        pageA
+          .waitForResponse(
+            (res) => res.url().includes("/api/health") && res.request().method() !== "GET",
+            { timeout: 15_000 }
+          )
+          .catch(() => {})
+      ),
+      saveBtnB.click().then(() =>
+        pageB
+          .waitForResponse(
+            (res) => res.url().includes("/api/health") && res.request().method() !== "GET",
+            { timeout: 15_000 }
+          )
+          .catch(() => {})
+      ),
+    ]);
+
+    await Promise.all([pageA.waitForTimeout(2_000), pageB.waitForTimeout(2_000)]);
+    await attach(pageA, testInfo, "W5C-14: タブA 保存後");
+    await attach(pageB, testInfo, "W5C-14: タブB 保存後");
+
+    const errorA = await pageA.locator("text=エラー").isVisible().catch(() => false);
+    const errorB = await pageB.locator("text=エラー").isVisible().catch(() => false);
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5C-14: 同時保存 - A=${saveA.status}(error=${errorA}), B=${saveB.status}(error=${errorB})`,
+    });
+
+    // 両方クラッシュしていないことを確認
+    const bodyA = await pageA.locator("body").isVisible();
+    const bodyB = await pageB.locator("body").isVisible();
+    expect(bodyA, "タブAのページが壊れていない").toBe(true);
+    expect(bodyB, "タブBのページが壊れていない").toBe(true);
+  } finally {
+    await ctxA.close();
+    await ctxB.close();
+  }
+});
+
+/**
+ * W5C-15: オンボーディングの質問を 2 タブで同時進行 → race condition 確認
+ */
+test("W5C-15: オンボーディング質問回答を 2 タブで同時進行 → 状態整合性確認", async ({ browser }, testInfo) => {
+  // オンボーディングが完了済みのユーザーの場合、/onboarding は /home へリダイレクトする
+  // ここでは /onboarding ページの挙動を 2 コンテキストで確認する
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctxA);
+    const pageB = await loginInContext(ctxB);
+
+    // 両タブで /onboarding にアクセス
+    await Promise.all([pageA.goto("/onboarding"), pageB.goto("/onboarding")]);
+    await Promise.all([
+      pageA.waitForLoadState("networkidle"),
+      pageB.waitForLoadState("networkidle"),
+    ]);
+
+    const urlA = pageA.url();
+    const urlB = pageB.url();
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5C-15: /onboarding アクセス後 - タブA URL=${urlA}, タブB URL=${urlB}`,
+    });
+
+    await attach(pageA, testInfo, "W5C-15: タブA /onboarding");
+    await attach(pageB, testInfo, "W5C-15: タブB /onboarding");
+
+    // オンボーディング完了済みならリダイレクトされているはず
+    if (urlA.includes("/home") || urlA.includes("/onboarding")) {
+      testInfo.annotations.push({
+        type: "info",
+        description: "W5C-15: /onboarding へのアクセス動作確認完了",
+      });
+    }
+
+    // エラーが出ていないこと
+    const errorA = await pageA.locator("text=エラー").isVisible().catch(() => false);
+    const errorB = await pageB.locator("text=エラー").isVisible().catch(() => false);
+    expect(errorA, "タブAにエラーなし").toBe(false);
+    expect(errorB, "タブBにエラーなし").toBe(false);
+  } finally {
+    await ctxA.close();
+    await ctxB.close();
+  }
+});
+
+// ============================================================
+// D. realtime subscription leak
+// ============================================================
+
+/**
+ * W5D-16: タブを 5 個開く → subscription 数の増加・コンソールエラー確認
+ *          (10 個は負荷が高いため 5 個に緩和)
+ */
+test("W5D-16: 5 タブで /menus/weekly を同時に開いてもコンソールエラーなし", async ({ browser }, testInfo) => {
+  const TAB_COUNT = 5;
+  const contexts: BrowserContext[] = [];
+  const pages: Page[] = [];
+
+  try {
+    // まず 1 つログイン
+    const ctxBase = await browser.newContext();
+    contexts.push(ctxBase);
+    const basePage = await loginInContext(ctxBase);
+
+    // 残りのタブを同一コンテキストで開く (同一ユーザーセッション)
+    for (let i = 1; i < TAB_COUNT; i++) {
+      const page = await ctxBase.newPage();
+      pages.push(page);
+    }
+    pages.unshift(basePage);
+
+    // 全タブで /menus/weekly を並列に開く
+    const consoleErrors: string[] = [];
+    pages.forEach((p, i) => {
+      p.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(`[Tab${i + 1}] ${msg.text()}`);
+        }
+      });
+    });
+
+    await Promise.all(pages.map((p) => p.goto("/menus/weekly")));
+    await Promise.all(pages.map((p) => p.waitForLoadState("networkidle").catch(() => {})));
+
+    // 3 秒待って subscription エラーが出ないか確認
+    await pages[0].waitForTimeout(3_000);
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5D-16: ${TAB_COUNT}タブ同時 /menus/weekly - コンソールエラー数=${consoleErrors.length}`,
+    });
+
+    if (consoleErrors.length > 0) {
+      testInfo.annotations.push({
+        type: "issue",
+        description: `[realtime][adversarial] W5D-16: ${TAB_COUNT}タブ開いた際にコンソールエラーが発生: ${consoleErrors.slice(0, 3).join("; ")}`,
+      });
+    }
+
+    // 各タブでエラー表示がないことを確認
+    for (let i = 0; i < pages.length; i++) {
+      const hasError = await pages[i].locator("text=エラー").isVisible().catch(() => false);
+      if (hasError) {
+        testInfo.annotations.push({
+          type: "issue",
+          description: `[realtime][adversarial] W5D-16: Tab${i + 1} でエラー表示`,
+        });
+      }
+    }
+
+    await attach(pages[0], testInfo, "W5D-16: Tab1 最終状態");
+  } finally {
+    for (const ctx of contexts) {
+      await ctx.close().catch(() => {});
+    }
+  }
+});
+
+/**
+ * W5D-17: タブを開いて閉じることを繰り返す → subscription cleanup 動作確認 (#120)
+ */
+test("W5D-17: タブ開閉を繰り返してもメモリリーク兆候がない (subscription cleanup 確認)", async ({ browser }, testInfo) => {
+  const ctx = await browser.newContext();
+  try {
+    // ベースページでログイン
+    const basePage = await loginInContext(ctx);
+    await basePage.goto("/menus/weekly");
+    await basePage.waitForLoadState("networkidle");
+
+    const errors: string[] = [];
+    basePage.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+
+    // 3 回タブを開いて閉じる
+    for (let round = 0; round < 3; round++) {
+      const tempPage = await ctx.newPage();
+      await tempPage.goto("/menus/weekly");
+      await tempPage.waitForLoadState("networkidle").catch(() => {});
+      await tempPage.waitForTimeout(1_000);
+      await tempPage.close();
+      await basePage.waitForTimeout(500);
+    }
+
+    // ベースページが引き続き正常動作していること
+    const isVisible = await basePage.locator("body").isVisible();
+    expect(isVisible, "ベースページが正常表示").toBe(true);
+
+    const hasError = await basePage.locator("text=エラー").isVisible().catch(() => false);
+    if (hasError) {
+      testInfo.annotations.push({
+        type: "issue",
+        description: "[realtime][adversarial] W5D-17: タブ開閉繰り返し後、ベースページにエラー表示",
+      });
+    }
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5D-17: 3回開閉後のコンソールエラー数=${errors.length}`,
+    });
+
+    if (errors.length > 0) {
+      testInfo.annotations.push({
+        type: "issue",
+        description: `[realtime][adversarial] W5D-17: タブ開閉繰り返し後にコンソールエラーが発生: ${errors.slice(0, 2).join("; ")}`,
+      });
+    }
+
+    await attach(basePage, testInfo, "W5D-17: ベースページ最終状態");
+  } finally {
+    await ctx.close();
+  }
+});
+
+/**
+ * W5D-18: signin → signout → signin を高速繰り返し → subscription が正常にクリーンアップされる
+ */
+test("W5D-18: signin → signout → signin 高速繰り返し → 状態が一貫している", async ({ browser }, testInfo) => {
+  const ctx = await browser.newContext();
+  try {
+    const page = await loginInContext(ctx);
+    await page.goto("/home");
+    await page.waitForLoadState("networkidle");
+    await attach(page, testInfo, "W5D-18: 初回ログイン後");
+
+    const errors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+
+    // 1 回だけサインアウト → サインインのサイクルを実行 (安全のため)
+    // /settings からサインアウト
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const logoutBtn = page
+      .getByRole("button", { name: /ログアウト/ })
+      .or(page.locator("button").filter({ hasText: /ログアウト/ }))
+      .first();
+    const logoutVisible = await logoutBtn.isVisible({ timeout: 8_000 }).catch(() => false);
+
+    if (!logoutVisible) {
+      testInfo.annotations.push({
+        type: "skip-reason",
+        description: "W5D-18: ログアウトボタンが見つからないためスキップ",
+      });
+      return;
+    }
+
+    page.on("dialog", (d) => d.accept());
+    await logoutBtn.click();
+
+    const confirmBtn = page.locator("button").filter({ hasText: /^ログアウト$/ }).last();
+    const confirmVisible = await confirmBtn.isVisible({ timeout: 3_000 }).catch(() => false);
+    if (confirmVisible) await confirmBtn.click();
+
+    await page.waitForURL((url) => url.pathname.startsWith("/login"), { timeout: 15_000 });
+    await attach(page, testInfo, "W5D-18: signout後 /login");
+
+    // 再サインイン
+    await page.locator("#email").fill(E2E_USER.email);
+    await page.locator("#password").fill(E2E_USER.password);
+    await Promise.all([
+      page.waitForURL(
+        (url) => !url.pathname.startsWith("/login") && !url.pathname.startsWith("/auth"),
+        { timeout: 25_000 }
+      ),
+      page.locator("button[type=submit]").click(),
+    ]);
+
+    await page.waitForLoadState("networkidle");
+    await attach(page, testInfo, "W5D-18: 再サインイン後");
+
+    // エラーが出ていないこと
+    const hasError = await page.locator("text=エラー").isVisible().catch(() => false);
+    expect(hasError, "再サインイン後にエラーなし").toBe(false);
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5D-18: signout→signin サイクル完了。コンソールエラー=${errors.length}件`,
+    });
+  } finally {
+    await ctx.close();
+  }
+});
+
+// ============================================================
+// E. session 同期
+// ============================================================
+
+/**
+ * W5E-19: session expire シミュレーション → middleware が /login にリダイレクト (#142)
+ */
+test("W5E-19: セッション Cookie 削除後に保護ページへのアクセスが /login にリダイレクト", async ({ browser }, testInfo) => {
+  const ctx = await browser.newContext();
+  try {
+    const page = await loginInContext(ctx);
+    await page.goto("/home");
+    await page.waitForLoadState("networkidle");
+    await attach(page, testInfo, "W5E-19: ログイン済み /home");
+
+    // セッション Cookie をクリアして session expire をシミュレート
+    await ctx.clearCookies();
+
+    // 別の保護ページにアクセス
+    await page.goto("/menus/weekly");
+    await page.waitForLoadState("networkidle");
+
+    const currentUrl = page.url();
+    const isOnLogin = currentUrl.includes("/login");
+
+    await attach(page, testInfo, "W5E-19: Cookie削除後のアクセス先");
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5E-19: Cookie削除後 /menus/weekly アクセス → URL=${currentUrl}, /login redirect=${isOnLogin}`,
+    });
+
+    if (!isOnLogin) {
+      testInfo.annotations.push({
+        type: "issue",
+        description: `[realtime][adversarial] W5E-19: セッションCookieクリア後も /menus/weekly にアクセス可能 (${currentUrl})。middleware が機能していない可能性`,
+      });
+    } else {
+      expect(isOnLogin, "セッション切れ後は /login にリダイレクト").toBe(true);
+    }
+  } finally {
+    await ctx.close();
+  }
+});
+
+/**
+ * W5E-20: token refresh の race condition を確認
+ *         2 コンテキストが同時に token refresh を試みても、どちらも正常に動作する
+ */
+test("W5E-20: 2 コンテキストが同時にトークンリフレッシュを行っても一方がエラーにならない", async ({ browser }, testInfo) => {
+  const ctxA = await browser.newContext();
+  const ctxB = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctxA);
+    const pageB = await loginInContext(ctxB);
+
+    // 両コンテキストで同時に認証が必要なページにアクセス (refresh を発火させる)
+    const errorsA: string[] = [];
+    const errorsB: string[] = [];
+    pageA.on("console", (msg) => { if (msg.type() === "error") errorsA.push(msg.text()); });
+    pageB.on("console", (msg) => { if (msg.type() === "error") errorsB.push(msg.text()); });
+
+    await Promise.all([
+      pageA.goto("/home"),
+      pageB.goto("/home"),
+    ]);
+    await Promise.all([
+      pageA.waitForLoadState("networkidle"),
+      pageB.waitForLoadState("networkidle"),
+    ]);
+
+    // 少し待ってコンソールエラーを収集
+    await Promise.all([pageA.waitForTimeout(2_000), pageB.waitForTimeout(2_000)]);
+
+    const urlA = pageA.url();
+    const urlB = pageB.url();
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5E-20: コンテキストA URL=${urlA}, B URL=${urlB}, エラーA=${errorsA.length}件, エラーB=${errorsB.length}件`,
+    });
+
+    // どちらも /home に到達しているべき
+    expect(urlA).not.toContain("/login");
+    expect(urlB).not.toContain("/login");
+
+    if (errorsA.length > 0 || errorsB.length > 0) {
+      testInfo.annotations.push({
+        type: "issue",
+        description: `[realtime][adversarial] W5E-20: 同時トークンリフレッシュでコンソールエラー。A=${errorsA.slice(0, 1)}, B=${errorsB.slice(0, 1)}`,
+      });
+    }
+  } finally {
+    await ctxA.close();
+    await ctxB.close();
+  }
+});
+
+// ============================================================
+// F. localStorage / sessionStorage 同期
+// ============================================================
+
+/**
+ * W5F-22: tab A で localStorage 書き込み → tab B (同一コンテキスト) で読める
+ *          別コンテキストでは読めないことも確認 (#141 quota 確認)
+ */
+test("W5F-22: localStorage は同一コンテキスト内タブで共有されるが別コンテキストでは独立している", async ({ browser }, testInfo) => {
+  const ctx = await browser.newContext();
+  const ctxOther = await browser.newContext();
+  try {
+    const pageA = await loginInContext(ctx);
+    await pageA.goto("/menus/weekly");
+    await pageA.waitForLoadState("networkidle");
+
+    // 同一コンテキストのタブ B
+    const pageB = await ctx.newPage();
+    await pageB.goto("/menus/weekly");
+    await pageB.waitForLoadState("networkidle");
+
+    // 別コンテキストのタブ C
+    const pageC = await loginInContext(ctxOther);
+    await pageC.goto("/menus/weekly");
+    await pageC.waitForLoadState("networkidle");
+
+    // タブ A: localStorage に値をセット
+    const testKey = "w5f22_test_key";
+    const testValue = `test_value_${Date.now()}`;
+    await pageA.evaluate(
+      ([k, v]) => localStorage.setItem(k, v),
+      [testKey, testValue]
+    );
+
+    // タブ B (同一コンテキスト): 読める
+    const valueInB = await pageB.evaluate((k) => localStorage.getItem(k), testKey);
+
+    // タブ C (別コンテキスト): 読めない
+    const valueInC = await pageC.evaluate((k) => localStorage.getItem(k), testKey);
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5F-22: タブB(同一ctx)=${valueInB}, タブC(別ctx)=${valueInC}`,
+    });
+
+    expect(valueInB, "同一コンテキスト内タブBで共有される").toBe(testValue);
+    expect(valueInC, "別コンテキストのタブCには伝播しない").toBeNull();
+
+    // クリーンアップ
+    await pageA.evaluate((k) => localStorage.removeItem(k), testKey);
+  } finally {
+    await ctx.close();
+    await ctxOther.close();
+  }
+});
+
+/**
+ * W5F-23: プライベートモード (incognito) で localStorage 書き込み失敗 → graceful 処理
+ *          safeLocalStorageSetItem の quota チェックを間接的に確認
+ */
+test("W5F-23: localStorage quota 超過時の graceful 処理 (safeLocalStorageSetItem)", async ({ browser }, testInfo) => {
+  const ctx = await browser.newContext();
+  try {
+    const page = await loginInContext(ctx);
+    await page.goto("/menus/weekly");
+    await page.waitForLoadState("networkidle");
+
+    const errors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+
+    // localStorage quota を強制的に超過させる (大量データを書き込む)
+    const quotaExceeded = await page.evaluate(async () => {
+      try {
+        // 5MB のダミーデータを書き込む
+        const bigData = "x".repeat(1024 * 1024); // 1MB
+        for (let i = 0; i < 5; i++) {
+          localStorage.setItem(`quota_test_${i}`, bigData);
+        }
+        return false; // quota に引っかからなかった
+      } catch (e: any) {
+        return e.name === "QuotaExceededError";
+      }
+    });
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5F-23: localStorage quota 超過テスト - 超過したか=${quotaExceeded}`,
+    });
+
+    // quota 超過後でもページがクラッシュしないこと
+    const bodyVisible = await page.locator("body").isVisible();
+    expect(bodyVisible, "quota超過後もページが存在する").toBe(true);
+
+    // safeLocalStorageSetItem の動作確認: 生成状態キーの書き込みエラーが console.warn レベルで扱われる
+    const criticalErrors = errors.filter(
+      (e) => !e.includes("localStorage") && !e.includes("quota")
+    );
+    if (criticalErrors.length > 0) {
+      testInfo.annotations.push({
+        type: "issue",
+        description: `[multi-tab][adversarial] W5F-23: quota超過後に予期しないエラー: ${criticalErrors.slice(0, 2).join("; ")}`,
+      });
+    }
+
+    // クリーンアップ
+    await page.evaluate(() => {
+      for (let i = 0; i < 5; i++) {
+        localStorage.removeItem(`quota_test_${i}`);
+      }
+    });
+
+    await attach(page, testInfo, "W5F-23: quota超過テスト後");
+  } finally {
+    await ctx.close();
+  }
+});
+
+// ============================================================
+// G. 異常な device 状態
+// ============================================================
+
+/**
+ * W5G-24: iPad のような大きめ viewport で split view 相当 (幅の狭い viewport) を 2 つ同時確認
+ */
+test("W5G-24: iPad split view 相当の viewport でアプリが正常動作する", async ({ browser }, testInfo) => {
+  // iPad Pro の半分程度の幅 (split view = 428px 程度)
+  const ctx1 = await browser.newContext({ viewport: { width: 428, height: 1024 } });
+  const ctx2 = await browser.newContext({ viewport: { width: 428, height: 1024 } });
+  try {
+    const page1 = await loginInContext(ctx1);
+    const page2 = await loginInContext(ctx2);
+
+    // 同時に /home と /menus/weekly を開く
+    await Promise.all([page1.goto("/home"), page2.goto("/menus/weekly")]);
+    await Promise.all([
+      page1.waitForLoadState("networkidle"),
+      page2.waitForLoadState("networkidle"),
+    ]);
+
+    await attach(page1, testInfo, "W5G-24: iPad split /home");
+    await attach(page2, testInfo, "W5G-24: iPad split /menus/weekly");
+
+    // エラーなし
+    const error1 = await page1.locator("text=エラー").isVisible().catch(() => false);
+    const error2 = await page2.locator("text=エラー").isVisible().catch(() => false);
+    expect(error1, "split view 1 でエラーなし").toBe(false);
+    expect(error2, "split view 2 でエラーなし").toBe(false);
+
+    // 横スクロールが発生していないか確認
+    const [scrollWidth1, clientWidth1] = await page1.evaluate(() => [
+      document.documentElement.scrollWidth,
+      document.documentElement.clientWidth,
+    ]);
+    const hasHorizontalScroll1 = scrollWidth1 > clientWidth1;
+
+    const [scrollWidth2, clientWidth2] = await page2.evaluate(() => [
+      document.documentElement.scrollWidth,
+      document.documentElement.clientWidth,
+    ]);
+    const hasHorizontalScroll2 = scrollWidth2 > clientWidth2;
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5G-24: 横スクロール - /home=${hasHorizontalScroll1}, /menus/weekly=${hasHorizontalScroll2}`,
+    });
+
+    if (hasHorizontalScroll1 || hasHorizontalScroll2) {
+      testInfo.annotations.push({
+        type: "issue",
+        description: `[multi-tab][adversarial] W5G-24: iPad split view (428px) で横スクロールが発生。レイアウト崩れの可能性`,
+      });
+    }
+  } finally {
+    await ctx1.close();
+    await ctx2.close();
+  }
+});
+
+/**
+ * W5G-25: ブラウザの back/forward を高速操作 → history API race condition 確認
+ */
+test("W5G-25: back/forward 高速操作で history API race condition が起きない", async ({ browser }, testInfo) => {
+  const ctx = await browser.newContext();
+  try {
+    const page = await loginInContext(ctx);
+
+    const errors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+
+    // 複数のページに順番にアクセスして履歴を積む
+    const routes = ["/home", "/menus/weekly", "/profile", "/settings"];
+    for (const route of routes) {
+      await page.goto(route);
+      await page.waitForLoadState("domcontentloaded").catch(() => {});
+    }
+
+    await attach(page, testInfo, "W5G-25: 複数ページ訪問後");
+
+    // 高速 back/forward を 5 回実行
+    for (let i = 0; i < 5; i++) {
+      await page.goBack({ timeout: 5_000 }).catch(() => {});
+      await page.waitForTimeout(200);
+    }
+
+    // 高速 forward を 5 回実行
+    for (let i = 0; i < 5; i++) {
+      await page.goForward({ timeout: 5_000 }).catch(() => {});
+      await page.waitForTimeout(200);
+    }
+
+    // 最終的なページ状態を確認
+    await page.waitForLoadState("networkidle").catch(() => {});
+    await attach(page, testInfo, "W5G-25: back/forward連打後");
+
+    const currentUrl = page.url();
+    const bodyVisible = await page.locator("body").isVisible();
+    expect(bodyVisible, "back/forward連打後もページが表示される").toBe(true);
+
+    const hasError = await page.locator("text=エラー").isVisible().catch(() => false);
+
+    testInfo.annotations.push({
+      type: "result",
+      description: `W5G-25: back/forward 連打後 URL=${currentUrl}, コンソールエラー=${errors.length}件, UI error=${hasError}`,
+    });
+
+    if (hasError || errors.length > 5) {
+      testInfo.annotations.push({
+        type: "issue",
+        description: `[multi-tab][adversarial] W5G-25: back/forward高速操作でエラー発生。UIエラー=${hasError}, コンソール=${errors.length}件`,
+      });
+    }
+  } finally {
+    await ctx.close();
+  }
+});


### PR DESCRIPTION
## 概要

G5 セキュリティクラスター 4件を修正します。

## 変更内容

### #272 [HIGH] SSRF 修正 (`src/lib/ai/gemini-json.ts`)
- `fetchImageAsBase64` に以下を追加:
  - hostname allowlist（`NEXT_PUBLIC_SUPABASE_URL` から動的取得 + 静的フォールバック）
  - private IP / link-local / localhost を拒否
  - `https:` プロトコル以外を拒否
  - `AbortSignal.timeout(10_000)` でタイムアウト設定

### #273 [MEDIUM] PostgREST injection 修正 (`src/app/api/admin/users/route.ts`)
- `.or('nickname.ilike.%${query}%,id.eq.${query}')` の生文字列埋め込みを廃止
- UUID 形式なら `.eq('id', query)`、それ以外は制御文字除去・長さ制限後に `.ilike('nickname', ...)` で安全分岐

### #274 [MEDIUM] rate limit 修正 (`src/app/api/contact/route.ts`)
- `@upstash/ratelimit` + `@upstash/redis` を導入
- `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` が設定されていれば sliding window 分散 ratelimit を使用
- env 未設定時は in-memory フォールバック + warn ログで継続動作
- TODO コメントで env 設定を促す

### #275 [LOW] CSP 修正 (`next.config.mjs`)
- `script-src` から `'unsafe-eval'` を削除
- `X-XSS-Protection: 1; mode=block` ヘッダーを追加
- `'unsafe-inline'` の nonce ベース移行は規模が大きいため別 issue で対応（本 issue で close）

## テスト計画

- [ ] TypeScript コンパイルエラーなし（`npx tsc --noEmit` 確認済み）
- [ ] `/api/ai/analyze-fridge` に非許可 URL を送信 → 400/500 エラーを返すこと
- [ ] `/api/admin/users?q=test)&id=eq.` のような injection パターン → 安全にフィルタされること
- [ ] `/api/contact` への連続リクエスト → 10回超で 429 を返すこと
- [ ] CSP ヘッダーに `unsafe-eval` が含まれないこと

## 関連 Issue

Closes #272, #273, #274, #275