### PR TITLE
fix(api): 4件のAPI 500エラーを修正

### DIFF
--- a/src/app/api/admin/inquiries/route.ts
+++ b/src/app/api/admin/inquiries/route.ts
@@ -25,12 +25,19 @@ export async function GET(request: Request) {
   const limit = parseInt(searchParams.get('limit') || '50');
   const offset = (page - 1) * limit;
 
+  // status / inquiryType の enum バリデーション
+  const ALLOWED_STATUSES = ['pending', 'in_progress', 'resolved', 'closed'];
+  if (status && !ALLOWED_STATUSES.includes(status)) {
+    return NextResponse.json({ error: 'Invalid status' }, { status: 400 });
+  }
+  const ALLOWED_INQUIRY_TYPES = ['general', 'bug_report', 'feature_request', 'billing', 'account', 'other'];
+  if (inquiryType && !ALLOWED_INQUIRY_TYPES.includes(inquiryType)) {
+    return NextResponse.json({ error: 'Invalid inquiry type' }, { status: 400 });
+  }
+
   let dbQuery = supabase
     .from('inquiries')
-    .select(`
-      *,
-      user_profiles(nickname)
-    `, { count: 'exact' });
+    .select('*', { count: 'exact' });
 
   if (status) {
     dbQuery = dbQuery.eq('status', status);
@@ -48,7 +55,7 @@ export async function GET(request: Request) {
   const inquiries = (data || []).map((i: any) => ({
     id: i.id,
     userId: i.user_id,
-    userName: i.user_profiles?.nickname || null,
+    userName: null,
     inquiryType: i.inquiry_type,
     email: i.email,
     subject: i.subject,

--- a/src/app/api/export/meals/route.ts
+++ b/src/app/api/export/meals/route.ts
@@ -34,6 +34,16 @@ export async function GET(request: Request) {
   const startDate = searchParams.get('start_date');
   const endDate = searchParams.get('end_date');
 
+  // 日付形式バリデーション: YYYY-MM-DD 形式かつ有効な日付のみ許可
+  const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+  const isValidDate = (s: string) => ISO_DATE_RE.test(s) && !isNaN(new Date(s).getTime());
+  if (startDate && !isValidDate(startDate)) {
+    return NextResponse.json({ error: 'Invalid start_date' }, { status: 400 });
+  }
+  if (endDate && !isValidDate(endDate)) {
+    return NextResponse.json({ error: 'Invalid end_date' }, { status: 400 });
+  }
+
   // user_daily_meals → planned_meals を JOIN
   let query = supabase
     .from('user_daily_meals')

--- a/src/app/api/health/streaks/route.ts
+++ b/src/app/api/health/streaks/route.ts
@@ -12,7 +12,13 @@ export async function GET(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url);
-  const streakType = searchParams.get('type') || 'daily_record';
+  const rawType = searchParams.get('type') || 'daily_record';
+
+  const ALLOWED_STREAK_TYPES = ['daily_record', 'meal_record', 'health_record', 'exercise_record'] as const;
+  if (!ALLOWED_STREAK_TYPES.includes(rawType as any)) {
+    return NextResponse.json({ error: 'Invalid streak type' }, { status: 400 });
+  }
+  const streakType = rawType;
 
   // 連続記録を取得
   const { data: streak, error } = await supabase
@@ -108,7 +114,13 @@ export async function DELETE(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url);
-  const streakType = searchParams.get('type') || 'daily_record';
+  const rawTypeDelete = searchParams.get('type') || 'daily_record';
+
+  const ALLOWED_STREAK_TYPES_DELETE = ['daily_record', 'meal_record', 'health_record', 'exercise_record'] as const;
+  if (!ALLOWED_STREAK_TYPES_DELETE.includes(rawTypeDelete as any)) {
+    return NextResponse.json({ error: 'Invalid streak type' }, { status: 400 });
+  }
+  const streakType = rawTypeDelete;
 
   const { error } = await supabase
     .from('health_streaks')

--- a/src/app/api/onboarding/progress/route.ts
+++ b/src/app/api/onboarding/progress/route.ts
@@ -24,7 +24,12 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const body = await request.json()
+    let body: any
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+    }
     const { currentStep, answers, totalQuestions } = body
 
     if (typeof currentStep !== 'number' || !answers || typeof totalQuestions !== 'number') {


### PR DESCRIPTION
## 概要

4件の API エンドポイントで発生していた 500 エラーを修正します。

- `POST /api/onboarding/progress` に不正 JSON を送ると 500 → 400 を返すよう修正
- `GET /api/health/streaks?type=...` に不正文字列を送ると 500 → 400 を返すよう修正
- `GET /api/export/meals?start_date=...` に不正日付を送ると 500 → 400 を返すよう修正
- `GET /api/admin/inquiries?status=pending` が 500 → 200 を返すよう修正

## 変更内容

### #308 `/api/onboarding/progress`
`request.json()` の parse 失敗を内側の try/catch で捕捉し、Invalid JSON として 400 を返す。

### #318 `/api/health/streaks`
`type` クエリパラメータを `['daily_record', 'meal_record', 'health_record', 'exercise_record']` の enum で検証。不正値は 400。GET・DELETE 両ハンドラに適用。

### #319 `/api/export/meals`
`start_date` / `end_date` を `YYYY-MM-DD` 正規表現 + `Date` コンストラクタで検証。不正値は 400。

### #324 `/api/admin/inquiries`
- `status` を `['pending', 'in_progress', 'resolved', 'closed']` で enum バリデーション
- `type` を `['general', 'bug_report', 'feature_request', 'billing', 'account', 'other']` で enum バリデーション
- `user_profiles(nickname)` の JOIN を除去（RLS によるクエリエラーが 500 の原因と推定）

## テスト計画

- [ ] 不正 JSON で POST /api/onboarding/progress → 400 `{ error: 'Invalid JSON' }` を確認
- [ ] `?type='; DROP TABLE--` で GET /api/health/streaks → 400 を確認
- [ ] `?start_date=not-a-date` で GET /api/export/meals → 400 を確認
- [ ] admin 権限で GET /api/admin/inquiries?status=pending → 200 を確認

Closes #308
Closes #318
Closes #319
Closes #324