### PR TITLE
fix(e2e): /favorites strict mode 違反を修正

### DIFF
--- a/tests/e2e/bug-104-favorites-system.spec.ts
+++ b/tests/e2e/bug-104-favorites-system.spec.ts
@@ -16,7 +16,7 @@ test.describe("Favorites system (#104 #106 #109)", () => {
     await authedPage.waitForLoadState("networkidle", { timeout: 15000 }).catch(() => {});
 
     // ページタイトルを確認
-    await expect(authedPage.locator("text=お気に入りレシピ")).toBeVisible({ timeout: 8000 });
+    await expect(authedPage.getByRole("heading", { name: "お気に入りレシピ", exact: true })).toBeVisible({ timeout: 8000 });
   });
 
   test("GET /favorites page shows empty state when no favorites", async ({ authedPage }) => {


### PR DESCRIPTION
## 概要

`locator("text=お気に入りレシピ")` が見出しと段落の 2 要素にマッチし Playwright strict mode 違反が発生していた問題を修正。

`getByRole("heading", { name: "お気に入りレシピ", exact: true })` に変更して見出し要素のみを対象にするようにした。

## 変更内容

- `tests/e2e/bug-104-favorites-system.spec.ts` L19 の locator を getByRole に変更

Closes #303