### PR TITLE
fix(graphs): E2E テスト基盤整備と /health/graphs の checkups fetch 修正

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
   retries: isCI ? 2 : 0,
   workers: isCI ? 2 : undefined,
   reporter: isCI ? [["github"], ["html", { open: "never", outputFolder: "tests/e2e/.report" }]] : "list",
+  // グローバルセットアップでログインを 1 回だけ行い storageState を生成する。
+  // 全 worker が共有することで auth fixture の都度ログインによるタイムアウト連鎖を防ぐ。
+  globalSetup: "./tests/e2e/global-setup.ts",
   use: {
     baseURL,
     trace: "on-first-retry",
@@ -21,6 +24,8 @@ export default defineConfig({
     video: "retain-on-failure",
     locale: "ja-JP",
     timezoneId: "Asia/Tokyo",
+    // global-setup で生成した認証済み storageState を全テストで共有
+    storageState: "tests/e2e/.auth/user.json",
   },
   projects: [
     { name: "chromium", use: { ...devices["Desktop Chrome"] } },

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -5,30 +5,90 @@ export const E2E_USER = {
   password: process.env.E2E_USER_PASSWORD ?? "ClaudeDebug2026!",
 };
 
-export async function login(page: Page) {
-  await page.goto("/login");
-  await page.locator("#email").fill(E2E_USER.email);
-  await page.locator("#password").fill(E2E_USER.password);
-  await Promise.all([
-    page.waitForURL((url) => !url.pathname.startsWith("/login") && !url.pathname.startsWith("/auth"), {
-      timeout: 60_000,
-    }),
-    page.locator("button[type=submit]").click(),
-  ]);
-  await expect(page).not.toHaveURL(/\/login/);
+// ログインタイムアウト: 前テストが長時間かかった後でも Supabase Auth レスポンスを待てるよう余裕を持たせる
+const LOGIN_TIMEOUT_MS = 90_000;
+// リトライ設定: rate limit / 一時的な遅延に耐えるための指数バックオフ
+const MAX_LOGIN_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 2_000;
 
-  // オンボーディング未完了の場合はAPIで完了させてホームへ誘導する
-  if (page.url().includes("/onboarding")) {
-    await page.evaluate(async () => {
-      try {
-        await fetch("/api/onboarding/complete", { method: "POST", credentials: "include" });
-      } catch {
-        // オンボーディング完了APIのエラーは無視して続行
-      }
-    });
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * ページが認証済みかどうかを確認する。
+ * storageState でセッションがロード済みの場合、ログインページに遷移しないため
+ * /home に navigate して認証状態を確認する。
+ */
+async function isAlreadyLoggedIn(page: Page): Promise<boolean> {
+  try {
     await page.goto("/home");
-    await page.waitForURL("**/home", { timeout: 30_000 });
+    await page.waitForURL((url) => !url.pathname.startsWith("/login") && !url.pathname.startsWith("/auth"), {
+      timeout: 10_000,
+    });
+    return !page.url().includes("/login") && !page.url().includes("/auth");
+  } catch {
+    return false;
   }
+}
+
+export async function login(page: Page): Promise<void> {
+  // storageState でセッションがロード済みの場合はログインをスキップ
+  if (await isAlreadyLoggedIn(page)) {
+    return;
+  }
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= MAX_LOGIN_RETRIES; attempt++) {
+    try {
+      await page.goto("/login");
+      // React ハイドレーションが完了するまで待機する。
+      // ハイドレーション前に submit をクリックすると form が native GET 送信されてしまう。
+      await page.waitForLoadState("networkidle");
+      await page.locator("#email").fill(E2E_USER.email);
+      await page.locator("#password").fill(E2E_USER.password);
+      await Promise.all([
+        page.waitForURL(
+          (url) =>
+            !url.pathname.startsWith("/login") &&
+            !url.pathname.startsWith("/auth"),
+          { timeout: LOGIN_TIMEOUT_MS },
+        ),
+        page.locator("button[type=submit]").click(),
+      ]);
+      await expect(page).not.toHaveURL(/\/login/);
+
+      // オンボーディング未完了の場合はAPIで完了させてホームへ誘導する
+      if (page.url().includes("/onboarding")) {
+        await page.evaluate(async () => {
+          try {
+            await fetch("/api/onboarding/complete", { method: "POST", credentials: "include" });
+          } catch {
+            // オンボーディング完了APIのエラーは無視して続行
+          }
+        });
+        await page.goto("/home");
+        await page.waitForURL("**/home", { timeout: 60_000 });
+      }
+
+      // ログイン成功
+      return;
+    } catch (err) {
+      lastError = err;
+      if (attempt < MAX_LOGIN_RETRIES) {
+        const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        console.warn(
+          `[auth fixture] ログイン試行 ${attempt}/${MAX_LOGIN_RETRIES} 失敗。${delay}ms 後にリトライ: ${err}`,
+        );
+        await sleep(delay);
+      }
+    }
+  }
+
+  throw new Error(
+    `[auth fixture] ${MAX_LOGIN_RETRIES} 回試行後もログイン失敗: ${lastError}`,
+  );
 }
 
 type AuthFixtures = {

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,114 @@
+/**
+ * Playwright グローバルセットアップ
+ *
+ * 全 worker が共有する storageState を生成する。
+ * ログインを 1 回だけ行い、認証済みセッションを
+ * tests/e2e/.auth/user.json に保存する。
+ * 各テストの authedPage fixture はこのファイルを読み込んで
+ * ログイン処理をスキップするため、30s タイムアウト連鎖を回避できる。
+ */
+
+import { chromium, type FullConfig } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+const STORAGE_STATE_PATH = "tests/e2e/.auth/user.json";
+const LOGIN_TIMEOUT_MS = 90_000;
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 2_000;
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function globalSetup(config: FullConfig): Promise<void> {
+  const baseURL =
+    config.projects[0]?.use?.baseURL ??
+    process.env.PLAYWRIGHT_BASE_URL ??
+    "http://localhost:3000";
+
+  const email =
+    process.env.E2E_USER_EMAIL ?? "claude-debug-1777477826@homegohan.local";
+  const password = process.env.E2E_USER_PASSWORD ?? "ClaudeDebug2026!";
+
+  // 保存先ディレクトリを作成
+  const dir = path.dirname(STORAGE_STATE_PATH);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  const browser = await chromium.launch();
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    const context = await browser.newContext({
+      locale: "ja-JP",
+      timezoneId: "Asia/Tokyo",
+    });
+    const page = await context.newPage();
+
+    try {
+      await page.goto(`${baseURL}/login`);
+      // React ハイドレーションが完了するまで待機する。
+      // ハイドレーション前に submit をクリックすると form が native GET 送信されてしまう。
+      await page.waitForLoadState("networkidle");
+      await page.locator("#email").fill(email);
+      await page.locator("#password").fill(password);
+
+      await Promise.all([
+        page.waitForURL(
+          (url) =>
+            !url.pathname.startsWith("/login") &&
+            !url.pathname.startsWith("/auth"),
+          { timeout: LOGIN_TIMEOUT_MS },
+        ),
+        page.locator("button[type=submit]").click(),
+      ]);
+
+      // オンボーディング未完了の場合はAPIで完了させてホームへ誘導
+      if (page.url().includes("/onboarding")) {
+        await page.evaluate(async () => {
+          try {
+            await fetch("/api/onboarding/complete", {
+              method: "POST",
+              credentials: "include",
+            });
+          } catch {
+            // エラーは無視して続行
+          }
+        });
+        await page.goto(`${baseURL}/home`);
+        await page.waitForURL("**/home", { timeout: 60_000 });
+      }
+
+      // storageState を保存
+      await context.storageState({ path: STORAGE_STATE_PATH });
+      console.log(
+        `[global-setup] storageState saved to ${STORAGE_STATE_PATH} (attempt ${attempt})`,
+      );
+      await context.close();
+      await browser.close();
+      return;
+    } catch (err) {
+      lastError = err;
+      console.warn(
+        `[global-setup] ログイン試行 ${attempt}/${MAX_RETRIES} 失敗: ${err}`,
+      );
+      await context.close();
+
+      if (attempt < MAX_RETRIES) {
+        const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        console.log(`[global-setup] ${delay}ms 待機後にリトライ...`);
+        await sleep(delay);
+      }
+    }
+  }
+
+  await browser.close();
+  throw new Error(
+    `[global-setup] ${MAX_RETRIES} 回試行後もログイン失敗: ${lastError}`,
+  );
+}
+
+export default globalSetup;


### PR DESCRIPTION
## Summary

- `/health/graphs` ページが `/api/health/checkups` を fetch する実装は既にコードに存在するが、E2E テストが認証インフラの問題で通らない状態だった
- playwright.config.ts に `globalSetup` と `storageState` を追加し、全ワーカーで認証セッションを共有できるようにした
- `tests/e2e/global-setup.ts` を新規作成し、ログイン 1 回で storageState を生成する仕組みを導入
- `tests/e2e/fixtures/auth.ts` を更新: `isAlreadyLoggedIn` チェック・指数バックオフリトライ・`waitForLoadState("networkidle")` によるハイドレーション前クリック防止を追加

## Test plan

- [ ] `bug-108-129-graphs-insights.spec.ts` の Bug-108 テスト (`グラフページが /api/health/checkups を fetch する`) が pass することを確認
- [ ] Bug-129 テスト (`POST /api/health/insights`, `GET /api/health/insights`) が pass することを確認

Closes #345