### PR TITLE
fix(migration): onboarding_completed boolean カラム除去で migration エラー解消

### DIFF
--- a/supabase/migrations/20260430230000_fix_e2e_user_onboarding_completed.sql
+++ b/supabase/migrations/20260430230000_fix_e2e_user_onboarding_completed.sql
@@ -1,8 +1,8 @@
 -- e2e テストユーザーの onboarding_completed_at を埋めて
 -- /pantry や /home が onboarding 画面に飛ばされないようにする
+-- (アプリは onboarding_completed_at の有無のみで完了判定しているため、このカラムのみ更新)
 UPDATE public.user_profiles
-   SET onboarding_completed_at = COALESCE(onboarding_completed_at, NOW()),
-       onboarding_completed   = TRUE
+   SET onboarding_completed_at = COALESCE(onboarding_completed_at, NOW())
  WHERE id IN (
    SELECT id FROM auth.users WHERE email IN (
      'e2e-user@homegohan.test',

--- a/supabase/migrations/20260430230000_fix_e2e_user_onboarding_completed.sql
+++ b/supabase/migrations/20260430230000_fix_e2e_user_onboarding_completed.sql
@@ -1,0 +1,12 @@
+-- e2e テストユーザーの onboarding_completed_at を埋めて
+-- /pantry や /home が onboarding 画面に飛ばされないようにする
+UPDATE public.user_profiles
+   SET onboarding_completed_at = COALESCE(onboarding_completed_at, NOW()),
+       onboarding_completed   = TRUE
+ WHERE id IN (
+   SELECT id FROM auth.users WHERE email IN (
+     'e2e-user@homegohan.test',
+     'e2e-admin@homegohan.test',
+     'e2e-super@homegohan.test'
+   )
+ );


### PR DESCRIPTION
## Summary

- PR #331 でマージした migration `20260430230000_fix_e2e_user_onboarding_completed.sql` が `onboarding_completed = TRUE` を SET しようとしたが、`user_profiles` に該当 boolean カラムが存在せず `ERROR: column "onboarding_completed" does not exist` で失敗した
- アプリは `onboarding_completed_at` (timestamp) の有無のみでオンボーディング完了を判定しているため、boolean カラムの更新は不要
- `SET onboarding_completed = TRUE` の行を削除して migration を修正

## Test plan

- [ ] GitHub Actions `deploy-supabase-migrations` が成功することを確認
- [ ] e2e テスト B-6 / B-18 / B-20 / B-21 が `/pantry` UI を正常に確認できることを確認

Closes #327