### PR TITLE
fix(mobile): 起動時セッション復元に getUser() サーバー検証を追加 (#437)

### DIFF
--- a/apps/mobile/src/providers/AuthProvider.tsx
+++ b/apps/mobile/src/providers/AuthProvider.tsx
@@ -20,9 +20,27 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     supabase.auth
       .getSession()
-      .then(({ data }) => {
+      .then(async ({ data }) => {
         if (!isMounted) return;
-        setSession(data.session ?? null);
+        const cachedSession = data.session ?? null;
+
+        if (cachedSession) {
+          // AsyncStorage のキャッシュだけを信頼せず、サーバー側で JWT を検証する
+          const { data: userData, error: userError } = await supabase.auth.getUser();
+          if (!isMounted) return;
+
+          if (userError || !userData.user) {
+            // revoked / 期限切れトークンはセッションをクリアする
+            await supabase.auth.signOut();
+            if (!isMounted) return;
+            setSession(null);
+          } else {
+            setSession(cachedSession);
+          }
+        } else {
+          setSession(null);
+        }
+
         setIsLoading(false);
       })
       .catch(() => {


### PR DESCRIPTION
Closes #437

## 概要

- `AuthProvider.tsx` の初期化時、`getSession()` でキャッシュセッションが存在する場合に `getUser()` を追加呼び出しし、サーバー側 JWT 検証を実施
- `getUser()` がエラーを返すか `user` が null の場合（revoked / 期限切れトークン）、`signOut()` でセッションをクリアして未認証状態にする
- Web の `middleware.ts` が `getUser()` でページナビゲーション時に検証する方針と一致させた

## 変更ファイル

- `apps/mobile/src/providers/AuthProvider.tsx`