### PR TITLE
fix(mobile): 冷蔵庫解析でカメラ直撮りを選択できるよう修正

### DIFF
--- a/apps/mobile/app/pantry/index.tsx
+++ b/apps/mobile/app/pantry/index.tsx
@@ -149,16 +149,46 @@ export default function PantryPage() {
   }
 
   async function analyzeFridge() {
-    const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (!perm.granted) {
-      Alert.alert("権限が必要です", "写真ライブラリへのアクセスを許可してください。");
-      return;
-    }
-    const picked = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ["images"],
-      base64: true,
-      quality: 0.8,
+    // ユーザーに入力元を選択させる
+    const source = await new Promise<"camera" | "library" | null>((resolve) => {
+      Alert.alert(
+        "写真の選択",
+        "冷蔵庫の写真をどこから取得しますか？",
+        [
+          { text: "カメラで撮影", onPress: () => resolve("camera") },
+          { text: "ライブラリから選択", onPress: () => resolve("library") },
+          { text: "キャンセル", style: "cancel", onPress: () => resolve(null) },
+        ],
+      );
     });
+    if (!source) return;
+
+    let picked: ImagePicker.ImagePickerResult;
+
+    if (source === "camera") {
+      const camPerm = await ImagePicker.requestCameraPermissionsAsync();
+      if (!camPerm.granted) {
+        Alert.alert("権限が必要です", "カメラへのアクセスを許可してください。");
+        return;
+      }
+      picked = await ImagePicker.launchCameraAsync({
+        mediaTypes: ["images"],
+        base64: true,
+        quality: 0.8,
+      });
+    } else {
+      const libPerm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!libPerm.granted) {
+        Alert.alert("権限が必要です", "写真ライブラリへのアクセスを許可してください。");
+        return;
+      }
+      picked = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ["images"],
+        base64: true,
+        quality: 0.8,
+      });
+    }
+
     if (picked.canceled) return;
     const asset = picked.assets?.[0];
     if (!asset?.base64) {


### PR DESCRIPTION
## 概要

- `analyzeFridge` に「カメラで撮影」/「ライブラリから選択」の選択 Alert を追加
- カメラ選択時: `requestCameraPermissionsAsync` → `launchCameraAsync`
- ライブラリ選択時: `requestMediaLibraryPermissionsAsync` → `launchImageLibraryAsync`
- `app.json` の iOS `NSCameraUsageDescription` / Android `CAMERA` 権限は既存設定済みのため変更なし

Closes #374

## テスト手順

- [ ] 「写真を選ぶ」ボタンをタップして選択 Alert が表示されること
- [ ] 「カメラで撮影」→ カメラ権限リクエスト → カメラ起動 → 解析完了
- [ ] 「ライブラリから選択」→ 写真ライブラリ権限リクエスト → ライブラリ起動 → 解析完了
- [ ] 「キャンセル」で何も起きないこと