### PR TITLE
fix: API routeのconsole.errorをdb-loggerへ置換

### DIFF
--- a/src/app/api/onboarding/progress/route.ts
+++ b/src/app/api/onboarding/progress/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
+import { createLogger, generateRequestId } from '@/lib/db-logger'
 import { NextResponse } from 'next/server'
 
 // #277: XSS ペイロードを除去するシンプルなサニタイズ関数
@@ -16,6 +17,8 @@ function sanitizeText(value: unknown): string {
 
 // オンボーディング進捗保存API (OB-API-01)
 export async function POST(request: Request) {
+  const requestId = generateRequestId()
+  const logger = createLogger('POST /api/onboarding/progress', requestId)
   try {
     const supabase = await createClient()
     const { data: { user }, error: authError } = await supabase.auth.getUser()
@@ -192,7 +195,7 @@ export async function POST(request: Request) {
       .single()
 
     if (error) {
-      console.error('Onboarding progress save error:', error)
+      logger.error('Onboarding progress save error', error)
       return NextResponse.json({ error: error.message }, { status: 500 })
     }
 
@@ -201,7 +204,7 @@ export async function POST(request: Request) {
       progress: data.onboarding_progress,
     })
   } catch (error: any) {
-    console.error('API Error:', error)
+    logger.error('API Error', error)
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
 }

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server'
+import { createLogger, generateRequestId } from '@/lib/db-logger'
 import { NextResponse } from 'next/server'
 import { fromUserProfile } from '@/lib/converter'
 import { calculateNutritionTargets } from '@homegohan/core'
@@ -58,6 +59,8 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
+  const requestId = generateRequestId()
+  const logger = createLogger('POST /api/profile', requestId)
   try {
     const supabase = await createClient()
     const { data: { user }, error: authError } = await supabase.auth.getUser()
@@ -118,25 +121,27 @@ export async function POST(request: Request) {
       .single()
 
     if (error) {
-      console.error('Profile update error:', error);
+      logger.error('Profile update error', error);
       return NextResponse.json({ error: error.message }, { status: 500 })
     }
 
     // 栄養目標に影響するフィールドが更新された場合、再計算を試みる
     const shouldRecalculate = checkShouldRecalculateNutrition(body);
     if (shouldRecalculate) {
-      await recalculateNutritionTargetsIfNeeded(supabase, user.id, data);
+      await recalculateNutritionTargetsIfNeeded(supabase, user.id, data, logger);
     }
 
     return NextResponse.json(data)
   } catch (error: unknown) {
-    console.error('API Error:', error);
+    logger.error('API Error', error);
     const message = error instanceof Error ? error.message : 'Unknown error'
     return NextResponse.json({ error: message }, { status: 500 })
   }
 }
 
 export async function PUT(request: Request) {
+  const requestId = generateRequestId()
+  const logger = createLogger('PUT /api/profile', requestId)
   try {
     const supabase = await createClient()
     const { data: { user }, error: authError } = await supabase.auth.getUser()
@@ -179,12 +184,12 @@ export async function PUT(request: Request) {
     // 栄養目標に影響するフィールドが更新された場合、再計算を試みる
     const shouldRecalculate = checkShouldRecalculateNutrition(body);
     if (shouldRecalculate) {
-      await recalculateNutritionTargetsIfNeeded(supabase, user.id, data);
+      await recalculateNutritionTargetsIfNeeded(supabase, user.id, data, logger);
     }
 
     return NextResponse.json(data)
   } catch (error: unknown) {
-    console.error("API Error (PUT /api/profile):", error);
+    logger.error('API Error (PUT /api/profile)', error);
     const message = error instanceof Error ? error.message : 'Unknown error'
     return NextResponse.json({ error: message }, { status: 500 })
   }
@@ -209,7 +214,8 @@ function checkShouldRecalculateNutrition(body: Record<string, unknown>): boolean
 async function recalculateNutritionTargetsIfNeeded(
   supabase: any,
   userId: string,
-  profile: any
+  profile: any,
+  logger: ReturnType<typeof createLogger>
 ): Promise<void> {
   try {
     // 現在の栄養目標を取得
@@ -247,7 +253,7 @@ async function recalculateNutritionTargetsIfNeeded(
     }
   } catch (error) {
     // エラーはログのみ（プロフィール更新自体は成功させる）
-    console.error('Nutrition targets recalculation error:', error);
+    logger.error('Nutrition targets recalculation error', error);
   }
 }
 

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
+import { createLogger, generateRequestId } from '@/lib/db-logger';
 import { NextResponse } from 'next/server';
 
 // レシピ一覧取得
@@ -95,6 +96,8 @@ export async function GET(request: Request) {
 
 // レシピ作成
 export async function POST(request: Request) {
+  const requestId = generateRequestId();
+  const logger = createLogger('POST /api/recipes', requestId);
   const supabase = await createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
   if (userError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -141,7 +144,7 @@ export async function POST(request: Request) {
     });
 
   } catch (error: any) {
-    console.error('Recipe creation error:', error);
+    logger.error('Recipe creation error', error);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- `recipes/route.ts`・`onboarding/progress/route.ts`・`profile/route.ts` に残存していた `console.error` 計6箇所を `createLogger` 経由の `logger.error()` に置換
- CLAUDE.md 規約（構造化ログは `src/lib/db-logger.ts` を使用）に準拠
- `recalculateNutritionTargetsIfNeeded` には `logger` を引数として渡すよう変更
- `npx tsc --noEmit` で型エラーなしを確認済み

## Test plan
- [ ] `npx tsc --noEmit` が通ること
- [ ] レシピ作成・プロフィール更新・オンボーディング保存のエラーケースで `app_logs` テーブルに記録されること