### PR TITLE
fix(a11y): 週間献立 日付タブボタンに type/aria-label/aria-pressed を追加 (Closes #315)

### DIFF
--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -5095,24 +5095,27 @@ export default function WeeklyMenuPage() {
               const isPast = day.dateStr < todayStr;
               return (
                 <button
+                  type="button"
                   key={day.dateStr}
                   onClick={() => {
                     setSelectedDayIndex(idx);
                     setIsDayNutritionExpanded(false);
                   }}
+                  aria-label={`${day.date.getMonth() + 1}月${day.date.getDate()}日 ${day.dayOfWeek}`}
+                  aria-pressed={isSelected}
                   className="flex-1 flex flex-col items-center gap-0.5 py-1.5 rounded-[10px] transition-all relative"
                   style={{
-                    background: isSelected 
-                      ? (isPast ? colors.textMuted : colors.accent) 
+                    background: isSelected
+                      ? (isPast ? colors.textMuted : colors.accent)
                       : (isPast ? 'rgba(0,0,0,0.03)' : 'transparent'),
                     border: isToday && !isSelected ? `2px solid ${colors.accent}` : 'none',
                   }}
                 >
                   <span style={{ fontSize: 9, color: isSelected ? 'rgba(255,255,255,0.7)' : colors.textMuted }}>{day.date.getDate()}</span>
-                  <span style={{ 
-                    fontSize: 13, 
-                    fontWeight: 600, 
-                    color: isSelected ? '#fff' : isPast ? colors.textMuted : isWeekend ? colors.accent : colors.text 
+                  <span style={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: isSelected ? '#fff' : isPast ? colors.textMuted : isWeekend ? colors.accent : colors.text
                   }}>{day.dayOfWeek}</span>
                 </button>
               );


### PR DESCRIPTION
## 概要

Issue #315 (Bug-08/23: 週間献立ページ aria-label 欠落) の確認・補完修正です。

## 変更内容

`src/app/(main)/menus/weekly/page.tsx` の日付タブボタン (月〜日) に対して:
- `type="button"` を追加 (デフォルト `submit` によるフォーム送信リスクを解消)
- `aria-label={月/日 曜日}` を追加 (WCAG 4.1.2 Level A 準拠)
- `aria-pressed={isSelected}` を追加 (選択状態をスクリーンリーダーに通知)

週ナビボタン (前の週/翌週) および右上3アクションアイコンの aria-label は既に付与済みであることを確認。

## E2E テスト

`tests/e2e/bug-08-23-week-aria-labels.spec.ts` にて:
- `getByRole('button', { name: '前の週' })` が visible であることを検証
- `getByRole('button', { name: '翌週' })` が visible であることを検証
- `getByRole('button', { name: '栄養分析を見る' })` が visible であることを検証
- `getByRole('button', { name: '冷蔵庫を確認' })` が visible であることを検証
- `getByRole('button', { name: '買い物リストを開く' })` が visible であることを検証

Closes #315

## テスト方法

- [ ] `npm run test:e2e -- tests/e2e/bug-08-23-week-aria-labels.spec.ts` がすべて PASS する
- [ ] 日付タブボタンがスクリーンリーダーで「N月M日 曜日」と読み上げられる

🤖 Generated with [Claude Code](https://claude.com/claude-code)