### PR TITLE
fix(pantry): 写真で追加ボタン・期限間近バッジ・空状態UI を修正 (#346)

### DIFF
--- a/src/app/(main)/pantry/page.tsx
+++ b/src/app/(main)/pantry/page.tsx
@@ -189,6 +189,7 @@ export default function PantryPage() {
         </div>
         <button
           onClick={() => fileInputRef.current?.click()}
+          data-testid="add-by-photo-btn"
           className="flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium"
           style={{ backgroundColor: colors.accent, color: "white" }}
         >
@@ -309,7 +310,10 @@ export default function PantryPage() {
             <RefreshCw size={24} className="animate-spin" style={{ color: colors.accent }} />
           </div>
         ) : items.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 gap-4">
+          <div
+            data-testid="pantry-empty-state"
+            className="flex flex-col items-center justify-center py-16 gap-4"
+          >
             <Package size={48} style={{ color: colors.textMuted }} />
             <p className="text-sm" style={{ color: colors.textMuted }}>食材がありません</p>
             <button
@@ -337,7 +341,11 @@ export default function PantryPage() {
                   <div className="flex items-center gap-2">
                     <p className="font-medium truncate" style={{ color: colors.text }}>{item.name}</p>
                     {item.expirationDate && isExpiringSoon(item.expirationDate) && (
-                      <span className="text-xs px-2 py-0.5 rounded-full" style={{ backgroundColor: "#FFEBEE", color: colors.error }}>
+                      <span
+                        data-testid="expiry-soon-badge"
+                        className="text-xs px-2 py-0.5 rounded-full"
+                        style={{ backgroundColor: "#FFEBEE", color: colors.error }}
+                      >
                         期限間近
                       </span>
                     )}


### PR DESCRIPTION
## Summary

- 写真で追加ボタン (`data-testid="add-by-photo-btn"`) を追加
- 期限間近バッジ (`data-testid="expiry-soon-badge"`) を追加
- 空状態コンテナ (`data-testid="pantry-empty-state"`) を追加

各 UI 要素は `/src/app/(main)/pantry/page.tsx` に実装済みだが、E2E テスト (r10-org-pantry-deep.spec.ts B-18/B-20/B-21) の安定性向上のために `data-testid` 属性を付与。

## Test plan

- [ ] `/pantry` にアクセスして「写真で追加」ボタンが表示されることを確認
- [ ] 期限 3 日以内の食材を登録して「期限間近」バッジが表示されることを確認
- [ ] 食材ゼロ状態で「食材がありません」メッセージが表示されることを確認

Closes #346