### PR TITLE
fix(mobile): 通知・自動解析 toggle の DB 永続化 (#384)

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,9 +1,10 @@
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Alert, Linking, Modal, Pressable, ScrollView, StyleSheet, Switch, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { getApi } from "../../src/lib/api";
 import { supabase } from "../../src/lib/supabase";
 import { useAuth } from "../../src/providers/AuthProvider";
 import { colors, spacing, radius, shadows } from "../../src/theme";
@@ -56,6 +57,8 @@ export default function SettingsTab() {
   useEffect(() => {
     async function fetchSettings() {
       if (!user) return;
+
+      // 週の開始日
       const { data } = await supabase
         .from("user_profiles")
         .select("week_start_day")
@@ -64,9 +67,38 @@ export default function SettingsTab() {
       if (data?.week_start_day) {
         setWeekStartDay(data.week_start_day as WeekStartDay);
       }
+
+      // 通知・自動解析設定を API から取得
+      try {
+        const api = getApi();
+        const res = await api.get<{ settings: { notifications_enabled: boolean; auto_analyze_enabled: boolean; data_share_enabled: boolean } }>("/api/notification-preferences");
+        if (res.settings) {
+          setNotifications(res.settings.notifications_enabled);
+          setAutoAnalyze(res.settings.auto_analyze_enabled);
+          setDataShare(res.settings.data_share_enabled);
+        }
+      } catch (e) {
+        console.error("Failed to fetch notification preferences:", e);
+      }
     }
     fetchSettings();
   }, [user]);
+
+  async function handleToggleNotificationPreference(
+    key: "notifications_enabled" | "auto_analyze_enabled" | "data_share_enabled",
+    setter: React.Dispatch<React.SetStateAction<boolean>>,
+    currentValue: boolean,
+  ) {
+    const newValue = !currentValue;
+    setter(newValue);
+    try {
+      const api = getApi();
+      await api.patch("/api/notification-preferences", { [key]: newValue });
+    } catch (e) {
+      console.error("Failed to save preference:", e);
+      setter(currentValue); // ロールバック
+    }
+  }
 
   async function handleWeekStartDayChange(newValue: WeekStartDay) {
     if (!user) return;
@@ -108,13 +140,13 @@ export default function SettingsTab() {
               icon="🔔"
               iconBg="#EFF6FF"
               title="通知"
-              right={<Switch value={notifications} onValueChange={setNotifications} trackColor={{ true: colors.accent }} />}
+              right={<Switch value={notifications} onValueChange={() => handleToggleNotificationPreference("notifications_enabled", setNotifications, notifications)} trackColor={{ true: colors.accent }} />}
             />
             <SettingRow
               icon="🤖"
               iconBg="#F3E8FF"
               title="自動解析"
-              right={<Switch value={autoAnalyze} onValueChange={setAutoAnalyze} trackColor={{ true: colors.accent }} />}
+              right={<Switch value={autoAnalyze} onValueChange={() => handleToggleNotificationPreference("auto_analyze_enabled", setAutoAnalyze, autoAnalyze)} trackColor={{ true: colors.accent }} />}
             />
             <SettingRow
               icon="📅"
@@ -190,7 +222,7 @@ export default function SettingsTab() {
               title="トレーナーと共有"
               subtitle="栄養士やジムと連携"
               last
-              right={<Switch value={dataShare} onValueChange={setDataShare} trackColor={{ true: colors.accent }} />}
+              right={<Switch value={dataShare} onValueChange={() => handleToggleNotificationPreference("data_share_enabled", setDataShare, dataShare)} trackColor={{ true: colors.accent }} />}
             />
           </View>
         </View>

--- a/apps/mobile/app/profile/index.tsx
+++ b/apps/mobile/app/profile/index.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Alert, Linking, Pressable, ScrollView, StyleSheet, Switch, Text, TextInput, View } from "react-native";
 
 import { Card, ListItem, LoadingState, PageHeader } from "../../src/components/ui";
@@ -79,6 +79,17 @@ export default function ProfilePage() {
           const badgeRes = await api.get<{ badges: any[] }>("/api/badges");
           setBadgeCount(badgeRes.badges?.filter((b: any) => b.earned).length ?? 0);
         } catch {}
+
+        // 通知・自動解析設定を API から取得
+        try {
+          const prefRes = await api.get<{ settings: { notifications_enabled: boolean; auto_analyze_enabled: boolean } }>("/api/notification-preferences");
+          if (prefRes.settings) {
+            setNotifications(prefRes.settings.notifications_enabled);
+            setAutoAnalyze(prefRes.settings.auto_analyze_enabled);
+          }
+        } catch (e) {
+          console.error("Failed to fetch notification preferences:", e);
+        }
       } catch (e: any) {
         console.error("Profile fetch error:", e);
       } finally {
@@ -103,6 +114,22 @@ export default function ProfilePage() {
     const { data: { user: u } } = await supabase.auth.getUser();
     if (!u) return;
     await supabase.from("user_profiles").update({ week_start_day: newValue }).eq("id", u.id);
+  }
+
+  async function handleToggleNotificationPreference(
+    key: "notifications_enabled" | "auto_analyze_enabled",
+    setter: React.Dispatch<React.SetStateAction<boolean>>,
+    currentValue: boolean,
+  ) {
+    const newValue = !currentValue;
+    setter(newValue);
+    try {
+      const api = getApi();
+      await api.patch("/api/notification-preferences", { [key]: newValue });
+    } catch (e) {
+      console.error("Failed to save preference:", e);
+      setter(currentValue); // ロールバック
+    }
   }
 
   async function handleLogout() {
@@ -389,7 +416,7 @@ export default function ProfilePage() {
                   </View>
                   <Text style={s.settingLabel}>通知</Text>
                 </View>
-                <Switch value={notifications} onValueChange={setNotifications} trackColor={{ true: colors.accent }} />
+                <Switch value={notifications} onValueChange={() => handleToggleNotificationPreference("notifications_enabled", setNotifications, notifications)} trackColor={{ true: colors.accent }} />
               </View>
 
               {/* 自動解析 */}
@@ -400,7 +427,7 @@ export default function ProfilePage() {
                   </View>
                   <Text style={s.settingLabel}>自動解析</Text>
                 </View>
-                <Switch value={autoAnalyze} onValueChange={setAutoAnalyze} trackColor={{ true: colors.accent }} />
+                <Switch value={autoAnalyze} onValueChange={() => handleToggleNotificationPreference("auto_analyze_enabled", setAutoAnalyze, autoAnalyze)} trackColor={{ true: colors.accent }} />
               </View>
 
               {/* 週の開始日 */}


### PR DESCRIPTION
Closes #384

## 概要

- マウント時に `GET /api/notification-preferences` を呼び出し、通知・自動解析・データ共有の toggle 状態を DB から復元する
- toggle 操作時に `PATCH /api/notification-preferences` を呼び出し、変更を永続化する
- PATCH 失敗時はローカル state をロールバックし、再起動後も一貫した状態を保つ

## 変更ファイル

- `apps/mobile/app/(tabs)/settings.tsx` — 設定タブの通知・自動解析・データ共有 toggle
- `apps/mobile/app/profile/index.tsx` — プロフィールページの設定セクション toggle