### PR TITLE
fix(mobile): 進捗リセット時に onboarding_completed_at を null 化

### DIFF
--- a/apps/mobile/app/onboarding/resume.tsx
+++ b/apps/mobile/app/onboarding/resume.tsx
@@ -36,6 +36,7 @@ export default function OnboardingResume() {
                   .from("user_profiles")
                   .update({
                     onboarding_started_at: null,
+                    onboarding_completed_at: null,
                     onboarding_progress: null,
                     updated_at: new Date().toISOString(),
                   })


### PR DESCRIPTION
## Summary

- `handleReset` の supabase update に `onboarding_completed_at: null` を追加
- リセット操作でオンボーディング完了フラグが残存する問題を修正

Closes #404