### PR TITLE
fix(mobile): submitPerformanceCheckin 後の health_records 同期を実装 (#405)

### DIFF
--- a/apps/mobile/src/hooks/useHomeData.ts
+++ b/apps/mobile/src/hooks/useHomeData.ts
@@ -467,6 +467,26 @@ export const useHomeData = (userId: string | undefined) => {
         .select()
         .single();
       if (error) return { success: false, error: error.message };
+
+      // sleepHours / sleepQuality が入力されている場合のみ health_records に同期する
+      // fatigue / focus / hunger は health_records に書き込まない
+      const hasSleepData =
+        checkinData.sleepHours !== undefined ||
+        checkinData.sleepQuality !== undefined;
+      if (hasSleepData) {
+        try {
+          const api = getApi();
+          await api.post("/api/health/records/quick", {
+            record_date: getTodayStr(),
+            ...(checkinData.sleepHours !== undefined && { sleep_hours: checkinData.sleepHours }),
+            ...(checkinData.sleepQuality !== undefined && { sleep_quality: checkinData.sleepQuality }),
+          });
+        } catch (syncErr) {
+          // 健康記録への同期失敗はチェックイン自体の成否には影響させない
+          console.warn("Health record sync after checkin failed:", syncErr);
+        }
+      }
+
       await fetchPerformanceAnalysis(userId);
       return { success: true, data };
     } catch (e: any) {


### PR DESCRIPTION
Closes #405

## 概要

- `submitPerformanceCheckin` 実行後、`sleepHours` または `sleepQuality` が入力されている場合に `POST /api/health/records/quick` を呼び出し、`health_records` テーブルへ同期する処理を追加
- `fatigue` / `focus` / `hunger` は `health_records` に送信しない
- 同期失敗時は `console.warn` のみでログ出力し、チェックイン自体の成功扱いは維持する
- `getApi()` ヘルパーと `getTodayStr()` を使用し、既存パターンに準拠
- Web 側の参照実装 (`src/hooks/useHomeData.ts` L782-800) と同等の動作