### PR TITLE
ci: migration auto-deploy workflow

### DIFF
--- a/.github/workflows/deploy-supabase-migrations.yml
+++ b/.github/workflows/deploy-supabase-migrations.yml
@@ -1,0 +1,45 @@
+name: Deploy Supabase Migrations
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'supabase/migrations/**'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  SUPABASE_PROJECT_ID: flmeolcfutuwwbjmzyoz
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Verify Supabase CLI version
+        run: npx --yes supabase@2.62.10 --version
+
+      - name: Link Supabase project
+        run: |
+          npx --yes supabase@2.62.10 link --project-ref ${{ env.SUPABASE_PROJECT_ID }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Apply migrations
+        run: |
+          npx --yes supabase@2.62.10 db push --linked --include-all
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Verify migration list
+        run: |
+          npx --yes supabase@2.62.10 migration list --linked
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}

--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -254,6 +254,19 @@ cat .env.local
 
 ---
 
+## GitHub Actions secrets
+
+migration auto-deploy のため以下の Repository secrets が必要:
+
+- `SUPABASE_ACCESS_TOKEN`: Personal Access Token
+  https://supabase.com/dashboard/account/tokens で生成
+- `SUPABASE_DB_PASSWORD`: 本番 DB password
+  Project Settings → Database → Connection string で取得
+
+設定場所: GitHub リポジトリ → Settings → Secrets and variables → Actions → New repository secret
+
+---
+
 ## 📚 参考リンク
 
 - [Next.js Environment Variables](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables)


### PR DESCRIPTION
## Summary

- `supabase/migrations/**` が main に push されたら自動で `supabase db push` が走るようにする
- SQL Editor での手動実行による migration tracking ズレを防止
- ENV_SETUP.md に必要な Repository secrets の手順を追記

## 必要な secrets (user 設定)

GitHub リポジトリ → Settings → Secrets and variables → Actions で以下を登録:

- `SUPABASE_ACCESS_TOKEN` — https://supabase.com/dashboard/account/tokens で生成
- `SUPABASE_DB_PASSWORD` — Project Settings → Database → Connection string で取得

## Test plan

- [ ] secrets 登録後、`supabase/migrations/` 配下にファイルを push して Actions が起動することを確認
- [ ] `migration list` ステップで対象マイグレーションが `applied` 表示になることを確認