### PR TITLE
perf(weekly): LCP改善・meal toggle debounce 250ms・lazy load追加

### DIFF
--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -13,17 +13,21 @@ import type { CatalogProductSummary } from "@/types/catalog";
 import ReactMarkdown from "react-markdown";
 import { useV4MenuGeneration } from "@/hooks/useV4MenuGeneration";
 import { notifyMenuGenerated } from "@/lib/local-notification";
-import { ProfileReminderBanner } from "@/components/ProfileReminderBanner";
+// ProfileReminderBanner は dynamic import で lazy load (#322)
 import { DEFAULT_RADAR_NUTRIENTS, getNutrientDefinition, calculateDriPercentage, NUTRIENT_DEFINITIONS, NUTRIENT_BY_CATEGORY, CATEGORY_LABELS } from "@/lib/nutrition-constants";
 import remarkGfm from "remark-gfm";
 
-// #182: dynamic import で初期バンドルを削減
+// #182/#322: dynamic import で初期バンドルを削減 (LCP 改善)
 const V4GenerateModal = dynamic(
   () => import("@/components/ai-assistant").then(m => ({ default: m.V4GenerateModal })),
   { ssr: false }
 );
 const NutritionRadarChart = dynamic(
   () => import("@/components/NutritionRadarChart").then(m => ({ default: m.NutritionRadarChart })),
+  { ssr: false }
+);
+const ProfileReminderBannerDynamic = dynamic(
+  () => import("@/components/ProfileReminderBanner").then(m => ({ default: m.ProfileReminderBanner })),
   { ssr: false }
 );
 import {
@@ -1382,6 +1386,15 @@ export default function WeeklyMenuPage() {
       }
     };
   }, [cleanupRealtime]);
+
+  // #322: debounce timer cleanup on unmount (メモリリーク防止)
+  useEffect(() => {
+    const timers = toggleDebounceTimerRef.current;
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
   
   // 生成中状態をDBから復元し、ポーリングを再開
   useEffect(() => {
@@ -2800,10 +2813,35 @@ export default function WeeklyMenuPage() {
     } catch (e) { console.error('Failed to update meal:', e); }
   };
   
-  // Toggle completion (can check and uncheck)
+  // #322: meal toggle debounce timer (メモリリーク防止のため cleanup は下の useEffect で実施)
+  const toggleDebounceTimerRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const pendingToggleWeeklyRef = useRef<Set<string>>(new Set());
+
+  // Toggle completion (can check and uncheck) — debounce 250ms (#322)
   const toggleMealCompletion = async (dayId: string, meal: PlannedMeal) => {
+    const mealId = meal.id ?? '';
+    // 既存タイマーをキャンセル
+    const existing = toggleDebounceTimerRef.current.get(mealId);
+    if (existing) {
+      clearTimeout(existing);
+      toggleDebounceTimerRef.current.delete(mealId);
+    }
+    // PATCH が進行中なら無視
+    if (pendingToggleWeeklyRef.current.has(mealId)) return;
+
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        toggleDebounceTimerRef.current.delete(mealId);
+        resolve();
+      }, 250);
+      toggleDebounceTimerRef.current.set(mealId, timer);
+    });
+
+    if (pendingToggleWeeklyRef.current.has(mealId)) return;
+    pendingToggleWeeklyRef.current.add(mealId);
     const newCompleted = !meal.isCompleted;
-    handleUpdateMeal(dayId, meal.id, { isCompleted: newCompleted });
+    await handleUpdateMeal(dayId, meal.id, { isCompleted: newCompleted });
+    pendingToggleWeeklyRef.current.delete(mealId);
   };
 
   // Add pantry item
@@ -5133,7 +5171,7 @@ export default function WeeklyMenuPage() {
       </div>
 
       {/* === Profile Reminder Banner === */}
-      <ProfileReminderBanner />
+      <ProfileReminderBannerDynamic />
 
       {/* === 生成失敗エラーモーダル === */}
       {generationFailedError && (

--- a/src/hooks/useHomeData.ts
+++ b/src/hooks/useHomeData.ts
@@ -57,8 +57,9 @@ export const useHomeData = () => {
   const [user, setUser] = useState<any>(null);
   const [todayPlan, setTodayPlan] = useState<TodayMealPlan | null>(null);
   const [loading, setLoading] = useState(true);
-  // #191: meal toggle debounce — pending mealId set to prevent duplicate PATCH
+  // #191/#322: meal toggle debounce — pending mealId set + 250ms debounce timer
   const pendingToggleRef = useRef<Set<string>>(new Set());
+  const toggleDebounceTimerRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const [dailySummary, setDailySummary] = useState<DailySummary>({
     totalCalories: 0,
     completedCount: 0,
@@ -865,9 +866,28 @@ export const useHomeData = () => {
     }
   };
 
-  // 食事完了をトグル (Bug-10: 楽観的UI更新 + 失敗時ロールバック, #191: debounce)
+  // 食事完了をトグル (Bug-10: 楽観的UI更新 + 失敗時ロールバック, #191/#322: debounce 250ms)
   const toggleMealCompletion = async (mealId: string, currentStatus: boolean) => {
+    // #322: 250ms debounce — 既存タイマーをキャンセルして再スケジュール
+    const existingTimer = toggleDebounceTimerRef.current.get(mealId);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+      toggleDebounceTimerRef.current.delete(mealId);
+    }
+
     // #191: 同一 mealId の PATCH が進行中なら無視（連打対策）
+    if (pendingToggleRef.current.has(mealId)) return;
+
+    // debounce: 250ms 後に実際の処理を実行
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        toggleDebounceTimerRef.current.delete(mealId);
+        resolve();
+      }, 250);
+      toggleDebounceTimerRef.current.set(mealId, timer);
+    });
+
+    // debounce 待機後、再度 pending チェック（待機中に別のリクエストが始まった可能性）
     if (pendingToggleRef.current.has(mealId)) return;
     pendingToggleRef.current.add(mealId);
 
@@ -930,6 +950,15 @@ export const useHomeData = () => {
     // #191: PATCH 完了後に pending を解除
     pendingToggleRef.current.delete(mealId);
   };
+
+  // #322: debounce timer cleanup on unmount (メモリリーク防止)
+  useEffect(() => {
+    const timers = toggleDebounceTimerRef.current;
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
 
   useEffect(() => {
     void fetchHomeData();


### PR DESCRIPTION
## Summary

- `ProfileReminderBanner` を `dynamic(() => import(...), { ssr: false })` に変更し、初期バンドルから除外 (LCP 改善)
- `weekly/page.tsx` の `toggleMealCompletion` に debounce 250ms を追加 (10回連打 → API 3回以下)
- `useHomeData.ts` の `toggleMealCompletion` に debounce 250ms を追加 (home ページの meal toggle も対象)
- 両コンポーネントで useEffect によるタイマー cleanup を実装 (メモリリーク防止)

Closes #322

## Test plan

- [ ] /menus/weekly LCP < 3000ms (B11-1)
- [ ] meal toggle 10回連打で Supabase API 呼び出し 3回以下 (B11-4a)
- [ ] `npx tsc --noEmit` エラーなし (確認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)