### PR TITLE
fix(weekly): progress bar/queue flow regression (#312)

### DIFF
--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -1500,7 +1500,7 @@ export default function WeeklyMenuPage() {
                 const statusRes = await fetch(`/api/ai/menu/weekly/status?requestId=${requestId}`);
                 if (statusRes.ok) {
                   const { status, error_message } = await statusRes.json();
-                  if (status === 'pending' || status === 'processing') {
+                  if (status === 'queued' || status === 'pending' || status === 'processing') {
                     console.log('📦 週間献立をlocalStorageから復元:', requestId, 'status:', status);
                     setIsGenerating(true);
                     subscribeToRequestStatus(targetDate, requestId);

--- a/tests/e2e/bug-01-15-19-queue-flow.spec.ts
+++ b/tests/e2e/bug-01-15-19-queue-flow.spec.ts
@@ -19,7 +19,11 @@ function getThisMonday(): string {
   const day = d.getDay(); // 0=Sun
   const diff = day === 0 ? -6 : 1 - day; // Monday
   d.setDate(d.getDate() + diff);
-  return d.toISOString().slice(0, 10);
+  // ローカル日付でフォーマット（page.tsx の formatLocalDate と一致させる）
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const dayStr = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${dayStr}`;
 }
 
 /**

--- a/tests/e2e/bug-03-progress-bar-server-sync.spec.ts
+++ b/tests/e2e/bug-03-progress-bar-server-sync.spec.ts
@@ -19,7 +19,8 @@ test("progress bar is restored from localStorage when request is still pending",
   const fakeRequestId = "00000000-0000-0000-0000-000000000001";
   const weekStartDate = new Date();
   weekStartDate.setDate(weekStartDate.getDate() - weekStartDate.getDay() + 1); // 今週月曜
-  const weekStr = weekStartDate.toISOString().slice(0, 10);
+  // ローカル日付でフォーマット（page.tsx の formatLocalDate と一致させる）
+  const weekStr = `${weekStartDate.getFullYear()}-${String(weekStartDate.getMonth() + 1).padStart(2, '0')}-${String(weekStartDate.getDate()).padStart(2, '0')}`;
 
   // ステータス API が 'processing' を返すようにモック
   await authedPage.route(`**/api/ai/menu/weekly/status*`, async (route) => {
@@ -84,7 +85,8 @@ test("progress bar is NOT shown when server status is completed on restore", asy
   const fakeRequestId = "00000000-0000-0000-0000-000000000002";
   const weekStartDate = new Date();
   weekStartDate.setDate(weekStartDate.getDate() - weekStartDate.getDay() + 1);
-  const weekStr = weekStartDate.toISOString().slice(0, 10);
+  // ローカル日付でフォーマット（page.tsx の formatLocalDate と一致させる）
+  const weekStr = `${weekStartDate.getFullYear()}-${String(weekStartDate.getMonth() + 1).padStart(2, '0')}-${String(weekStartDate.getDate()).padStart(2, '0')}`;
 
   // ステータス API が 'completed' を返すようにモック
   await authedPage.route(`**/api/ai/menu/weekly/status*`, async (route) => {


### PR DESCRIPTION
## 真因

2つのバグが複合していた。

### Bug 1: `queued` status がlocalStorage復元条件から漏れていた

`src/app/(main)/menus/weekly/page.tsx` のlocalStorage復元パス（`checkPendingRequests` step 3）で、status API のレスポンスが `queued` の場合に `setIsGenerating(true)` されず進捗バーが表示されなかった。

```ts
// 修正前
if (status === 'pending' || status === 'processing') {
// 修正後
if (status === 'queued' || status === 'pending' || status === 'processing') {
```

### Bug 2: E2E spec の weekStr が UTC ベースで page.tsx のローカル日付と不一致

`bug-01-15-19-queue-flow.spec.ts` と `bug-03-progress-bar-server-sync.spec.ts` の `weekStr` 計算が `toISOString().slice(0,10)` (UTC) を使用していた。  
page.tsx の `formatLocalDate()` はローカル時刻ベースのため、日本時間の深夜0〜8時台に `weekStartDate === targetDate` 比較が false になり、localStorage が即座にクリアされて進捗バーが消えていた。

spec 側をローカル日付フォーマット（`getFullYear()`/`getMonth()`/`getDate()`）に統一することで解消。

## 変更ファイル

- `src/app/(main)/menus/weekly/page.tsx` — localStorage復元条件に `queued` を追加
- `tests/e2e/bug-01-15-19-queue-flow.spec.ts` — weekStr をローカル日付に変更
- `tests/e2e/bug-03-progress-bar-server-sync.spec.ts` — weekStr をローカル日付に変更（2箇所）

## テスト計画

- [ ] bug-01 test 1: `queued` status で進捗バーが表示される
- [ ] bug-01 test 4: `completed` status で localStorage がクリアされ進捗バーが消える
- [ ] bug-03 test 1: `processing` ステータスでページリロード後に進捗バーが復元される
- [ ] bug-03 test 2: `completed` ステータスで進捗バーが表示されない + localStorage クリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)