### PR TITLE
fix(onboarding): user_profiles 欠落カラム追加で DB 保存を修正 (Closes #349)

### DIFF
--- a/supabase/migrations/20260430240000_add_onboarding_progress_columns.sql
+++ b/supabase/migrations/20260430240000_add_onboarding_progress_columns.sql
@@ -1,0 +1,48 @@
+-- #349: /api/onboarding/progress の DB 保存ロジック修正
+-- user_profiles に onboarding 関連カラムおよびプロフィール詳細カラムを追加
+-- progress/route.ts および complete/route.ts が参照するが未定義だったカラムをすべて追加する
+
+ALTER TABLE user_profiles
+  -- オンボーディング進捗
+  ADD COLUMN IF NOT EXISTS onboarding_progress         JSONB,
+  ADD COLUMN IF NOT EXISTS onboarding_started_at       TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS onboarding_completed_at     TIMESTAMPTZ,
+  -- 基本プロフィール
+  ADD COLUMN IF NOT EXISTS age                         INTEGER,
+  ADD COLUMN IF NOT EXISTS occupation                  TEXT,
+  ADD COLUMN IF NOT EXISTS height                      NUMERIC,
+  ADD COLUMN IF NOT EXISTS weight                      NUMERIC,
+  -- 目標
+  ADD COLUMN IF NOT EXISTS nutrition_goal              TEXT,
+  ADD COLUMN IF NOT EXISTS target_weight               NUMERIC,
+  ADD COLUMN IF NOT EXISTS target_date                 DATE,
+  ADD COLUMN IF NOT EXISTS weight_change_rate          TEXT,
+  ADD COLUMN IF NOT EXISTS fitness_goals               TEXT[],
+  ADD COLUMN IF NOT EXISTS weekly_exercise_minutes     INTEGER,
+  -- 運動習慣
+  ADD COLUMN IF NOT EXISTS exercise_types              TEXT[],
+  ADD COLUMN IF NOT EXISTS exercise_frequency          INTEGER,
+  ADD COLUMN IF NOT EXISTS exercise_intensity          TEXT,
+  ADD COLUMN IF NOT EXISTS exercise_duration_per_session INTEGER,
+  -- ライフスタイル
+  ADD COLUMN IF NOT EXISTS work_style                  TEXT,
+  ADD COLUMN IF NOT EXISTS health_conditions           TEXT[],
+  ADD COLUMN IF NOT EXISTS cold_sensitivity            BOOLEAN,
+  ADD COLUMN IF NOT EXISTS swelling_prone              BOOLEAN,
+  ADD COLUMN IF NOT EXISTS sleep_quality               TEXT,
+  ADD COLUMN IF NOT EXISTS stress_level                TEXT,
+  ADD COLUMN IF NOT EXISTS pregnancy_status            TEXT,
+  ADD COLUMN IF NOT EXISTS medications                 TEXT[],
+  -- 食事嗜好
+  ADD COLUMN IF NOT EXISTS favorite_ingredients        TEXT[],
+  ADD COLUMN IF NOT EXISTS diet_style                  TEXT,
+  -- 調理情報
+  ADD COLUMN IF NOT EXISTS cooking_experience          TEXT,
+  ADD COLUMN IF NOT EXISTS weekday_cooking_minutes     INTEGER,
+  ADD COLUMN IF NOT EXISTS cuisine_preferences         JSONB,
+  ADD COLUMN IF NOT EXISTS family_size                 INTEGER,
+  ADD COLUMN IF NOT EXISTS shopping_frequency          TEXT,
+  ADD COLUMN IF NOT EXISTS weekly_food_budget          INTEGER,
+  ADD COLUMN IF NOT EXISTS kitchen_appliances          TEXT[],
+  -- その他
+  ADD COLUMN IF NOT EXISTS hobbies                     TEXT[];


### PR DESCRIPTION
## Summary

- `user_profiles` テーブルに `onboarding_progress`, `onboarding_started_at`, `onboarding_completed_at` など 38 カラムが migration に定義されておらず、`/api/onboarding/progress` の upsert が DB エラーで失敗していた
- migration `20260430240000_add_onboarding_progress_columns.sql` を追加し、`ALTER TABLE ... ADD COLUMN IF NOT EXISTS` で全カラムを安全に追加
- `complete/route.ts` が参照する `fitness_goals`, `weekly_exercise_minutes` も同時に追加

## Test plan

- [ ] main merge 後に GitHub Actions の Supabase migration が自動 apply されることを確認
- [ ] `PLAYWRIGHT_BASE_URL=https://homegohan-app.vercel.app npm run test:e2e -- w5-1-onboarding-adversarial` で B-9 等がパスすることを確認

Closes #349