### PR TITLE
fix(pantry): POST /api/pantry で空文字・空白 name を 400 で弾く

### DIFF
--- a/src/app/api/pantry/route.ts
+++ b/src/app/api/pantry/route.ts
@@ -36,6 +36,10 @@ export async function POST(request: Request) {
     const json = await request.json();
     const { name, amount, category, expirationDate } = json;
 
+    if (!name?.trim()) {
+      return NextResponse.json({ error: 'name is required' }, { status: 400 });
+    }
+
     const { data, error } = await supabase
       .from('pantry_items')
       .insert({


### PR DESCRIPTION
## Summary

- `src/app/api/pantry/route.ts` の POST ハンドラに name バリデーションを追加
- `!name?.trim()` で空文字・空白のみを検知し、`{ error: 'name is required' }` + HTTP 400 を返す
- 既存の他フィールドのバリデーションパターンと整合

## Test plan

- [ ] `POST /api/pantry` に `{ name: "" }` を送信 → 400 が返ること
- [ ] `POST /api/pantry` に `{ name: "   " }` を送信 → 400 が返ること
- [ ] `POST /api/pantry` に有効な name を送信 → 200 が返ること
- [ ] w5-13-new-features-adversarial.spec.ts:304 の spec が pass すること

Closes #350