### PR TITLE
fix(mobile): signOut前にAsyncStorageのユーザースコープキーをクリア (#435)

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { supabase } from "../../src/lib/supabase";
 import { useAuth } from "../../src/providers/AuthProvider";
 import { colors, spacing, radius, shadows } from "../../src/theme";
+import { clearUserScopedAsyncStorage } from "../../src/lib/user-storage";
 
 type WeekStartDay = "sunday" | "monday";
 
@@ -86,6 +87,7 @@ export default function SettingsTab() {
 
   async function handleLogout() {
     try {
+      await clearUserScopedAsyncStorage(user?.id ?? null);
       await supabase.auth.signOut();
     } catch {}
     router.replace("/");

--- a/apps/mobile/app/settings/account.tsx
+++ b/apps/mobile/app/settings/account.tsx
@@ -5,6 +5,7 @@ import { Alert, ScrollView, StyleSheet, Text, View } from "react-native";
 import { Button, Card, PageHeader, SectionHeader } from "../../src/components/ui";
 import { getApi } from "../../src/lib/api";
 import { supabase } from "../../src/lib/supabase";
+import { clearUserScopedAsyncStorage } from "../../src/lib/user-storage";
 import { colors, spacing } from "../../src/theme";
 import { typography } from "../../src/theme/typography";
 
@@ -19,6 +20,8 @@ export default function AccountSettingsPage() {
     if (!ok) return;
 
     try {
+      const { data: { user } } = await supabase.auth.getUser();
+      await clearUserScopedAsyncStorage(user?.id ?? null);
       const api = getApi();
       await api.post("/api/account/delete", { confirm: true });
       await supabase.auth.signOut();

--- a/apps/mobile/src/lib/user-storage.ts
+++ b/apps/mobile/src/lib/user-storage.ts
@@ -1,0 +1,57 @@
+/**
+ * ユーザースコープ AsyncStorage ヘルパー。
+ *
+ * 認証セッションに紐づくキーはここで管理する。
+ * サインアウト・アカウント削除時に clearUserScopedAsyncStorage() を呼んで
+ * 別ユーザーへのデータ漏洩を防ぐ。
+ *
+ * Web 側の src/lib/user-storage.ts と対になる実装。
+ */
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+/**
+ * ユーザー ID を含まないフラットなキー (将来追加時はここに列挙)。
+ */
+const STATIC_USER_SCOPED_KEYS: readonly string[] = [];
+
+/**
+ * ユーザー ID をサフィックスに持つキーのプレフィックス一覧。
+ * 実際のキーは `${prefix}:${userId}` の形式で保存される。
+ */
+const USER_ID_KEY_PREFIXES: readonly string[] = [
+  "push_token_registered_v1",
+];
+
+/**
+ * ログアウト・アカウント削除時にユーザースコープの AsyncStorage キーを削除する。
+ *
+ * @param userId - 現在サインインしているユーザーの UUID。
+ *                 `null` を渡した場合は静的キーのみ削除し、プレフィックス付きキーは
+ *                 getAllKeys() でスキャンして一致するものを削除する (フォールバック)。
+ */
+export async function clearUserScopedAsyncStorage(userId: string | null): Promise<void> {
+  const keysToRemove: string[] = [...STATIC_USER_SCOPED_KEYS];
+
+  if (userId) {
+    for (const prefix of USER_ID_KEY_PREFIXES) {
+      keysToRemove.push(`${prefix}:${userId}`);
+    }
+  } else {
+    // userId が不明な場合は全キーをスキャンしてプレフィックス一致で削除
+    try {
+      const allKeys = await AsyncStorage.getAllKeys();
+      for (const key of allKeys) {
+        if (USER_ID_KEY_PREFIXES.some((prefix) => key.startsWith(`${prefix}:`))) {
+          keysToRemove.push(key);
+        }
+      }
+    } catch {
+      // スキャン失敗時は静的キーのみ削除して続行
+    }
+  }
+
+  if (keysToRemove.length > 0) {
+    await AsyncStorage.multiRemove(keysToRemove);
+  }
+}


### PR DESCRIPTION
Closes #435

## 概要

- `apps/mobile/src/lib/user-storage.ts` を新規作成し `clearUserScopedAsyncStorage(userId)` ヘルパーを実装 (Web側 `src/lib/user-storage.ts` の `clearUserScopedLocalStorage()` に相当)
- `handleLogout()` (settings.tsx): `supabase.auth.signOut()` の前にヘルパーを呼ぶよう修正
- `deleteAccount()` (settings/account.tsx): `supabase.auth.getUser()` でユーザーIDを取得し同様にヘルパーを呼ぶよう修正

ログアウト後に `push_token_registered_v1:{user_id}` が残留し別ユーザーのプッシュトークン再登録がスキップされる問題を解消する。