### PR TITLE
fix(mobile): 食事詳細画面に材料・作り方・ハートボタンを追加

### DIFF
--- a/apps/mobile/app/meals/[id].tsx
+++ b/apps/mobile/app/meals/[id].tsx
@@ -1,11 +1,20 @@
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
-import { useEffect, useState } from "react";
-import { Alert, Image, ScrollView, Text, View } from "react-native";
+import { useCallback, useEffect, useState } from "react";
+import { Alert, Image, Pressable, ScrollView, Text, View } from "react-native";
 
 import { Button, Card, LoadingState, PageHeader, SectionHeader, StatusBadge } from "../../src/components/ui";
 import { colors, spacing, radius } from "../../src/theme";
 import { getApi } from "../../src/lib/api";
+
+type Dish = {
+  name?: string | null;
+  role?: string | null;
+  calories_kcal?: number | null;
+  ingredientsMd?: string | null;
+  recipeStepsMd?: string | null;
+  ingredients?: string[] | null;
+};
 
 type PlannedMealDetail = {
   id: string;
@@ -20,7 +29,7 @@ type PlannedMealDetail = {
   carbs_g: number | null;
   is_completed: boolean | null;
   completed_at: string | null;
-  dishes: any[] | null;
+  dishes: Dish[] | null;
   is_simple: boolean | null;
   cooking_time_minutes: number | null;
   daily_meal_id: string;
@@ -43,11 +52,88 @@ const MODE_CONFIG: Record<string, { label: string; color: string; bg: string }> 
   skip: { label: "なし", color: colors.textMuted, bg: colors.bg },
 };
 
+const ROLE_LABEL: Record<string, string> = {
+  main: "主菜",
+  side: "副菜",
+  soup: "汁物",
+  rice: "主食",
+};
+
+const ROLE_COLOR: Record<string, string> = {
+  main: colors.accent,
+  side: colors.success,
+  soup: colors.blue,
+  rice: "#8B4513",
+};
+
+/** Markdownテキストを行単位で簡易レンダリング */
+function SimpleMarkdown({ text }: { text: string }) {
+  const lines = text.split("\n");
+  return (
+    <View style={{ gap: 2 }}>
+      {lines.map((line, i) => {
+        // テーブル行
+        if (line.startsWith("|")) {
+          const cells = line.split("|").filter((c) => c.trim() !== "");
+          // 区切り行は非表示
+          if (cells.every((c) => /^[-: ]+$/.test(c))) return null;
+          return (
+            <View key={i} style={{ flexDirection: "row", borderBottomWidth: 1, borderBottomColor: colors.border }}>
+              {cells.map((cell, j) => (
+                <Text key={j} style={{ flex: 1, fontSize: 13, color: colors.text, paddingVertical: 4, paddingHorizontal: 4 }}>
+                  {cell.trim()}
+                </Text>
+              ))}
+            </View>
+          );
+        }
+        // 番号付きリスト
+        const orderedMatch = line.match(/^(\d+)\.\s+(.*)/);
+        if (orderedMatch) {
+          return (
+            <View key={i} style={{ flexDirection: "row", gap: 4, marginBottom: 2 }}>
+              <Text style={{ fontSize: 13, color: colors.textMuted, minWidth: 20 }}>{orderedMatch[1]}.</Text>
+              <Text style={{ flex: 1, fontSize: 13, color: colors.text, lineHeight: 20 }}>{orderedMatch[2]}</Text>
+            </View>
+          );
+        }
+        // 箇条書き
+        if (line.startsWith("- ") || line.startsWith("* ")) {
+          return (
+            <View key={i} style={{ flexDirection: "row", gap: 6, marginBottom: 2 }}>
+              <Text style={{ fontSize: 13, color: colors.textMuted }}>•</Text>
+              <Text style={{ flex: 1, fontSize: 13, color: colors.text, lineHeight: 20 }}>{line.slice(2)}</Text>
+            </View>
+          );
+        }
+        // 見出し
+        if (line.startsWith("## ")) {
+          return <Text key={i} style={{ fontSize: 14, fontWeight: "700", color: colors.text, marginTop: 6, marginBottom: 2 }}>{line.slice(3)}</Text>;
+        }
+        if (line.startsWith("# ")) {
+          return <Text key={i} style={{ fontSize: 15, fontWeight: "800", color: colors.text, marginTop: 6, marginBottom: 2 }}>{line.slice(2)}</Text>;
+        }
+        // 空行
+        if (line.trim() === "") return <View key={i} style={{ height: 4 }} />;
+        // 通常テキスト
+        return <Text key={i} style={{ fontSize: 13, color: colors.text, lineHeight: 20 }}>{line}</Text>;
+      })}
+    </View>
+  );
+}
+
 export default function MealDetailPage() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const [meal, setMeal] = useState<PlannedMealDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // お気に入り状態
+  const [isFavorite, setIsFavorite] = useState(false);
+  const [isFavoriteLoading, setIsFavoriteLoading] = useState(false);
+
+  // 買い物リスト追加中フラグ
+  const [isAddingToCart, setIsAddingToCart] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -80,6 +166,16 @@ export default function MealDetailPage() {
     run();
     return () => { cancelled = true; };
   }, [id]);
