### PR TITLE
fix(api): analyze-fridge で images[] 配列を受け付けるよう対応

### DIFF
--- a/src/app/api/ai/analyze-fridge/route.ts
+++ b/src/app/api/ai/analyze-fridge/route.ts
@@ -29,13 +29,18 @@ export async function POST(request: Request) {
     const body = await request.json();
     const { imageUrl, imageBase64, mimeType } = body;
 
-    if (!imageUrl && !imageBase64) {
+    const images: { base64: string; mimeType: string }[] =
+      Array.isArray(body.images) && body.images.length > 0
+        ? body.images
+        : imageBase64
+          ? [{ base64: imageBase64, mimeType: mimeType || 'image/jpeg' }]
+          : imageUrl
+            ? [await fetchImageAsBase64(imageUrl)]
+            : [];
+
+    if (images.length === 0) {
       return NextResponse.json({ error: 'Image URL or Base64 is required' }, { status: 400 });
     }
-
-    const images = imageBase64
-      ? [{ base64: imageBase64, mimeType: mimeType || 'image/jpeg' }]
-      : [await fetchImageAsBase64(imageUrl)];
 
     const { data, model } = await generateGeminiJson<FridgeAnalysisResult>({
       prompt: buildPrompt(images.length),


### PR DESCRIPTION
## Summary

- `src/app/api/ai/analyze-fridge/route.ts` の POST ハンドラに `body.images[]` 配列対応を追加
- `classify-photo/route.ts` と同様に `images[] → imageBase64 → imageUrl` の順でフォールバック
- いずれも空の場合は 400 を返す（既存動作を維持）

## Test plan

- [ ] mobile から `{ images: [{base64, mimeType}] }` 形式で送信 → 正常に冷蔵庫解析が返る
- [ ] 従来の `{ imageBase64, mimeType }` 単一形式も引き続き動作する
- [ ] `{ imageUrl }` 形式も引き続き動作する
- [ ] 空ボディで 400 が返る

Closes #411