### PR TITLE
chore(migrations): remote → local 整合 (6 件 pull)

### DIFF
--- a/supabase/migrations/20260320042733_add_meal_image_jobs.sql
+++ b/supabase/migrations/20260320042733_add_meal_image_jobs.sql
@@ -1,0 +1,36 @@
+create table if not exists public.meal_image_jobs (
+  id uuid primary key default gen_random_uuid(),
+  planned_meal_id uuid not null references public.planned_meals(id) on delete cascade,
+  user_id uuid not null,
+  dish_index integer not null,
+  job_kind text not null default 'dish',
+  subject_hash text not null,
+  idempotency_key text not null,
+  prompt text not null,
+  model text not null,
+  reference_image_urls jsonb not null default '[]'::jsonb,
+  status text not null default 'pending',
+  attempt_count integer not null default 0,
+  priority integer not null default 100,
+  lease_token uuid null,
+  leased_until timestamptz null,
+  last_error text null,
+  result_image_url text null,
+  request_id uuid null,
+  trigger_source text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists meal_image_jobs_status_priority_created_idx
+  on public.meal_image_jobs (status, priority desc, created_at asc);
+
+create index if not exists meal_image_jobs_planned_meal_dish_idx
+  on public.meal_image_jobs (planned_meal_id, dish_index);
+
+create index if not exists meal_image_jobs_user_created_idx
+  on public.meal_image_jobs (user_id, created_at desc);
+
+create unique index if not exists meal_image_jobs_idempotency_pending_idx
+  on public.meal_image_jobs (idempotency_key)
+  where status in ('pending', 'processing');;

--- a/supabase/migrations/20260320042751_enable_meal_image_jobs_rls.sql
+++ b/supabase/migrations/20260320042751_enable_meal_image_jobs_rls.sql
@@ -1,0 +1,20 @@
+alter table public.meal_image_jobs enable row level security;
+
+create policy "meal_image_jobs_select_own"
+  on public.meal_image_jobs
+  for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+create policy "meal_image_jobs_insert_own"
+  on public.meal_image_jobs
+  for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "meal_image_jobs_update_own"
+  on public.meal_image_jobs
+  for update
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);;

--- a/supabase/migrations/20260402053616_create_iroca_measurements.sql
+++ b/supabase/migrations/20260402053616_create_iroca_measurements.sql
@@ -1,0 +1,95 @@
+
+-- IROCA測色データ管理テーブル
+-- 1行 = 1回のCxF3ファイルアップロード（M0/M1/M2の3条件を含む）
+
+CREATE TABLE iroca_measurements (
+  id bigserial PRIMARY KEY,
+  sample_name text NOT NULL,           -- ファイル名から取得（例: A-01_N3_white100）
+  meas_index int NOT NULL DEFAULT 1,   -- 5回測定の何回目か（1-5）
+  
+  -- M0スペクトル（380-730nm, 10nm刻み, 36値）
+  m0_spectrum float8[] NOT NULL,
+  -- M1スペクトル
+  m1_spectrum float8[],
+  -- M2スペクトル
+  m2_spectrum float8[],
+  
+  -- M0から計算したLab (D50/2°)
+  lab_l float8,
+  lab_a float8,
+  lab_b float8,
+  
+  -- sRGB変換値
+  srgb_r int,
+  srgb_g int,
+  srgb_b int,
+  hex_color text,
+  
+  -- M0-M1のΔE（蛍光QC用）
+  delta_e_m0m1 float8,
+  
+  -- メタデータ
+  device_serial text,
+  notes text,
+  raw_xml text,                         -- 元のCxF3 XML（監査用）
+  
+  created_at timestamptz NOT NULL DEFAULT now(),
+  
+  -- sample_name + meas_index でユニーク
+  UNIQUE(sample_name, meas_index)
+);
+
+-- 中央値スペクトル（5回測定から自動計算）のビュー用
+CREATE TABLE iroca_sample_summary (
+  id bigserial PRIMARY KEY,
+  sample_name text NOT NULL UNIQUE,
+  
+  -- 中央値スペクトル
+  median_spectrum float8[],
+  
+  -- 中央値Lab
+  median_lab_l float8,
+  median_lab_a float8,
+  median_lab_b float8,
+  
+  -- sRGB
+  srgb_r int,
+  srgb_g int,
+  srgb_b int,
+  hex_color text,
+  
+  -- 測定回数
+  measurement_count int DEFAULT 0,
+  
+  -- メタ
+  notes text,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 実験計画テーブル（170サンプルの計画を事前登録）
+CREATE TABLE iroca_experiment_plan (
+  id text PRIMARY KEY,                  -- A-01, B-33, E-28 等
+  seq_no int NOT NULL,                  -- 通し番号 1-170
+  phase text NOT NULL,                  -- A/B/C/D/E
+  drug text NOT NULL,                   -- N7, N7+B, Racc+Y7等
+  ratio text,                           -- 単品, 8:2, 1:1:1等
+  hair_type text NOT NULL,              -- 白髪100%, 黒髪0%, 白髪50%等
+  purpose text,                         -- K/S基礎, 混色曲線等
+  recipe_name text,                     -- Phase Eのレシピ名
+  status text DEFAULT 'pending',        -- pending/measured/analyzed
+  notes text
+);
+
+-- RLSを有効化（匿名アクセス許可：実験用なので）
+ALTER TABLE iroca_measurements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE iroca_sample_summary ENABLE ROW LEVEL SECURITY;
+ALTER TABLE iroca_experiment_plan ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow all on iroca_measurements" ON iroca_measurements FOR ALL USING (true) WITH CHECK (true);
+CREATE POLICY "Allow all on iroca_sample_summary" ON iroca_sample_summary FOR ALL USING (true) WITH CHECK (true);
+CREATE POLICY "Allow all on iroca_experiment_plan" ON iroca_experiment_plan FOR ALL USING (true) WITH CHECK (true);
+
+-- インデックス
+CREATE INDEX idx_iroca_meas_sample ON iroca_measurements(sample_name);
+CREATE INDEX idx_iroca_plan_phase ON iroca_experiment_plan(phase);
+;

--- a/supabase/migrations/20260429184654_add_recipe_likes.sql
+++ b/supabase/migrations/20260429184654_add_recipe_likes.sql
@@ -1,0 +1,30 @@
+-- recipe_likes: ユーザーがレシピにいいねできるテーブル
+-- recipe_id は dish.name (テキスト) を使用
+
+CREATE TABLE IF NOT EXISTS recipe_likes (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  recipe_id   TEXT        NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, recipe_id)
+);
+
+-- インデックス
+CREATE INDEX IF NOT EXISTS idx_recipe_likes_user_id   ON recipe_likes (user_id);
+CREATE INDEX IF NOT EXISTS idx_recipe_likes_recipe_id ON recipe_likes (recipe_id);
+
+-- RLS
+ALTER TABLE recipe_likes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own recipe likes"
+  ON recipe_likes FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own recipe likes"
+  ON recipe_likes FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own recipe likes"
+  ON recipe_likes FOR DELETE
+  USING (auth.uid() = user_id);
+;

