### PR TITLE
fix(catalog): pg_cron schedule + 手動 trigger API (#290 #291)

### DIFF
--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -15,6 +15,13 @@
    - `CRON_SECRET` - Vercel Cron からのリクエストを認証するシークレット（未設定の場合、cron エンドポイントは 503 を返す）
      - Vercel Dashboard → Settings → Environment Variables に設定
      - ランダムな英数字 32 文字以上を推奨
+   - `app.cron_secret` (Supabase DB GUC) - pg_cron から Edge Function を呼び出す際の Bearer トークン
+     - **設定方法**: Supabase Dashboard → SQL Editor で以下を実行:
+       ```sql
+       ALTER DATABASE postgres SET "app.cron_secret" = '<CRON_SECRET と同じ値>';
+       ```
+     - 設定後、Supabase プロジェクトの DB を再起動（または pg_cron worker を restart）すると反映される
+     - 未設定の場合 `current_setting('app.cron_secret', true)` は NULL を返し、Edge Function が 401 エラーになる
 
 4. **Google AI (Gemini) 関連**
    - `GOOGLE_AI_STUDIO_API_KEY` または `GOOGLE_GEN_AI_API_KEY` - Google AI APIキー

--- a/docs/convenience-catalog-architecture.md
+++ b/docs/convenience-catalog-architecture.md
@@ -570,6 +570,42 @@ OpenAI に任せないもの:
 - `src/app/api/catalog/products/[id]/route.ts`
 - `supabase/migrations/<timestamp>_create_catalog_tables.sql`
 
+## Current Cron Schedules
+
+以下のスケジュールが `supabase/migrations/20260430200000_catalog_cron_schedules.sql` で登録される。
+実行基盤は `pg_cron` + `pg_net` + `public.invoke_catalog_import()` ヘルパー関数。
+
+| ジョブ名 | Edge Function | スケジュール (UTC) | JST 換算 |
+|---|---|---|---|
+| `catalog-import-seven` | `import-seven-eleven-catalog` | 毎日 03:00 | 毎日 12:00 |
+| `catalog-import-familymart` | `import-familymart-catalog` | 毎日 03:15 | 毎日 12:15 |
+| `catalog-import-lawson` | `import-lawson-catalog` | 毎日 03:30 | 毎日 12:30 |
+| `catalog-import-natural-lawson` | `import-natural-lawson-catalog` | 毎日 03:45 | 毎日 12:45 |
+| `catalog-import-ministop` | `import-ministop-catalog` | 毎日 04:00 | 毎日 13:00 |
+
+### 手動 trigger API
+
+管理者は以下の API エンドポイントから任意のタイミングで取り込みを実行できる。
+
+```
+POST /api/admin/catalog/import
+Content-Type: application/json
+
+{ "sourceCode": "seven_eleven_jp" }
+```
+
+有効な `sourceCode` 値: `seven_eleven_jp`, `familymart_jp`, `lawson_jp`, `natural_lawson_jp`, `ministop_jp`
+
+実装: `src/app/api/admin/catalog/import/route.ts`
+
+### 前提: Dashboard 操作
+
+migration 適用前に Supabase Dashboard → Database → Extensions で以下を有効化する必要がある:
+- `pg_cron`
+- `pg_net`
+
+また `app.cron_secret` GUC を SQL Editor で設定する（`ENV_SETUP.md` 参照）。
+
 ## Operational Risks
 - robots.txt / 利用規約の確認が必要
 - 画像URL直参照が不安定なら storage へ保存する必要がある

--- a/src/app/api/admin/catalog/import/route.ts
+++ b/src/app/api/admin/catalog/import/route.ts
@@ -1,0 +1,67 @@
+// #291: 管理者向けカタログ手動インポート trigger API
+import { createClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+
+const SOURCE_TO_FUNCTION: Record<string, string> = {
+  seven_eleven_jp:  'import-seven-eleven-catalog',
+  familymart_jp:    'import-familymart-catalog',
+  lawson_jp:        'import-lawson-catalog',
+  natural_lawson_jp:'import-natural-lawson-catalog',
+  ministop_jp:      'import-ministop-catalog',
+};
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  // 認証確認
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  // 管理者ロール確認
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('roles')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  const isAdmin = profile?.roles?.some((r: string) =>
+    ['admin', 'super_admin'].includes(r)
+  );
+  if (!isAdmin) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+  }
+
+  // リクエスト body 検証
+  let body: { sourceCode?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const sourceCode = body.sourceCode;
+  if (!sourceCode || typeof sourceCode !== 'string') {
+    return NextResponse.json(
+      { error: 'invalid_source', validSources: Object.keys(SOURCE_TO_FUNCTION) },
+      { status: 400 }
+    );
+  }
+
+  const functionName = SOURCE_TO_FUNCTION[sourceCode];
+  if (!functionName) {
+    return NextResponse.json(
+      { error: 'invalid_source', validSources: Object.keys(SOURCE_TO_FUNCTION) },
+      { status: 400 }
+    );
+  }
+
+  // Edge Function を手動 trigger
+  const { data, error } = await supabase.functions.invoke(functionName, { body: {} });
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, sourceCode, functionName, result: data });
+}

