### PR TITLE
fix(mobile): お気に入りページを新規作成 (#414)

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -82,6 +82,13 @@ export default function TabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="favorites"
+        options={{
+          title: "お気に入り",
+          tabBarIcon: ({ color, size }) => <Ionicons name="heart" size={size} color={color} />,
+        }}
+      />
+      <Tabs.Screen
         name="comparison"
         options={{
           title: "比較",

--- a/apps/mobile/app/(tabs)/favorites.tsx
+++ b/apps/mobile/app/(tabs)/favorites.tsx
@@ -1,0 +1,394 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { getApi } from "../../src/lib/api";
+import { colors, radius, shadows, spacing } from "../../src/theme";
+
+type FavoriteItem = {
+  id: string;
+  recipeName: string;
+  recipeUuid: string | null;
+  likedAt: string;
+};
+
+type SortOption = "newest" | "oldest" | "name";
+
+const PAGE_SIZE = 50;
+
+const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: "newest", label: "新しい順" },
+  { value: "oldest", label: "古い順" },
+  { value: "name", label: "名前順" },
+];
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export default function FavoritesScreen() {
+  const insets = useSafeAreaInsets();
+  const api = getApi();
+
+  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sort, setSort] = useState<SortOption>("newest");
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+
+  const searchInputRef = useRef<TextInput>(null);
+
+  const fetchFavorites = useCallback(
+    async (nextOffset: number, currentQuery: string, currentSort: SortOption) => {
+      if (nextOffset === 0) {
+        setLoading(true);
+      } else {
+        setLoadingMore(true);
+      }
+      try {
+        const params = new URLSearchParams({
+          limit: String(PAGE_SIZE),
+          offset: String(nextOffset),
+          sort: currentSort,
+        });
+        if (currentQuery) params.set("q", currentQuery);
+
+        const res = await api.get<{ favorites: FavoriteItem[]; total: number }>(
+          `/api/favorites?${params.toString()}`,
+        );
+        const fetched = res.favorites ?? [];
+
+        if (nextOffset === 0) {
+          setFavorites(fetched);
+        } else {
+          setFavorites((prev) => [...prev, ...fetched]);
+        }
+        setTotal(res.total ?? 0);
+        setOffset(nextOffset + fetched.length);
+        setHasMore(fetched.length === PAGE_SIZE);
+      } catch (err) {
+        console.error("fetchFavorites error:", err);
+        Alert.alert("エラー", "お気に入りの読み込みに失敗しました");
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    },
+    [api],
+  );
+
+  // searchQuery / sort 変更時はリセットして再取得
+  useEffect(() => {
+    setOffset(0);
+    fetchFavorites(0, searchQuery, sort);
+  }, [searchQuery, sort]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleRemove = async (item: FavoriteItem) => {
+    if (removingId) return;
+    setRemovingId(item.id);
+    try {
+      const encodedName = encodeURIComponent(item.recipeName);
+      await api.del(`/api/recipes/${encodedName}/like`);
+      setFavorites((prev) => prev.filter((f) => f.id !== item.id));
+      setTotal((prev) => Math.max(0, prev - 1));
+    } catch (err) {
+      console.error("handleRemove error:", err);
+      Alert.alert("エラー", "お気に入りの解除に失敗しました");
+    } finally {
+      setRemovingId(null);
+    }
+  };
+
+  const renderItem = ({ item }: { item: FavoriteItem }) => (
+    <View
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        gap: spacing.md,
+        backgroundColor: colors.card,
+        borderRadius: radius.xl,
+        padding: spacing.md,
+        borderWidth: 1,
+        borderColor: colors.border,
+        marginBottom: spacing.sm,
+        ...shadows.sm,
+      }}
+    >
+      {/* アイコン */}
+      <View
+        style={{
+          width: 44,
+          height: 44,
+          borderRadius: radius.lg,
+          backgroundColor: "#FFF0F0",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        <Ionicons name="restaurant" size={20} color="#FF6B6B" />
+      </View>
+
+      {/* レシピ情報 */}
+      <View style={{ flex: 1, minWidth: 0 }}>
+        <Text
+          style={{
+            fontWeight: "600",
+            fontSize: 15,
+            color: colors.text,
+            marginBottom: 2,
+          }}
+          numberOfLines={1}
+        >
+          {item.recipeName}
+        </Text>
+        <View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+          <Ionicons name="time-outline" size={11} color={colors.textMuted} />
+          <Text style={{ fontSize: 12, color: colors.textMuted }}>
+            {formatDate(item.likedAt)} に追加
+          </Text>
+        </View>
+      </View>
+
+      {/* ハートボタン */}
+      <Pressable
+        onPress={() => handleRemove(item)}
+        disabled={removingId === item.id}
+        accessibilityLabel="お気に入りから削除"
+        style={({ pressed }) => ({
+          width: 36,
+          height: 36,
+          borderRadius: 18,
+          backgroundColor: removingId === item.id ? colors.bg : "#FFF0F0",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+          opacity: removingId === item.id ? 0.5 : pressed ? 0.7 : 1,
+        })}
+      >
+        <Ionicons
+          name={removingId === item.id ? "heart-outline" : "heart"}
+          size={18}
+          color="#FF6B6B"
+        />
+      </Pressable>
+    </View>
+  );
+
+  const renderEmpty = () => {
+    if (loading) return null;
+    return (
+      <View
+        style={{
+          alignItems: "center",
+          justifyContent: "center",
+          paddingTop: 80,
+          gap: spacing.lg,
+        }}
+      >
+        <Ionicons name="heart-outline" size={56} color={colors.border} />
+        <Text
+          style={{
+            color: colors.textMuted,
+            fontSize: 15,
+            textAlign: "center",
+            lineHeight: 22,
+          }}
+        >
+          {searchQuery
+            ? `「${searchQuery}」に一致するレシピが\n見つかりませんでした`
+            : "お気に入りレシピはまだありません\n週間献立のレシピからハートを押して追加できます"}
+        </Text>
+      </View>
+    );
+  };
+
+  const renderFooter = () => {
+    if (loadingMore) {
+      return (
+        <View style={{ paddingVertical: spacing.lg, alignItems: "center" }}>
+          <ActivityIndicator color={colors.accent} />
+        </View>
+      );
+    }
+    if (hasMore) {
+      return (
+        <Pressable
+          onPress={() => fetchFavorites(offset, searchQuery, sort)}
+          style={({ pressed }) => ({
+            margin: spacing.sm,
+            padding: spacing.md,
+            borderRadius: radius.xl,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.card,
+            alignItems: "center",
+            opacity: pressed ? 0.7 : 1,
+          })}
+        >
+          <Text style={{ fontSize: 14, fontWeight: "600", color: colors.textLight }}>
+            次の50件を表示
+          </Text>
+        </Pressable>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+      {/* ヘッダー */}
+      <View
+        style={{
+          backgroundColor: colors.card,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border,
+          paddingTop: insets.top + 8,
+          paddingBottom: 12,
+          paddingHorizontal: spacing.lg,
+        }}
+      >
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+            <Ionicons name="heart" size={22} color="#FF6B6B" />
+            <Text style={{ fontSize: 18, fontWeight: "700", color: colors.text }}>
+              お気に入りレシピ
+            </Text>
+          </View>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+            {!loading && (
+              <Text style={{ fontSize: 12, color: colors.textMuted }}>{total} 件</Text>
+            )}
+            <Pressable
+              onPress={() => fetchFavorites(0, searchQuery, sort)}
+              hitSlop={8}
+              accessibilityLabel="再読み込み"
+            >
+              <Ionicons name="refresh" size={20} color={colors.textLight} />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+
+      {/* 検索 + ソート */}
+      <View
+        style={{
+          paddingHorizontal: spacing.lg,
+          paddingVertical: spacing.sm,
+          gap: spacing.sm,
+          backgroundColor: colors.card,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border,
+        }}
+      >
+        {/* 検索ボックス */}
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+            backgroundColor: colors.bg,
+            borderWidth: 1,
+            borderColor: colors.border,
+            borderRadius: radius.lg,
+            paddingHorizontal: spacing.md,
+            paddingVertical: 8,
+          }}
+        >
+          <Ionicons name="search" size={16} color={colors.textMuted} />
+          <TextInput
+            ref={searchInputRef}
+            value={searchQuery}
+            onChangeText={setSearchQuery}
+            placeholder="レシピ名で検索..."
+            placeholderTextColor={colors.textMuted}
+            style={{ flex: 1, fontSize: 14, color: colors.text }}
+            returnKeyType="search"
+            clearButtonMode="while-editing"
+          />
+          {searchQuery.length > 0 && (
+            <Pressable onPress={() => setSearchQuery("")} hitSlop={8}>
+              <Ionicons name="close-circle" size={16} color={colors.textMuted} />
+            </Pressable>
+          )}
+        </View>
+
+        {/* ソートピッカー */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ gap: spacing.sm }}
+        >
+          {SORT_OPTIONS.map((opt) => (
+            <Pressable
+              key={opt.value}
+              onPress={() => setSort(opt.value)}
+              style={{
+                paddingHorizontal: spacing.md,
+                paddingVertical: 6,
+                borderRadius: radius.xl,
+                backgroundColor: sort === opt.value ? colors.accent : colors.bg,
+                borderWidth: 1,
+                borderColor: sort === opt.value ? colors.accent : colors.border,
+              }}
+            >
+              <Text
+                style={{
+                  fontSize: 13,
+                  fontWeight: "600",
+                  color: sort === opt.value ? "#fff" : colors.textLight,
+                }}
+              >
+                {opt.label}
+              </Text>
+            </Pressable>
+          ))}
+        </ScrollView>
+      </View>
+
+      {/* コンテンツ */}
+      {loading ? (
+        <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+          <ActivityIndicator size="large" color={colors.accent} />
+          <Text style={{ marginTop: spacing.md, color: colors.textMuted, fontSize: 14 }}>
+            読み込み中...
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={favorites}
+          keyExtractor={(item) => item.id}
+          renderItem={renderItem}
+          ListEmptyComponent={renderEmpty}
+          ListFooterComponent={renderFooter}
+          contentContainerStyle={{
+            padding: spacing.lg,
+            paddingBottom: insets.bottom + spacing.lg,
+          }}
+          showsVerticalScrollIndicator={false}
+        />
+      )}
+    </View>
+  );
+}

--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -1,5 +1,4 @@
 import { Ionicons } from "@expo/vector-icons";
-import { LinearGradient } from "expo-linear-gradient";
 import { router } from "expo-router";
 import { useMemo, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
@@ -43,16 +42,6 @@ const CHECKIN_FIELDS = [
   { key: "focus" as const, label: "🎯 集中力", options: ["低い", "やや低い", "普通", "良い", "最高"] },
   { key: "hunger" as const, label: "🍽️ 空腹感", options: ["ない", "少し", "普通", "ある", "すごくある"] },
 ];
-
-const NEXT_ACTION_LABEL: Record<string, string> = {
-  increase_calories: "カロリーを少し増やしましょう",
-  decrease_calories: "カロリーを少し減らしましょう",
-  increase_protein: "タンパク質を増やしましょう",
-  increase_carbs: "炭水化物を増やしましょう",
-  improve_sleep: "睡眠の質を改善しましょう",
-  reduce_fatigue: "疲労回復を優先しましょう",
-  maintain: "現状を維持しましょう",
-};
 
 const getGreeting = () => {
   const hour = new Date().getHours();

--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
 import { router } from "expo-router";
 import { useMemo, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
@@ -42,6 +43,16 @@ const CHECKIN_FIELDS = [
   { key: "focus" as const, label: "🎯 集中力", options: ["低い", "やや低い", "普通", "良い", "最高"] },
   { key: "hunger" as const, label: "🍽️ 空腹感", options: ["ない", "少し", "普通", "ある", "すごくある"] },
 ];
+
+const NEXT_ACTION_LABEL: Record<string, string> = {
+  increase_calories: "カロリーを少し増やしましょう",
+  decrease_calories: "カロリーを少し減らしましょう",
+  increase_protein: "タンパク質を増やしましょう",
+  increase_carbs: "炭水化物を増やしましょう",
+  improve_sleep: "睡眠の質を改善しましょう",
+  reduce_fatigue: "疲労回復を優先しましょう",
+  maintain: "現状を維持しましょう",
+};
 
 const getGreeting = () => {
   const hour = new Date().getHours();
@@ -422,6 +433,39 @@ export default function HomeScreen() {
                 </Text>
               )}
             </Card>
+          )}
+
+          {/* ========== 次の一手カード ========== */}
+          {performanceAnalysis.nextAction && (
+            <LinearGradient
+              colors={["#8B5CF6", "#6366F1"]}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 0 }}
+              style={{ borderRadius: radius.xl, padding: spacing.lg, ...shadows.md, overflow: "hidden" }}
+            >
+              {/* 装飾円 */}
+              <View style={{
+                position: "absolute", top: -20, right: -20,
+                width: 80, height: 80, borderRadius: 40,
+                backgroundColor: "rgba(255,255,255,0.12)",
+              }} />
+              <View style={{ flexDirection: "row", alignItems: "flex-start", gap: spacing.sm }}>
+                <Ionicons name="navigate" size={18} color="#fff" style={{ marginTop: 2 }} />
+                <View style={{ flex: 1 }}>
+                  <Text style={{ fontSize: 11, fontWeight: "800", color: "rgba(255,255,255,0.8)", marginBottom: 4 }}>
+                    🎯 今日の次の一手
+                  </Text>
+                  <Text style={{ fontSize: 14, fontWeight: "700", color: "#fff", lineHeight: 20 }}>
+                    {NEXT_ACTION_LABEL[performanceAnalysis.nextAction.actionType] ?? performanceAnalysis.nextAction.actionType}
+                  </Text>
+                  {performanceAnalysis.nextAction.reason ? (
+                    <Text style={{ fontSize: 12, color: "rgba(255,255,255,0.75)", marginTop: 4, lineHeight: 18 }}>
+                      {performanceAnalysis.nextAction.reason}
+                    </Text>
+                  ) : null}
+                </View>
+              </View>
+            </LinearGradient>
           )}
 
           {/* チェックイン完了済み */}

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -4,11 +4,13 @@ import { ActivityIndicator, Pressable, Text, View } from "react-native";
 
 import { colors, spacing, shadows, radius } from "../src/theme";
 import { useAuth } from "../src/providers/AuthProvider";
