### PR TITLE
fix(onboarding): not_started ユーザーの questions ページ遷移を修正 (Closes #349)

### DIFF
--- a/lib/onboarding-routing.ts
+++ b/lib/onboarding-routing.ts
@@ -56,12 +56,12 @@ export function resolveOnboardingRedirect(input: OnboardingRedirectInput): strin
     return null;
   }
 
-  // #268: not_started ユーザーは /onboarding/questions にも直アクセス不可
+  // #268: not_started ユーザーは resume/complete には直アクセス不可
+  // /onboarding/questions は welcome → questions のフローで必要なため許可する
   if (
     pathname === "/onboarding" ||
     pathname === "/onboarding/resume" ||
-    pathname === "/onboarding/complete" ||
-    pathname === "/onboarding/questions"
+    pathname === "/onboarding/complete"
   ) {
     return "/onboarding/welcome";
   }

--- a/tests/onboarding-routing.test.ts
+++ b/tests/onboarding-routing.test.ts
@@ -69,7 +69,7 @@ describe("resolveOnboardingRedirect", () => {
     ).toBeNull();
   });
 
-  it("#268: not_started users are redirected from /onboarding/questions to welcome", () => {
+  it("#349: not_started users can access /onboarding/questions (welcome → questions flow)", () => {
     expect(
       resolveOnboardingRedirect({
         pathname: "/onboarding/questions",
@@ -77,7 +77,7 @@ describe("resolveOnboardingRedirect", () => {
         onboardingStartedAt: null,
         onboardingCompletedAt: null,
       }),
-    ).toBe("/onboarding/welcome");
+    ).toBeNull();
   });
 
   it("redirects admins to admin for onboarding routes", () => {


### PR DESCRIPTION
## Summary

- `#268` で `not_started` ユーザーが `/onboarding/questions` に直アクセスできないよう routing を変更した結果、`welcome` ページの「はじめる」リンクをクリックしても middleware がブロックして welcome に戻されるループが発生していた
- この影響で `saveProgress` が一度も呼ばれず、`/api/onboarding/progress` への POST が 0 件になり、DB への保存が全く機能していなかった
- `onboarding-routing.ts` から `/onboarding/questions` の除外条件を削除し、`welcome → questions` の正常なフローを回復する
- 対応するユニットテストも `#349` の期待動作に合わせて更新

## Test plan

- [ ] `npx vitest run tests/onboarding-routing.test.ts` が 7 tests pass
- [ ] 本番で B-9 spec が pass: `PLAYWRIGHT_BASE_URL=https://homegohan-app.vercel.app npm run test:e2e -- w5-1-onboarding-adversarial --grep B-9`

Closes #349