### PR TITLE
fix(favorites): GET /api/favorites の HTTP 500 を修正

### DIFF
--- a/src/app/api/favorites/route.ts
+++ b/src/app/api/favorites/route.ts
@@ -1,15 +1,22 @@
 import { createClient } from '@/lib/supabase/server';
+import { createLogger, generateRequestId } from '@/lib/db-logger';
 import { NextResponse } from 'next/server';
 
 /**
  * GET /api/favorites
  * ログインユーザーのお気に入りレシピ一覧を返す (#109)
  * recipe_likes テーブルから recipe_id (dish name) を取得する
+ * #302: recipe_uuid カラムが存在しない場合の 500 を修正
  */
 export async function GET(request: Request) {
+  const requestId = generateRequestId();
+  const logger = createLogger('GET /api/favorites', requestId);
+
   const supabase = await createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
   if (userError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const userLogger = logger.withUser(user.id);
 
   const { searchParams } = new URL(request.url);
   const limit = Math.min(Number(searchParams.get('limit') ?? '100'), 200);
@@ -18,6 +25,9 @@ export async function GET(request: Request) {
   const sort = searchParams.get('sort') ?? 'newest'; // newest | oldest | name
 
   try {
+    // recipe_uuid は ADD COLUMN IF NOT EXISTS で追加済みだが、
+    // 本番 DB に未適用の場合でも id/recipe_id/created_at は必ず存在するため
+    // recipe_uuid を別途フォールバック付きで取得する (#302)
     let dbQuery = supabase
       .from('recipe_likes')
       .select('id, recipe_id, recipe_uuid, created_at', { count: 'exact' })
@@ -42,20 +52,49 @@ export async function GET(request: Request) {
 
     dbQuery = dbQuery.range(offset, offset + limit - 1);
 
-    const { data, error, count } = await dbQuery;
-    if (error) throw error;
+    let result = await dbQuery;
+
+    // recipe_uuid カラムが存在しない場合 (column not found) は
+    // recipe_uuid を除いたクエリでリトライして 500 を回避する (#302)
+    if (result.error && (result.error.message?.includes('recipe_uuid') || result.error.code === '42703')) {
+      userLogger.warn('recipe_uuid column not found, retrying without it', { error: result.error.message });
+      let fallbackQuery = supabase
+        .from('recipe_likes')
+        .select('id, recipe_id, created_at', { count: 'exact' })
+        .eq('user_id', user.id);
+
+      if (query) {
+        fallbackQuery = fallbackQuery.ilike('recipe_id', `%${query}%`);
+      }
+
+      switch (sort) {
+        case 'oldest':
+          fallbackQuery = fallbackQuery.order('created_at', { ascending: true });
+          break;
+        case 'name':
+          fallbackQuery = fallbackQuery.order('recipe_id', { ascending: true });
+          break;
+        default:
+          fallbackQuery = fallbackQuery.order('created_at', { ascending: false });
+      }
+
+      fallbackQuery = fallbackQuery.range(offset, offset + limit - 1);
+      result = await fallbackQuery as typeof result;
+    }
+
+    if (result.error) throw result.error;
 
     return NextResponse.json({
-      favorites: (data ?? []).map((row: any) => ({
+      favorites: (result.data ?? []).map((row: any) => ({
         id: row.id,
         recipeName: row.recipe_id,
         recipeUuid: row.recipe_uuid ?? null,
         likedAt: row.created_at,
       })),
-      total: count ?? 0,
+      total: result.count ?? 0,
     });
   } catch (error: any) {
-    console.error('Favorites fetch error:', error);
+    userLogger.error('Favorites fetch error', error);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/supabase/migrations/20260430240000_ensure_recipe_likes_recipe_uuid.sql
+++ b/supabase/migrations/20260430240000_ensure_recipe_likes_recipe_uuid.sql
@@ -1,0 +1,8 @@
+-- Issue #302: GET /api/favorites が HTTP 500 を返す修正
+-- recipe_likes.recipe_uuid カラムが本番 DB に存在しない場合に 500 が発生するため、
+-- IF NOT EXISTS で冪等的に追加して確実に存在を保証する。
+
+ALTER TABLE recipe_likes
+  ADD COLUMN IF NOT EXISTS recipe_uuid UUID REFERENCES recipes(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_recipe_likes_recipe_uuid ON recipe_likes (recipe_uuid);


### PR DESCRIPTION
## 概要

- Issue #302: GET /api/favorites が HTTP 500 を返す問題を修正

## 原因

`recipe_likes.recipe_uuid` カラムが本番 DB に未適用の場合、Supabase が PostgreSQL error code `42703` (column not found) を返し、`throw error` で HTTP 500 になっていた。

## 修正内容

- **migration `20260430240000_ensure_recipe_likes_recipe_uuid.sql`**: `ADD COLUMN IF NOT EXISTS` で冪等的に `recipe_uuid` カラムを追加し、本番への適用漏れを解消
- **`src/app/api/favorites/route.ts`**: `recipe_uuid` を含むクエリが `42703` エラーを返した場合、`recipe_uuid` を除いたクエリでリトライするフォールバックを追加
- `db-logger` を導入してエラーを `app_logs` テーブルへ構造化記録

## テスト

```bash
PLAYWRIGHT_BASE_URL=https://homegohan-app.vercel.app npm run test:e2e -- tests/e2e/bug-104-favorites-system.spec.ts --workers=1 --reporter=list
```

Closes #302