--- a/supabase/migrations/20260429193923_add_menu_queue_columns.sql
+++ b/supabase/migrations/20260429193923_add_menu_queue_columns.sql
@@ -1,0 +1,37 @@
+-- weekly_menu_requests を queue として運用するための補助カラム
+ALTER TABLE weekly_menu_requests
+  ADD COLUMN IF NOT EXISTS worker_id TEXT NULL,
+  ADD COLUMN IF NOT EXISTS worker_acquired_at TIMESTAMPTZ NULL,
+  ADD COLUMN IF NOT EXISTS attempt_count INTEGER NOT NULL DEFAULT 0;
+
+-- queued 行を高速 pick するための部分インデックス
+CREATE INDEX IF NOT EXISTS idx_weekly_menu_requests_queued
+  ON weekly_menu_requests (created_at)
+  WHERE status = 'queued';
+
+-- atomic claim 関数
+CREATE OR REPLACE FUNCTION claim_menu_request(p_worker_id TEXT)
+RETURNS weekly_menu_requests AS $$
+DECLARE
+  v_row weekly_menu_requests;
+BEGIN
+  UPDATE weekly_menu_requests
+  SET status = 'processing',
+      worker_id = p_worker_id,
+      worker_acquired_at = now(),
+      attempt_count = attempt_count + 1
+  WHERE id = (
+    SELECT id FROM weekly_menu_requests
+    WHERE status = 'queued'
+       OR (status = 'processing' AND worker_acquired_at < now() - interval '5 minutes')
+    ORDER BY created_at ASC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED
+  )
+  RETURNING * INTO v_row;
+  RETURN v_row;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION claim_menu_request(TEXT) TO service_role;
+;

--- a/supabase/migrations/20260430004141_add_settings_toggle_columns_to_notification_preferences.sql
+++ b/supabase/migrations/20260430004141_add_settings_toggle_columns_to_notification_preferences.sql
@@ -1,0 +1,30 @@
+-- Issue #69: 通知/自動解析/データシェア toggle を永続化するためのカラム追加
+CREATE TABLE IF NOT EXISTS notification_preferences (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  UNIQUE (user_id)
+);
+
+ALTER TABLE notification_preferences ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'notification_preferences' AND policyname = 'own row'
+  ) THEN
+    CREATE POLICY "own row" ON notification_preferences
+      FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+  END IF;
+END
+$$;
+
+ALTER TABLE notification_preferences
+  ADD COLUMN IF NOT EXISTS notifications_enabled boolean NOT NULL DEFAULT true;
+ALTER TABLE notification_preferences
+  ADD COLUMN IF NOT EXISTS auto_analyze_enabled boolean NOT NULL DEFAULT true;
+ALTER TABLE notification_preferences
+  ADD COLUMN IF NOT EXISTS data_share_enabled boolean NOT NULL DEFAULT false;
+;


### PR DESCRIPTION
## 背景
GitHub Actions migration auto-deploy workflow が remote-only migration を検出して失敗。

## 修正
supabase migration fetch で remote にある 6 個を local に取り込み、履歴を整合。

対象 migration:
- 20260320042733_add_meal_image_jobs
- 20260320042751_enable_meal_image_jobs_rls
- 20260402053616_create_iroca_measurements
- 20260429184654_add_recipe_likes
- 20260429193923_add_menu_queue_columns
- 20260430004141_add_settings_toggle_columns_to_notification_preferences

## 影響
- DB schema 変更なし (既に remote に適用済み)
- 次回以降の workflow 実行で正常 db push 可能