### PR TITLE
test(e2e): Wave5 W5-6 settings/account/profile adversarial spec を追加

### DIFF
--- a/tests/e2e/wave5-w56-settings-account-profile-adversarial.spec.ts
+++ b/tests/e2e/wave5-w56-settings-account-profile-adversarial.spec.ts
@@ -1,0 +1,1327 @@
+/**
+ * Wave 5 / W5-6: Settings / Account 削除 / Profile 完全嫌がらせ
+ *
+ * prefix: [settings][adversarial] or [account][adversarial] or [profile][adversarial]
+ *
+ * シナリオグループ:
+ *   A. アカウント削除 (#215 fix 後) — 全角/半角、連打、CSRF、JS無効チェック
+ *   B. 設定 toggle 全パターン — 連続反転、並列タブ競合
+ *   C. プロフィール編集 — XSS/空文字/長文、境界値、アレルギー大量
+ *   D. CSV エクスポート (#133) — インジェクション、Content-Type
+ *   E. プラン制限 (#134) — free plan 402、履歴制限
+ *
+ * 実行方法:
+ *   PLAYWRIGHT_BASE_URL=https://homegohan-app.vercel.app npm run test:e2e -- wave5-w56
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { login } from "./fixtures/auth";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/** 削除確認モーダルを開く */
+async function openDeleteModal(page: Page) {
+  await page.goto("/settings");
+  await page.waitForLoadState("networkidle");
+  await page.getByRole("button", { name: /アカウントを削除する/ }).click();
+  await expect(page.getByText("アカウントを削除しますか？")).toBeVisible({
+    timeout: 5_000,
+  });
+}
+
+/** Switch ボタン (bg-[#FF8A65] = ON) の状態を取得 */
+async function isSwitchOn(page: Page, nth: number): Promise<boolean> {
+  const cls =
+    (await page
+      .locator("button.w-12.h-7.rounded-full")
+      .nth(nth)
+      .getAttribute("class")) ?? "";
+  return cls.includes("FF8A65");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A. アカウント削除
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe("[account][adversarial] A. アカウント削除", () => {
+  /**
+   * A-1: 確認テキストに全角「削除します」ではなく半角スペース混入
+   *      → ボタンは disabled のまま
+   */
+  test("A-1: 確認テキスト全角/半角ミスマッチでは削除ボタンが disabled", async ({
+    page,
+  }) => {
+    await login(page);
+    await openDeleteModal(page);
+
+    const input = page.getByRole("textbox", { name: /削除確認テキスト入力/ });
+
+    // 半角スペース混入
+    await input.fill("削除 します");
+    const btn = page.getByRole("button", { name: /アカウントを完全に削除する/ });
+    await expect(btn).toBeDisabled();
+
+    // 英字 "削除shimasu"
+    await input.fill("削除shimasu");
+    await expect(btn).toBeDisabled();
+
+    // 全角スペース混入
+    await input.fill("削除　します");
+    await expect(btn).toBeDisabled();
+
+    // 正解
+    await input.fill("削除します");
+    await expect(btn).toBeEnabled();
+  });
+
+  /**
+   * A-2: 削除ボタンを 5 回連打 → POST が 1 度しか飛ばない (deleting guard)
+   *      実際の削除は行わないため、ネットワークをインターセプトして mock する
+   */
+  test("A-2: 削除ボタン 5 回連打でもリクエストは 1 件のみ (deleting guard)", async ({
+    page,
+  }) => {
+    await login(page);
+    await openDeleteModal(page);
+
+    const input = page.getByRole("textbox", { name: /削除確認テキスト入力/ });
+    await input.fill("削除します");
+
+    // API をインターセプトして 永遠に pending のままにすることで
+    // deleting=true 状態を維持し、実削除を防ぐ
+    let deleteRequestCount = 0;
+    await page.route("**/api/account/delete", async (route) => {
+      deleteRequestCount++;
+      // 最初の 1 件だけ 200 OK を返す（実際の DB 削除は行われない mock）
+      await route.fulfill({ status: 200, body: JSON.stringify({ success: true }) });
+    });
+
+    const confirmBtn = page.getByRole("button", {
+      name: /アカウントを完全に削除する/,
+    });
+
+    // 5 回連打
+    await confirmBtn.click();
+    await confirmBtn.click({ timeout: 500 }).catch(() => {});
+    await confirmBtn.click({ timeout: 500 }).catch(() => {});
+    await confirmBtn.click({ timeout: 500 }).catch(() => {});
+    await confirmBtn.click({ timeout: 500 }).catch(() => {});
+
+    // 少し待って route interceptor が全部捕捉
+    await page.waitForTimeout(1_000);
+
+    // deleting guard が機能していれば 1 件のみ
+    expect(deleteRequestCount).toBe(1);
+  });
+
+  /**
+   * A-3: モーダルキャンセル後に入力テキストがリセットされる
+   *      (再オープン時は空フィールドで始まること)
+   */
+  test("A-3: キャンセル後の再オープンで入力テキストがリセットされる", async ({
+    page,
+  }) => {
+    await login(page);
+    await openDeleteModal(page);
+
+    await page
+      .getByRole("textbox", { name: /削除確認テキスト入力/ })
+      .fill("削除します");
+
+    // キャンセル
+    await page.getByRole("button", { name: /キャンセル/ }).click();
+    await expect(page.getByText("アカウントを削除しますか？")).not.toBeVisible({
+      timeout: 3_000,
+    });
+
+    // 再オープン
+    await page.getByRole("button", { name: /アカウントを削除する/ }).click();
+    await expect(page.getByText("アカウントを削除しますか？")).toBeVisible();
+
+    const input = page.getByRole("textbox", { name: /削除確認テキスト入力/ });
+    const value = await input.inputValue();
+    expect(value).toBe("");
+  });
+
+  /**
+   * A-4: 確認テキスト未入力 / 空白のみでは削除ボタンが disabled
+   */
+  test("A-4: 空文字・空白のみでは削除ボタンが disabled", async ({ page }) => {
+    await login(page);
+    await openDeleteModal(page);
+
+    const input = page.getByRole("textbox", { name: /削除確認テキスト入力/ });
+    const btn = page.getByRole("button", { name: /アカウントを完全に削除する/ });
+
+    // 空文字
+    await input.fill("");
+    await expect(btn).toBeDisabled();
+
+    // スペースのみ
+    await input.fill("   ");
+    await expect(btn).toBeDisabled();
+  });
+
+  /**
+   * A-5: CSRF 的攻撃 — confirm フィールド無しで POST /api/account/delete → 400
+   *      (ブラウザ外から直接 fetch して確認)
+   */
+  test("A-5: confirm フラグ無しの直接 POST は 400 を返す", async ({ page }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const status = await page.evaluate(async () => {
+      const res = await fetch("/api/account/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}), // confirm フィールドなし
+      });
+      return res.status;
+    });
+
+    expect(status).toBe(400);
+  });
+
+  /**
+   * A-6: 未認証 (ログアウト後) での POST /api/account/delete → 401
+   */
+  test("A-6: 未認証での DELETE API は 401 を返す", async ({ page }) => {
+    // ログインせずに直接 fetch
+    await page.goto("/");
+    const status = await page.evaluate(async () => {
+      const res = await fetch("/api/account/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirm: true }),
+      });
+      return res.status;
+    });
+
+    // 401 または 403 (ミドルウェアによるリダイレクトの場合もあるため)
+    expect([401, 403, 302]).toContain(status);
+  });
+
+  /**
+   * A-7: 削除中 (ネットワーク pending) にキャンセルボタンが disabled になる
+   */
+  test("A-7: 削除中はキャンセルボタンが disabled になる", async ({ page }) => {
+    await login(page);
+    await openDeleteModal(page);
+
+    await page
+      .getByRole("textbox", { name: /削除確認テキスト入力/ })
+      .fill("削除します");
+
+    // API を遅延させる
+    await page.route("**/api/account/delete", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+      await route.fulfill({ status: 200, body: JSON.stringify({ success: true }) });
+    });
+
+    const confirmBtn = page.getByRole("button", {
+      name: /アカウントを完全に削除する/,
+    });
+    const cancelBtn = page.getByRole("button", { name: /キャンセル/ });
+
+    await confirmBtn.click();
+    // 「削除中…」表示とキャンセルの disabled を確認
+    await expect(page.getByText("削除中")).toBeVisible({ timeout: 5_000 });
+    await expect(cancelBtn).toBeDisabled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// B. 設定 toggle 全パターン
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe("[settings][adversarial] B. 設定 toggle", () => {
+  /**
+   * B-1: 通知 toggle 10 回連続反転 → 最終状態が DB に一致する
+   *      (奇数回 = 初期値の逆、偶数回 = 初期値と同じ)
+   */
+  test("B-1: 通知 toggle 10 回連続反転で最終状態が保持される", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const notifRow = page
+      .locator("div.flex.items-center.justify-between", {
+        has: page.locator("span", { hasText: "通知" }),
+      })
+      .first();
+    const toggle = notifRow.locator("button").first();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+
+    const initial = await isSwitchOn(page, 0);
+
+    // 10 回連続反転 (各クリック後に PATCH 完了を待つ)
+    for (let i = 0; i < 10; i++) {
+      await Promise.all([
+        page
+          .waitForResponse(
+            (res) =>
+              res.url().includes("/api/notification-preferences") &&
+              res.request().method() === "PATCH",
+            { timeout: 15_000 },
+          )
+          .catch(() => null),
+        toggle.click(),
+      ]);
+    }
+
+    // 10 回反転 = 偶数 → 初期値に戻る
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    const finalState = await isSwitchOn(page, 0);
+    expect(finalState).toBe(initial);
+  });
+
+  /**
+   * B-2: 自動解析 toggle を 3 回反転 → 奇数回なので反転状態が保持される
+   */
+  test("B-2: 自動解析 toggle 3 回反転でリロード後も反転状態が維持される", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const autoRow = page
+      .locator("div.flex.items-center.justify-between", {
+        has: page.locator("span", { hasText: "自動解析" }),
+      })
+      .first();
+    const toggle = autoRow.locator("button").first();
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+
+    const initial = await isSwitchOn(page, 1);
+
+    for (let i = 0; i < 3; i++) {
+      await Promise.all([
+        page
+          .waitForResponse(
+            (res) =>
+              res.url().includes("/api/notification-preferences") &&
+              res.request().method() === "PATCH",
+            { timeout: 15_000 },
+          )
+          .catch(() => null),
+        toggle.click(),
+      ]);
+    }
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    const finalState = await isSwitchOn(page, 1);
+    expect(finalState).toBe(!initial);
+  });
+
+  /**
+   * B-3: toggle PATCH が 5xx を返した場合、UI がロールバックされる
+   */
+  test("B-3: PATCH 5xx 時に toggle がロールバックされ alert が表示される", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const toggle = page.locator("button.w-12.h-7.rounded-full").nth(0);
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+
+    const initialState = await isSwitchOn(page, 0);
+
+    // PATCH を失敗させる
+    await page.route("**/api/notification-preferences", async (route) => {
+      if (route.request().method() === "PATCH") {
+        await route.fulfill({ status: 500, body: JSON.stringify({ error: "server error" }) });
+      } else {
+        await route.continue();
+      }
+    });
+
+    let alertMessage = "";
+    page.once("dialog", async (dialog) => {
+      alertMessage = dialog.message();
+      await dialog.dismiss();
+    });
+
+    await toggle.click();
+    await page.waitForTimeout(2_000);
+
+    // alert が出る
+    expect(alertMessage).toContain("失敗");
+
+    // UI がロールバックされる (= 初期状態に戻る)
+    const afterState = await isSwitchOn(page, 0);
+    expect(afterState).toBe(initialState);
+  });
+
+  /**
+   * B-4: 週の開始日を日曜→月曜→日曜と往復変更 → DB に保持される
+   */
+  test("B-4: 週の開始日 日曜→月曜→日曜 往復でリロード後も正しい値", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const sundayBtn = page.getByRole("button", { name: "日曜" });
+    const mondayBtn = page.getByRole("button", { name: "月曜" });
+    await expect(sundayBtn).toBeVisible({ timeout: 10_000 });
+
+    // 月曜に変更
+    await mondayBtn.click();
+    await page.waitForTimeout(1_500);
+
+    // 日曜に変更
+    await sundayBtn.click();
+    await page.waitForTimeout(1_500);
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    // 日曜がアクティブ (bg-[#FF8A65]) であること
+    const sundayClass =
+      (await page.getByRole("button", { name: "日曜" }).getAttribute("class")) ?? "";
+    expect(sundayClass).toContain("FF8A65");
+  });
+
+  /**
+   * B-5: 通知 OFF で PATCH /api/notification-preferences が呼ばれることを確認
+   *      (Bug #70 修正後の regression テスト)
+   */
+  test("B-5: 通知 toggle クリックで PATCH リクエストが発行される (#70 regression)", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const patchRequests: string[] = [];
+    page.on("request", (req) => {
+      if (
+        req.method() === "PATCH" &&
+        req.url().includes("/api/notification-preferences")
+      ) {
+        patchRequests.push(req.url());
+      }
+    });
+
+    const toggle = page.locator("button.w-12.h-7.rounded-full").nth(0);
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+
+    await Promise.all([
+      page.waitForResponse(
+        (res) =>
+          res.url().includes("/api/notification-preferences") &&
+          res.request().method() === "PATCH",
+        { timeout: 15_000 },
+      ),
+      toggle.click(),
+    ]);
+
+    expect(patchRequests.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// C. プロフィール編集
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe("[profile][adversarial] C. プロフィール編集", () => {
+  /** プロフィール編集モーダルの基本タブを開くヘルパー */
+  async function openProfileBasicTab(page: Page) {
+    await page.goto("/profile");
+    await page.waitForLoadState("networkidle", { timeout: 20_000 }).catch(() => {});
+
+    const basicBtn = page.getByRole("button", { name: /基本情報/ }).first();
+    const isVisible = await basicBtn.isVisible({ timeout: 5_000 }).catch(() => false);
+    if (isVisible) {
+      await basicBtn.click();
+    } else {
+      await page.locator("button").filter({ hasText: /基本情報/ }).first().click();
+    }
+
+    await page.waitForTimeout(1_000);
+  }
+
+  /**
+   * C-1: ニックネームに XSS ペイロード → 保存されてもスクリプトが実行されない
+   */
+  test("C-1: ニックネームの XSS ペイロードがエスケープされる", async ({
+    page,
+  }) => {
+    await login(page);
+    await openProfileBasicTab(page);
+
+    const ageInput = page.locator("#profile-age-input");
+    const visible = await ageInput.isVisible({ timeout: 5_000 }).catch(() => false);
+    if (!visible) {
+      test.skip();
+      return;
+    }
+
+    const nicknameInput = page
+      .locator("input[type='text']")
+      .or(page.locator(".pointer-events-auto input"))
+      .first();
+
+    const xssPayload = '<script>alert("xss")</script>';
+
+    await nicknameInput.fill(xssPayload);
+
+    let alertFired = false;
+    page.on("dialog", async (dialog) => {
+      alertFired = true;
+      await dialog.dismiss();
+    });
+
+    // 保存ボタンをクリック
+    const saveBtn = page
+      .locator(".pointer-events-auto button:has-text('変更を保存')")
+      .or(page.getByRole("button", { name: /変更を保存/ }))
+      .first();
+
+    await saveBtn.click({ timeout: 5_000 }).catch(() => {});
+    await page.waitForTimeout(2_000);
+
+    // XSS は実行されない
+    expect(alertFired).toBe(false);
+  });
+
+  /**
+   * C-2: ニックネームに 1000 文字入力 → API がエラーを返すかサーバーサイドで切り詰める
+   */
+  test("C-2: 1000 文字ニックネームで API がクラッシュしない", async ({
+    page,
+  }) => {
+    await login(page);
+    await openProfileBasicTab(page);
+
+    const ageInput = page.locator("#profile-age-input");
+    const visible = await ageInput.isVisible({ timeout: 5_000 }).catch(() => false);
+    if (!visible) {
+      test.skip();
+      return;
+    }
+
+    const longName = "あ".repeat(1000);
+    const nicknameInput = page
+      .locator(".pointer-events-auto input[type='text']")
+      .first();
+
+    await nicknameInput.fill(longName);
+
+    const responsePromise = page.waitForResponse(
+      (res) => res.url().includes("/api/profile"),
+      { timeout: 15_000 },
+    );
+
+    const saveBtn = page
+      .locator(".pointer-events-auto button:has-text('変更を保存')")
+      .first();
+    await saveBtn.click({ timeout: 5_000 }).catch(() => {});
+
+    const res = await responsePromise.catch(() => null);
+    if (res) {
+      // 5xx は許容しない (400 エラーは許容)
+      expect(res.status()).toBeLessThan(500);
+    }
+  });
+
+  /**
+   * C-3: 空ニックネームで保存 → 何かしらのデフォルト値かエラーが返る
+   */
+  test("C-3: 空ニックネームで保存しても 5xx エラーが発生しない", async ({
+    page,
+  }) => {
+    await login(page);
+    await openProfileBasicTab(page);
+
+    const ageInput = page.locator("#profile-age-input");
+    const visible = await ageInput.isVisible({ timeout: 5_000 }).catch(() => false);
+    if (!visible) {
+      test.skip();
+      return;
+    }
+
+    const nicknameInput = page
+      .locator(".pointer-events-auto input[type='text']")
+      .first();
+    await nicknameInput.fill("");
+
+    const responsePromise = page.waitForResponse(
+      (res) => res.url().includes("/api/profile"),
+      { timeout: 15_000 },
+    );
+
+    const saveBtn = page
+      .locator(".pointer-events-auto button:has-text('変更を保存')")
+      .first();
+    await saveBtn.click({ timeout: 5_000 }).catch(() => {});
+
+    const res = await responsePromise.catch(() => null);
+    if (res) {
+      expect(res.status()).toBeLessThan(500);
+    }
+  });
+
+  /**
+   * C-4: 体重境界値テスト — 0, 負数, 999, 9999 を入力
+   *      API が 5xx を返さないこと
+   */
+  test("C-4: 体重に境界値 (0/負数/999/9999) を入力しても 5xx にならない", async ({
+    page,
+  }) => {
+    await login(page);
+    await openProfileBasicTab(page);
+
+    const ageInput = page.locator("#profile-age-input");
+    const visible = await ageInput.isVisible({ timeout: 5_000 }).catch(() => false);
+    if (!visible) {
+      test.skip();
+      return;
+    }
+
+    const weightInput = page.locator("#profile-weight-input");
+    await expect(weightInput).toBeVisible();
+
+    const testValues = ["0", "-1", "999", "9999"];
+
+    for (const val of testValues) {
+      await weightInput.fill(val);
+
+      const responsePromise = page.waitForResponse(
+        (res) => res.url().includes("/api/profile"),
+        { timeout: 15_000 },
+      );
+
+      const saveBtn = page
+        .locator(".pointer-events-auto button:has-text('変更を保存')")
+        .first();
+      await saveBtn.click({ timeout: 5_000 }).catch(() => {});
+
+      const res = await responsePromise.catch(() => null);
+      if (res) {
+        expect(res.status()).toBeLessThan(500);
+      }
+
+      // 再度モーダルを開く
+      await page.waitForTimeout(500);
+      const modal = await page
+        .locator("text=プロフィール編集")
+        .isVisible()
+        .catch(() => false);
+      if (!modal) {
+        await openProfileBasicTab(page);
+      }
+    }
+  });
+
+  /**
+   * C-5: 身長に 0, 負数, 250, 9999 を入力
+   */
+  test("C-5: 身長に境界値入力しても 5xx にならない", async ({ page }) => {
+    await login(page);
+    await openProfileBasicTab(page);
+
+    const heightInput = page.locator("#profile-height-input");
+    const visible = await heightInput
+      .isVisible({ timeout: 5_000 })
+      .catch(() => false);
+    if (!visible) {
+      test.skip();
+      return;
+    }
+
+    const testValues = ["0", "-1", "250", "9999"];
+
+    for (const val of testValues) {
+      await heightInput.fill(val);
+
+      const responsePromise = page.waitForResponse(
+        (res) => res.url().includes("/api/profile"),
+        { timeout: 15_000 },
+      );
+
+      const saveBtn = page
+        .locator(".pointer-events-auto button:has-text('変更を保存')")
+        .first();
+      await saveBtn.click({ timeout: 5_000 }).catch(() => {});
+
+      const res = await responsePromise.catch(() => null);
+      if (res) {
+        expect(res.status()).toBeLessThan(500);
+      }
+
+      await page.waitForTimeout(500);
+      const modal = await page
+        .locator("text=プロフィール編集")
+        .isVisible()
+        .catch(() => false);
+      if (!modal) {
+        await openProfileBasicTab(page);
+      }
+    }
+  });
+
+  /**
+   * C-6: 年齢に負数・0・200 を入力
+   */
+  test("C-6: 年齢に境界値 (負数/0/200) 入力しても 5xx にならない", async ({
+    page,
+  }) => {
+    await login(page);
+    await openProfileBasicTab(page);
+
+    const ageInput = page.locator("#profile-age-input");
+    const visible = await ageInput.isVisible({ timeout: 5_000 }).catch(() => false);
+    if (!visible) {
+      test.skip();
+      return;
+    }
+
+    const testValues = ["-1", "0", "200"];
+
+    for (const val of testValues) {
+      await ageInput.fill(val);
+
+      const responsePromise = page.waitForResponse(
+        (res) => res.url().includes("/api/profile"),
+        { timeout: 15_000 },
+      );
+
+      const saveBtn = page
+        .locator(".pointer-events-auto button:has-text('変更を保存')")
+        .first();
+      await saveBtn.click({ timeout: 5_000 }).catch(() => {});
+
+      const res = await responsePromise.catch(() => null);
+      if (res) {
+        expect(res.status()).toBeLessThan(500);
+      }
+
+      await page.waitForTimeout(500);
+      const modal = await page
+        .locator("text=プロフィール編集")
+        .isVisible()
+        .catch(() => false);
+      if (!modal) {
+        await openProfileBasicTab(page);
+      }
+    }
+  });
+
+  /**
+   * C-7: 目標期限に過去日付 (2000-01-01) を設定 → 5xx にならない
+   */
+  test("C-7: 目標期限に過去日付を設定しても 5xx にならない", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/profile");
+    await page.waitForLoadState("networkidle", { timeout: 20_000 }).catch(() => {});
+
+    // 目標タブを開く
+    const goalBtn = page.getByRole("button", { name: /目標設定/ }).first();
+    const goalVisible = await goalBtn.isVisible({ timeout: 5_000 }).catch(() => false);
+    if (goalVisible) {
+      await goalBtn.click();
+    }
+    await page.waitForTimeout(1_000);
+
+    const dateInput = page.locator(".pointer-events-auto input[type='date']").first();
+    const dateVisible = await dateInput
+      .isVisible({ timeout: 5_000 })
+      .catch(() => false);
+    if (!dateVisible) {
+      test.skip();
+      return;
+    }
+
+    await dateInput.fill("2000-01-01");
+
+    const responsePromise = page.waitForResponse(
+      (res) => res.url().includes("/api/profile"),
+      { timeout: 15_000 },
+    );
+
+    const saveBtn = page
+      .locator(".pointer-events-auto button:has-text('変更を保存')")
+      .first();
+    await saveBtn.click({ timeout: 5_000 }).catch(() => {});
+
+    const res = await responsePromise.catch(() => null);
+    if (res) {
+      expect(res.status()).toBeLessThan(500);
+    }
+  });
+
+  /**
+   * C-8: 目標期限に 9999-12-31 (遠未来) → 5xx にならない
+   */
+  test("C-8: 目標期限に 9999-12-31 を設定しても 5xx にならない", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/profile");
+    await page.waitForLoadState("networkidle", { timeout: 20_000 }).catch(() => {});
+
+    const goalBtn = page.getByRole("button", { name: /目標設定/ }).first();
+    const goalVisible = await goalBtn.isVisible({ timeout: 5_000 }).catch(() => false);
+    if (goalVisible) {
+      await goalBtn.click();
+    }
+    await page.waitForTimeout(1_000);
+
+    const dateInput = page.locator(".pointer-events-auto input[type='date']").first();
+    const dateVisible = await dateInput
+      .isVisible({ timeout: 5_000 })
+      .catch(() => false);
+    if (!dateVisible) {
+      test.skip();
+      return;
+    }
+
+    await dateInput.fill("9999-12-31");
+
+    const responsePromise = page.waitForResponse(
+      (res) => res.url().includes("/api/profile"),
+      { timeout: 15_000 },
+    );
+
+    const saveBtn = page
+      .locator(".pointer-events-auto button:has-text('変更を保存')")
+      .first();
+    await saveBtn.click({ timeout: 5_000 }).catch(() => {});
+
+    const res = await responsePromise.catch(() => null);
+    if (res) {
+      expect(res.status()).toBeLessThan(500);
+    }
+  });
+
+  /**
+   * C-9: 性別を奇数回 (3 回) 切り替えた後に保存 → 栄養目標再計算 API が走る
+   *      (gender は NUTRITION_TRIGGER_FIELDS に含まれるので PUT /api/profile 後に
+   *       nutrition_targets の更新が走ることを確認)
+   */
+  test("C-9: 性別 3 回切り替えで保存後に栄養計算 API が更新される", async ({
+    page,
+  }) => {
+    await login(page);
+    await openProfileBasicTab(page);
+
+    const genderSelect = page
+      .locator(".pointer-events-auto select")
+      .first();
+    const genderVisible = await genderSelect
+      .isVisible({ timeout: 5_000 })
+      .catch(() => false);
+    if (!genderVisible) {
+      test.skip();
+      return;
+    }
+
+    // 3 回切り替え
+    const options = ["male", "female", "unspecified", "male", "female", "unspecified"];
+    for (let i = 0; i < 3; i++) {
+      await genderSelect.selectOption(options[i]);
+      await page.waitForTimeout(100);
+    }
+
+    const profileResponsePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes("/api/profile") && res.request().method() === "PUT",
+      { timeout: 15_000 },
+    );
+
+    const saveBtn = page
+      .locator(".pointer-events-auto button:has-text('変更を保存')")
+      .first();
+    await saveBtn.click({ timeout: 5_000 }).catch(() => {});
+
+    const res = await profileResponsePromise.catch(() => null);
+    if (res) {
+      expect(res.status()).toBeLessThan(500);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// D. CSV エクスポート (#133)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe("[settings][adversarial] D. CSV エクスポート", () => {
+  /**
+   * D-1: CSV ダウンロードされたファイルのヘッダー行が正しい
+   */
+  test("D-1: CSV エクスポートのヘッダー行が正しい", async ({ page }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const downloadPromise = page.waitForEvent("download", { timeout: 30_000 });
+    const csvButton = page.getByRole("button", { name: /献立をCSVエクスポート/ });
+    await expect(csvButton).toBeVisible();
+    await csvButton.click();
+
+    const download = await downloadPromise;
+    const filename = download.suggestedFilename();
+    expect(filename).toMatch(/^homegohan-meals-.*\.csv$/);
+
+    // ストリームからテキストを読む
+    const stream = await download.createReadStream();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const text = Buffer.concat(chunks).toString("utf-8");
+
+    // ヘッダー行のチェック
+    const firstLine = text.split("\r\n")[0] || text.split("\n")[0];
+    expect(firstLine).toContain("date");
+    expect(firstLine).toContain("dish_name");
+    expect(firstLine).toContain("calories_kcal");
+  });
+
+  /**
+   * D-2: CSV エクスポート Content-Type が text/csv であること
+   */
+  test("D-2: CSV エクスポートの Content-Type が text/csv", async ({ page }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const responsePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes("/api/export/meals") && res.request().method() === "GET",
+      { timeout: 30_000 },
+    );
+
+    const csvButton = page.getByRole("button", { name: /献立をCSVエクスポート/ });
+    await csvButton.click();
+
+    const res = await responsePromise.catch(() => null);
+    if (res) {
+      const contentType = res.headers()["content-type"] ?? "";
+      expect(contentType).toContain("text/csv");
+    }
+  });
+
+  /**
+   * D-3: CSV エクスポートボタンを 2 回連打しても 2 重リクエストが飛ばない
+   *      (exportingCsv guard が機能する)
+   */
+  test("D-3: CSV エクスポートボタン 2 回連打でリクエストは 1 件のみ", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    let csvRequestCount = 0;
+    page.on("request", (req) => {
+      if (
+        req.url().includes("/api/export/meals") &&
+        req.method() === "GET"
+      ) {
+        csvRequestCount++;
+      }
+    });
+
+    const csvButton = page.getByRole("button", { name: /献立をCSVエクスポート/ });
+    await csvButton.click();
+    await csvButton.click({ timeout: 500 }).catch(() => {});
+
+    // ダウンロード完了を待つ
+    await page.waitForEvent("download", { timeout: 30_000 }).catch(() => {});
+    await page.waitForTimeout(1_000);
+
+    expect(csvRequestCount).toBe(1);
+  });
+
+  /**
+   * D-4: 未認証での /api/export/meals GET → 401
+   */
+  test("D-4: 未認証での CSV エクスポート API は 401 を返す", async ({ page }) => {
+    await page.goto("/");
+    const status = await page.evaluate(async () => {
+      const res = await fetch("/api/export/meals", { method: "GET" });
+      return res.status;
+    });
+    expect([401, 403, 302]).toContain(status);
+  });
+
+  /**
+   * D-5: CSV に formula injection ペイロードが含まれる場合でも
+   *      エクスポート自体は正常終了する
+   *      (サーバーがクラッシュしないことを確認。実際の injection 防御は
+   *       escapeCsv 関数でダブルクォートエスケープされているため)
+   */
+  test("D-5: description に CSV injection ペイロードがあっても API クラッシュしない", async ({
+    page,
+  }) => {
+    await login(page);
+
+    // API を直接叩いて確認
+    const res = await page.evaluate(async () => {
+      const r = await fetch("/api/export/meals", { method: "GET" });
+      return { status: r.status, ok: r.ok };
+    });
+
+    // エクスポート自体は成功すること
+    expect(res.status).toBe(200);
+  });
+
+  /**
+   * D-6: start_date / end_date クエリパラメータで SQL injection 試行
+   */
+  test("D-6: start_date に SQL injection を試みても 5xx にならない", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const status = await page.evaluate(async () => {
+      const url = "/api/export/meals?start_date=2020-01-01' OR '1'='1&end_date=2030-12-31";
+      const res = await fetch(url);
+      return res.status;
+    });
+
+    // 5xx でないこと (Supabase parameterized query で注入は無効化される)
+    expect(status).toBeLessThan(500);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// E. プラン制限 (#134)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe("[settings][adversarial] E. プラン制限 (#134)", () => {
+  /**
+   * E-1: free plan 向け checkHistoryLimit の境界値テスト (30 日ちょうど)
+   *      GET /api/export/meals?start_date=<30日前+1日> → 200
+   *      GET /api/export/meals?start_date=<31日前> → (free plan なら 402 を返すはず)
+   *      ※ 現在の E2E ユーザーが free plan かどうかわからないため status を記録するのみ
+   */
+  test("E-1: 30 日境界の start_date で export が 200 または 402 を返す", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const today = new Date();
+    const d30 = new Date(today);
+    d30.setDate(today.getDate() - 30);
+    const d31 = new Date(today);
+    d31.setDate(today.getDate() - 31);
+
+    const fmt = (d: Date) => d.toISOString().split("T")[0];
+
+    // 30 日前のデータ → free plan でも OK (境界内)
+    const status30 = await page.evaluate(async (date) => {
+      const res = await fetch(`/api/export/meals?start_date=${date}`);
+      return res.status;
+    }, fmt(d30));
+
+    // 31 日前 → free plan なら 402、有料なら 200
+    const status31 = await page.evaluate(async (date) => {
+      const res = await fetch(`/api/export/meals?start_date=${date}`);
+      return res.status;
+    }, fmt(d31));
+
+    // どちらも 5xx でないこと
+    expect(status30).toBeLessThan(500);
+    expect(status31).toBeLessThan(500);
+    // 有効なステータスコードの確認
+    expect([200, 400, 402]).toContain(status30);
+    expect([200, 400, 402]).toContain(status31);
+  });
+
+  /**
+   * E-2: /api/export/meals の Cache-Control が no-store であること
+   *      (キャッシュによる誤データ配信防止)
+   */
+  test("E-2: CSV エクスポートレスポンスの Cache-Control が no-store", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const responsePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes("/api/export/meals") && res.request().method() === "GET",
+      { timeout: 30_000 },
+    );
+
+    const csvButton = page.getByRole("button", { name: /献立をCSVエクスポート/ });
+    await csvButton.click();
+
+    const res = await responsePromise.catch(() => null);
+    if (res) {
+      const cacheControl = res.headers()["cache-control"] ?? "";
+      expect(cacheControl).toContain("no-store");
+    }
+  });
+
+  /**
+   * E-3: checkDailyMealLimit のヘルパー関数ロジック確認 (ユニットレベル、API経由)
+   *      POST /api/meals に対して free plan で 4 回目を試みると 402 が返ることを期待
+   *      ※ 現 E2E ユーザーのプランが不明なので、ステータスを記録して 5xx でないことのみ確認
+   */
+  test("E-3: 食事記録 API が 200 または 402 を返す (5xx でない)", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const today = new Date().toISOString().split("T")[0];
+
+    // 食事記録の典型的なエンドポイントへのテスト (実際のエンドポイントに合わせて調整)
+    const status = await page.evaluate(async (date) => {
+      const res = await fetch("/api/meals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          date,
+          meal_type: "breakfast",
+          dish_name: "テスト料理",
+        }),
+      }).catch(() => ({ status: 0 }));
+      return (res as Response).status;
+    }, today);
+
+    // 5xx でないこと (404 も許容、エンドポイントが存在しない場合)
+    expect(status).not.toBe(500);
+    expect(status).not.toBe(502);
+    expect(status).not.toBe(503);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// F. 追加の嫌がらせシナリオ
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe("[settings][adversarial] F. 追加シナリオ", () => {
+  /**
+   * F-1: 設定ページでログアウト → ブラウザバック → /settings は /login にリダイレクト
+   */
+  test("F-1: ログアウト後にブラウザバックで /settings に戻っても /login にリダイレクトされる", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    // ログアウト実行
+    await page.getByRole("button", { name: "ログアウト" }).click();
+    await expect(page.locator("text=ログアウトしますか？")).toBeVisible({
+      timeout: 5_000,
+    });
+    await page.locator(".pointer-events-auto button:has-text('ログアウト')").click();
+    await page.waitForURL(/\/login/, { timeout: 20_000 });
+
+    // ブラウザバック
+    await page.goBack();
+    await page.waitForTimeout(2_000);
+
+    // 認証が切れているため /login にリダイレクトされるか /settings のままでも未認証状態
+    const currentUrl = page.url();
+    // /settings のままの場合でも、APIリクエストは 401 になる
+    const apiStatus = await page.evaluate(async () => {
+      const res = await fetch("/api/notification-preferences");
+      return res.status;
+    });
+    expect([401, 403]).toContain(apiStatus);
+  });
+
+  /**
+   * F-2: JSONデータエクスポート (account/export) Content-Type が application/json
+   */
+  test("F-2: JSON データエクスポートが application/json を返す", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/settings");
+    await page.waitForLoadState("networkidle");
+
+    const responsePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes("/api/account/export") && res.request().method() === "GET",
+      { timeout: 30_000 },
+    );
+
+    const exportButton = page.getByRole("button", { name: /データをエクスポート/ });
+    await exportButton.click();
+
+    const res = await responsePromise.catch(() => null);
+    if (res) {
+      const contentType = res.headers()["content-type"] ?? "";
+      expect(contentType.toLowerCase()).toContain("json");
+    }
+  });
+
+  /**
+   * F-3: /settings ページのセキュリティヘッダー確認
+   *      X-Frame-Options または CSP に frame-ancestors が設定されているべき
+   */
+  test("F-3: /settings ページに X-Frame-Options または CSP frame-ancestors が設定されている", async ({
+    page,
+  }) => {
+    await login(page);
+
+    const responsePromise = page.waitForResponse(
+      (res) => res.url().includes("/settings") && res.status() === 200,
+      { timeout: 15_000 },
+    );
+
+    await page.goto("/settings");
+    const res = await responsePromise.catch(() => null);
+
+    if (res) {
+      const headers = res.headers();
+      const xFrameOptions = headers["x-frame-options"] ?? "";
+      const csp = headers["content-security-policy"] ?? "";
+
+      // どちらかが設定されていること
+      const hasFrameProtection =
+        xFrameOptions.toLowerCase().includes("deny") ||
+        xFrameOptions.toLowerCase().includes("sameorigin") ||
+        csp.includes("frame-ancestors");
+
+      // Vercel はデフォルトで X-Frame-Options: DENY を設定することが多い
+      // なければ warning として記録
+      if (!hasFrameProtection) {
+        console.warn(
+          "[security] X-Frame-Options / CSP frame-ancestors が未設定 → Clickjacking リスク",
+        );
+      }
+
+      // このテストは現状の確認のみ (hard fail ではなく観測)
+      expect(typeof xFrameOptions + typeof csp).toBe("stringstring");
+    }
+  });
+
+  /**
+   * F-4: プロフィール API に不正な JSON を送信 → 5xx でなく 400 または graceful error
+   */
+  test("F-4: プロフィール PUT に不正 JSON を送信しても 5xx にならない", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/profile");
+    await page.waitForLoadState("networkidle");
+
+    const status = await page.evaluate(async () => {
+      const res = await fetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: "{ invalid json ~~~ }",
+      });
+      return res.status;
+    });
+
+    // 400 (Bad Request) が返るべき
+    expect(status).toBeLessThan(500);
+  });
+
+  /**
+   * F-5: プロフィール API に非常に深いネスト JSON を送信 → 5xx にならない
+   */
+  test("F-5: プロフィール PUT に深いネスト JSON を送信しても 5xx にならない", async ({
+    page,
+  }) => {
+    await login(page);
+    await page.goto("/profile");
+    await page.waitForLoadState("networkidle");
+
+    // 深さ 100 のネスト
+    let nested: Record<string, unknown> = { value: "end" };
+    for (let i = 0; i < 100; i++) {
+      nested = { nested };
+    }
+
+    const status = await page.evaluate(async (body) => {
+      const res = await fetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      return res.status;
+    }, nested);
+
+    expect(status).toBeLessThan(500);
+  });
+
+  /**
+   * F-6: 削除モーダルで Enter キーを押しても (テキスト未入力) 削除が実行されない
+   */
+  test("F-6: 削除確認テキスト未入力で Enter キーを押しても削除が実行されない", async ({
+    page,
+  }) => {
+    await login(page);
+    await openDeleteModal(page);
+
+    let deleteRequested = false;
+    page.on("request", (req) => {
+      if (
+        req.url().includes("/api/account/delete") &&
+        req.method() === "POST"
+      ) {
+        deleteRequested = true;
+      }
+    });
+
+    const input = page.getByRole("textbox", { name: /削除確認テキスト入力/ });
+    // 何も入力せずに Enter
+    await input.press("Enter");
+    await page.waitForTimeout(1_000);
+
+    expect(deleteRequested).toBe(false);
+  });
+
+  /**
+   * F-7: 削除モーダルの背景を念押しクリック → モーダルが閉じない (pointer-events-auto 確認)
+   *       (モーダル外のバックドロップクリックで閉じないことを確認)
+   *       ※ 実装によっては閉じる場合もあるが、deleting 中は閉じないべき
+   */
+  test("F-7: 削除中 (pending) のモーダルはバックドロップクリックで閉じない", async ({
+    page,
+  }) => {
+    await login(page);
+    await openDeleteModal(page);
+
+    await page
+      .getByRole("textbox", { name: /削除確認テキスト入力/ })
+      .fill("削除します");
+
+    // API を遅延させる
+    await page.route("**/api/account/delete", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+      await route.fulfill({ status: 200, body: JSON.stringify({ success: true }) });
+    });
+
+    await page
+      .getByRole("button", { name: /アカウントを完全に削除する/ })
+      .click();
+
+    // 削除中の表示を確認
+    await expect(page.getByText("削除中")).toBeVisible({ timeout: 5_000 });
+
+    // モーダルがまだ表示されている
+    await expect(page.getByText("アカウントを削除しますか？")).toBeVisible();
+  });
+});
+


### PR DESCRIPTION
## Summary
未 commit のまま残っていた Wave5 W5-6 嫌がらせテスト 1 件を取り込む。

- `tests/e2e/wave5-w56-settings-account-profile-adversarial.spec.ts`

過去のローカル作業で作成されたが origin/main に push されていなかったため、本 PR で正規化する。

## Test plan
- [x] tsc 影響なし (テストファイルのみ追加)