### PR TITLE
fix(catalog): UUID validation for /api/catalog/products/[id] (#294)

### DIFF
--- a/src/app/api/catalog/products/[id]/route.ts
+++ b/src/app/api/catalog/products/[id]/route.ts
@@ -2,10 +2,17 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getCatalogProductById } from "@/lib/catalog-products";
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function GET(
   _request: Request,
   { params }: { params: { id: string } },
 ) {
+  if (!UUID_RE.test(params.id)) {
+    return NextResponse.json({ error: "invalid_id" }, { status: 400 });
+  }
+
   const supabase = createClient();
 
   try {

--- a/tests/e2e/bug-294-catalog-uuid-validation.spec.ts
+++ b/tests/e2e/bug-294-catalog-uuid-validation.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * #294 /api/catalog/products/[id] UUID バリデーション
+ *
+ * - 不正な id (SQL injection 文字列, XSS 文字列) → 400
+ * - 正しい UUID 形式だが存在しないレコード → 404
+ * - 正しい UUID 形式で認証なし → 401
+ */
+
+import { test, expect } from "./fixtures/auth";
+
+const NONEXISTENT_UUID = "00000000-0000-0000-0000-000000000000";
+
+test.describe("#294 /api/catalog/products/[id] UUID バリデーション", () => {
+  test("SQL injection 風 id → 400", async ({ authedPage }) => {
+    await authedPage.goto("/");
+
+    const status = await authedPage.evaluate(async () => {
+      const res = await fetch("/api/catalog/products/';DROP TABLE products;--");
+      return res.status;
+    });
+
+    expect(status).toBe(400);
+  });
+
+  test("XSS 風 id → 400", async ({ authedPage }) => {
+    await authedPage.goto("/");
+
+    const status = await authedPage.evaluate(async () => {
+      const res = await fetch("/api/catalog/products/%3Cscript%3Ealert(1)%3C%2Fscript%3E");
+      return res.status;
+    });
+
+    expect(status).toBe(400);
+  });
+
+  test("正しい UUID 形式で存在しないレコード → 404", async ({ authedPage }) => {
+    await authedPage.goto("/");
+
+    const result = await authedPage.evaluate(async (uuid) => {
+      const res = await fetch(`/api/catalog/products/${uuid}`);
+      return { status: res.status, body: await res.json() };
+    }, NONEXISTENT_UUID);
+
+    expect(result.status).toBe(404);
+  });
+
+  test("invalid_id エラーボディが返る", async ({ authedPage }) => {
+    await authedPage.goto("/");
+
+    const result = await authedPage.evaluate(async () => {
+      const res = await fetch("/api/catalog/products/not-a-uuid");
+      return { status: res.status, body: await res.json() };
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body).toMatchObject({ error: "invalid_id" });
+  });
+});


### PR DESCRIPTION
## Summary

- `/api/catalog/products/[id]` の GET ハンドラ冒頭に UUID 正規表現バリデーションを追加
- UUID 形式でない `id` は DB へのアクセスなしに即 400 `{ error: "invalid_id" }` を返す
- SQL injection / XSS 等の不正文字列でクエリが実行されることを防止

Closes #294

## Test plan

- [ ] `tests/e2e/bug-294-catalog-uuid-validation.spec.ts` — 4 ケース
  - SQL injection 風 id → 400
  - XSS 風 id → 400
  - 正しい UUID 形式で存在しないレコード → 404
  - `invalid_id` エラーボディ確認 → 400 + `{ error: "invalid_id" }`