### PR TITLE
fix(mobile): EAS projectId プレースホルダーを除去し env var で動的注入 (#436)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -51,7 +51,7 @@
     ],
     "extra": {
       "eas": {
-        "projectId": "PLEASE_SET_VIA_EAS_INIT"
+        "projectId": ""
       }
     }
   }

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -25,7 +25,8 @@
         "buildType": "apk"
       },
       "env": {
-        "EXPO_PUBLIC_APP_ENV": "preview"
+        "EXPO_PUBLIC_APP_ENV": "preview",
+        "EXPO_PUBLIC_EAS_PROJECT_ID": "$EXPO_PUBLIC_EAS_PROJECT_ID"
       }
     },
     "production": {
@@ -38,7 +39,8 @@
         "buildType": "app-bundle"
       },
       "env": {
-        "EXPO_PUBLIC_APP_ENV": "production"
+        "EXPO_PUBLIC_APP_ENV": "production",
+        "EXPO_PUBLIC_EAS_PROJECT_ID": "$EXPO_PUBLIC_EAS_PROJECT_ID"
       }
     }
   },

--- a/apps/mobile/env.example
+++ b/apps/mobile/env.example
@@ -8,5 +8,9 @@ EXPO_PUBLIC_API_BASE_URL=https://homegohan.com
 # 環境
 EXPO_PUBLIC_APP_ENV=development
 
+# EAS push token 取得に必要。`eas init` で発行された UUID を設定する
+# 本番・preview ビルドでは EAS Secrets に登録して自動注入される
+EXPO_PUBLIC_EAS_PROJECT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
 
 

--- a/apps/mobile/src/lib/pushNotifications.ts
+++ b/apps/mobile/src/lib/pushNotifications.ts
@@ -30,13 +30,22 @@ export async function registerAndSaveExpoPushToken(): Promise<string | null> {
     });
   }
 
-  const projectId =
-    // EAS
+  // プレースホルダーを無効値として扱う
+  const PLACEHOLDER = "PLEASE_SET_VIA_EAS_INIT";
+
+  const rawProjectId =
+    // 1. 環境変数（EAS Secrets / eas.json env で注入）
+    process.env.EXPO_PUBLIC_EAS_PROJECT_ID ||
+    // 2. EAS ランタイム（本番ビルドで自動設定）
     (Constants as any).easConfig?.projectId ||
+    // 3. app.json extra.eas.projectId（開発時フォールバック）
     (Constants as any).expoConfig?.extra?.eas?.projectId ||
     (Constants as any).expoConfig?.extra?.projectId;
 
-  const token = (await Notifications.getExpoPushTokenAsync(projectId ? { projectId } : undefined)).data;
+  const projectId =
+    rawProjectId && rawProjectId !== PLACEHOLDER ? rawProjectId : undefined;
+
+  const token = (await Notifications.getExpoPushTokenAsync(projectId ? { projectId } : {})).data;
 
   // DB保存（RLSで本人のみ）
   const { error } = await supabase.from("user_push_tokens").upsert(


### PR DESCRIPTION
Closes #436

## 変更概要

### 問題
`apps/mobile/app.json` の `extra.eas.projectId` に `"PLEASE_SET_VIA_EAS_INIT"` というプレースホルダーが残存しており、`registerAndSaveExpoPushToken()` がこれを有効な projectId として `getExpoPushTokenAsync()` に渡すため、本番ビルドで無効なトークンが発行されていた。

### 対応内容
- **`pushNotifications.ts`**: `EXPO_PUBLIC_EAS_PROJECT_ID` 環境変数を最優先ソースとして追加。プレースホルダー文字列 `"PLEASE_SET_VIA_EAS_INIT"` を無効値として検出・除外するガードを追加
- **`app.json`**: `extra.eas.projectId` のプレースホルダーを空文字に変更（EAS ランタイムの `Constants.easConfig.projectId` が正しいソースのため）
- **`eas.json`**: `preview` / `production` ビルドの `env` セクションに `EXPO_PUBLIC_EAS_PROJECT_ID` を追記（EAS Secrets から注入）
- **`env.example`**: `EXPO_PUBLIC_EAS_PROJECT_ID` の説明と記入例を追加

### projectId 解決の優先順位（修正後）
1. `process.env.EXPO_PUBLIC_EAS_PROJECT_ID`（EAS Secrets / eas.json env）
2. `Constants.easConfig?.projectId`（EAS ランタイム自動設定）
3. `Constants.expoConfig?.extra?.eas?.projectId`（app.json フォールバック）
4. いずれも未設定の場合は `{}` で呼び出し（Expo デフォルト動作）

### 設定方法
本番利用前に `eas init` で発行された UUID を EAS Secrets に登録する:
```sh
eas secret:create --name EXPO_PUBLIC_EAS_PROJECT_ID --value <uuid> --scope project
```