+import { useProfile } from "../src/providers/ProfileProvider";
 
 export default function Index() {
-  const { session, isLoading } = useAuth();
+  const { session, isLoading: authLoading } = useAuth();
+  const { profile, isLoading: profileLoading } = useProfile();
 
-  if (isLoading) {
+  if (authLoading || (session && profileLoading)) {
     return (
       <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.bg }}>
         <ActivityIndicator color={colors.accent} size="large" />
@@ -16,7 +18,8 @@ export default function Index() {
     );
   }
 
-  if (session) return <Redirect href="/(tabs)/home" />;
+  if (session && !profile?.onboardingCompletedAt) return <Redirect href="/onboarding" />;
+  if (session && profile?.onboardingCompletedAt) return <Redirect href="/(tabs)/home" />;
 
   return (
     <View style={{ flex: 1, backgroundColor: "#FFF7ED" }}>


### PR DESCRIPTION
## Summary

- `apps/mobile/app/(tabs)/favorites.tsx` を新規作成
  - `GET /api/favorites`（limit=50 / offset / q / sort=newest|oldest|name）でお気に入り一覧を取得・表示
  - 検索フィールド・ソートピッカーを実装
  - ハートボタンで `DELETE /api/recipes/{name}/like` を呼び出してお気に入り解除
  - offset ベースのページネーション（次の50件ボタン）に対応
- `apps/mobile/app/(tabs)/_layout.tsx` にお気に入りタブを追加（heart アイコン）

## Test plan

- [ ] お気に入りタブをタップして一覧が表示されること
- [ ] 検索フィールドに入力するとフィルタされること
- [ ] ソートを切り替えると並び順が変わること
- [ ] ハートボタンをタップするとお気に入りが解除されリストから消えること
- [ ] 50件超の場合に「次の50件を表示」ボタンが表示されること

Closes #414