### PR TITLE
fix: demandVector null 参照によるランタイムクラッシュを修正

### DIFF
--- a/packages/core/src/nutrition/adaptive-loop.ts
+++ b/packages/core/src/nutrition/adaptive-loop.ts
@@ -284,6 +284,9 @@ export function analyzeCheckinLoop(
   if (performanceProfile?.sport) {
     const { phase, demandVector } = performanceProfile.sport;
 
+    // demandVector が未設定 (オンボーディング進行中などの状態) ではスポーツ特有調整をスキップ
+    if (demandVector) {
+
     // 試合期は炭水化物を優先
     if (phase === 'competition' && demandVector.endurance > 0.5) {
       recommendations.push({
@@ -305,6 +308,7 @@ export function analyzeCheckinLoop(
         priority: 2,
       });
     }
+    } // end if (demandVector)
   }
 
   // 優先度でソート

--- a/packages/core/src/nutrition/calculate.ts
+++ b/packages/core/src/nutrition/calculate.ts
@@ -1122,6 +1122,11 @@ function applyPerformanceGuardrails(input: GuardrailInput): GuardrailOutput {
   if (performanceProfile?.sport) {
     const demandVector = performanceProfile.sport.demandVector;
 
+    // demandVector が未設定 (オンボーディング進行中などの状態) ではスポーツ特有調整をスキップ
+    if (!demandVector) {
+      // noop
+    } else {
+
     // 持久系スポーツ: 炭水化物を増加
     if (demandVector.endurance > 0.7) {
       const minCarbsRatio = 0.55;
@@ -1181,6 +1186,7 @@ function applyPerformanceGuardrails(input: GuardrailInput): GuardrailOutput {
         severity: 'info',
       });
     }
+    } // end else (demandVector exists)
   }
 
   // ================================================


### PR DESCRIPTION
## 概要

スポーツ変更直後などオンボーディング完了前に `demandVector: null` が保存された状態で `/api/performance/analyze` を呼ぶと、`null.endurance` 参照で 500 エラーが発生していた。

## 変更内容

- `packages/core/src/nutrition/calculate.ts` (1122-1189 行のスポーツ特有調整ブロック): `demandVector` が null/undefined の場合は調整全体をスキップ
- `packages/core/src/nutrition/adaptive-loop.ts` (283-311 行の競技特有調整ブロック): 同様に `demandVector` null 時はスキップ

## テスト

- `calculate.test.ts` 27件全パス
- `npx tsc --noEmit` エラーなし