### PR TITLE
fix(ai-chat): z-index競合とisTogglingリセット漏れ修正 (#314 #320)

### DIFF
--- a/src/components/AIChatBubble.tsx
+++ b/src/components/AIChatBubble.tsx
@@ -782,7 +782,7 @@ export default function AIChatBubble() {
             type="button"
             aria-label="AIアドバイザーを開く"
             data-testid="ai-chat-floating-button"
-            className="fixed bottom-24 right-4 z-[40] w-14 h-14 rounded-full shadow-lg flex items-center justify-center"
+            className="fixed bottom-24 right-4 z-[51] w-14 h-14 rounded-full shadow-lg flex items-center justify-center"
             style={{
               background: `linear-gradient(135deg, ${colors.primary} 0%, ${colors.warning} 100%)`,
             }}
@@ -804,7 +804,7 @@ export default function AIChatBubble() {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 100, scale: 0.9 }}
             transition={{ type: 'spring', damping: 25, stiffness: 300 }}
-            className="fixed bottom-24 right-4 z-[30] w-[calc(100vw-32px)] max-w-[380px] h-[500px] rounded-2xl shadow-2xl flex flex-col overflow-hidden"
+            className="fixed bottom-24 right-4 z-[51] w-[calc(100vw-32px)] max-w-[380px] h-[500px] rounded-2xl shadow-2xl flex flex-col overflow-hidden"
             style={{ background: colors.bg }}
           >
             {/* ヘッダー */}
@@ -849,8 +849,8 @@ export default function AIChatBubble() {
                   <ChevronDown size={18} color={colors.textMuted} />
                 </button>
                 <button
-                  onClick={() => setIsOpen(false)}
-                  aria-label="AIチャットを閉じる"
+                  onClick={() => { setIsOpen(false); setIsToggling(false); }}
+                  aria-label="閉じる"
                   className="p-2 rounded-full hover:bg-gray-100"
                 >
                   <X size={18} color={colors.textMuted} />


### PR DESCRIPTION
## Summary

- floating ボタン・チャット窓の z-index を `z-[40]`/`z-[30]` → `z-[51]` に統一  
  モバイルボトムナビ (`z-50`) より低かったため、明示的ボタンクリックが nav バーに遮られていた (#314 の「ボタン直クリックで開かない」)
- 閉じるボタンの `onClick` で `setIsToggling(false)` を追加  
  チャットを素早く閉じると 400ms タイマー完了前に `isToggling=true` が残留し、再オープンを阻害していた (#320 の「閉じて再度開けない」)
- 閉じるボタンの `aria-label` を `"AIチャットを閉じる"` → `"閉じる"` に修正  
  spec の `button[aria-label="閉じる"]` セレクターに一致させるため (#320)

## 真因

| Bug | 真因 |
|-----|------|
| #314 ボタン直クリックで開かない | モバイルナビ `z-50` がフローティングボタン `z-[40]` を上書き。Playwright の click interception チェックでブロック |
| #314 背景クリックで開く | 上記 z-index 問題によりボタン領域が nav に覆われ、クリックが意図せずルーティングされる場合がある |
| #320 閉じて再オープン不可 | `setIsOpen(false)` のみで `setIsToggling(false)` が欠落。400ms タイマー完了前に閉じると `isToggling=true` のまま残留 |
| #320 aria-label 不一致 | 閉じるボタンの label が spec 期待値と異なっていた |

## 変更ファイル

- `src/components/AIChatBubble.tsx` (+4 / -4)

## Test plan

- [ ] `npm run test:e2e -- tests/e2e/bug-06-ai-chat-misclick.spec.ts --workers=1`
- [ ] `npm run test:e2e -- tests/e2e/bug-125-126-ai-chat-cluster.spec.ts`

Closes #314
Closes #320