### PR TITLE
fix(onboarding): 新規コンテキストでオンボーディング完了ユーザーが再 redirect される問題を修正

### DIFF
--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -113,23 +113,28 @@ export async function updateSession(request: NextRequest) {
 
   if (user) {
     // user_profiles からオンボーディング状態を取得
-    const { data: profile } = await supabase
+    // #348: error を必ず捕捉し、DB 参照失敗時はリダイレクト判定をスキップする
+    // (RLS 拒否・カラム不在・ネットワーク障害などで data=null になった場合に
+    //  not_started 扱いで /onboarding/welcome へ飛ばしてしまうバグを防ぐ)
+    const { data: profile, error: profileError } = await supabase
       .from('user_profiles')
       .select('roles, onboarding_started_at, onboarding_completed_at')
       .eq('id', user.id)
       .maybeSingle()
 
-    const redirectPath = resolveOnboardingRedirect({
-      pathname: request.nextUrl.pathname,
-      roles: profile?.roles || [],
-      onboardingStartedAt: profile?.onboarding_started_at ?? null,
-      onboardingCompletedAt: profile?.onboarding_completed_at ?? null,
-    })
+    if (!profileError) {
+      const redirectPath = resolveOnboardingRedirect({
+        pathname: request.nextUrl.pathname,
+        roles: profile?.roles || [],
+        onboardingStartedAt: profile?.onboarding_started_at ?? null,
+        onboardingCompletedAt: profile?.onboarding_completed_at ?? null,
+      })
 
-    if (redirectPath && redirectPath !== request.nextUrl.pathname) {
-      const url = request.nextUrl.clone()
-      url.pathname = redirectPath
-      return NextResponse.redirect(url)
+      if (redirectPath && redirectPath !== request.nextUrl.pathname) {
+        const url = request.nextUrl.clone()
+        url.pathname = redirectPath
+        return NextResponse.redirect(url)
+      }
     }
   }
 

--- a/supabase/migrations/20260430240000_add_user_profiles_onboarding_and_roles.sql
+++ b/supabase/migrations/20260430240000_add_user_profiles_onboarding_and_roles.sql
@@ -1,0 +1,53 @@
+-- #348: 新規ブラウザコンテキストでオンボーディング完了ユーザーが再 redirect される問題の修正
+-- middleware が user_profiles から roles / onboarding_started_at / onboarding_completed_at を
+-- SELECT するが、これらのカラムが migration で未定義だったため RLS/クエリ失敗時に
+-- data=null → not_started 扱いで /onboarding/welcome へ飛んでいた。
+-- 本 migration で必要カラムをすべて追加する。
+
+ALTER TABLE user_profiles
+  -- #348: middleware の resolveOnboardingRedirect で参照する roles カラム
+  -- (embedding_jobs の RLS ポリシーでも参照されていたが migration 未定義だった)
+  ADD COLUMN IF NOT EXISTS roles                        TEXT[]    DEFAULT '{}'::text[],
+  -- オンボーディング進捗
+  ADD COLUMN IF NOT EXISTS onboarding_progress         JSONB,
+  ADD COLUMN IF NOT EXISTS onboarding_started_at       TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS onboarding_completed_at     TIMESTAMPTZ,
+  -- 基本プロフィール
+  ADD COLUMN IF NOT EXISTS age                         INTEGER,
+  ADD COLUMN IF NOT EXISTS occupation                  TEXT,
+  ADD COLUMN IF NOT EXISTS height                      NUMERIC,
+  ADD COLUMN IF NOT EXISTS weight                      NUMERIC,
+  -- 目標
+  ADD COLUMN IF NOT EXISTS nutrition_goal              TEXT,
+  ADD COLUMN IF NOT EXISTS target_weight               NUMERIC,
+  ADD COLUMN IF NOT EXISTS target_date                 DATE,
+  ADD COLUMN IF NOT EXISTS weight_change_rate          TEXT,
+  ADD COLUMN IF NOT EXISTS fitness_goals               TEXT[],
+  ADD COLUMN IF NOT EXISTS weekly_exercise_minutes     INTEGER,
+  -- 運動習慣
+  ADD COLUMN IF NOT EXISTS exercise_types              TEXT[],
+  ADD COLUMN IF NOT EXISTS exercise_frequency          INTEGER,
+  ADD COLUMN IF NOT EXISTS exercise_intensity          TEXT,
+  ADD COLUMN IF NOT EXISTS exercise_duration_per_session INTEGER,
+  -- ライフスタイル
+  ADD COLUMN IF NOT EXISTS work_style                  TEXT,
+  ADD COLUMN IF NOT EXISTS health_conditions           TEXT[],
+  ADD COLUMN IF NOT EXISTS cold_sensitivity            BOOLEAN,
+  ADD COLUMN IF NOT EXISTS swelling_prone              BOOLEAN,
+  ADD COLUMN IF NOT EXISTS sleep_quality               TEXT,
+  ADD COLUMN IF NOT EXISTS stress_level                TEXT,
+  ADD COLUMN IF NOT EXISTS pregnancy_status            TEXT,
+  ADD COLUMN IF NOT EXISTS medications                 TEXT[],
+  -- 食事嗜好
+  ADD COLUMN IF NOT EXISTS favorite_ingredients        TEXT[],
+  ADD COLUMN IF NOT EXISTS diet_style                  TEXT,
+  -- 調理情報
+  ADD COLUMN IF NOT EXISTS cooking_experience          TEXT,
+  ADD COLUMN IF NOT EXISTS weekday_cooking_minutes     INTEGER,
+  ADD COLUMN IF NOT EXISTS cuisine_preferences         JSONB,
+  ADD COLUMN IF NOT EXISTS family_size                 INTEGER,
+  ADD COLUMN IF NOT EXISTS shopping_frequency          TEXT,
+  ADD COLUMN IF NOT EXISTS weekly_food_budget          INTEGER,
+  ADD COLUMN IF NOT EXISTS kitchen_appliances          TEXT[],
+  -- その他
+  ADD COLUMN IF NOT EXISTS hobbies                     TEXT[];


### PR DESCRIPTION
## Summary

- `lib/supabase/middleware.ts`: `user_profiles` クエリの `error` を捕捉し、DB 参照失敗時は `resolveOnboardingRedirect` をスキップ。RLS 拒否・カラム不在などで `data=null` になっても `not_started` 扱いで `/onboarding/welcome` へ飛ばさないよう修正。
- `supabase/migrations/20260430240000`: `user_profiles` に `roles TEXT[]` およびオンボーディング関連カラムを `ADD COLUMN IF NOT EXISTS` で追加。migration 未定義によるクエリ失敗を根本解消。

## Test plan

- [ ] `w5-1-onboarding-adversarial.spec.ts` の A-3 テスト（新規コンテキストでのログイン後オンボーディング非表示）が pass することを本番で確認
- [ ] 既存の onboarding-routing unit tests が引き続き pass すること (`npm run test`)
- [ ] 完了済みユーザーが `/onboarding` にアクセスしても `/home` へ redirect されること

Closes #348