+
+  // お気に入り状態の取得
+  useEffect(() => {
+    if (!meal?.dish_name) return;
+    const encodedId = encodeURIComponent(meal.dish_name);
+    const api = getApi();
+    api.get<{ liked: boolean }>(`/api/recipes/${encodedId}/like`)
+      .then((data) => { if (data) setIsFavorite(data.liked); })
+      .catch(() => {/* 取得失敗は無視 */});
+  }, [meal?.dish_name]);
 
   async function toggleCompletion() {
     if (!meal) return;
@@ -117,6 +213,61 @@ export default function MealDetailPage() {
     ]);
   }
 
+  const handleToggleFavorite = useCallback(async () => {
+    if (!meal?.dish_name || isFavoriteLoading) return;
+    const prev = isFavorite;
+    setIsFavorite(!prev);
+    setIsFavoriteLoading(true);
+    try {
+      const encodedId = encodeURIComponent(meal.dish_name);
+      const api = getApi();
+      if (prev) {
+        await api.del(`/api/recipes/${encodedId}/like`);
+      } else {
+        await api.post(`/api/recipes/${encodedId}/like`, {});
+      }
+    } catch {
+      setIsFavorite(prev);
+    } finally {
+      setIsFavoriteLoading(false);
+    }
+  }, [meal?.dish_name, isFavorite, isFavoriteLoading]);
+
+  const handleAddToShoppingList = useCallback(async () => {
+    if (!meal || isAddingToCart) return;
+    setIsAddingToCart(true);
+    try {
+      let allIngredients: string[] = [];
+      if (Array.isArray(meal.dishes)) {
+        for (const dish of meal.dishes) {
+          if (Array.isArray(dish.ingredients)) {
+            allIngredients = [...allIngredients, ...dish.ingredients];
+          }
+        }
+      }
+
+      if (allIngredients.length === 0) {
+        Alert.alert("材料なし", "材料情報がありません。AIで再生成してください。");
+        return;
+      }
+
+      const parsedIngredients = allIngredients.map((ing) => {
+        const match = ing.match(/^(.+?)\s+(\d+.*|少々|適量|適宜)$/);
+        if (match) return { name: match[1], amount: match[2] };
+        return { name: ing, amount: null };
+      });
+
+      const api = getApi();
+      await api.post("/api/shopping-list/add-recipe", { ingredients: parsedIngredients });
+
+      Alert.alert("追加完了", `${parsedIngredients.length}件の材料を買い物リストに追加しました。`);
+    } catch (e: any) {
+      Alert.alert("エラー", e?.message ?? "追加に失敗しました。");
+    } finally {
+      setIsAddingToCart(false);
+    }
+  }, [meal, isAddingToCart]);
+
   if (isLoading) return (
     <View style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader title="食事詳細" />
@@ -138,9 +289,13 @@ export default function MealDetailPage() {
     );
   }
 
-  const mealCfg = MEAL_CONFIG[meal.meal_type] ?? { icon: "ellipse", label: meal.meal_type, color: colors.textMuted };
+  const mealCfg = MEAL_CONFIG[meal.meal_type] ?? { icon: "ellipse" as keyof typeof Ionicons.glyphMap, label: meal.meal_type, color: colors.textMuted };
   const modeCfg = MODE_CONFIG[meal.mode ?? "cook"] ?? MODE_CONFIG.cook;
   const totalPFC = (meal.protein_g ?? 0) + (meal.fat_g ?? 0) + (meal.carbs_g ?? 0);
+
+  const primaryDish: Dish | null = Array.isArray(meal.dishes) && meal.dishes.length > 0 ? meal.dishes[0] : null;
+  const ingredientsMd = primaryDish?.ingredientsMd ?? null;
+  const recipeStepsMd = primaryDish?.recipeStepsMd ?? null;
 
   return (
     <View style={{ flex: 1, backgroundColor: colors.bg }}>
@@ -159,7 +314,20 @@ export default function MealDetailPage() {
         {/* タイトル & メタ */}
         <View style={{ gap: spacing.sm }}>
           <Text style={{ fontSize: 22, fontWeight: "800", color: colors.text }}>{meal.dish_name || "食事"}</Text>
-          <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm, flexWrap: "wrap" }}>
+            {/* 役割バッジ */}
+            {primaryDish?.role && (
+              <View style={{
+                backgroundColor: ROLE_COLOR[primaryDish.role] ?? colors.accent,
+                paddingHorizontal: 8,
+                paddingVertical: 2,
+                borderRadius: 4,
+              }}>
+                <Text style={{ fontSize: 11, fontWeight: "700", color: "#fff" }}>
+                  {ROLE_LABEL[primaryDish.role] ?? primaryDish.role}
+                </Text>
+              </View>
+            )}
             <View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
               <Ionicons name={mealCfg.icon} size={14} color={mealCfg.color} />
               <Text style={{ fontSize: 13, color: colors.textMuted }}>{mealCfg.label}</Text>
