### PR TITLE
fix(mobile): week_start_day 設定が週間献立画面で無視される問題を修正

### DIFF
--- a/apps/mobile/app/(tabs)/menus.tsx
+++ b/apps/mobile/app/(tabs)/menus.tsx
@@ -7,6 +7,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button, Card, EmptyState, LoadingState, StatusBadge } from "../../src/components/ui";
 import { colors, spacing } from "../../src/theme";
 import { getApi } from "../../src/lib/api";
+import { useProfile } from "../../src/providers/ProfileProvider";
+import type { WeekStartDay } from "../../src/providers/ProfileProvider";
 
 const formatLocalDate = (date: Date): string => {
   const y = date.getFullYear();
@@ -15,11 +17,13 @@ const formatLocalDate = (date: Date): string => {
   return `${y}-${m}-${d}`;
 };
 
-function getWeekStart(date: Date): Date {
+function getWeekStart(date: Date, weekStartDay: WeekStartDay = 'monday'): Date {
   const d = new Date(date);
-  const day = d.getDay();
-  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-  d.setDate(diff);
+  const currentDay = d.getDay();
+  const targetDay = weekStartDay === 'sunday' ? 0 : 1;
+  let diff = currentDay - targetDay;
+  if (diff < 0) diff += 7;
+  d.setDate(d.getDate() - diff);
   d.setHours(0, 0, 0, 0);
   return d;
 }
@@ -33,11 +37,13 @@ type DaySummary = {
 
 export default function MenusScreen() {
   const insets = useSafeAreaInsets();
+  const { profile } = useProfile();
+  const weekStartDay = profile?.weekStartDay ?? 'monday';
   const [days, setDays] = useState<DaySummary[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [hasPlan, setHasPlan] = useState(false);
 
-  const weekStartStr = useMemo(() => formatLocalDate(getWeekStart(new Date())), []);
+  const weekStartStr = useMemo(() => formatLocalDate(getWeekStart(new Date(), weekStartDay)), [weekStartDay]);
 
   const loadData = useCallback(async () => {
     setIsLoading(true);

--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -7,6 +7,8 @@ import { Button, Card, EmptyState, LoadingState, PageHeader, ProgressBar, Status
 import { colors, spacing, radius, shadows } from "../../../src/theme";
 import { getApi } from "../../../src/lib/api";
 import { supabase } from "../../../src/lib/supabase";
+import { useProfile } from "../../../src/providers/ProfileProvider";
+import type { WeekStartDay } from "../../../src/providers/ProfileProvider";
 
 type PlannedMealRow = {
   id: string;
@@ -49,11 +51,13 @@ const formatLocalDate = (date: Date): string => {
   return `${y}-${m}-${d}`;
 };
 
-function getWeekStart(date: Date): Date {
+function getWeekStart(date: Date, weekStartDay: WeekStartDay = 'monday'): Date {
   const d = new Date(date);
-  const day = d.getDay();
-  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-  d.setDate(diff);
+  const currentDay = d.getDay();
+  const targetDay = weekStartDay === 'sunday' ? 0 : 1;
+  let diff = currentDay - targetDay;
+  if (diff < 0) diff += 7;
+  d.setDate(d.getDate() - diff);
   d.setHours(0, 0, 0, 0);
   return d;
 }
@@ -79,7 +83,9 @@ const MODE_CONFIG: Record<string, { label: string; color: string; bg: string }> 
 };
 
 export default function WeeklyMenuPage() {
-  const [weekStart, setWeekStart] = useState<Date>(() => getWeekStart(new Date()));
+  const { profile } = useProfile();
+  const weekStartDay = profile?.weekStartDay ?? 'monday';
+  const [weekStart, setWeekStart] = useState<Date>(() => getWeekStart(new Date(), weekStartDay));
   const weekStartStr = useMemo(() => formatLocalDate(weekStart), [weekStart]);
   const weekEndStr = useMemo(() => {
     const end = new Date(weekStart);
@@ -96,6 +102,10 @@ export default function WeeklyMenuPage() {
   const [pendingRequestId, setPendingRequestId] = useState<string | null>(null);
   const [pendingStatus, setPendingStatus] = useState<string | null>(null);
   const [pendingProgress, setPendingProgress] = useState<PendingProgress | null>(null);
+
+  useEffect(() => {
+    setWeekStart(getWeekStart(new Date(), weekStartDay));
+  }, [weekStartDay]);
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
@@ -155,7 +165,7 @@ export default function WeeklyMenuPage() {
   function shiftWeek(delta: number) {
     const d = new Date(weekStart);
     d.setDate(d.getDate() + delta * 7);
-    setWeekStart(getWeekStart(d));
+    setWeekStart(getWeekStart(d, weekStartDay));
     setSelectedDate(formatLocalDate(d));
   }
 
@@ -310,8 +320,8 @@ export default function WeeklyMenuPage() {
   // Day selector helpers
   const getDayOfWeek = (dateStr: string): string => {
     const d = new Date(dateStr + "T00:00:00");
-    const dayIdx = (d.getDay() + 6) % 7; // Mon=0
-    return DOW[dayIdx] ?? "";
+    const DAY_LABELS_SUN = ["日", "月", "火", "水", "木", "金", "土"];
+    return DAY_LABELS_SUN[d.getDay()] ?? "";
   };
 
   const sortedMeals = useMemo(() => {

--- a/apps/mobile/app/menus/weekly/request/index.tsx
+++ b/apps/mobile/app/menus/weekly/request/index.tsx
@@ -1,12 +1,14 @@
 import { Ionicons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
 import { router } from "expo-router";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Alert, Image, ScrollView, Text, View } from "react-native";
 
 import { Button, Card, ChipSelector, Input, PageHeader, SectionHeader } from "../../../../src/components/ui";
 import { getApi } from "../../../../src/lib/api";
 import { colors, radius, spacing } from "../../../../src/theme";
+import { useProfile } from "../../../../src/providers/ProfileProvider";
+import type { WeekStartDay } from "../../../../src/providers/ProfileProvider";
 
 const formatLocalDate = (date: Date): string => {
   const y = date.getFullYear();
@@ -15,17 +17,21 @@ const formatLocalDate = (date: Date): string => {
   return `${y}-${m}-${d}`;
 };
 
-function getWeekStart(date: Date): Date {
+function getWeekStart(date: Date, weekStartDay: WeekStartDay = 'monday'): Date {
   const d = new Date(date);
-  const day = d.getDay();
-  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-  d.setDate(diff);
+  const currentDay = d.getDay();
+  const targetDay = weekStartDay === 'sunday' ? 0 : 1;
+  let diff = currentDay - targetDay;
+  if (diff < 0) diff += 7;
+  d.setDate(d.getDate() - diff);
   d.setHours(0, 0, 0, 0);
   return d;
 }
 
 export default function WeeklyRequestPage() {
-  const [startDate, setStartDate] = useState(() => formatLocalDate(getWeekStart(new Date())));
+  const { profile } = useProfile();
+  const weekStartDay = profile?.weekStartDay ?? 'monday';
+  const [startDate, setStartDate] = useState(() => formatLocalDate(getWeekStart(new Date(), weekStartDay)));
   const [familySize, setFamilySize] = useState("1");
   const [cheatDay, setCheatDay] = useState("");
   const [note, setNote] = useState("");
@@ -34,6 +40,10 @@ export default function WeeklyRequestPage() {
   const [fridgeImageUri, setFridgeImageUri] = useState<string | null>(null);
   const [fridgeSummary, setFridgeSummary] = useState<string | null>(null);
   const [fridgeSuggestions, setFridgeSuggestions] = useState<string[]>([]);
+
+  useEffect(() => {
+    setStartDate(formatLocalDate(getWeekStart(new Date(), weekStartDay)));
+  }, [weekStartDay]);
 
   const [isUploading, setIsUploading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -111,7 +121,7 @@ export default function WeeklyRequestPage() {
         setIsSubmitting(false);
         return;
       }
-      const ws = getWeekStart(parsedDate);
+      const ws = getWeekStart(parsedDate, weekStartDay);
       const weekStartStr = formatLocalDate(ws);
 
       const useFridgeFirst = selectedThemes.includes("冷蔵庫の食材を優先");
@@ -160,7 +170,7 @@ export default function WeeklyRequestPage() {
         />
         <View style={{ marginTop: spacing.sm }}>
           <Input
-            label="週の月曜日推奨"
+            label={weekStartDay === 'sunday' ? "週の日曜日推奨" : "週の月曜日推奨"}
             value={startDate}
             onChangeText={setStartDate}
             placeholder="YYYY-MM-DD"

--- a/apps/mobile/src/providers/ProfileProvider.tsx
+++ b/apps/mobile/src/providers/ProfileProvider.tsx
@@ -3,6 +3,8 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useS
 import { supabase } from "../lib/supabase";
 import { useAuth } from "./AuthProvider";
 
+export type WeekStartDay = 'sunday' | 'monday';
+
 export type MobileUserProfile = {
   id: string;
   nickname?: string | null;
@@ -16,6 +18,7 @@ export type MobileUserProfile = {
     totalQuestions: number;
     lastUpdatedAt: string;
   } | null;
+  weekStartDay: WeekStartDay;
 };
 
 type ProfileState = {
@@ -43,7 +46,7 @@ export function ProfileProvider({ children }: { children: React.ReactNode }) {
     setIsLoading(true);
     const { data, error } = await supabase
       .from("user_profiles")
-      .select("id,nickname,roles,organization_id,onboarding_started_at,onboarding_completed_at,onboarding_progress")
+      .select("id,nickname,roles,organization_id,onboarding_started_at,onboarding_completed_at,onboarding_progress,week_start_day")
       .eq("id", user.id)
       .maybeSingle();
 
@@ -58,6 +61,7 @@ export function ProfileProvider({ children }: { children: React.ReactNode }) {
         onboardingStartedAt: null,
         onboardingCompletedAt: "skip", // エラー時はオンボーディングにリダイレクトしない
         onboardingProgress: null,
+        weekStartDay: 'monday',
       });
       setIsLoading(false);
       return;
@@ -73,10 +77,15 @@ export function ProfileProvider({ children }: { children: React.ReactNode }) {
         onboardingStartedAt: null,
         onboardingCompletedAt: null,
         onboardingProgress: null,
+        weekStartDay: 'monday',
       });
       setIsLoading(false);
       return;
     }
+
+    const rawWeekStartDay = (data as any).week_start_day;
+    const weekStartDay: WeekStartDay =
+      rawWeekStartDay === 'sunday' || rawWeekStartDay === 'monday' ? rawWeekStartDay : 'monday';
 
     setProfile({
       id: data.id,
@@ -86,6 +95,7 @@ export function ProfileProvider({ children }: { children: React.ReactNode }) {
       onboardingStartedAt: (data as any).onboarding_started_at ?? null,
       onboardingCompletedAt: (data as any).onboarding_completed_at ?? null,
       onboardingProgress: (data as any).onboarding_progress ?? null,
+      weekStartDay,
     });
     setIsLoading(false);
   }, [user?.id]);


### PR DESCRIPTION
## Summary
- `ProfileProvider` に `weekStartDay` フィールドを追加し、`user_profiles.week_start_day` を取得
- `menus.tsx`・`weekly/index.tsx`・`weekly/request/index.tsx` の `getWeekStart()` に `weekStartDay` 引数を追加（月曜固定ハードコードを廃止）
- 日曜始まり設定のユーザーで週の区切りが正しく反映されるよう修正

## Test plan
- [ ] 設定で `week_start_day = sunday` のユーザーでログインし、献立タブの週開始が日曜になることを確認
- [ ] 設定で `week_start_day = monday` のユーザーで週開始が月曜のままであることを確認
- [ ] `npx tsc --noEmit` が通ること（確認済み）

Closes #443