### PR TITLE
fix(middleware): manifest.json と robots.txt を redirect 対象から除外 (#284)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@google/genai": "^1.44.0",
         "@supabase/ssr": "^0.1.0",
         "@supabase/supabase-js": "^2.78.0",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.37.0",
         "@vercel/functions": "^3.3.4",
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.24",
@@ -6892,6 +6894,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@urql/core": {
       "version": "5.2.0",
@@ -19143,6 +19178,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "6.22.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@google/genai": "^1.44.0",
     "@supabase/ssr": "^0.1.0",
     "@supabase/supabase-js": "^2.78.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.37.0",
     "@vercel/functions": "^3.3.4",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.24",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,9 +12,12 @@ export const config = {
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
+     * - manifest.json (PWA manifest — must not be redirected to /login)
+     * - robots.txt (crawler instructions)
+     * - sw.js / workbox-* (service worker files)
      * Feel free to modify this pattern to include more paths.
      */
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!_next/static|_next/image|favicon\\.ico|manifest\\.json|robots\\.txt|sw\\.js|workbox-|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 }
 


### PR DESCRIPTION
## Summary

- `src/middleware.ts` の `matcher` パターンに `manifest.json`、`robots.txt`、`sw.js`、`workbox-*` を除外対象として追加
- 未認証ユーザーの `/login` リダイレクトが PWA マニフェストおよびサービスワーカー関連ファイルに適用されなくなり、PWA インストールが正常に動作するようになる
- 修正方法は matcher 変更（early return よりシンプルで副作用が少ない）

Closes #284

## Test plan

- [ ] `/manifest.json` に未認証でアクセスして 200 が返ること（リダイレクトなし）
- [ ] `/robots.txt` に未認証でアクセスして 200 が返ること
- [ ] `/login` など保護ルートは引き続き未認証で `/login` にリダイレクトされること
- [ ] PWA インストールダイアログが表示されること