### PR TITLE
fix(migration): onboarding_completed boolean カラム除去で migration エラー解消

### DIFF
--- a/supabase/migrations/20260430230000_fix_e2e_user_onboarding_completed.sql
+++ b/supabase/migrations/20260430230000_fix_e2e_user_onboarding_completed.sql
@@ -1,8 +1,8 @@
 -- e2e テストユーザーの onboarding_completed_at を埋めて
 -- /pantry や /home が onboarding 画面に飛ばされないようにする
+-- (アプリは onboarding_completed_at の有無のみで完了判定しているため、このカラムのみ更新)
 UPDATE public.user_profiles
-   SET onboarding_completed_at = COALESCE(onboarding_completed_at, NOW()),
-       onboarding_completed   = TRUE
+   SET onboarding_completed_at = COALESCE(onboarding_completed_at, NOW())
  WHERE id IN (
    SELECT id FROM auth.users WHERE email IN (
      'e2e-user@homegohan.test',


### PR DESCRIPTION
## Summary

- PR #331 で merge した migration が `user_profiles.onboarding_completed` boolean カラムへ SET していたが、該当カラムが存在せず `Deploy Supabase Migrations` が失敗していた
- アプリは `onboarding_completed_at` (timestamp) の有無のみで完了判定しているため、boolean 行を削除

## Test plan

- [x] migration ファイル修正済み
- [ ] mainマージ後 GitHub Actions `deploy-supabase-migrations` 成功確認

Closes PR #334 (置き換え)