@@ -216,13 +384,50 @@ export default function MealDetailPage() {
           </Card>
         )}
 
+        {/* 材料 */}
+        <Card>
+          <View style={{ gap: spacing.sm }}>
+            <SectionHeader title="材料" />
+            {ingredientsMd ? (
+              <SimpleMarkdown text={ingredientsMd} />
+            ) : (
+              <Text style={{ fontSize: 13, color: colors.textMuted }}>
+                材料情報なし。AIで再生成すると表示されます。
+              </Text>
+            )}
+          </View>
+        </Card>
+
+        {/* 作り方 */}
+        <Card>
+          <View style={{ gap: spacing.sm }}>
+            <SectionHeader title="作り方" />
+            {recipeStepsMd ? (
+              <SimpleMarkdown text={recipeStepsMd} />
+            ) : (
+              <Text style={{ fontSize: 13, color: colors.textMuted }}>
+                レシピはAI献立を生成すると自動で作成されます。
+              </Text>
+            )}
+          </View>
+        </Card>
+
         {/* 料理内訳 */}
         {Array.isArray(meal.dishes) && meal.dishes.length > 0 && (
           <Card>
             <View style={{ gap: spacing.sm }}>
               <SectionHeader title="料理内訳" />
-              {meal.dishes.map((d: any, idx: number) => (
-                <View key={`${d?.name ?? idx}-${idx}`} style={{ flexDirection: "row", justifyContent: "space-between", paddingVertical: 4, borderBottomWidth: idx < meal.dishes!.length - 1 ? 1 : 0, borderBottomColor: colors.border }}>
+              {meal.dishes.map((d, idx) => (
+                <View
+                  key={`${d?.name ?? idx}-${idx}`}
+                  style={{
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                    paddingVertical: 4,
+                    borderBottomWidth: idx < meal.dishes!.length - 1 ? 1 : 0,
+                    borderBottomColor: colors.border,
+                  }}
+                >
                   <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
                     <Text style={{ fontSize: 13, color: colors.text }}>{d?.name ?? "?"}</Text>
                     <Text style={{ fontSize: 11, color: colors.textMuted }}>({d?.role ?? "?"})</Text>
@@ -233,6 +438,46 @@ export default function MealDetailPage() {
             </View>
           </Card>
         )}
+
+        {/* ハートボタン + 買い物リスト追加 */}
+        <View style={{ flexDirection: "row", gap: spacing.sm, alignItems: "center" }}>
+          <Pressable
+            onPress={handleToggleFavorite}
+            disabled={isFavoriteLoading}
+            accessibilityLabel={isFavorite ? "お気に入りから削除" : "お気に入りに追加"}
+            style={({ pressed }) => ({
+              width: 48,
+              height: 48,
+              borderRadius: 24,
+              backgroundColor: isFavorite ? "#FFF0F0" : colors.card,
+              borderWidth: 1,
+              borderColor: isFavorite ? "#FF6B6B" : colors.border,
+              alignItems: "center",
+              justifyContent: "center",
+              opacity: pressed || isFavoriteLoading ? 0.7 : 1,
+            })}
+          >
+            <Ionicons
+              name={isFavorite ? "heart" : "heart-outline"}
+              size={22}
+              color={isFavorite ? "#FF6B6B" : colors.textMuted}
+            />
+          </Pressable>
+
+          <Button
+            style={{ flex: 1 }}
+            variant="secondary"
+            onPress={handleAddToShoppingList}
+            disabled={isAddingToCart}
+          >
+            <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+              <Ionicons name="cart-outline" size={18} color={colors.accent} />
+              <Text style={{ fontWeight: "700", color: colors.accent }}>
+                {isAddingToCart ? "追加中..." : "材料を買い物リストに追加"}
+              </Text>
+            </View>
+          </Button>
+        </View>
 
         {/* アクション */}
         <Button variant="secondary" onPress={() => router.push(`/meals/${meal.id}/edit`)}>


### PR DESCRIPTION
## Summary

- `apps/mobile/app/meals/[id].tsx` に `ingredientsMd` / `recipeStepsMd` の Markdown 表示 (`SimpleMarkdown` インライン実装) を追加
- 役割バッジ (主菜/副菜/汁物/主食) を追加
- ハートボタン (GET/POST/DELETE `/api/recipes/{encodedId}/like`) を追加
- 「材料を買い物リストに追加」ボタン (`/api/shopping-list/add-recipe`) を追加
- 外部依存の追加なし

Closes #418

## Test plan

- [ ] 週間献立 → 料理カードタップ → 食事詳細画面で材料・作り方が表示される
- [ ] ハートボタンタップで liked 状態がトグルされる
- [ ] 「材料を買い物リストに追加」で買い物リストに追加完了アラートが表示される
- [ ] ingredientsMd が null の場合はプレースホルダーテキストが表示される