### PR TITLE
fix(weekly): v4MenuGenerating 復元時のステータス確認を API 経由に変更 (Closes #313)

### DIFF
--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -972,9 +972,11 @@ export default function WeeklyMenuPage() {
 
         console.log('[restore] Restoring V4 generation progress for requestId:', requestId);
 
-        // まずDBから現在の状態を取得（リロード中に完了していた場合に対応）
-        const currentStatus = await v4Generation.getRequestStatus(requestId);
-        console.log('[restore] Current status from DB:', currentStatus);
+        // まずステータスAPIで現在の状態を取得（リロード中に完了していた場合に対応）
+        // Supabase クライアント直接参照ではなく API 経由とすることで E2E モックが機能する
+        const statusRes = await fetch(`/api/ai/menu/weekly/status?requestId=${requestId}`);
+        const currentStatus = statusRes.ok ? await statusRes.json() : null;
+        console.log('[restore] Current status from API:', currentStatus);
 
         // すでに完了している場合
         if (currentStatus?.status === 'completed') {


### PR DESCRIPTION
## Summary

- `v4MenuGenerating` localStorage 復元パスで Supabase クライアント直接参照 (`getRequestStatus`) を `/api/ai/menu/weekly/status?requestId=...` HTTP API 経由に変更
- Supabase を直接呼ぶと E2E テストのルートモック (`**/api/ai/menu/weekly/status*`) が迂回され、completed 状態が検知できなかった
- API 経由にすることで復元時に `completed` が検出された場合に `refreshMealPlan()` + 成功モーダル (`refreshOnDismiss: true`) が確実に表示される
- OK 押下後に `meal-plans` が再フェッチされるパスが正常に機能するようになる

## 真因

`restoreGeneration` useEffect 内の `v4Generation.getRequestStatus(requestId)` は Supabase JS クライアントで直接 DB を参照していた。E2E テストは `**/api/ai/menu/weekly/status*` ルートをモック (`{ status: "completed" }`) しているが、クライアント直接参照ではこのモックが機能しないため、フェイク requestId に対して null が返り続け、成功モーダルが表示されなかった。

## Test plan

- [ ] `tests/e2e/bug-04-cache-refetch-after-generation.spec.ts` の「success modal OK triggers a meal-plans refetch」テストが成功モーダルパス (smoke-only でない) を通ること
- [ ] OK 押下後に `meal-plans` API コールが発生すること (`requestsAfterOK > requestsBeforeOK`)
- [ ] `npm run build` がコンパイルエラーなしで完了すること

Closes #313