### PR TITLE
fix(e2e): global-setup ログイン失敗フォールバックと storageState 条件付き適用

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig, devices } from "@playwright/test";
+import * as fs from "fs";
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
 const isCI = !!process.env.CI;
 const useExistingServer = !!process.env.PLAYWRIGHT_BASE_URL;
+
+// global-setup が生成する storageState ファイルが存在する場合のみ設定する。
+// 存在しない場合は各テストの authedPage fixture が個別ログインにフォールバックする。
+const STORAGE_STATE_PATH = "tests/e2e/.auth/user.json";
+const storageState = fs.existsSync(STORAGE_STATE_PATH) ? STORAGE_STATE_PATH : undefined;
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -24,8 +30,8 @@ export default defineConfig({
     video: "retain-on-failure",
     locale: "ja-JP",
     timezoneId: "Asia/Tokyo",
-    // global-setup で生成した認証済み storageState を全テストで共有
-    storageState: "tests/e2e/.auth/user.json",
+    // global-setup で生成した認証済み storageState を全テストで共有 (存在する場合のみ)
+    ...(storageState ? { storageState } : {}),
   },
   projects: [
     { name: "chromium", use: { ...devices["Desktop Chrome"] } },

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -6,6 +6,8 @@
  * tests/e2e/.auth/user.json に保存する。
  * 各テストの authedPage fixture はこのファイルを読み込んで
  * ログイン処理をスキップするため、30s タイムアウト連鎖を回避できる。
+ *
+ * ログイン失敗時は警告を出力して続行する (storageState なしで各テストが個別ログインにフォールバック)。
  */
 
 import { chromium, type FullConfig } from "@playwright/test";
@@ -103,8 +105,11 @@ async function globalSetup(config: FullConfig): Promise<void> {
   }
 
   await browser.close();
-  throw new Error(
-    `[global-setup] ${MAX_RETRIES} 回試行後もログイン失敗: ${lastError}`,
+  // ログイン失敗時はエラーをスローせず警告のみ出力して続行する。
+  // storageState が生成されなかった場合、各テストの authedPage fixture が
+  // 個別ログインにフォールバックする。
+  console.warn(
+    `[global-setup] ${MAX_RETRIES} 回試行後もログイン失敗。storageState なしで続行: ${lastError}`,
   );
 }
 


### PR DESCRIPTION
## 概要

PR #355 のフォローアップ: global-setup ログイン失敗時に全テストが落ちる問題を修正。

## 変更内容

- **`tests/e2e/global-setup.ts`**: 全リトライ失敗時に `throw` せず `console.warn` で続行。storageState 未生成でも各テストが個別ログインにフォールバック可能にする。
- **`playwright.config.ts`**: `storageState` を `fs.existsSync` で条件付き設定。ファイル未生成時に "file not found" で全テストが失敗するのを防ぐ。