### PR TITLE
fix(mobile): 献立一覧が常に空表示になる問題を修正 (#442)

### DIFF
--- a/apps/mobile/app/(tabs)/menus.tsx
+++ b/apps/mobile/app/(tabs)/menus.tsx
@@ -37,21 +37,27 @@ export default function MenusScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [hasPlan, setHasPlan] = useState(false);
 
-  const weekStartStr = useMemo(() => formatLocalDate(getWeekStart(new Date())), []);
+  const weekStart = useMemo(() => getWeekStart(new Date()), []);
+  const weekStartStr = useMemo(() => formatLocalDate(weekStart), [weekStart]);
+  const weekEndStr = useMemo(() => {
+    const end = new Date(weekStart);
+    end.setDate(end.getDate() + 6);
+    return formatLocalDate(end);
+  }, [weekStart]);
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
     try {
       const api = getApi();
-      const res = await api.get<{ mealPlan: any }>(`/api/meal-plans?date=${weekStartStr}`);
-      const mealPlan = res.mealPlan;
-      if (!mealPlan) {
+      const res = await api.get<{ dailyMeals: any[] }>(`/api/meal-plans?startDate=${weekStartStr}&endDate=${weekEndStr}`);
+      const dailyMeals = res.dailyMeals ?? [];
+      if (dailyMeals.length === 0) {
         setHasPlan(false);
         setDays([]);
         return;
       }
       setHasPlan(true);
-      const mapped: DaySummary[] = (mealPlan.days ?? []).map((d: any) => {
+      const mapped: DaySummary[] = dailyMeals.map((d: any) => {
         const meals = d.meals ?? [];
         return {
           dayDate: d.dayDate,
@@ -67,7 +73,7 @@ export default function MenusScreen() {
     } finally {
       setIsLoading(false);
     }
-  }, [weekStartStr]);
+  }, [weekStartStr, weekEndStr]);
 
   useEffect(() => { loadData(); }, [loadData]);
 

--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -103,38 +103,36 @@ export default function WeeklyMenuPage() {
 
     try {
       const api = getApi();
-      const res = await api.get<{ mealPlan: any }>(`/api/meal-plans?date=${weekStartStr}`);
-      const mealPlan = res.mealPlan;
+      const res = await api.get<{ dailyMeals: any[]; startDate: string; endDate: string }>(`/api/meal-plans?startDate=${weekStartStr}&endDate=${weekEndStr}`);
+      const dailyMeals = res.dailyMeals ?? [];
 
-      if (!mealPlan) {
+      if (dailyMeals.length === 0) {
         setPlan(null);
         setDays([]);
         return;
       }
 
       setPlan({
-        id: mealPlan.id,
-        start_date: mealPlan.startDate,
-        end_date: mealPlan.endDate,
-        title: mealPlan.title ?? "週間献立",
+        id: dailyMeals[0].id,
+        start_date: res.startDate ?? weekStartStr,
+        end_date: res.endDate ?? weekEndStr,
+        title: "週間献立",
       });
 
-      const mappedDays: DayRow[] =
-        (mealPlan.days ?? []).map((d: any) => ({
-          id: d.id,
-          day_date: d.dayDate,
-          planned_meals:
-            (d.meals ?? []).map((m: any) => ({
-              id: m.id,
-              meal_type: m.mealType,
-              dish_name: m.dishName,
-              mode: m.mode,
-              calories_kcal: m.caloriesKcal,
-              is_completed: m.isCompleted,
-              is_generating: m.isGenerating,
-              display_order: m.displayOrder,
-            })) ?? [],
-        })) ?? [];
+      const mappedDays: DayRow[] = dailyMeals.map((d: any) => ({
+        id: d.id,
+        day_date: d.dayDate,
+        planned_meals: (d.meals ?? []).map((m: any) => ({
+          id: m.id,
+          meal_type: m.mealType,
+          dish_name: m.dishName,
+          mode: m.mode,
+          calories_kcal: m.caloriesKcal,
+          is_completed: m.isCompleted,
+          is_generating: m.isGenerating,
+          display_order: m.displayOrder,
+        })),
+      }));
 
       setDays(mappedDays);
     } catch (e: any) {
@@ -144,7 +142,7 @@ export default function WeeklyMenuPage() {
     } finally {
       setIsLoading(false);
     }
-  }, [weekStartStr]);
+  }, [weekStartStr, weekEndStr]);
 
   useEffect(() => {
     loadData();


### PR DESCRIPTION
## Summary
- `/api/meal-plans?date=` を `?startDate=&endDate=` に変更
- レスポンスの `res.mealPlan` 参照を `res.dailyMeals` 配列に切り替え
- `menus.tsx` と `weekly/index.tsx` の両画面で週間献立が正しく表示される

## Test plan
- [ ] 献立タブを開いて週間サマリが表示されること
- [ ] weekly/index.tsx で日別献立一覧が表示されること
- [ ] 献立が存在しない週は「今週の献立がまだありません」と表示されること

Closes #442