--- a/supabase/migrations/20260430200000_catalog_cron_schedules.sql
+++ b/supabase/migrations/20260430200000_catalog_cron_schedules.sql
@@ -1,0 +1,79 @@
+-- #290: pg_cron + pg_net 拡張を有効化し、カタログ自動取り込みスケジュールを登録する
+-- 注意: pg_cron / pg_net は Supabase Dashboard → Database → Extensions で
+--       事前に「Enabled」状態にしてから、この migration を apply してください。
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- ---------------------------------------------------------------------------
+-- helper function: Edge Function を呼び出す共通ラッパー
+-- app.cron_secret は Supabase Dashboard → Settings → Database → Parameters で
+-- ALTER DATABASE postgres SET "app.cron_secret" = '<your-secret>' を実行して設定する
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.invoke_catalog_import(p_function_name text)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_url      text;
+  v_headers  jsonb;
+  v_request_id bigint;
+BEGIN
+  v_url := 'https://flmeolcfutuwwbjmzyoz.supabase.co/functions/v1/' || p_function_name;
+  v_headers := jsonb_build_object(
+    'Authorization', 'Bearer ' || current_setting('app.cron_secret', true),
+    'Content-Type',  'application/json'
+  );
+
+  SELECT net.http_post(
+    url     := v_url,
+    headers := v_headers,
+    body    := '{}'::jsonb
+  ) INTO v_request_id;
+
+  RETURN v_request_id;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- cron schedules — 毎日 3:00–4:00 UTC (JST 12:00–13:00)
+-- 既存の同名スケジュールがあれば unschedule してから再登録する
+-- ---------------------------------------------------------------------------
+
+SELECT cron.unschedule('catalog-import-seven')          WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'catalog-import-seven');
+SELECT cron.unschedule('catalog-import-familymart')      WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'catalog-import-familymart');
+SELECT cron.unschedule('catalog-import-lawson')          WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'catalog-import-lawson');
+SELECT cron.unschedule('catalog-import-natural-lawson')  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'catalog-import-natural-lawson');
+SELECT cron.unschedule('catalog-import-ministop')        WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'catalog-import-ministop');
+
+SELECT cron.schedule(
+  'catalog-import-seven',
+  '0 3 * * *',
+  $$ SELECT public.invoke_catalog_import('import-seven-eleven-catalog') $$
+);
+
+SELECT cron.schedule(
+  'catalog-import-familymart',
+  '15 3 * * *',
+  $$ SELECT public.invoke_catalog_import('import-familymart-catalog') $$
+);
+
+SELECT cron.schedule(
+  'catalog-import-lawson',
+  '30 3 * * *',
+  $$ SELECT public.invoke_catalog_import('import-lawson-catalog') $$
+);
+
+SELECT cron.schedule(
+  'catalog-import-natural-lawson',
+  '45 3 * * *',
+  $$ SELECT public.invoke_catalog_import('import-natural-lawson-catalog') $$
+);
+
+SELECT cron.schedule(
+  'catalog-import-ministop',
+  '0 4 * * *',
+  $$ SELECT public.invoke_catalog_import('import-ministop-catalog') $$
+);


### PR DESCRIPTION
## Summary

- **#290 [HIGH]**: `pg_cron` + `pg_net` 拡張を有効化し、5 コンビニ向けカタログ取り込みの cron job を登録する migration を追加
- **#291 [MEDIUM]**: 管理者が任意のタイミングで任意 source の取り込みを起動できる `POST /api/admin/catalog/import` を実装

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `supabase/migrations/20260430200000_catalog_cron_schedules.sql` | pg_cron/pg_net 有効化・helper 関数・5 schedules 登録 |
| `src/app/api/admin/catalog/import/route.ts` | 手動 trigger API (admin/super_admin ロール要求) |
| `ENV_SETUP.md` | `app.cron_secret` GUC 設定手順を追記 |
| `docs/convenience-catalog-architecture.md` | cron schedule 一覧・手動 API・Dashboard 前提を追記 |

## Cron スケジュール (UTC)

| ジョブ | 時刻 |
|---|---|
| `import-seven-eleven-catalog` | 毎日 03:00 |
| `import-familymart-catalog` | 毎日 03:15 |
| `import-lawson-catalog` | 毎日 03:30 |
| `import-natural-lawson-catalog` | 毎日 03:45 |
| `import-ministop-catalog` | 毎日 04:00 |

## Dashboard 操作 (migration apply 前に必要)

1. Supabase Dashboard → Database → Extensions → `pg_cron` / `pg_net` を有効化
2. SQL Editor で実行:
   ```sql
   ALTER DATABASE postgres SET "app.cron_secret" = '<CRON_SECRET と同じ値>';
   ```

## Test plan

- [ ] Dashboard で pg_cron / pg_net を有効化 → migration apply が成功すること
- [ ] `cron.job` テーブルに 5 件のジョブが登録されていること
- [ ] `POST /api/admin/catalog/import` に admin ユーザーで `{ "sourceCode": "seven_eleven_jp" }` を送信 → 200 が返ること
- [ ] 非 admin ユーザーで同 API を呼ぶと 403 が返ること
- [ ] 無効な `sourceCode` を送ると 400 + `validSources` が返ること

Closes #290 #291