### PR TITLE
fix(mobile): fetchPerformanceAnalysis の API パラメータ不一致を修正 (#398)

### DIFF
--- a/apps/mobile/src/hooks/useHomeData.ts
+++ b/apps/mobile/src/hooks/useHomeData.ts
@@ -416,18 +416,27 @@ export const useHomeData = (userId: string | undefined) => {
   async function fetchPerformanceAnalysis(uid: string) {
     try {
       setPerformanceAnalysis((prev) => ({ ...prev, loading: true }));
+      const todayStr = getTodayStr();
       const api = getApi();
-      const data = await api.get<any>(`/api/performance/analyze?userId=${uid}`);
+      const [data, checkinResult] = await Promise.all([
+        api.get<any>(`/api/performance/analyze?date=${todayStr}`),
+        supabase
+          .from("user_performance_checkins")
+          .select("*")
+          .eq("user_id", uid)
+          .eq("checkin_date", todayStr)
+          .maybeSingle(),
+      ]);
       if (data) {
         setPerformanceAnalysis({
           eligible: data.eligible ?? false,
           eligibilityReason: data.eligibilityReason ?? null,
-          nextAction: data.nextAction ?? null,
-          todayCheckin: data.todayCheckin ?? null,
+          nextAction: data.analysis?.nextAction ?? null,
+          todayCheckin: checkinResult.data ?? null,
           loading: false,
         });
       } else {
-        setPerformanceAnalysis((prev) => ({ ...prev, loading: false }));
+        setPerformanceAnalysis((prev) => ({ ...prev, todayCheckin: checkinResult.data ?? null, loading: false }));
       }
     } catch {
       setPerformanceAnalysis((prev) => ({ ...prev, loading: false }));


### PR DESCRIPTION
## 概要

- `?userId=` クエリパラメータを `?date=YYYY-MM-DD` に修正 (API 仕様に合わせる)
- レスポンスマッピングを `data.nextAction` → `data.analysis?.nextAction` に修正
- `todayCheckin` は API レスポンスに含まれないため、Supabase で `user_performance_checkins` を別途クエリ (web 版と同様)

Closes #398