### PR TITLE
fix(validation): onboarding 体重上限 200kg & pantry name trim 修正

### DIFF
--- a/src/app/api/pantry/from-photo/route.ts
+++ b/src/app/api/pantry/from-photo/route.ts
@@ -91,11 +91,12 @@ export async function POST(request: Request) {
 
     // 各アイテムを処理
     for (const ingredient of ingredients) {
-      if (!ingredient.name) {
+      if (!ingredient.name?.trim()) {
         results.skipped++;
         continue;
       }
 
+      const trimmedName = ingredient.name.trim();
       const category = mapCategory(ingredient.category);
       const expirationDate = ingredient.expirationDate || estimateExpirationDate(ingredient.daysRemaining);
 
@@ -105,7 +106,7 @@ export async function POST(request: Request) {
           .from('pantry_items')
           .insert({
             user_id: user.id,
-            name: ingredient.name,
+            name: trimmedName,
             amount: ingredient.amount || null,
             category,
             expiration_date: expirationDate,
@@ -127,7 +128,7 @@ export async function POST(request: Request) {
           .from('pantry_items')
           .select('id')
           .eq('user_id', user.id)
-          .eq('name', ingredient.name)
+          .eq('name', trimmedName)
           .maybeSingle();
 
         if (existing) {
@@ -157,7 +158,7 @@ export async function POST(request: Request) {
             .from('pantry_items')
             .insert({
               user_id: user.id,
-              name: ingredient.name,
+              name: trimmedName,
               amount: ingredient.amount || null,
               category,
               expiration_date: expirationDate,

--- a/src/app/onboarding/questions/page.tsx
+++ b/src/app/onboarding/questions/page.tsx
@@ -1063,7 +1063,7 @@ function OnboardingQuestionsContent() {
                         type="number"
                         placeholder="60"
                         min={10}
-                        max={300}
+                        max={200}
                         step={0.1}
                         value={answers.weight || ''}
                         className="py-4 sm:py-5 rounded-lg sm:rounded-xl text-center text-base sm:text-lg"
@@ -1076,7 +1076,7 @@ function OnboardingQuestionsContent() {
                     disabled={
                       !answers.age ||
                       !answers.height || Number(answers.height) < 50 || Number(answers.height) > 250 ||
-                      !answers.weight || Number(answers.weight) < 10 || Number(answers.weight) > 300
+                      !answers.weight || Number(answers.weight) < 10 || Number(answers.weight) > 200
                     }
                     className="w-full py-4 sm:py-5 rounded-xl sm:rounded-2xl bg-gray-900 hover:bg-black text-white font-bold mt-3 sm:mt-4 text-sm sm:text-base"
                   >


### PR DESCRIPTION
## Summary

- **#309**: onboarding 体重入力の上限を 300kg → 200kg に修正。`999999` など 200 超の異常値を入力した場合、`次へ` ボタンが `disabled` になる
- **#328**: `/api/pantry/from-photo` でスペースのみの `name`（例: `"   "`）を `ingredient.name?.trim()` で検出してスキップ。DB への保存も `trimmedName`（trim 済み文字列）を使用

Closes #309
Closes #328

## 変更ファイル

- `src/app/onboarding/questions/page.tsx` — `custom_stats` セクションの体重 Input `max={300}→200`、disabled 条件 `> 300 → > 200`
- `src/app/api/pantry/from-photo/route.ts` — name チェックを `!ingredient.name` → `!ingredient.name?.trim()` に変更、`trimmedName` 変数を導入して replace/append 両モードの insert/update に適用

## Test plan

- [ ] onboarding 体重欄に `999999` を入力 → `次へ` ボタンが disabled になることを確認
- [ ] onboarding 体重欄に `200` を入力 → `次へ` ボタンが有効になることを確認
- [ ] `/api/pantry/from-photo` に `{ "name": "   " }` を送信 → `skipped: 1`, `created: 0` が返ることを確認
- [ ] 通常の name を送信 → 正常に保存されることを確認