### PR TITLE
fix(ci): expo-image-manipulator の lock 整合を修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "expo-constants": "~17.0.0",
         "expo-device": "~7.0.1",
         "expo-haptics": "~14.0.1",
+        "expo-image-manipulator": "~13.0.6",
         "expo-image-picker": "~16.0.6",
         "expo-linear-gradient": "~14.0.2",
         "expo-notifications": "~0.29.9",
@@ -10552,6 +10553,18 @@
       "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.0.0.tgz",
       "integrity": "sha512-Eg+5FHtyzv3Jjw9dHwu2pWy4xjf8fu3V0Asyy42kO+t/FbvW/vjUixpTjPtgKQLQh+2/9Nk4JjFDV6FwCnF2ZA==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-13.0.6.tgz",
+      "integrity": "sha512-Rz8Kcfx1xYm0AsIDi6zfKYUDnwCP8edgYXWb00KAkzOF8bDxwzTrnvESWhCiveM4IB3fojjLpNeENME34p3bzA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.0.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }


### PR DESCRIPTION
## Summary
- `apps/mobile/package.json` に `expo-image-manipulator: ~13.0.6` が追加されたが、root `package-lock.json` に node_modules エントリが入っておらず CI 上の `npm ci` が `Missing: expo-image-manipulator@13.0.6 from lock file` で失敗していた
- `npm install` で root lock を再生成し、`expo-image-manipulator@13.0.6` のエントリを追記
- ローカル `npm ci --dry-run` で `added 102 packages` を確認

## Test plan
- [x] ローカル `npm ci --dry-run` pass
- [ ] CI e2e ワークフローの npm ci ステップが pass することを確認