### PR TITLE
fix(migration): e2e ユーザーの onboarding_completed フラグを修正

### DIFF
--- a/supabase/migrations/20260430230000_fix_e2e_user_onboarding_completed.sql
+++ b/supabase/migrations/20260430230000_fix_e2e_user_onboarding_completed.sql
@@ -1,0 +1,12 @@
+-- e2e テストユーザーの onboarding_completed_at を埋めて
+-- /pantry や /home が onboarding 画面に飛ばされないようにする
+UPDATE public.user_profiles
+   SET onboarding_completed_at = COALESCE(onboarding_completed_at, NOW()),
+       onboarding_completed   = TRUE
+ WHERE id IN (
+   SELECT id FROM auth.users WHERE email IN (
+     'e2e-user@homegohan.test',
+     'e2e-admin@homegohan.test',
+     'e2e-super@homegohan.test'
+   )
+ );


### PR DESCRIPTION
## Summary

- e2e テストユーザー (`e2e-user@homegohan.test`, `e2e-admin@homegohan.test`, `e2e-super@homegohan.test`) の `onboarding_completed` が `false` / `null` のままのため、`/pantry` アクセス時にオンボーディング画面へリダイレクトされていた
- migration で `onboarding_completed = TRUE` かつ `onboarding_completed_at = COALESCE(existing, NOW())` を設定し解消
- GitHub Actions `deploy-supabase-migrations` により自動 apply される

## Test plan

- [ ] PR マージ後、`deploy-supabase-migrations` ワークフローが成功することを確認
- [ ] e2e テスト B-6 / B-18 / B-20 / B-21 が `/pantry` UI を正常に確認できることを確認
- [ ] `e2e-user@homegohan.test` でログイン後 `/pantry` にアクセスしてオンボーディング画面が表示されないことを確認

Closes #327