### PR TITLE
fix(e2e): オンボーディング未完了ユーザーへのリダイレクト対応 (#317 #321)

### DIFF
--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -16,6 +16,19 @@ export async function login(page: Page) {
     page.locator("button[type=submit]").click(),
   ]);
   await expect(page).not.toHaveURL(/\/login/);
+
+  // オンボーディング未完了の場合はAPIで完了させてホームへ誘導する
+  if (page.url().includes("/onboarding")) {
+    await page.evaluate(async () => {
+      try {
+        await fetch("/api/onboarding/complete", { method: "POST", credentials: "include" });
+      } catch {
+        // オンボーディング完了APIのエラーは無視して続行
+      }
+    });
+    await page.goto("/home");
+    await page.waitForURL("**/home", { timeout: 30_000 });
+  }
 }
 
 type AuthFixtures = {


### PR DESCRIPTION
## 真因

E2E テストユーザー（`e2e-user@homegohan.test`）の `onboarding_completed_at` が未設定のため、`/home` や `/health/graphs` へのアクセス時にミドルウェアが `/onboarding/resume` へリダイレクトしていた。その結果:

- **#317 (bug-09)**: `/home` にアクセスできず、チェックインフォーム自体が表示されないためフィードバックも表示されない
- **#321 (bug-108)**: `/health/graphs` にアクセスできず、`/api/health/checkups` の fetch が発生しない

なおアプリケーションコード側の実装（checkin feedback の表示ロジック・graphs ページの checkups fetch）はいずれも正しく実装済みであり、テスト環境のユーザー状態が問題の原因だった。

## 修正内容

`tests/e2e/fixtures/auth.ts` の `login()` 関数に、ログイン後にオンボーディングページへリダイレクトされた場合の対処を追加:

1. ログイン後の URL が `/onboarding` を含む場合、`POST /api/onboarding/complete` を呼び出してオンボーディングを完了状態にする
2. その後 `/home` へ誘導して通常のテストフローを継続する

## テスト結果

```
4 passed (10.4s)
✓ bug-09: 30-second check-in shows success feedback after submit
✓ bug-108: グラフページが /api/health/checkups を fetch する
✓ bug-129: POST /api/health/insights が 200 か 400 を返す
✓ bug-129: GET /api/health/insights は 200 を返す
```

Closes #317 #321