### PR TITLE
feat(mobile): 健康診断(checkups)画面を実装

### DIFF
--- a/apps/mobile/app/(tabs)/health.tsx
+++ b/apps/mobile/app/(tabs)/health.tsx
@@ -367,14 +367,14 @@ export default function HealthDashboardTab() {
         <View>
           <View style={styles.sectionRow}>
             <Text style={styles.sectionTitle}>健康診断</Text>
-            <Link href="/health/blood-tests" asChild>
+            <Link href="/health/checkups" asChild>
               <Pressable style={styles.seeAllRow}>
                 <Text style={styles.seeAllText}>すべて見る</Text>
                 <Ionicons name="chevron-forward" size={16} color={colors.accent} />
               </Pressable>
             </Link>
           </View>
-          <Link href="/health/blood-tests" asChild>
+          <Link href="/health/checkups" asChild>
             <Pressable style={styles.checkupCard}>
               <View style={[styles.iconBox, { backgroundColor: "#FFEBEE" }]}>
                 <Ionicons name="pulse" size={24} color={colors.error} />

--- a/apps/mobile/app/health/checkups/index.tsx
+++ b/apps/mobile/app/health/checkups/index.tsx
@@ -1,0 +1,548 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useCallback, useEffect, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { Card, EmptyState, LoadingState } from "../../../src/components/ui";
+import { getApi } from "../../../src/lib/api";
+import { colors, radius, shadows, spacing } from "../../../src/theme";
+
+// ─── Types ────────────────────────────────────────────
+interface IndividualReview {
+  summary: string;
+  concerns: string[];
+  positives: string[];
+  recommendations: string[];
+  riskLevel: "low" | "medium" | "high";
+}
+
+interface HealthCheckup {
+  id: string;
+  checkup_date: string;
+  facility_name?: string;
+  checkup_type?: string;
+  blood_pressure_systolic?: number;
+  blood_pressure_diastolic?: number;
+  hba1c?: number;
+  ldl_cholesterol?: number;
+  triglycerides?: number;
+  individual_review?: IndividualReview;
+}
+
+interface TrendMetric {
+  metric: string;
+  detail: string;
+}
+
+interface TrendAnalysis {
+  overallAssessment: string;
+  improvingMetrics?: TrendMetric[];
+  worseningMetrics?: (TrendMetric & { severity: string })[];
+  stableMetrics?: string[];
+  priorityActions?: string[];
+}
+
+interface NutritionGuidance {
+  generalDirection: string;
+  avoidanceHints?: string[];
+  emphasisHints?: string[];
+  specialNotes?: string;
+}
+
+interface LongitudinalReview {
+  id: string;
+  review_date: string;
+  trend_analysis?: TrendAnalysis;
+  nutrition_guidance?: NutritionGuidance;
+}
+
+// ─── Helpers ──────────────────────────────────────────
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}/${m}/${day}`;
+}
+
+function getRiskColor(level?: string): { bg: string; text: string } {
+  switch (level) {
+    case "high":
+      return { bg: colors.errorLight, text: colors.error };
+    case "medium":
+      return { bg: colors.warningLight, text: colors.warning };
+    default:
+      return { bg: colors.successLight, text: colors.success };
+  }
+}
+
+function getRiskIcon(level?: string): keyof typeof Ionicons.glyphMap {
+  switch (level) {
+    case "high":
+      return "warning-outline";
+    case "medium":
+      return "time-outline";
+    default:
+      return "checkmark-circle-outline";
+  }
+}
+
+function getRiskLabel(level?: string): string {
+  switch (level) {
+    case "high":
+      return "要注意";
+    case "medium":
+      return "注意";
+    default:
+      return "良好";
+  }
+}
+
+// ─── Component ────────────────────────────────────────
+export default function CheckupsPage() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  const [loading, setLoading] = useState(true);
+  const [checkups, setCheckups] = useState<HealthCheckup[]>([]);
+  const [longitudinalReview, setLongitudinalReview] = useState<LongitudinalReview | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const api = getApi();
+      const data = await api.get<{ checkups: HealthCheckup[]; longitudinalReview: LongitudinalReview | null }>(
+        "/api/health/checkups",
+      );
+      setCheckups(data.checkups ?? []);
+      setLongitudinalReview(data.longitudinalReview ?? null);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  if (loading) {
+    return (
+      <View style={[styles.screen, { paddingTop: insets.top }]}>
+        <LoadingState message="健康診断データを読み込み中..." />
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.screen, { paddingTop: insets.top }]}>
+      {/* ─── Header ─── */}
+      <View style={styles.header}>
+        <Pressable onPress={() => router.back()} hitSlop={12}>
+          <Ionicons name="arrow-back" size={24} color={colors.text} />
+        </Pressable>
+        <Text style={styles.headerTitle}>健康診断記録</Text>
+        <Pressable
+          onPress={() => router.push("/health/checkups/new")}
+          style={styles.addBtn}
+          hitSlop={12}
+        >
+          <Ionicons name="add" size={22} color="#fff" />
+        </Pressable>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+
+        {/* ─── 経年分析カード ─── */}
+        {longitudinalReview?.trend_analysis && (
+          <View style={styles.longitudinalCard}>
+            <View style={styles.longitudinalHeader}>
+              <Ionicons name="analytics-outline" size={20} color="#fff" />
+              <Text style={styles.longitudinalTitle}>経年分析</Text>
+              <Text style={styles.longitudinalDate}>{formatDate(longitudinalReview.review_date)}</Text>
+            </View>
+
+            <Text style={styles.longitudinalAssessment}>
+              {longitudinalReview.trend_analysis.overallAssessment}
+            </Text>
+
+            {/* 改善指標 */}
+            {(longitudinalReview.trend_analysis.improvingMetrics ?? []).slice(0, 2).map((item, i) => (
+              <View key={i} style={styles.trendRow}>
+                <View style={styles.trendIconBox}>
+                  <Ionicons name="trending-down" size={14} color="#86efac" />
+                </View>
+                <Text style={styles.trendMetric}>{item.metric}</Text>
+                <Text style={styles.trendBadgeGood}>改善</Text>
+              </View>
+            ))}
+
+            {/* 悪化指標 */}
+            {(longitudinalReview.trend_analysis.worseningMetrics ?? []).slice(0, 2).map((item, i) => (
+              <View key={i} style={styles.trendRow}>
+                <View style={styles.trendIconBox}>
+                  <Ionicons name="trending-up" size={14} color="#fca5a5" />
+                </View>
+                <Text style={styles.trendMetric}>{item.metric}</Text>
+                <Text style={styles.trendBadgeBad}>要注意</Text>
+              </View>
+            ))}
+
+            {/* 食事方針 */}
+            {longitudinalReview.nutrition_guidance?.generalDirection && (
+              <View style={styles.nutritionBox}>
+                <Text style={styles.nutritionLabel}>食事方針</Text>
+                <Text style={styles.nutritionText}>
+                  {longitudinalReview.nutrition_guidance.generalDirection}
+                </Text>
+              </View>
+            )}
+          </View>
+        )}
+
+        {/* ─── 健康診断一覧 ─── */}
+        {checkups.length === 0 ? (
+          <EmptyState
+            icon={<Ionicons name="document-text-outline" size={48} color={colors.textMuted} />}
+            message="健康診断の記録がありません。最初の記録を追加しましょう"
+            actionLabel="記録を追加"
+            onAction={() => router.push("/health/checkups/new")}
+          />
+        ) : (
+          <View style={{ gap: spacing.sm }}>
+            {checkups.map((checkup) => {
+              const riskColor = getRiskColor(checkup.individual_review?.riskLevel);
+              const riskIcon = getRiskIcon(checkup.individual_review?.riskLevel);
+              const riskLabel = getRiskLabel(checkup.individual_review?.riskLevel);
+              return (
+                <Pressable
+                  key={checkup.id}
+                  style={styles.checkupCard}
+                  onPress={() => router.push(`/health/checkups/${checkup.id}` as any)}
+                >
+                  {/* 上段: 日付・種別・リスクバッジ */}
+                  <View style={styles.checkupTop}>
+                    <View style={{ flex: 1 }}>
+                      <View style={styles.checkupDateRow}>
+                        <Text style={styles.checkupDate}>{formatDate(checkup.checkup_date)}</Text>
+                        {checkup.checkup_type && (
+                          <View style={styles.typeBadge}>
+                            <Text style={styles.typeBadgeText}>{checkup.checkup_type}</Text>
+                          </View>
+                        )}
+                      </View>
+                      {checkup.facility_name && (
+                        <Text style={styles.facilityName}>{checkup.facility_name}</Text>
+                      )}
+                    </View>
+
+                    {checkup.individual_review?.riskLevel && (
+                      <View style={[styles.riskBadge, { backgroundColor: riskColor.bg }]}>
+                        <Ionicons name={riskIcon} size={14} color={riskColor.text} />
+                        <Text style={[styles.riskBadgeText, { color: riskColor.text }]}>
+                          {riskLabel}
+                        </Text>
+                      </View>
+                    )}
+                  </View>
+
+                  {/* 主要指標 */}
+                  <View style={styles.metricsRow}>
+                    {checkup.blood_pressure_systolic != null && (
+                      <View style={styles.metric}>
+                        <Ionicons name="heart-outline" size={12} color={colors.error} />
+                        <Text style={styles.metricText}>
+                          {checkup.blood_pressure_systolic}/{checkup.blood_pressure_diastolic}
+                        </Text>
+                      </View>
+                    )}
+                    {checkup.hba1c != null && (
+                      <View style={styles.metric}>
+                        <Ionicons name="water-outline" size={12} color={colors.purple} />
+                        <Text style={styles.metricText}>HbA1c {checkup.hba1c}%</Text>
+                      </View>
+                    )}
+                    {checkup.ldl_cholesterol != null && (
+                      <View style={styles.metric}>
+                        <Ionicons name="pulse-outline" size={12} color={colors.warning} />
+                        <Text style={styles.metricText}>LDL {checkup.ldl_cholesterol}</Text>
+                      </View>
+                    )}
+                  </View>
+
+                  {/* AI サマリー */}
+                  {checkup.individual_review?.summary && (
+                    <Text style={styles.aiSummary} numberOfLines={2}>
+                      {checkup.individual_review.summary}
+                    </Text>
+                  )}
+
+                  {/* AI レビュー詳細 (concerns / positives / recommendations) */}
+                  {checkup.individual_review && (
+                    <View style={styles.reviewSection}>
+                      {(checkup.individual_review.concerns ?? []).length > 0 && (
+                        <View style={[styles.reviewBlock, { backgroundColor: colors.warningLight }]}>
+                          <View style={styles.reviewBlockHeader}>
+                            <Ionicons name="warning-outline" size={14} color={colors.warning} />
+                            <Text style={[styles.reviewBlockTitle, { color: colors.warning }]}>気になる点</Text>
+                          </View>
+                          {checkup.individual_review.concerns.slice(0, 2).map((item, i) => (
+                            <Text key={i} style={styles.reviewBlockItem}>• {item}</Text>
+                          ))}
+                        </View>
+                      )}
+
+                      {(checkup.individual_review.positives ?? []).length > 0 && (
+                        <View style={[styles.reviewBlock, { backgroundColor: colors.successLight }]}>
+                          <View style={styles.reviewBlockHeader}>
+                            <Ionicons name="checkmark-circle-outline" size={14} color={colors.success} />
+                            <Text style={[styles.reviewBlockTitle, { color: colors.success }]}>良い点</Text>
+                          </View>
+                          {checkup.individual_review.positives.slice(0, 2).map((item, i) => (
+                            <Text key={i} style={styles.reviewBlockItem}>• {item}</Text>
+                          ))}
+                        </View>
+                      )}
+
+                      {(checkup.individual_review.recommendations ?? []).length > 0 && (
+                        <View style={[styles.reviewBlock, { backgroundColor: colors.purpleLight }]}>
+                          <View style={styles.reviewBlockHeader}>
+                            <Ionicons name="sparkles-outline" size={14} color={colors.purple} />
+                            <Text style={[styles.reviewBlockTitle, { color: colors.purple }]}>改善アドバイス</Text>
+                          </View>
+                          {checkup.individual_review.recommendations.slice(0, 2).map((item, i) => (
+                            <Text key={i} style={styles.reviewBlockItem}>{i + 1}. {item}</Text>
+                          ))}
+                        </View>
+                      )}
+                    </View>
+                  )}
+
+                  <Ionicons
+                    name="chevron-forward"
+                    size={16}
+                    color={colors.textMuted}
+                    style={styles.chevron}
+                  />
+                </Pressable>
+              );
+            })}
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    gap: spacing.md,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 20,
+    fontWeight: "800",
+    color: colors.text,
+  },
+  addBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: radius.full,
+    backgroundColor: colors.accent,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  scrollContent: {
+    padding: spacing.lg,
+    gap: spacing.md,
+    paddingBottom: 100,
+  },
+
+  // ─── 経年分析 ───
+  longitudinalCard: {
+    borderRadius: radius.xl,
+    padding: spacing.lg,
+    gap: spacing.sm,
+    backgroundColor: colors.purple,
+  },
+  longitudinalHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  longitudinalTitle: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: "800",
+    color: "#fff",
+  },
+  longitudinalDate: {
+    fontSize: 11,
+    color: "rgba(255,255,255,0.6)",
+  },
+  longitudinalAssessment: {
+    fontSize: 13,
+    color: "rgba(255,255,255,0.9)",
+    lineHeight: 20,
+  },
+  trendRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  trendIconBox: {
+    width: 24,
+    height: 24,
+    borderRadius: radius.full,
+    backgroundColor: "rgba(255,255,255,0.15)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  trendMetric: {
+    flex: 1,
+    fontSize: 13,
+    color: "rgba(255,255,255,0.9)",
+  },
+  trendBadgeGood: {
+    fontSize: 11,
+    color: "#86efac",
+    fontWeight: "700",
+  },
+  trendBadgeBad: {
+    fontSize: 11,
+    color: "#fca5a5",
+    fontWeight: "700",
+  },
+  nutritionBox: {
+    marginTop: spacing.xs,
+    paddingTop: spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: "rgba(255,255,255,0.2)",
+  },
+  nutritionLabel: {
+    fontSize: 11,
+    color: "rgba(255,255,255,0.6)",
+    marginBottom: 4,
+  },
+  nutritionText: {
+    fontSize: 13,
+    color: "#fff",
+    lineHeight: 18,
+  },
+
+  // ─── 一覧カード ───
+  checkupCard: {
+    backgroundColor: colors.card,
+    borderRadius: radius.xl,
+    padding: spacing.lg,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  checkupTop: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: spacing.sm,
+  },
+  checkupDateRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    marginBottom: 2,
+  },
+  checkupDate: {
+    fontSize: 15,
+    fontWeight: "800",
+    color: colors.text,
+  },
+  typeBadge: {
+    backgroundColor: colors.blueLight,
+    borderRadius: radius.full,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+  },
+  typeBadgeText: {
+    fontSize: 11,
+    color: colors.blue,
+    fontWeight: "600",
+  },
+  facilityName: {
+    fontSize: 12,
+    color: colors.textMuted,
+  },
+  riskBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    borderRadius: radius.full,
+  },
+  riskBadgeText: {
+    fontSize: 11,
+    fontWeight: "700",
+  },
+
+  // ─── 主要指標 ───
+  metricsRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.md,
+  },
+  metric: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  metricText: {
+    fontSize: 12,
+    color: colors.textLight,
+  },
+
+  // ─── AI サマリー ───
+  aiSummary: {
+    fontSize: 12,
+    color: colors.textMuted,
+    lineHeight: 18,
+  },
+
+  // ─── AI レビューブロック ───
+  reviewSection: {
+    gap: spacing.xs,
+  },
+  reviewBlock: {
+    borderRadius: radius.md,
+    padding: spacing.sm,
+    gap: 4,
+  },
+  reviewBlockHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    marginBottom: 2,
+  },
+  reviewBlockTitle: {
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  reviewBlockItem: {
+    fontSize: 12,
+    color: colors.textLight,
+    lineHeight: 18,
+  },
+
+  chevron: {
+    alignSelf: "flex-end",
+    marginTop: -spacing.xs,
+  },
+});

--- a/apps/mobile/app/health/checkups/new.tsx
+++ b/apps/mobile/app/health/checkups/new.tsx
@@ -1,0 +1,565 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useState } from "react";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { Button } from "../../../src/components/ui";
+import { getApi } from "../../../src/lib/api";
+import { colors, radius, shadows, spacing } from "../../../src/theme";
+
+// ─── Types ────────────────────────────────────────────
+interface FormData {
+  checkup_date: string;
+  facility_name: string;
+  checkup_type: string;
+  // 血圧・代謝
+  blood_pressure_systolic: string;
+  blood_pressure_diastolic: string;
+  hba1c: string;
+  fasting_glucose: string;
+  // 身体測定
+  height: string;
+  weight: string;
+  bmi: string;
+  waist_circumference: string;
+  // 脂質
+  total_cholesterol: string;
+  ldl_cholesterol: string;
+  hdl_cholesterol: string;
+  triglycerides: string;
+  // 肝機能
+  ast: string;
+  alt: string;
+  gamma_gtp: string;
+  // 腎機能
+  creatinine: string;
+  egfr: string;
+  uric_acid: string;
+}
+
+type Step = "form" | "review";
+
+const CHECKUP_TYPES = ["定期健診", "人間ドック", "特定健診", "その他"];
+
+function todayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function toNum(v: string): number | undefined {
+  const s = v.trim();
+  if (!s) return undefined;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+// ─── Component ────────────────────────────────────────
+export default function NewCheckupPage() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  const [step, setStep] = useState<Step>("form");
+  const [saving, setSaving] = useState(false);
+  const [savedCheckup, setSavedCheckup] = useState<any>(null);
+
+  const [form, setForm] = useState<FormData>({
+    checkup_date: todayStr(),
+    facility_name: "",
+    checkup_type: "定期健診",
+    blood_pressure_systolic: "",
+    blood_pressure_diastolic: "",
+    hba1c: "",
+    fasting_glucose: "",
+    height: "",
+    weight: "",
+    bmi: "",
+    waist_circumference: "",
+    total_cholesterol: "",
+    ldl_cholesterol: "",
+    hdl_cholesterol: "",
+    triglycerides: "",
+    ast: "",
+    alt: "",
+    gamma_gtp: "",
+    creatinine: "",
+    egfr: "",
+    uric_acid: "",
+  });
+
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
+    basic: true,
+    body: true,
+    lipid: false,
+    liver: false,
+    kidney: false,
+  });
+
+  function update(field: keyof FormData, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function toggleSection(key: string) {
+    setExpandedSections((prev) => ({ ...prev, [key]: !prev[key] }));
+  }
+
+  async function handleSave() {
+    if (!form.checkup_date) {
+      Alert.alert("エラー", "検査日を入力してください。");
+      return;
+    }
+    setSaving(true);
+    try {
+      const numericFields = [
+        "blood_pressure_systolic", "blood_pressure_diastolic",
+        "hba1c", "fasting_glucose",
+        "height", "weight", "bmi", "waist_circumference",
+        "total_cholesterol", "ldl_cholesterol", "hdl_cholesterol", "triglycerides",
+        "ast", "alt", "gamma_gtp",
+        "creatinine", "egfr", "uric_acid",
+      ] as const;
+
+      const payload: Record<string, unknown> = {
+        checkup_date: form.checkup_date,
+        facility_name: form.facility_name || null,
+        checkup_type: form.checkup_type || null,
+      };
+
+      for (const field of numericFields) {
+        const n = toNum(form[field]);
+        if (n !== undefined) payload[field] = n;
+      }
+
+      const api = getApi();
+      const data = await api.post<{ checkup: any }>("/api/health/checkups", payload);
+      setSavedCheckup(data.checkup);
+      setStep("review");
+    } catch (e: any) {
+      Alert.alert("保存失敗", e?.message ?? "記録の保存に失敗しました。");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // ─── Sub-renders ──────────────────────────────────
+  function renderField(
+    field: keyof FormData,
+    label: string,
+    unit?: string,
+    placeholder?: string,
+  ) {
+    return (
+      <View key={field} style={styles.fieldRow}>
+        <Text style={styles.fieldLabel}>{label}</Text>
+        <View style={styles.fieldInputWrap}>
+          <TextInput
+            style={styles.fieldInput}
+            value={form[field]}
+            onChangeText={(v) => update(field, v)}
+            placeholder={placeholder}
+            placeholderTextColor={colors.textMuted}
+            keyboardType="decimal-pad"
+          />
+          {unit && <Text style={styles.fieldUnit}>{unit}</Text>}
+        </View>
+      </View>
+    );
+  }
+
+  function renderSection(
+    key: string,
+    title: string,
+    iconName: keyof typeof Ionicons.glyphMap,
+    children: React.ReactNode,
+  ) {
+    return (
+      <View style={styles.section}>
+        <Pressable style={styles.sectionHeader} onPress={() => toggleSection(key)}>
+          <View style={styles.sectionIconBox}>
+            <Ionicons name={iconName} size={18} color={colors.accent} />
+          </View>
+          <Text style={styles.sectionTitle}>{title}</Text>
+          <Ionicons
+            name={expandedSections[key] ? "chevron-up" : "chevron-down"}
+            size={18}
+            color={colors.textMuted}
+          />
+        </Pressable>
+        {expandedSections[key] && <View style={styles.sectionBody}>{children}</View>}
+      </View>
+    );
+  }
+
+  // ─── Review step ──────────────────────────────────
+  if (step === "review" && savedCheckup) {
+    const review = savedCheckup.individual_review;
+    return (
+      <View style={[styles.screen, { paddingTop: insets.top }]}>
+        <View style={styles.header}>
+          <Pressable onPress={() => router.back()} hitSlop={12}>
+            <Ionicons name="arrow-back" size={24} color={colors.text} />
+          </Pressable>
+          <Text style={styles.headerTitle}>AI分析結果</Text>
+          <View style={{ width: 24 }} />
+        </View>
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          {review ? (
+            <>
+              {/* 総評 */}
+              <View style={styles.reviewCard}>
+                <View style={styles.reviewCardHeader}>
+                  <Ionicons name="sparkles-outline" size={20} color={colors.purple} />
+                  <Text style={styles.reviewCardTitle}>AI分析結果</Text>
+                </View>
+                <Text style={styles.reviewCardBody}>{review.summary}</Text>
+              </View>
+
+              {/* 気になる点 */}
+              {(review.concerns ?? []).length > 0 && (
+                <View style={[styles.reviewCard, { backgroundColor: colors.warningLight }]}>
+                  <View style={styles.reviewCardHeader}>
+                    <Ionicons name="warning-outline" size={18} color={colors.warning} />
+                    <Text style={[styles.reviewCardTitle, { color: colors.warning }]}>気になる点</Text>
+                  </View>
+                  {review.concerns.map((item: string, i: number) => (
+                    <Text key={i} style={styles.reviewItem}>• {item}</Text>
+                  ))}
+                </View>
+              )}
+
+              {/* 良い点 */}
+              {(review.positives ?? []).length > 0 && (
+                <View style={[styles.reviewCard, { backgroundColor: colors.successLight }]}>
+                  <View style={styles.reviewCardHeader}>
+                    <Ionicons name="checkmark-circle-outline" size={18} color={colors.success} />
+                    <Text style={[styles.reviewCardTitle, { color: colors.success }]}>良い点</Text>
+                  </View>
+                  {review.positives.map((item: string, i: number) => (
+                    <Text key={i} style={styles.reviewItem}>• {item}</Text>
+                  ))}
+                </View>
+              )}
+
+              {/* アドバイス */}
+              {(review.recommendations ?? []).length > 0 && (
+                <View style={[styles.reviewCard, { backgroundColor: colors.purpleLight }]}>
+                  <View style={styles.reviewCardHeader}>
+                    <Ionicons name="sparkles-outline" size={18} color={colors.purple} />
+                    <Text style={[styles.reviewCardTitle, { color: colors.purple }]}>改善アドバイス</Text>
+                  </View>
+                  {review.recommendations.map((item: string, i: number) => (
+                    <Text key={i} style={styles.reviewItem}>{i + 1}. {item}</Text>
+                  ))}
+                </View>
+              )}
+            </>
+          ) : (
+            <View style={styles.reviewCard}>
+              <Text style={[styles.reviewCardBody, { color: colors.textMuted, textAlign: "center" }]}>
+                AI分析を実行できませんでした
+              </Text>
+            </View>
+          )}
+
+          <Button onPress={() => router.push("/health/checkups" as any)}>完了</Button>
+        </ScrollView>
+      </View>
+    );
+  }
+
+  // ─── Form step ────────────────────────────────────
+  return (
+    <KeyboardAvoidingView
+      style={styles.screen}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <View style={{ paddingTop: insets.top }}>
+        <View style={styles.header}>
+          <Pressable onPress={() => router.back()} hitSlop={12}>
+            <Ionicons name="arrow-back" size={24} color={colors.text} />
+          </Pressable>
+          <Text style={styles.headerTitle}>健康診断を記録</Text>
+          <View style={{ width: 24 }} />
+        </View>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+
+        {/* 基本情報 */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <View style={styles.sectionIconBox}>
+              <Ionicons name="calendar-outline" size={18} color={colors.accent} />
+            </View>
+            <Text style={styles.sectionTitle}>基本情報</Text>
+          </View>
+          <View style={styles.sectionBody}>
+            {/* 検査日 */}
+            <View style={styles.fieldRow}>
+              <Text style={styles.fieldLabel}>検査日</Text>
+              <TextInput
+                style={[styles.fieldInput, { flex: 1 }]}
+                value={form.checkup_date}
+                onChangeText={(v) => update("checkup_date", v)}
+                placeholder="YYYY-MM-DD"
+                placeholderTextColor={colors.textMuted}
+              />
+            </View>
+            {/* 医療機関 */}
+            <View style={styles.fieldRow}>
+              <Text style={styles.fieldLabel}>医療機関</Text>
+              <TextInput
+                style={[styles.fieldInput, { flex: 1 }]}
+                value={form.facility_name}
+                onChangeText={(v) => update("facility_name", v)}
+                placeholder="〇〇クリニック"
+                placeholderTextColor={colors.textMuted}
+              />
+            </View>
+            {/* 種類 */}
+            <View style={styles.fieldRow}>
+              <Text style={styles.fieldLabel}>種類</Text>
+              <View style={styles.typeRow}>
+                {CHECKUP_TYPES.map((t) => (
+                  <Pressable
+                    key={t}
+                    style={[styles.typeBtn, form.checkup_type === t && styles.typeBtnActive]}
+                    onPress={() => update("checkup_type", t)}
+                  >
+                    <Text
+                      style={[styles.typeBtnText, form.checkup_type === t && styles.typeBtnTextActive]}
+                    >
+                      {t}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+          </View>
+        </View>
+
+        {/* 血圧・代謝 */}
+        {renderSection("basic", "血圧・代謝", "pulse-outline", (
+          <>
+            {renderField("blood_pressure_systolic", "収縮期血圧", "mmHg", "120")}
+            {renderField("blood_pressure_diastolic", "拡張期血圧", "mmHg", "80")}
+            {renderField("hba1c", "HbA1c", "%", "5.6")}
+            {renderField("fasting_glucose", "空腹時血糖", "mg/dL", "100")}
+          </>
+        ))}
+
+        {/* 身体測定 */}
+        {renderSection("body", "身体測定", "body-outline", (
+          <>
+            {renderField("height", "身長", "cm", "170")}
+            {renderField("weight", "体重", "kg", "65")}
+            {renderField("bmi", "BMI", "", "22.5")}
+            {renderField("waist_circumference", "腹囲", "cm", "85")}
+          </>
+        ))}
+
+        {/* 脂質 */}
+        {renderSection("lipid", "脂質", "water-outline", (
+          <>
+            {renderField("total_cholesterol", "総コレステロール", "mg/dL", "200")}
+            {renderField("ldl_cholesterol", "LDL", "mg/dL", "120")}
+            {renderField("hdl_cholesterol", "HDL", "mg/dL", "60")}
+            {renderField("triglycerides", "中性脂肪", "mg/dL", "150")}
+          </>
+        ))}
+
+        {/* 肝機能 */}
+        {renderSection("liver", "肝機能", "fitness-outline", (
+          <>
+            {renderField("ast", "AST(GOT)", "U/L", "25")}
+            {renderField("alt", "ALT(GPT)", "U/L", "20")}
+            {renderField("gamma_gtp", "γ-GTP", "U/L", "30")}
+          </>
+        ))}
+
+        {/* 腎機能 */}
+        {renderSection("kidney", "腎機能・尿酸", "leaf-outline", (
+          <>
+            {renderField("creatinine", "クレアチニン", "mg/dL", "0.8")}
+            {renderField("egfr", "eGFR", "", "90")}
+            {renderField("uric_acid", "尿酸", "mg/dL", "5.5")}
+          </>
+        ))}
+
+        <Button onPress={handleSave} loading={saving} disabled={saving}>
+          {saving ? "保存中..." : "保存してAI分析を実行"}
+        </Button>
+
+        <Text style={styles.ocrHint}>
+          ※ OCR取込機能は別途対応予定です。手動で数値を入力してください。
+        </Text>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    gap: spacing.md,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 20,
+    fontWeight: "800",
+    color: colors.text,
+  },
+  scrollContent: {
+    padding: spacing.lg,
+    gap: spacing.md,
+    paddingBottom: 120,
+  },
+
+  // ─── Section ───
+  section: {
+    backgroundColor: colors.card,
+    borderRadius: radius.xl,
+    overflow: "hidden",
+    ...shadows.sm,
+  },
+  sectionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  sectionIconBox: {
+    width: 36,
+    height: 36,
+    borderRadius: radius.md,
+    backgroundColor: colors.accentLight,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  sectionTitle: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: "700",
+    color: colors.text,
+  },
+  sectionBody: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.lg,
+    gap: spacing.sm,
+  },
+
+  // ─── Fields ───
+  fieldRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  fieldLabel: {
+    width: 90,
+    fontSize: 13,
+    color: colors.textLight,
+    flexShrink: 0,
+  },
+  fieldInputWrap: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+  },
+  fieldInput: {
+    flex: 1,
+    backgroundColor: colors.bg,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    fontSize: 14,
+    color: colors.text,
+  },
+  fieldUnit: {
+    width: 48,
+    fontSize: 12,
+    color: colors.textMuted,
+  },
+
+  // ─── Type selector ───
+  typeRow: {
+    flex: 1,
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  typeBtn: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    borderRadius: radius.full,
+    backgroundColor: colors.bg,
+  },
+  typeBtnActive: {
+    backgroundColor: colors.accentLight,
+    borderWidth: 1,
+    borderColor: colors.accent,
+  },
+  typeBtnText: {
+    fontSize: 12,
+    color: colors.textMuted,
+  },
+  typeBtnTextActive: {
+    color: colors.accent,
+    fontWeight: "700",
+  },
+
+  // ─── OCR hint ───
+  ocrHint: {
+    fontSize: 12,
+    color: colors.textMuted,
+    textAlign: "center",
+    lineHeight: 18,
+  },
+
+  // ─── Review step ───
+  reviewCard: {
+    backgroundColor: colors.card,
+    borderRadius: radius.xl,
+    padding: spacing.lg,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  reviewCardHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  reviewCardTitle: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: colors.text,
+  },
+  reviewCardBody: {
+    fontSize: 13,
+    color: colors.textLight,
+    lineHeight: 20,
+  },
+  reviewItem: {
+    fontSize: 13,
+    color: colors.textLight,
+    lineHeight: 20,
+  },
+});


### PR DESCRIPTION
## Summary
- `apps/mobile/app/health/checkups/index.tsx` 新規作成: 一覧+経年分析カード+個別AIレビュー(riskLevel バッジ・concerns/positives/recommendations)
- `apps/mobile/app/health/checkups/new.tsx` 新規作成: 手動入力フォーム+保存後AIレビュー表示(OCRは別issue化推奨)
- ダッシュボードの健康診断リンクを `/health/blood-tests` → `/health/checkups` に修正

## Test plan
- [ ] ダッシュボードの「健康診断」タップで `/health/checkups` へ遷移する
- [ ] 一覧画面で健康診断レコードが表示される
- [ ] 各レコードに riskLevel バッジ・concerns/positives/recommendations が展開表示される
- [ ] 経年分析カード(trend_analysis・nutrition_guidance)が表示される
- [ ] 新規登録フォームから保存しAIレビュー結果が表示される

Closes #377