### PR TITLE
fix(mobile): チェックイン完了バナーの表示条件を web と同一にする (#402)

### DIFF
--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -469,7 +469,7 @@ export default function HomeScreen() {
           )}
 
           {/* チェックイン完了済み */}
-          {performanceAnalysis.todayCheckin && !performanceAnalysis.nextAction && (
+          {performanceAnalysis.todayCheckin && (
             <View style={{
               flexDirection: "row", alignItems: "center", gap: spacing.sm,
               backgroundColor: colors.successLight, padding: spacing.lg, borderRadius: radius.xl,


### PR DESCRIPTION
Closes #402

## 概要

- `apps/mobile/app/(tabs)/home.tsx` L472 の表示条件から `!performanceAnalysis.nextAction` を除去
- `todayCheckin` のみで完了バナーを制御するよう修正（web の参照実装と同一）
- nextAction カード（上）と完了バナー（下）が同時に表示されるようになった