### PR TITLE
fix(mobile): インサイト本文フィールドを summary から content に修正 (#381)

### DIFF
--- a/apps/mobile/app/(tabs)/health.tsx
+++ b/apps/mobile/app/(tabs)/health.tsx
@@ -367,14 +367,14 @@ export default function HealthDashboardTab() {
         <View>
           <View style={styles.sectionRow}>
             <Text style={styles.sectionTitle}>健康診断</Text>
-            <Link href="/health/blood-tests" asChild>
+            <Link href="/health/checkups" asChild>
               <Pressable style={styles.seeAllRow}>
                 <Text style={styles.seeAllText}>すべて見る</Text>
                 <Ionicons name="chevron-forward" size={16} color={colors.accent} />
               </Pressable>
             </Link>
           </View>
-          <Link href="/health/blood-tests" asChild>
+          <Link href="/health/checkups" asChild>
             <Pressable style={styles.checkupCard}>
               <View style={[styles.iconBox, { backgroundColor: "#FFEBEE" }]}>
                 <Ionicons name="pulse" size={24} color={colors.error} />

--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
 import { router } from "expo-router";
 import { useMemo, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
@@ -42,6 +43,16 @@ const CHECKIN_FIELDS = [
   { key: "focus" as const, label: "🎯 集中力", options: ["低い", "やや低い", "普通", "良い", "最高"] },
   { key: "hunger" as const, label: "🍽️ 空腹感", options: ["ない", "少し", "普通", "ある", "すごくある"] },
 ];
+
+const NEXT_ACTION_LABEL: Record<string, string> = {
+  increase_calories: "カロリーを少し増やしましょう",
+  decrease_calories: "カロリーを少し減らしましょう",
+  increase_protein: "タンパク質を増やしましょう",
+  increase_carbs: "炭水化物を増やしましょう",
+  improve_sleep: "睡眠の質を改善しましょう",
+  reduce_fatigue: "疲労回復を優先しましょう",
+  maintain: "現状を維持しましょう",
+};
 
 const getGreeting = () => {
   const hour = new Date().getHours();
@@ -422,6 +433,39 @@ export default function HomeScreen() {
                 </Text>
               )}
             </Card>
+          )}
+
+          {/* ========== 次の一手カード ========== */}
+          {performanceAnalysis.nextAction && (
+            <LinearGradient
+              colors={["#8B5CF6", "#6366F1"]}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 0 }}
+              style={{ borderRadius: radius.xl, padding: spacing.lg, ...shadows.md, overflow: "hidden" }}
+            >
+              {/* 装飾円 */}
+              <View style={{
+                position: "absolute", top: -20, right: -20,
+                width: 80, height: 80, borderRadius: 40,
+                backgroundColor: "rgba(255,255,255,0.12)",
+              }} />
+              <View style={{ flexDirection: "row", alignItems: "flex-start", gap: spacing.sm }}>
+                <Ionicons name="navigate" size={18} color="#fff" style={{ marginTop: 2 }} />
+                <View style={{ flex: 1 }}>
+                  <Text style={{ fontSize: 11, fontWeight: "800", color: "rgba(255,255,255,0.8)", marginBottom: 4 }}>
+                    🎯 今日の次の一手
+                  </Text>
+                  <Text style={{ fontSize: 14, fontWeight: "700", color: "#fff", lineHeight: 20 }}>
+                    {NEXT_ACTION_LABEL[performanceAnalysis.nextAction.actionType] ?? performanceAnalysis.nextAction.actionType}
+                  </Text>
+                  {performanceAnalysis.nextAction.reason ? (
+                    <Text style={{ fontSize: 12, color: "rgba(255,255,255,0.75)", marginTop: 4, lineHeight: 18 }}>
+                      {performanceAnalysis.nextAction.reason}
+                    </Text>
+                  ) : null}
+                </View>
+              </View>
+            </LinearGradient>
           )}
 
           {/* チェックイン完了済み */}

--- a/apps/mobile/app/health/checkups/index.tsx
+++ b/apps/mobile/app/health/checkups/index.tsx
@@ -1,0 +1,548 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useCallback, useEffect, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { Card, EmptyState, LoadingState } from "../../../src/components/ui";
+import { getApi } from "../../../src/lib/api";
+import { colors, radius, shadows, spacing } from "../../../src/theme";
+
+// ─── Types ────────────────────────────────────────────
+interface IndividualReview {
+  summary: string;
+  concerns: string[];
+  positives: string[];
+  recommendations: string[];
+  riskLevel: "low" | "medium" | "high";
+}
+
+interface HealthCheckup {
+  id: string;
+  checkup_date: string;
+  facility_name?: string;
+  checkup_type?: string;
+  blood_pressure_systolic?: number;
+  blood_pressure_diastolic?: number;
+  hba1c?: number;
+  ldl_cholesterol?: number;
+  triglycerides?: number;
+  individual_review?: IndividualReview;
+}
+
+interface TrendMetric {
+  metric: string;
+  detail: string;
+}
+
+interface TrendAnalysis {
+  overallAssessment: string;
+  improvingMetrics?: TrendMetric[];
+  worseningMetrics?: (TrendMetric & { severity: string })[];
+  stableMetrics?: string[];
+  priorityActions?: string[];
+}
+
+interface NutritionGuidance {
+  generalDirection: string;
+  avoidanceHints?: string[];
+  emphasisHints?: string[];
+  specialNotes?: string;
+}
+
+interface LongitudinalReview {
+  id: string;
+  review_date: string;
+  trend_analysis?: TrendAnalysis;
+  nutrition_guidance?: NutritionGuidance;
+}
+
+// ─── Helpers ──────────────────────────────────────────
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}/${m}/${day}`;
+}
+
+function getRiskColor(level?: string): { bg: string; text: string } {
+  switch (level) {
+    case "high":
+      return { bg: colors.errorLight, text: colors.error };
+    case "medium":
+      return { bg: colors.warningLight, text: colors.warning };
+    default:
+      return { bg: colors.successLight, text: colors.success };
+  }
+}
+
+function getRiskIcon(level?: string): keyof typeof Ionicons.glyphMap {
+  switch (level) {
+    case "high":
+      return "warning-outline";
+    case "medium":
+      return "time-outline";
+    default:
+      return "checkmark-circle-outline";
+  }
+}
+
+function getRiskLabel(level?: string): string {
+  switch (level) {
+    case "high":
+      return "要注意";
+    case "medium":
+      return "注意";
+    default:
+      return "良好";
+  }
+}
+
+// ─── Component ────────────────────────────────────────
+export default function CheckupsPage() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  const [loading, setLoading] = useState(true);
+  const [checkups, setCheckups] = useState<HealthCheckup[]>([]);
+  const [longitudinalReview, setLongitudinalReview] = useState<LongitudinalReview | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const api = getApi();
+      const data = await api.get<{ checkups: HealthCheckup[]; longitudinalReview: LongitudinalReview | null }>(
+        "/api/health/checkups",
+      );
+      setCheckups(data.checkups ?? []);
+      setLongitudinalReview(data.longitudinalReview ?? null);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  if (loading) {
+    return (
+      <View style={[styles.screen, { paddingTop: insets.top }]}>
+        <LoadingState message="健康診断データを読み込み中..." />
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.screen, { paddingTop: insets.top }]}>
+      {/* ─── Header ─── */}
+      <View style={styles.header}>
+        <Pressable onPress={() => router.back()} hitSlop={12}>
+          <Ionicons name="arrow-back" size={24} color={colors.text} />
+        </Pressable>
+        <Text style={styles.headerTitle}>健康診断記録</Text>
+        <Pressable
+          onPress={() => router.push("/health/checkups/new")}
+          style={styles.addBtn}
+          hitSlop={12}
+        >
+          <Ionicons name="add" size={22} color="#fff" />
+        </Pressable>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+
+        {/* ─── 経年分析カード ─── */}
+        {longitudinalReview?.trend_analysis && (
+          <View style={styles.longitudinalCard}>
+            <View style={styles.longitudinalHeader}>
+              <Ionicons name="analytics-outline" size={20} color="#fff" />
+              <Text style={styles.longitudinalTitle}>経年分析</Text>
+              <Text style={styles.longitudinalDate}>{formatDate(longitudinalReview.review_date)}</Text>
+            </View>
+
+            <Text style={styles.longitudinalAssessment}>
+              {longitudinalReview.trend_analysis.overallAssessment}
+            </Text>
+
+            {/* 改善指標 */}
+            {(longitudinalReview.trend_analysis.improvingMetrics ?? []).slice(0, 2).map((item, i) => (
+              <View key={i} style={styles.trendRow}>
+                <View style={styles.trendIconBox}>
+                  <Ionicons name="trending-down" size={14} color="#86efac" />
+                </View>
+                <Text style={styles.trendMetric}>{item.metric}</Text>
+                <Text style={styles.trendBadgeGood}>改善</Text>
+              </View>
+            ))}
+
+            {/* 悪化指標 */}
+            {(longitudinalReview.trend_analysis.worseningMetrics ?? []).slice(0, 2).map((item, i) => (
+              <View key={i} style={styles.trendRow}>
+                <View style={styles.trendIconBox}>
+                  <Ionicons name="trending-up" size={14} color="#fca5a5" />
+                </View>
+                <Text style={styles.trendMetric}>{item.metric}</Text>
+                <Text style={styles.trendBadgeBad}>要注意</Text>
+              </View>
+            ))}
+
+            {/* 食事方針 */}
+            {longitudinalReview.nutrition_guidance?.generalDirection && (
+              <View style={styles.nutritionBox}>
+                <Text style={styles.nutritionLabel}>食事方針</Text>
+                <Text style={styles.nutritionText}>
+                  {longitudinalReview.nutrition_guidance.generalDirection}
+                </Text>
+              </View>
+            )}
+          </View>
+        )}
+
+        {/* ─── 健康診断一覧 ─── */}
+        {checkups.length === 0 ? (
+          <EmptyState
+            icon={<Ionicons name="document-text-outline" size={48} color={colors.textMuted} />}
+            message="健康診断の記録がありません。最初の記録を追加しましょう"
+            actionLabel="記録を追加"
+            onAction={() => router.push("/health/checkups/new")}
+          />
+        ) : (
+          <View style={{ gap: spacing.sm }}>
+            {checkups.map((checkup) => {
+              const riskColor = getRiskColor(checkup.individual_review?.riskLevel);
+              const riskIcon = getRiskIcon(checkup.individual_review?.riskLevel);
+              const riskLabel = getRiskLabel(checkup.individual_review?.riskLevel);
+              return (
+                <Pressable
+                  key={checkup.id}
+                  style={styles.checkupCard}
+                  onPress={() => router.push(`/health/checkups/${checkup.id}` as any)}
+                >
+                  {/* 上段: 日付・種別・リスクバッジ */}
+                  <View style={styles.checkupTop}>
+                    <View style={{ flex: 1 }}>
+                      <View style={styles.checkupDateRow}>
+                        <Text style={styles.checkupDate}>{formatDate(checkup.checkup_date)}</Text>
+                        {checkup.checkup_type && (
+                          <View style={styles.typeBadge}>
+                            <Text style={styles.typeBadgeText}>{checkup.checkup_type}</Text>
+                          </View>
+                        )}
+                      </View>
+                      {checkup.facility_name && (
+                        <Text style={styles.facilityName}>{checkup.facility_name}</Text>
+                      )}
+                    </View>
+
+                    {checkup.individual_review?.riskLevel && (
+                      <View style={[styles.riskBadge, { backgroundColor: riskColor.bg }]}>
+                        <Ionicons name={riskIcon} size={14} color={riskColor.text} />
+                        <Text style={[styles.riskBadgeText, { color: riskColor.text }]}>
+                          {riskLabel}
+                        </Text>
+                      </View>
+                    )}
+                  </View>
+
+                  {/* 主要指標 */}
+                  <View style={styles.metricsRow}>
+                    {checkup.blood_pressure_systolic != null && (
+                      <View style={styles.metric}>
+                        <Ionicons name="heart-outline" size={12} color={colors.error} />
+                        <Text style={styles.metricText}>
+                          {checkup.blood_pressure_systolic}/{checkup.blood_pressure_diastolic}
+                        </Text>
+                      </View>
+                    )}
+                    {checkup.hba1c != null && (
+                      <View style={styles.metric}>
+                        <Ionicons name="water-outline" size={12} color={colors.purple} />
+                        <Text style={styles.metricText}>HbA1c {checkup.hba1c}%</Text>
+                      </View>
+                    )}
+                    {checkup.ldl_cholesterol != null && (
+                      <View style={styles.metric}>
+                        <Ionicons name="pulse-outline" size={12} color={colors.warning} />
+                        <Text style={styles.metricText}>LDL {checkup.ldl_cholesterol}</Text>
+                      </View>
+                    )}
+                  </View>
+
+                  {/* AI サマリー */}
+                  {checkup.individual_review?.summary && (
+                    <Text style={styles.aiSummary} numberOfLines={2}>
+                      {checkup.individual_review.summary}
+                    </Text>
+                  )}
+
+                  {/* AI レビュー詳細 (concerns / positives / recommendations) */}
+                  {checkup.individual_review && (
+                    <View style={styles.reviewSection}>
+                      {(checkup.individual_review.concerns ?? []).length > 0 && (
+                        <View style={[styles.reviewBlock, { backgroundColor: colors.warningLight }]}>
+                          <View style={styles.reviewBlockHeader}>
+                            <Ionicons name="warning-outline" size={14} color={colors.warning} />
+                            <Text style={[styles.reviewBlockTitle, { color: colors.warning }]}>気になる点</Text>
+                          </View>
+                          {checkup.individual_review.concerns.slice(0, 2).map((item, i) => (
+                            <Text key={i} style={styles.reviewBlockItem}>• {item}</Text>
+                          ))}
+                        </View>
+                      )}
+
+                      {(checkup.individual_review.positives ?? []).length > 0 && (
+                        <View style={[styles.reviewBlock, { backgroundColor: colors.successLight }]}>
+                          <View style={styles.reviewBlockHeader}>
+                            <Ionicons name="checkmark-circle-outline" size={14} color={colors.success} />
+                            <Text style={[styles.reviewBlockTitle, { color: colors.success }]}>良い点</Text>
+                          </View>
+                          {checkup.individual_review.positives.slice(0, 2).map((item, i) => (
+                            <Text key={i} style={styles.reviewBlockItem}>• {item}</Text>
+                          ))}
+                        </View>
+                      )}
+
+                      {(checkup.individual_review.recommendations ?? []).length > 0 && (
+                        <View style={[styles.reviewBlock, { backgroundColor: colors.purpleLight }]}>
+                          <View style={styles.reviewBlockHeader}>
+                            <Ionicons name="sparkles-outline" size={14} color={colors.purple} />
+                            <Text style={[styles.reviewBlockTitle, { color: colors.purple }]}>改善アドバイス</Text>
+                          </View>
+                          {checkup.individual_review.recommendations.slice(0, 2).map((item, i) => (
+                            <Text key={i} style={styles.reviewBlockItem}>{i + 1}. {item}</Text>
+                          ))}
+                        </View>
+                      )}
+                    </View>
+                  )}
+
+                  <Ionicons
+                    name="chevron-forward"
+                    size={16}
+                    color={colors.textMuted}
+                    style={styles.chevron}
+                  />
+                </Pressable>
+              );
+            })}
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    gap: spacing.md,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 20,
+    fontWeight: "800",
+    color: colors.text,
+  },
+  addBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: radius.full,
+    backgroundColor: colors.accent,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  scrollContent: {
+    padding: spacing.lg,
+    gap: spacing.md,
+    paddingBottom: 100,
+  },
+
+  // ─── 経年分析 ───
+  longitudinalCard: {
+    borderRadius: radius.xl,
+    padding: spacing.lg,
+    gap: spacing.sm,
+    backgroundColor: colors.purple,
+  },
+  longitudinalHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  longitudinalTitle: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: "800",
+    color: "#fff",
+  },
+  longitudinalDate: {
+    fontSize: 11,
+    color: "rgba(255,255,255,0.6)",
+  },
+  longitudinalAssessment: {
+    fontSize: 13,
+    color: "rgba(255,255,255,0.9)",
+    lineHeight: 20,
+  },
+  trendRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  trendIconBox: {
+    width: 24,
+    height: 24,
+    borderRadius: radius.full,
+    backgroundColor: "rgba(255,255,255,0.15)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  trendMetric: {
+    flex: 1,
+    fontSize: 13,
+    color: "rgba(255,255,255,0.9)",
+  },
+  trendBadgeGood: {
+    fontSize: 11,
+    color: "#86efac",
+    fontWeight: "700",
+  },
+  trendBadgeBad: {
+    fontSize: 11,
+    color: "#fca5a5",
+    fontWeight: "700",
+  },
+  nutritionBox: {
+    marginTop: spacing.xs,
+    paddingTop: spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: "rgba(255,255,255,0.2)",
+  },
+  nutritionLabel: {
+    fontSize: 11,
+    color: "rgba(255,255,255,0.6)",
+    marginBottom: 4,
+  },
+  nutritionText: {
+    fontSize: 13,
+    color: "#fff",
+    lineHeight: 18,
+  },
+
+  // ─── 一覧カード ───
+  checkupCard: {
+    backgroundColor: colors.card,
+    borderRadius: radius.xl,
+    padding: spacing.lg,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  checkupTop: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: spacing.sm,
+  },
+  checkupDateRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    marginBottom: 2,
+  },
+  checkupDate: {
+    fontSize: 15,
+    fontWeight: "800",
+    color: colors.text,
+  },
+  typeBadge: {
+    backgroundColor: colors.blueLight,
+    borderRadius: radius.full,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+  },
+  typeBadgeText: {
+    fontSize: 11,
+    color: colors.blue,
+    fontWeight: "600",
+  },
+  facilityName: {
+    fontSize: 12,
+    color: colors.textMuted,
+  },
+  riskBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    borderRadius: radius.full,
+  },
+  riskBadgeText: {
+    fontSize: 11,
+    fontWeight: "700",
+  },
+
+  // ─── 主要指標 ───
+  metricsRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.md,
+  },
+  metric: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  metricText: {
+    fontSize: 12,
+    color: colors.textLight,
+  },
+
+  // ─── AI サマリー ───
+  aiSummary: {
+    fontSize: 12,
+    color: colors.textMuted,
+    lineHeight: 18,
+  },
+
+  // ─── AI レビューブロック ───
+  reviewSection: {
+    gap: spacing.xs,
+  },
+  reviewBlock: {
+    borderRadius: radius.md,
+    padding: spacing.sm,
+    gap: 4,
+  },
+  reviewBlockHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    marginBottom: 2,
+  },
+  reviewBlockTitle: {
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  reviewBlockItem: {
+    fontSize: 12,
+    color: colors.textLight,
+    lineHeight: 18,
+  },
+
+  chevron: {
+    alignSelf: "flex-end",
+    marginTop: -spacing.xs,
+  },
+});

--- a/apps/mobile/app/health/checkups/new.tsx
+++ b/apps/mobile/app/health/checkups/new.tsx
@@ -1,0 +1,565 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { useState } from "react";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { Button } from "../../../src/components/ui";
+import { getApi } from "../../../src/lib/api";
+import { colors, radius, shadows, spacing } from "../../../src/theme";
+
+// ─── Types ────────────────────────────────────────────
+interface FormData {
+  checkup_date: string;
+  facility_name: string;
+  checkup_type: string;
+  // 血圧・代謝
+  blood_pressure_systolic: string;
+  blood_pressure_diastolic: string;
+  hba1c: string;
+  fasting_glucose: string;
+  // 身体測定
+  height: string;
+  weight: string;
+  bmi: string;
+  waist_circumference: string;
+  // 脂質
+  total_cholesterol: string;
+  ldl_cholesterol: string;
+  hdl_cholesterol: string;
+  triglycerides: string;
+  // 肝機能
+  ast: string;
+  alt: string;
+  gamma_gtp: string;
+  // 腎機能
+  creatinine: string;
+  egfr: string;
+  uric_acid: string;
+}
+
+type Step = "form" | "review";
+
+const CHECKUP_TYPES = ["定期健診", "人間ドック", "特定健診", "その他"];
+
+function todayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function toNum(v: string): number | undefined {
+  const s = v.trim();
+  if (!s) return undefined;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+// ─── Component ────────────────────────────────────────
+export default function NewCheckupPage() {
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  const [step, setStep] = useState<Step>("form");
+  const [saving, setSaving] = useState(false);
+  const [savedCheckup, setSavedCheckup] = useState<any>(null);
+
+  const [form, setForm] = useState<FormData>({
+    checkup_date: todayStr(),
+    facility_name: "",
+    checkup_type: "定期健診",
+    blood_pressure_systolic: "",
+    blood_pressure_diastolic: "",
+    hba1c: "",
+    fasting_glucose: "",
+    height: "",
+    weight: "",
+    bmi: "",
+    waist_circumference: "",
+    total_cholesterol: "",
+    ldl_cholesterol: "",
+    hdl_cholesterol: "",
+    triglycerides: "",
+    ast: "",
+    alt: "",
+    gamma_gtp: "",
+    creatinine: "",
+    egfr: "",
+    uric_acid: "",
+  });
+
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
+    basic: true,
+    body: true,
+    lipid: false,
+    liver: false,
+    kidney: false,
+  });
+
+  function update(field: keyof FormData, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function toggleSection(key: string) {
+    setExpandedSections((prev) => ({ ...prev, [key]: !prev[key] }));
+  }
+
+  async function handleSave() {
+    if (!form.checkup_date) {
+      Alert.alert("エラー", "検査日を入力してください。");
+      return;
+    }
+    setSaving(true);
+    try {
+      const numericFields = [
+        "blood_pressure_systolic", "blood_pressure_diastolic",
+        "hba1c", "fasting_glucose",
+        "height", "weight", "bmi", "waist_circumference",
+        "total_cholesterol", "ldl_cholesterol", "hdl_cholesterol", "triglycerides",
+        "ast", "alt", "gamma_gtp",
+        "creatinine", "egfr", "uric_acid",
+      ] as const;
+
+      const payload: Record<string, unknown> = {
+        checkup_date: form.checkup_date,
+        facility_name: form.facility_name || null,
+        checkup_type: form.checkup_type || null,
+      };
+
+      for (const field of numericFields) {
+        const n = toNum(form[field]);
+        if (n !== undefined) payload[field] = n;
+      }
+
+      const api = getApi();
+      const data = await api.post<{ checkup: any }>("/api/health/checkups", payload);
+      setSavedCheckup(data.checkup);
+      setStep("review");
+    } catch (e: any) {
+      Alert.alert("保存失敗", e?.message ?? "記録の保存に失敗しました。");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // ─── Sub-renders ──────────────────────────────────
+  function renderField(
+    field: keyof FormData,
+    label: string,
+    unit?: string,
+    placeholder?: string,
+  ) {
+    return (
+      <View key={field} style={styles.fieldRow}>
+        <Text style={styles.fieldLabel}>{label}</Text>
+        <View style={styles.fieldInputWrap}>
+          <TextInput
+            style={styles.fieldInput}
+            value={form[field]}
+            onChangeText={(v) => update(field, v)}
+            placeholder={placeholder}
+            placeholderTextColor={colors.textMuted}
+            keyboardType="decimal-pad"
+          />
+          {unit && <Text style={styles.fieldUnit}>{unit}</Text>}
+        </View>
+      </View>
+    );
+  }
+
+  function renderSection(
+    key: string,
+    title: string,
+    iconName: keyof typeof Ionicons.glyphMap,
+    children: React.ReactNode,
+  ) {
+    return (
+      <View style={styles.section}>
+        <Pressable style={styles.sectionHeader} onPress={() => toggleSection(key)}>
+          <View style={styles.sectionIconBox}>
+            <Ionicons name={iconName} size={18} color={colors.accent} />
+          </View>
+          <Text style={styles.sectionTitle}>{title}</Text>
+          <Ionicons
+            name={expandedSections[key] ? "chevron-up" : "chevron-down"}
+            size={18}
+            color={colors.textMuted}
+          />
+        </Pressable>
+        {expandedSections[key] && <View style={styles.sectionBody}>{children}</View>}
+      </View>
+    );
+  }
+
+  // ─── Review step ──────────────────────────────────
+  if (step === "review" && savedCheckup) {
+    const review = savedCheckup.individual_review;
+    return (
+      <View style={[styles.screen, { paddingTop: insets.top }]}>
+        <View style={styles.header}>
+          <Pressable onPress={() => router.back()} hitSlop={12}>
+            <Ionicons name="arrow-back" size={24} color={colors.text} />
+          </Pressable>
+          <Text style={styles.headerTitle}>AI分析結果</Text>
+          <View style={{ width: 24 }} />
+        </View>
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          {review ? (
+            <>
+              {/* 総評 */}
+              <View style={styles.reviewCard}>
+                <View style={styles.reviewCardHeader}>
+                  <Ionicons name="sparkles-outline" size={20} color={colors.purple} />
+                  <Text style={styles.reviewCardTitle}>AI分析結果</Text>
+                </View>
+                <Text style={styles.reviewCardBody}>{review.summary}</Text>
+              </View>
+
+              {/* 気になる点 */}
+              {(review.concerns ?? []).length > 0 && (
+                <View style={[styles.reviewCard, { backgroundColor: colors.warningLight }]}>
+                  <View style={styles.reviewCardHeader}>
+                    <Ionicons name="warning-outline" size={18} color={colors.warning} />
+                    <Text style={[styles.reviewCardTitle, { color: colors.warning }]}>気になる点</Text>
+                  </View>
+                  {review.concerns.map((item: string, i: number) => (
+                    <Text key={i} style={styles.reviewItem}>• {item}</Text>
+                  ))}
+                </View>
+              )}
+
+              {/* 良い点 */}
+              {(review.positives ?? []).length > 0 && (
+                <View style={[styles.reviewCard, { backgroundColor: colors.successLight }]}>
+                  <View style={styles.reviewCardHeader}>
+                    <Ionicons name="checkmark-circle-outline" size={18} color={colors.success} />
+                    <Text style={[styles.reviewCardTitle, { color: colors.success }]}>良い点</Text>
+                  </View>
+                  {review.positives.map((item: string, i: number) => (
+                    <Text key={i} style={styles.reviewItem}>• {item}</Text>
+                  ))}
+                </View>
+              )}
+
+              {/* アドバイス */}
+              {(review.recommendations ?? []).length > 0 && (
+                <View style={[styles.reviewCard, { backgroundColor: colors.purpleLight }]}>
+                  <View style={styles.reviewCardHeader}>
+                    <Ionicons name="sparkles-outline" size={18} color={colors.purple} />
+                    <Text style={[styles.reviewCardTitle, { color: colors.purple }]}>改善アドバイス</Text>
+                  </View>
+                  {review.recommendations.map((item: string, i: number) => (
+                    <Text key={i} style={styles.reviewItem}>{i + 1}. {item}</Text>
+                  ))}
+                </View>
+              )}
+            </>
+          ) : (
+            <View style={styles.reviewCard}>
+              <Text style={[styles.reviewCardBody, { color: colors.textMuted, textAlign: "center" }]}>
+                AI分析を実行できませんでした
+              </Text>
+            </View>
+          )}
+
+          <Button onPress={() => router.push("/health/checkups" as any)}>完了</Button>
+        </ScrollView>
+      </View>
+    );
+  }
+
+  // ─── Form step ────────────────────────────────────
+  return (
+    <KeyboardAvoidingView
+      style={styles.screen}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <View style={{ paddingTop: insets.top }}>
+        <View style={styles.header}>
+          <Pressable onPress={() => router.back()} hitSlop={12}>
+            <Ionicons name="arrow-back" size={24} color={colors.text} />
+          </Pressable>
+          <Text style={styles.headerTitle}>健康診断を記録</Text>
+          <View style={{ width: 24 }} />
+        </View>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+
+        {/* 基本情報 */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <View style={styles.sectionIconBox}>
+              <Ionicons name="calendar-outline" size={18} color={colors.accent} />
+            </View>
+            <Text style={styles.sectionTitle}>基本情報</Text>
+          </View>
+          <View style={styles.sectionBody}>
+            {/* 検査日 */}
+            <View style={styles.fieldRow}>
+              <Text style={styles.fieldLabel}>検査日</Text>
+              <TextInput
+                style={[styles.fieldInput, { flex: 1 }]}
+                value={form.checkup_date}
+                onChangeText={(v) => update("checkup_date", v)}
+                placeholder="YYYY-MM-DD"
+                placeholderTextColor={colors.textMuted}
+              />
+            </View>
+            {/* 医療機関 */}
+            <View style={styles.fieldRow}>
+              <Text style={styles.fieldLabel}>医療機関</Text>
+              <TextInput
+                style={[styles.fieldInput, { flex: 1 }]}
+                value={form.facility_name}
+                onChangeText={(v) => update("facility_name", v)}
+                placeholder="〇〇クリニック"
+                placeholderTextColor={colors.textMuted}
+              />
+            </View>
+            {/* 種類 */}
+            <View style={styles.fieldRow}>
+              <Text style={styles.fieldLabel}>種類</Text>
+              <View style={styles.typeRow}>
+                {CHECKUP_TYPES.map((t) => (
+                  <Pressable
+                    key={t}
+                    style={[styles.typeBtn, form.checkup_type === t && styles.typeBtnActive]}
+                    onPress={() => update("checkup_type", t)}
+                  >
+                    <Text
+                      style={[styles.typeBtnText, form.checkup_type === t && styles.typeBtnTextActive]}
+                    >
+                      {t}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+          </View>
+        </View>
+
+        {/* 血圧・代謝 */}
+        {renderSection("basic", "血圧・代謝", "pulse-outline", (
+          <>
+            {renderField("blood_pressure_systolic", "収縮期血圧", "mmHg", "120")}
+            {renderField("blood_pressure_diastolic", "拡張期血圧", "mmHg", "80")}
+            {renderField("hba1c", "HbA1c", "%", "5.6")}
+            {renderField("fasting_glucose", "空腹時血糖", "mg/dL", "100")}
+          </>
+        ))}
+
+        {/* 身体測定 */}
+        {renderSection("body", "身体測定", "body-outline", (
+          <>
+            {renderField("height", "身長", "cm", "170")}
+            {renderField("weight", "体重", "kg", "65")}
+            {renderField("bmi", "BMI", "", "22.5")}
+            {renderField("waist_circumference", "腹囲", "cm", "85")}
+          </>
+        ))}
+
+        {/* 脂質 */}
+        {renderSection("lipid", "脂質", "water-outline", (
+          <>
+            {renderField("total_cholesterol", "総コレステロール", "mg/dL", "200")}
+            {renderField("ldl_cholesterol", "LDL", "mg/dL", "120")}
+            {renderField("hdl_cholesterol", "HDL", "mg/dL", "60")}
+            {renderField("triglycerides", "中性脂肪", "mg/dL", "150")}
+          </>
+        ))}
+
+        {/* 肝機能 */}
+        {renderSection("liver", "肝機能", "fitness-outline", (
+          <>
+            {renderField("ast", "AST(GOT)", "U/L", "25")}
+            {renderField("alt", "ALT(GPT)", "U/L", "20")}
+            {renderField("gamma_gtp", "γ-GTP", "U/L", "30")}
+          </>
+        ))}
+
+        {/* 腎機能 */}
+        {renderSection("kidney", "腎機能・尿酸", "leaf-outline", (
+          <>
+            {renderField("creatinine", "クレアチニン", "mg/dL", "0.8")}
+            {renderField("egfr", "eGFR", "", "90")}
+            {renderField("uric_acid", "尿酸", "mg/dL", "5.5")}
+          </>
+        ))}
+
+        <Button onPress={handleSave} loading={saving} disabled={saving}>
+          {saving ? "保存中..." : "保存してAI分析を実行"}
+        </Button>
+
+        <Text style={styles.ocrHint}>
+          ※ OCR取込機能は別途対応予定です。手動で数値を入力してください。
+        </Text>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    gap: spacing.md,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 20,
+    fontWeight: "800",
+    color: colors.text,
+  },
+  scrollContent: {
+    padding: spacing.lg,
+    gap: spacing.md,
+    paddingBottom: 120,
+  },
+
+  // ─── Section ───
+  section: {
+    backgroundColor: colors.card,
+    borderRadius: radius.xl,
+    overflow: "hidden",
+    ...shadows.sm,
+  },
+  sectionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  sectionIconBox: {
+    width: 36,
+    height: 36,
+    borderRadius: radius.md,
+    backgroundColor: colors.accentLight,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  sectionTitle: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: "700",
+    color: colors.text,
+  },
+  sectionBody: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.lg,
+    gap: spacing.sm,
+  },
+
+  // ─── Fields ───
+  fieldRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  fieldLabel: {
+    width: 90,
+    fontSize: 13,
+    color: colors.textLight,
+    flexShrink: 0,
+  },
+  fieldInputWrap: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+  },
+  fieldInput: {
+    flex: 1,
+    backgroundColor: colors.bg,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    fontSize: 14,
+    color: colors.text,
+  },
+  fieldUnit: {
+    width: 48,
+    fontSize: 12,
+    color: colors.textMuted,
+  },
+
+  // ─── Type selector ───
+  typeRow: {
+    flex: 1,
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  typeBtn: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    borderRadius: radius.full,
+    backgroundColor: colors.bg,
+  },
+  typeBtnActive: {
+    backgroundColor: colors.accentLight,
+    borderWidth: 1,
+    borderColor: colors.accent,
+  },
+  typeBtnText: {
+    fontSize: 12,
+    color: colors.textMuted,
+  },
+  typeBtnTextActive: {
+    color: colors.accent,
+    fontWeight: "700",
+  },
+
+  // ─── OCR hint ───
+  ocrHint: {
+    fontSize: 12,
+    color: colors.textMuted,
+    textAlign: "center",
+    lineHeight: 18,
+  },
+
+  // ─── Review step ───
+  reviewCard: {
+    backgroundColor: colors.card,
+    borderRadius: radius.xl,
+    padding: spacing.lg,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  reviewCardHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  reviewCardTitle: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: colors.text,
+  },
+  reviewCardBody: {
+    fontSize: 13,
+    color: colors.textLight,
+    lineHeight: 20,
+  },
+  reviewItem: {
+    fontSize: 13,
+    color: colors.textLight,
+    lineHeight: 20,
+  },
+});

--- a/apps/mobile/app/health/insights.tsx
+++ b/apps/mobile/app/health/insights.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Link } from "expo-router";
 import { useEffect, useState } from "react";
-import { Alert, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Alert, Modal, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 
 import { Button, Card, ChipSelector, EmptyState, LoadingState, PageHeader, StatCard, StatusBadge } from "../../src/components/ui";
 import { colors, spacing } from "../../src/theme";
@@ -10,10 +10,28 @@ import { getApi } from "../../src/lib/api";
 type Insight = {
   id: string;
   title: string;
-  summary: string;
+  content: string;
   is_read: boolean;
   is_alert: boolean;
   created_at: string;
+  analysis_date?: string;
+  priority?: string;
+  recommendations?: string[];
+  insight_type?: string;
+};
+
+const PRIORITY_LABELS: Record<string, string> = {
+  low: "低",
+  medium: "中",
+  high: "高",
+  critical: "緊急",
+};
+
+const PRIORITY_COLORS_MAP: Record<string, string> = {
+  low: colors.accent,
+  medium: colors.warning,
+  high: colors.error,
+  critical: colors.error,
 };
 
 export default function HealthInsightsPage() {
@@ -21,8 +39,10 @@ export default function HealthInsightsPage() {
   const [unreadCount, setUnreadCount] = useState(0);
   const [alertCount, setAlertCount] = useState(0);
   const [unreadOnly, setUnreadOnly] = useState(false);
+  const [selectedInsight, setSelectedInsight] = useState<Insight | null>(null);
 
   const [isLoading, setIsLoading] = useState(true);
+  const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   async function load() {
@@ -47,14 +67,40 @@ export default function HealthInsightsPage() {
     load();
   }, [unreadOnly]);
 
+  async function generateInsights() {
+    setIsGenerating(true);
+    try {
+      const api = getApi();
+      await api.post(`/api/health/insights`, {});
+      await load();
+    } catch (e: any) {
+      Alert.alert("生成失敗", e?.message ?? "インサイト生成に失敗しました。");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
   async function markRead(id: string) {
     try {
       const api = getApi();
       await api.post(`/api/health/insights/${id}/read`, {});
-      await load();
+      setItems((prev) => prev.map((item) => item.id === id ? { ...item, is_read: true } : item));
+      setUnreadCount((prev) => Math.max(0, prev - 1));
     } catch (e: any) {
       Alert.alert("失敗", e?.message ?? "失敗しました。");
     }
+  }
+
+  function handleSelectInsight(insight: Insight) {
+    setSelectedInsight(insight);
+    if (!insight.is_read) {
+      markRead(insight.id);
+    }
+  }
+
+  function formatDate(dateStr?: string) {
+    if (!dateStr) return "";
+    return new Date(dateStr).toLocaleDateString("ja-JP", { month: "long", day: "numeric" });
   }
 
   return (
@@ -69,73 +115,153 @@ export default function HealthInsightsPage() {
       />
       <ScrollView contentContainerStyle={styles.container}>
 
-      <View style={styles.statsRow}>
-        <StatCard
-          icon={<Ionicons name="mail-unread-outline" size={22} color={colors.accent} />}
-          label="未読"
-          value={unreadCount}
-          accentColor={colors.accentLight}
-        />
-        <StatCard
-          icon={<Ionicons name="warning-outline" size={22} color={colors.warning} />}
-          label="アラート"
-          value={alertCount}
-          accentColor={colors.warningLight}
-        />
-      </View>
-
-      <ChipSelector
-        options={[
-          { value: "all", label: "すべて" },
-          { value: "unread", label: "未読のみ" },
-        ]}
-        selected={unreadOnly ? "unread" : "all"}
-        onSelect={(v) => setUnreadOnly(v === "unread")}
-      />
-
-      {isLoading ? (
-        <LoadingState message="インサイトを読み込み中..." />
-      ) : error ? (
-        <Card variant="error">
-          <View style={styles.errorRow}>
-            <Ionicons name="alert-circle" size={20} color={colors.error} />
-            <Text style={styles.errorText}>{error}</Text>
-          </View>
-        </Card>
-      ) : items.length === 0 ? (
-        <EmptyState
-          icon={<Ionicons name="bulb-outline" size={40} color={colors.textMuted} />}
-          message="インサイトがありません。"
-        />
-      ) : (
-        <View style={styles.list}>
-          {items.map((i) => (
-            <Card key={i.id} variant={i.is_alert ? "warning" : "default"}>
-              <View style={styles.insightHeader}>
-                <View style={styles.insightTitleRow}>
-                  {i.is_alert && <Ionicons name="alert-circle" size={18} color={colors.warning} />}
-                  <Text style={styles.insightTitle}>{i.title}</Text>
-                </View>
-                {!i.is_read && <StatusBadge variant="alert" label="未読" />}
-              </View>
-              <Text style={styles.insightSummary}>{i.summary}</Text>
-              <Text style={styles.insightDate}>{new Date(i.created_at).toLocaleString("ja-JP")}</Text>
-              {!i.is_read && (
-                <Button onPress={() => markRead(i.id)} variant="primary" size="sm" style={styles.markReadBtn}>
-                  <Ionicons name="checkmark-outline" size={14} color="#FFFFFF" />
-                  <Text style={styles.markReadText}>既読にする</Text>
-                </Button>
-              )}
-            </Card>
-          ))}
+        <View style={styles.statsRow}>
+          <StatCard
+            icon={<Ionicons name="mail-unread-outline" size={22} color={colors.accent} />}
+            label="未読"
+            value={unreadCount}
+            accentColor={colors.accentLight}
+          />
+          <StatCard
+            icon={<Ionicons name="warning-outline" size={22} color={colors.warning} />}
+            label="アラート"
+            value={alertCount}
+            accentColor={colors.warningLight}
+          />
         </View>
-      )}
 
-      <Button onPress={load} variant="ghost" size="sm">
-        <Ionicons name="refresh-outline" size={16} color={colors.textLight} />
-        <Text style={{ color: colors.textLight, fontWeight: "700", fontSize: 13 }}>更新</Text>
-      </Button>
-    </ScrollView>
+        <Button
+          onPress={generateInsights}
+          variant="primary"
+          size="sm"
+          disabled={isGenerating}
+          style={styles.generateBtn}
+        >
+          <Ionicons name="sparkles-outline" size={16} color="#FFFFFF" />
+          <Text style={styles.generateBtnText}>
+            {isGenerating ? "AI分析中..." : "AIインサイトを生成"}
+          </Text>
+        </Button>
+
+        <ChipSelector
+          options={[
+            { value: "all", label: "すべて" },
+            { value: "unread", label: "未読のみ" },
+          ]}
+          selected={unreadOnly ? "unread" : "all"}
+          onSelect={(v) => setUnreadOnly(v === "unread")}
+        />
+
+        {isLoading ? (
+          <LoadingState message="インサイトを読み込み中..." />
+        ) : error ? (
+          <Card variant="error">
+            <View style={styles.errorRow}>
+              <Ionicons name="alert-circle" size={20} color={colors.error} />
+              <Text style={styles.errorText}>{error}</Text>
+            </View>
+          </Card>
+        ) : items.length === 0 ? (
+          <EmptyState
+            icon={<Ionicons name="bulb-outline" size={40} color={colors.textMuted} />}
+            message="インサイトがありません。AIインサイトを生成してみましょう。"
+          />
+        ) : (
+          <View style={styles.list}>
+            {items.map((i) => (
+              <Pressable key={i.id} onPress={() => handleSelectInsight(i)}>
+                <Card variant={i.is_alert ? "warning" : "default"}>
+                  <View style={styles.insightHeader}>
+                    <View style={styles.insightTitleRow}>
+                      {i.is_alert && <Ionicons name="alert-circle" size={18} color={colors.warning} />}
+                      <Text style={styles.insightTitle}>{i.title}</Text>
+                    </View>
+                    <View style={styles.insightBadges}>
+                      {!i.is_read && <StatusBadge variant="alert" label="未読" />}
+                      {i.priority && i.priority !== "low" && (
+                        <View style={[styles.priorityBadge, { backgroundColor: PRIORITY_COLORS_MAP[i.priority] ?? colors.accent }]}>
+                          <Text style={styles.priorityBadgeText}>{PRIORITY_LABELS[i.priority] ?? i.priority}</Text>
+                        </View>
+                      )}
+                    </View>
+                  </View>
+                  <Text style={styles.insightContent} numberOfLines={3}>{i.content}</Text>
+                  <View style={styles.insightFooter}>
+                    {i.analysis_date ? (
+                      <Text style={styles.insightDate}>{formatDate(i.analysis_date)}の分析</Text>
+                    ) : (
+                      <Text style={styles.insightDate}>{new Date(i.created_at).toLocaleString("ja-JP")}</Text>
+                    )}
+                    <Ionicons name="chevron-forward-outline" size={16} color={colors.textMuted} />
+                  </View>
+                </Card>
+              </Pressable>
+            ))}
+          </View>
+        )}
+
+        <Button onPress={load} variant="ghost" size="sm">
+          <Ionicons name="refresh-outline" size={16} color={colors.textLight} />
+          <Text style={{ color: colors.textLight, fontWeight: "700", fontSize: 13 }}>更新</Text>
+        </Button>
+      </ScrollView>
+
+      {/* 詳細BottomSheet */}
+      <Modal
+        visible={selectedInsight !== null}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setSelectedInsight(null)}
+      >
+        <Pressable style={styles.modalOverlay} onPress={() => setSelectedInsight(null)}>
+          <Pressable style={styles.modalSheet} onPress={() => {}}>
+            <View style={styles.modalHandle} />
+            {selectedInsight && (
+              <ScrollView showsVerticalScrollIndicator={false}>
+                <View style={styles.modalHeader}>
+                  {selectedInsight.is_alert && (
+                    <Ionicons name="alert-circle" size={24} color={colors.error} style={styles.modalAlertIcon} />
+                  )}
+                  <View style={styles.modalTitleBlock}>
+                    <Text style={styles.modalTitle}>{selectedInsight.title}</Text>
+                    {selectedInsight.analysis_date && (
+                      <Text style={styles.modalSubtitle}>{formatDate(selectedInsight.analysis_date)}の分析</Text>
+                    )}
+                  </View>
+                  {selectedInsight.priority && (
+                    <View style={[styles.priorityBadge, { backgroundColor: PRIORITY_COLORS_MAP[selectedInsight.priority] ?? colors.accent }]}>
+                      <Text style={styles.priorityBadgeText}>{PRIORITY_LABELS[selectedInsight.priority] ?? selectedInsight.priority}</Text>
+                    </View>
+                  )}
+                </View>
+
+                <Text style={styles.modalContent}>{selectedInsight.content}</Text>
+
+                {selectedInsight.recommendations && selectedInsight.recommendations.length > 0 && (
+                  <View style={styles.recommendationsBlock}>
+                    <Text style={styles.recommendationsTitle}>おすすめアクション</Text>
+                    {selectedInsight.recommendations.map((rec, idx) => (
+                      <View key={idx} style={styles.recommendationItem}>
+                        <Ionicons name="checkmark-circle-outline" size={18} color={colors.accent} style={styles.recommendationIcon} />
+                        <Text style={styles.recommendationText}>{rec}</Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+
+                <Button
+                  onPress={() => setSelectedInsight(null)}
+                  variant="ghost"
+                  size="sm"
+                  style={styles.modalCloseBtn}
+                >
+                  <Text style={styles.modalCloseBtnText}>閉じる</Text>
+                </Button>
+              </ScrollView>
+            )}
+          </Pressable>
+        </Pressable>
+      </Modal>
     </View>
   );
 }
@@ -158,6 +284,16 @@ const styles = StyleSheet.create({
   statsRow: {
     flexDirection: "row",
     gap: spacing.md,
+  },
+  generateBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+  },
+  generateBtnText: {
+    color: "#FFFFFF",
+    fontWeight: "700",
+    fontSize: 14,
   },
   errorRow: {
     flexDirection: "row",
@@ -191,23 +327,121 @@ const styles = StyleSheet.create({
     color: colors.text,
     flex: 1,
   },
-  insightSummary: {
+  insightBadges: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    marginLeft: spacing.xs,
+  },
+  priorityBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  priorityBadgeText: {
+    color: "#FFFFFF",
+    fontSize: 11,
+    fontWeight: "700",
+  },
+  insightContent: {
     fontSize: 14,
     color: colors.textLight,
     lineHeight: 20,
   },
+  insightFooter: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginTop: spacing.xs,
+  },
   insightDate: {
     fontSize: 12,
     color: colors.textMuted,
-    marginTop: spacing.xs,
   },
-  markReadBtn: {
-    alignSelf: "flex-start",
+  // Modal styles
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "flex-end",
+  },
+  modalSheet: {
+    backgroundColor: "#FFFFFF",
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    padding: spacing.lg,
+    paddingBottom: spacing["4xl"],
+    maxHeight: "80%",
+  },
+  modalHandle: {
+    width: 48,
+    height: 4,
+    backgroundColor: "#E0E0E0",
+    borderRadius: 2,
+    alignSelf: "center",
+    marginBottom: spacing.lg,
+  },
+  modalHeader: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: spacing.sm,
+    marginBottom: spacing.md,
+  },
+  modalAlertIcon: {
+    marginTop: 2,
+  },
+  modalTitleBlock: {
+    flex: 1,
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: "800",
+    color: colors.text,
+  },
+  modalSubtitle: {
+    fontSize: 13,
+    color: colors.textMuted,
+    marginTop: 2,
+  },
+  modalContent: {
+    fontSize: 15,
+    color: colors.textLight,
+    lineHeight: 22,
+    marginBottom: spacing.lg,
+  },
+  recommendationsBlock: {
+    marginBottom: spacing.lg,
+  },
+  recommendationsTitle: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: colors.text,
+    marginBottom: spacing.sm,
+  },
+  recommendationItem: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: spacing.xs,
+    marginBottom: spacing.sm,
+    backgroundColor: colors.bg,
+    borderRadius: 8,
+    padding: spacing.sm,
+  },
+  recommendationIcon: {
+    marginTop: 1,
+  },
+  recommendationText: {
+    fontSize: 14,
+    color: colors.textLight,
+    flex: 1,
+    lineHeight: 20,
+  },
+  modalCloseBtn: {
+    width: "100%",
     marginTop: spacing.sm,
   },
-  markReadText: {
-    color: "#FFFFFF",
-    fontWeight: "700",
-    fontSize: 13,
+  modalCloseBtnText: {
+    color: colors.textLight,
+    fontWeight: "600",
+    fontSize: 15,
   },
 });

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -4,11 +4,13 @@ import { ActivityIndicator, Pressable, Text, View } from "react-native";
 
 import { colors, spacing, shadows, radius } from "../src/theme";
 import { useAuth } from "../src/providers/AuthProvider";
+import { useProfile } from "../src/providers/ProfileProvider";
 
 export default function Index() {
-  const { session, isLoading } = useAuth();
+  const { session, isLoading: authLoading } = useAuth();
+  const { profile, isLoading: profileLoading } = useProfile();
 
-  if (isLoading) {
+  if (authLoading || (session && profileLoading)) {
     return (
       <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.bg }}>
         <ActivityIndicator color={colors.accent} size="large" />
@@ -16,7 +18,8 @@ export default function Index() {
     );
   }
 
-  if (session) return <Redirect href="/(tabs)/home" />;
+  if (session && !profile?.onboardingCompletedAt) return <Redirect href="/onboarding" />;
+  if (session && profile?.onboardingCompletedAt) return <Redirect href="/(tabs)/home" />;
 
   return (
     <View style={{ flex: 1, backgroundColor: "#FFF7ED" }}>

--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -3,7 +3,7 @@ import { router } from "expo-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Alert, Pressable, ScrollView, Text, View } from "react-native";
 
-import { Button, Card, EmptyState, LoadingState, PageHeader, ProgressBar, StatusBadge } from "../../../src/components/ui";
+import { Button, Card, EmptyState, LoadingState, PageHeader, StatusBadge } from "../../../src/components/ui";
 import { colors, spacing, radius, shadows } from "../../../src/theme";
 import { getApi } from "../../../src/lib/api";
 import { supabase } from "../../../src/lib/supabase";
@@ -56,6 +56,182 @@ function getWeekStart(date: Date): Date {
   d.setDate(diff);
   d.setHours(0, 0, 0, 0);
   return d;
+}
+
+// AI生成進捗フェーズ定義（Webの PROGRESS_PHASES / ULTIMATE_PROGRESS_PHASES に準拠）
+const PROGRESS_PHASES = [
+  { phase: "user_context", label: "ユーザー情報を取得", threshold: 5 },
+  { phase: "search_references", label: "参考レシピを検索", threshold: 10 },
+  { phase: "generating", label: "献立をAIが作成", threshold: 15 },
+  { phase: "step1_complete", label: "献立生成完了", threshold: 40 },
+  { phase: "reviewing", label: "献立のバランスをチェック", threshold: 45 },
+  { phase: "review_done", label: "改善点を発見", threshold: 55 },
+  { phase: "fixing", label: "改善点を修正", threshold: 60 },
+  { phase: "no_issues", label: "問題なし", threshold: 70 },
+  { phase: "step2_complete", label: "レビュー完了", threshold: 75 },
+  { phase: "calculating", label: "栄養価を計算", threshold: 80 },
+  { phase: "saving", label: "献立を保存", threshold: 88 },
+  { phase: "completed", label: "完了！", threshold: 100 },
+];
+
+const ULTIMATE_PROGRESS_PHASES = [
+  { phase: "user_context", label: "ユーザー情報を取得", threshold: 3 },
+  { phase: "search_references", label: "参考レシピを検索", threshold: 6 },
+  { phase: "generating", label: "献立をAIが作成", threshold: 10 },
+  { phase: "step1_complete", label: "献立生成完了", threshold: 25 },
+  { phase: "reviewing", label: "献立のバランスをチェック", threshold: 28 },
+  { phase: "fixing", label: "改善点を修正", threshold: 32 },
+  { phase: "step2_complete", label: "レビュー完了", threshold: 38 },
+  { phase: "calculating", label: "栄養価を計算", threshold: 42 },
+  { phase: "step3_complete", label: "栄養計算完了", threshold: 48 },
+  { phase: "nutrition_analyzing", label: "栄養バランスを詳細分析", threshold: 55 },
+  { phase: "nutrition_feedback", label: "改善アドバイスを生成", threshold: 62 },
+  { phase: "improving", label: "献立を改善中", threshold: 70 },
+  { phase: "step5_complete", label: "改善完了", threshold: 82 },
+  { phase: "final_saving", label: "最終保存中", threshold: 90 },
+  { phase: "completed", label: "究極の献立が完成！", threshold: 100 },
+];
+
+type PhaseDefinition = { phase: string; label: string; threshold: number };
+
+type ProgressTodoCardProps = {
+  progress: PendingProgress | null;
+  phases?: PhaseDefinition[];
+  defaultMessage?: string;
+};
+
+function ProgressTodoCard({ progress, phases = PROGRESS_PHASES, defaultMessage = "AIが献立を生成中..." }: ProgressTodoCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const currentPercentage = progress?.percentage ?? 0;
+  const currentPhase = progress?.phase ?? "";
+  const totalSlots = progress?.totalSlots ?? 0;
+  const totalDays = totalSlots > 0 ? Math.ceil(totalSlots / 3) : 0;
+
+  const dynamicPhases = useMemo(() => {
+    return phases.map((p) => {
+      if (p.phase === "generating" && totalDays > 0) {
+        const dayLabel = totalDays === 1 ? "1日分" : `${totalDays}日分`;
+        return { ...p, label: `${dayLabel}の献立をAIが作成` };
+      }
+      return p;
+    });
+  }, [phases, totalDays]);
+
+  const getPhaseStatus = (phase: PhaseDefinition): "completed" | "in_progress" | "pending" => {
+    if (currentPercentage >= phase.threshold) return "completed";
+    if (
+      currentPhase === phase.phase ||
+      (currentPhase.startsWith(phase.phase.split("_")[0]) && currentPercentage < phase.threshold)
+    )
+      return "in_progress";
+    return "pending";
+  };
+
+  const headerMessage =
+    totalDays > 0
+      ? `献立を生成中...（${progress?.completedSlots ?? 0}/${totalSlots}食、${totalDays}日分）`
+      : (progress?.message ?? defaultMessage);
+
+  return (
+    <View
+      style={{
+        borderRadius: radius.lg,
+        overflow: "hidden",
+        backgroundColor: colors.accent,
+      }}
+    >
+      {/* ヘッダー */}
+      <Pressable
+        onPress={() => setIsExpanded((prev) => !prev)}
+        style={{ padding: spacing.md, gap: spacing.sm }}
+      >
+        <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+          <ActivityIndicator size="small" color="#fff" />
+          <Text style={{ flex: 1, color: "#fff", fontWeight: "700", fontSize: 13 }}>
+            {headerMessage}
+          </Text>
+          {currentPercentage > 0 && (
+            <Text style={{ color: "rgba(255,255,255,0.7)", fontSize: 11 }}>{currentPercentage}%</Text>
+          )}
+          <Ionicons
+            name={isExpanded ? "chevron-up" : "chevron-down"}
+            size={14}
+            color="rgba(255,255,255,0.7)"
+          />
+        </View>
+        {currentPercentage > 0 && (
+          <View style={{ height: 6, backgroundColor: "rgba(255,255,255,0.2)", borderRadius: 3, overflow: "hidden" }}>
+            <View
+              style={{
+                width: `${currentPercentage}%`,
+                height: "100%",
+                backgroundColor: "#fff",
+                borderRadius: 3,
+              }}
+            />
+          </View>
+        )}
+      </Pressable>
+
+      {/* 展開時のフェーズToDoリスト */}
+      {isExpanded && (
+        <View
+          style={{
+            paddingHorizontal: spacing.md,
+            paddingBottom: spacing.md,
+            paddingTop: spacing.sm,
+            borderTopWidth: 1,
+            borderTopColor: "rgba(255,255,255,0.2)",
+            gap: spacing.sm,
+          }}
+        >
+          {dynamicPhases.filter((p) => p.phase !== "failed").map((phase) => {
+            const status = getPhaseStatus(phase);
+            return (
+              <View key={phase.phase} style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+                {status === "completed" ? (
+                  <View
+                    style={{
+                      width: 16,
+                      height: 16,
+                      borderRadius: 8,
+                      backgroundColor: "#fff",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <Ionicons name="checkmark" size={10} color={colors.accent} />
+                  </View>
+                ) : status === "in_progress" ? (
+                  <ActivityIndicator size="small" color="#fff" style={{ width: 16, height: 16 }} />
+                ) : (
+                  <View
+                    style={{
+                      width: 16,
+                      height: 16,
+                      borderRadius: 8,
+                      borderWidth: 2,
+                      borderColor: "rgba(255,255,255,0.4)",
+                    }}
+                  />
+                )}
+                <Text
+                  style={{
+                    fontSize: 11,
+                    color: status === "pending" ? "rgba(255,255,255,0.5)" : "#fff",
+                    fontWeight: status === "in_progress" ? "600" : "400",
+                  }}
+                >
+                  {phase.label}
+                </Text>
+              </View>
+            );
+          })}
+        </View>
+      )}
+    </View>
+  );
 }
 
 const DOW = ["月", "火", "水", "木", "金", "土", "日"];
@@ -406,25 +582,7 @@ export default function WeeklyMenuPage() {
         <>
           {/* AI生成中プログレス */}
           {pendingRequestId && (
-            <Card variant="accent">
-              <View style={{ gap: spacing.md }}>
-                <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
-                  <ActivityIndicator size="small" color={colors.accent} />
-                  <Text style={{ flex: 1, fontWeight: "700", color: colors.text, fontSize: 14 }}>
-                    {pendingProgress?.message ?? "AIが献立を生成中..."}
-                  </Text>
-                  <StatusBadge variant="generating" label="生成中" />
-                </View>
-                {pendingProgress?.percentage != null && (
-                  <ProgressBar
-                    value={pendingProgress.percentage}
-                    max={100}
-                    color={colors.accent}
-                    showPercentage
-                  />
-                )}
-              </View>
-            </Card>
+            <ProgressTodoCard progress={pendingProgress} />
           )}
 
           {/* 日付セレクタ — 横並び丸型ピル */}

--- a/apps/mobile/app/onboarding/questions.tsx
+++ b/apps/mobile/app/onboarding/questions.tsx
@@ -64,6 +64,13 @@ type Question =
       text: string;
       type: "servings_grid";
       showIf?: (answers: Record<string, any>) => boolean;
+    }
+  | {
+      id: string;
+      text: string;
+      type: "date";
+      allowSkip?: boolean;
+      showIf?: (answers: Record<string, any>) => boolean;
     };
 
 // 曜日別人数設定のデフォルト値
@@ -142,6 +149,66 @@ const QUESTIONS: Question[] = [
       { label: "現状維持・健康管理", value: "maintain", description: "今の体型を維持したい" },
       { label: "競技パフォーマンス", value: "athlete_performance", description: "大会・試合に向けて" },
     ],
+  },
+  // Performance OS v3: アスリート向け追加質問
+  {
+    id: "sport_type",
+    text: "主に取り組んでいる競技は？",
+    type: "choice",
+    showIf: (answers) => answers.nutrition_goal === "athlete_performance",
+    options: [
+      { label: "サッカー", value: "soccer" },
+      { label: "バスケットボール", value: "basketball" },
+      { label: "バレーボール", value: "volleyball" },
+      { label: "野球", value: "baseball" },
+      { label: "テニス", value: "tennis" },
+      { label: "水泳", value: "swimming" },
+      { label: "陸上競技", value: "track_and_field" },
+      { label: "自転車", value: "road_cycling" },
+      { label: "格闘技", value: "martial_arts_general" },
+      { label: "ウェイトリフティング", value: "weightlifting" },
+      { label: "その他", value: "custom" },
+    ],
+  },
+  {
+    id: "sport_custom_name",
+    text: "競技名を入力してください",
+    type: "text",
+    placeholder: "例: トライアスロン",
+    showIf: (answers) =>
+      answers.nutrition_goal === "athlete_performance" && answers.sport_type === "custom",
+  },
+  {
+    id: "sport_experience",
+    text: "競技経験はどのくらいですか？",
+    type: "choice",
+    showIf: (answers) => answers.nutrition_goal === "athlete_performance",
+    options: [
+      { label: "初心者（1年未満）", value: "beginner", description: "始めたばかり" },
+      { label: "中級者（1〜3年）", value: "intermediate", description: "基礎は身についている" },
+      { label: "上級者（3年以上）", value: "advanced", description: "競技会・大会出場レベル" },
+    ],
+  },
+  {
+    id: "training_phase",
+    text: "現在のトレーニング期は？",
+    type: "choice",
+    showIf: (answers) => answers.nutrition_goal === "athlete_performance",
+    options: [
+      { label: "トレーニング期", value: "training", description: "体力・技術向上中" },
+      { label: "試合期", value: "competition", description: "大会・試合シーズン" },
+      { label: "減量期", value: "cut", description: "体重調整中（階級制など）" },
+      { label: "回復期", value: "recovery", description: "オフシーズン・ケガからの復帰" },
+    ],
+  },
+  {
+    id: "competition_date",
+    text: "次の大会・試合はいつですか？",
+    type: "date",
+    allowSkip: true,
+    showIf: (answers) =>
+      answers.nutrition_goal === "athlete_performance" &&
+      (answers.training_phase === "competition" || answers.training_phase === "cut"),
   },
   {
     id: "weight_change_rate",
@@ -408,6 +475,39 @@ function transformAnswersToProfile(ans: Record<string, any>) {
   if (ans.stove_type) appliances.push(ans.stove_type);
   if (appliances.length > 0) profile.kitchenAppliances = appliances;
 
+  // Performance OS v3: performance_profile 構築
+  if (ans.nutrition_goal === "athlete_performance") {
+    const sportId = ans.sport_type === "custom" ? "custom" : ans.sport_type;
+    const sportName = ans.sport_type === "custom" ? ans.sport_custom_name : null;
+    profile.performanceProfile = {
+      sport: {
+        id: sportId || null,
+        name: sportName || null,
+        role: null,
+        experience: ans.sport_experience || "intermediate",
+        phase: ans.training_phase || "training",
+        demandVector: null,
+      },
+      growth: {
+        isUnder18: ans.age ? parseInt(ans.age) < 18 : false,
+        heightChangeRecent: null,
+        growthProtectionEnabled: ans.age ? parseInt(ans.age) < 18 : false,
+      },
+      cut: {
+        enabled: ans.training_phase === "cut",
+        targetWeight: ans.target_weight ? parseFloat(ans.target_weight) : null,
+        targetDate: ans.competition_date || ans.target_date || null,
+        strategy: "gradual",
+      },
+      priorities: {
+        protein: "high",
+        carbs: ans.training_phase === "competition" ? "high" : "moderate",
+        fat: "moderate",
+        hydration: "high",
+      },
+    };
+  }
+
   return profile;
 }
 
@@ -439,6 +539,7 @@ function toDbProfileUpdates(body: any, userId: string) {
   if (body.shoppingFrequency) updates.shopping_frequency = body.shoppingFrequency;
   if (body.weeklyFoodBudget !== undefined) updates.weekly_food_budget = body.weeklyFoodBudget;
   if (body.kitchenAppliances) updates.kitchen_appliances = body.kitchenAppliances;
+  if (body.performanceProfile) updates.performance_profile = body.performanceProfile;
 
   if (!updates.nickname) updates.nickname = "Guest";
   if (!updates.age_group && !updates.age) updates.age_group = "unspecified";
@@ -919,6 +1020,43 @@ export default function OnboardingQuestions() {
             </Pressable>
           </View>
         )}
+
+      {/* Date input */}
+      {currentQuestion.type === "date" && (
+        <View style={{ gap: spacing.md }}>
+          <Text style={{ color: colors.textMuted, fontSize: 13, textAlign: "center" }}>
+            YYYY-MM-DD 形式で入力してください（例: 2025-08-15）
+          </Text>
+          <View style={styles.inputRow}>
+            <TextInput
+              autoFocus
+              keyboardType="numbers-and-punctuation"
+              placeholder="例: 2025-08-15"
+              placeholderTextColor={colors.textMuted}
+              value={inputValue}
+              onChangeText={setInputValue}
+              onSubmitEditing={() => {
+                if (inputValue.trim()) handleAnswer(inputValue.trim());
+              }}
+              style={[styles.textInput, { flex: 1 }]}
+            />
+            <Pressable
+              onPress={() => {
+                if (inputValue.trim()) handleAnswer(inputValue.trim());
+              }}
+              disabled={!inputValue.trim()}
+              style={[styles.arrowButton, !inputValue.trim() && styles.arrowButtonDisabled]}
+            >
+              <Ionicons name="arrow-forward" size={20} color="#fff" />
+            </Pressable>
+          </View>
+          {canSkip && (
+            <Pressable onPress={() => handleAnswer(null)} style={styles.skipButton}>
+              <Text style={styles.skipButtonText}>スキップ</Text>
+            </Pressable>
+          )}
+        </View>
+      )}
 
       {/* Servings grid */}
       {currentQuestion.type === "servings_grid" ? (

--- a/apps/mobile/app/onboarding/questions.tsx
+++ b/apps/mobile/app/onboarding/questions.tsx
@@ -64,13 +64,6 @@ type Question =
       text: string;
       type: "servings_grid";
       showIf?: (answers: Record<string, any>) => boolean;
-    }
-  | {
-      id: string;
-      text: string;
-      type: "date";
-      allowSkip?: boolean;
-      showIf?: (answers: Record<string, any>) => boolean;
     };
 
 // 曜日別人数設定のデフォルト値
@@ -149,66 +142,6 @@ const QUESTIONS: Question[] = [
       { label: "現状維持・健康管理", value: "maintain", description: "今の体型を維持したい" },
       { label: "競技パフォーマンス", value: "athlete_performance", description: "大会・試合に向けて" },
     ],
-  },
-  // Performance OS v3: アスリート向け追加質問
-  {
-    id: "sport_type",
-    text: "主に取り組んでいる競技は？",
-    type: "choice",
-    showIf: (answers) => answers.nutrition_goal === "athlete_performance",
-    options: [
-      { label: "サッカー", value: "soccer" },
-      { label: "バスケットボール", value: "basketball" },
-      { label: "バレーボール", value: "volleyball" },
-      { label: "野球", value: "baseball" },
-      { label: "テニス", value: "tennis" },
-      { label: "水泳", value: "swimming" },
-      { label: "陸上競技", value: "track_and_field" },
-      { label: "自転車", value: "road_cycling" },
-      { label: "格闘技", value: "martial_arts_general" },
-      { label: "ウェイトリフティング", value: "weightlifting" },
-      { label: "その他", value: "custom" },
-    ],
-  },
-  {
-    id: "sport_custom_name",
-    text: "競技名を入力してください",
-    type: "text",
-    placeholder: "例: トライアスロン",
-    showIf: (answers) =>
-      answers.nutrition_goal === "athlete_performance" && answers.sport_type === "custom",
-  },
-  {
-    id: "sport_experience",
-    text: "競技経験はどのくらいですか？",
-    type: "choice",
-    showIf: (answers) => answers.nutrition_goal === "athlete_performance",
-    options: [
-      { label: "初心者（1年未満）", value: "beginner", description: "始めたばかり" },
-      { label: "中級者（1〜3年）", value: "intermediate", description: "基礎は身についている" },
-      { label: "上級者（3年以上）", value: "advanced", description: "競技会・大会出場レベル" },
-    ],
-  },
-  {
-    id: "training_phase",
-    text: "現在のトレーニング期は？",
-    type: "choice",
-    showIf: (answers) => answers.nutrition_goal === "athlete_performance",
-    options: [
-      { label: "トレーニング期", value: "training", description: "体力・技術向上中" },
-      { label: "試合期", value: "competition", description: "大会・試合シーズン" },
-      { label: "減量期", value: "cut", description: "体重調整中（階級制など）" },
-      { label: "回復期", value: "recovery", description: "オフシーズン・ケガからの復帰" },
-    ],
-  },
-  {
-    id: "competition_date",
-    text: "次の大会・試合はいつですか？",
-    type: "date",
-    allowSkip: true,
-    showIf: (answers) =>
-      answers.nutrition_goal === "athlete_performance" &&
-      (answers.training_phase === "competition" || answers.training_phase === "cut"),
   },
   {
     id: "weight_change_rate",
@@ -475,39 +408,6 @@ function transformAnswersToProfile(ans: Record<string, any>) {
   if (ans.stove_type) appliances.push(ans.stove_type);
   if (appliances.length > 0) profile.kitchenAppliances = appliances;
 
-  // Performance OS v3: performance_profile 構築
-  if (ans.nutrition_goal === "athlete_performance") {
-    const sportId = ans.sport_type === "custom" ? "custom" : ans.sport_type;
-    const sportName = ans.sport_type === "custom" ? ans.sport_custom_name : null;
-    profile.performanceProfile = {
-      sport: {
-        id: sportId || null,
-        name: sportName || null,
-        role: null,
-        experience: ans.sport_experience || "intermediate",
-        phase: ans.training_phase || "training",
-        demandVector: null,
-      },
-      growth: {
-        isUnder18: ans.age ? parseInt(ans.age) < 18 : false,
-        heightChangeRecent: null,
-        growthProtectionEnabled: ans.age ? parseInt(ans.age) < 18 : false,
-      },
-      cut: {
-        enabled: ans.training_phase === "cut",
-        targetWeight: ans.target_weight ? parseFloat(ans.target_weight) : null,
-        targetDate: ans.competition_date || ans.target_date || null,
-        strategy: "gradual",
-      },
-      priorities: {
-        protein: "high",
-        carbs: ans.training_phase === "competition" ? "high" : "moderate",
-        fat: "moderate",
-        hydration: "high",
-      },
-    };
-  }
-
   return profile;
 }
 
@@ -539,7 +439,6 @@ function toDbProfileUpdates(body: any, userId: string) {
   if (body.shoppingFrequency) updates.shopping_frequency = body.shoppingFrequency;
   if (body.weeklyFoodBudget !== undefined) updates.weekly_food_budget = body.weeklyFoodBudget;
   if (body.kitchenAppliances) updates.kitchen_appliances = body.kitchenAppliances;
-  if (body.performanceProfile) updates.performance_profile = body.performanceProfile;
 
   if (!updates.nickname) updates.nickname = "Guest";
   if (!updates.age_group && !updates.age) updates.age_group = "unspecified";
@@ -1020,43 +919,6 @@ export default function OnboardingQuestions() {
             </Pressable>
           </View>
         )}
-
-      {/* Date input */}
-      {currentQuestion.type === "date" && (
-        <View style={{ gap: spacing.md }}>
-          <Text style={{ color: colors.textMuted, fontSize: 13, textAlign: "center" }}>
-            YYYY-MM-DD 形式で入力してください（例: 2025-08-15）
-          </Text>
-          <View style={styles.inputRow}>
-            <TextInput
-              autoFocus
-              keyboardType="numbers-and-punctuation"
-              placeholder="例: 2025-08-15"
-              placeholderTextColor={colors.textMuted}
-              value={inputValue}
-              onChangeText={setInputValue}
-              onSubmitEditing={() => {
-                if (inputValue.trim()) handleAnswer(inputValue.trim());
-              }}
-              style={[styles.textInput, { flex: 1 }]}
-            />
-            <Pressable
-              onPress={() => {
-                if (inputValue.trim()) handleAnswer(inputValue.trim());
-              }}
-              disabled={!inputValue.trim()}
-              style={[styles.arrowButton, !inputValue.trim() && styles.arrowButtonDisabled]}
-            >
-              <Ionicons name="arrow-forward" size={20} color="#fff" />
-            </Pressable>
-          </View>
-          {canSkip && (
-            <Pressable onPress={() => handleAnswer(null)} style={styles.skipButton}>
-              <Text style={styles.skipButtonText}>スキップ</Text>
-            </Pressable>
-          )}
-        </View>
-      )}
 
       {/* Servings grid */}
       {currentQuestion.type === "servings_grid" ? (

--- a/apps/mobile/src/hooks/useHomeData.ts
+++ b/apps/mobile/src/hooks/useHomeData.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { supabase } from "../lib/supabase";
 import { getApi } from "../lib/api";
 
@@ -85,6 +85,10 @@ export const useHomeData = (userId: string | undefined) => {
   const [shoppingRemaining, setShoppingRemaining] = useState(0);
   const [badgeCount, setBadgeCount] = useState(0);
   const [latestBadge, setLatestBadge] = useState<{ name: string; code: string; obtainedAt: string } | null>(null);
+
+  // #407: meal toggle debounce — pending mealId set + 250ms debounce timer
+  const pendingToggleRef = useRef<Set<string>>(new Set());
+  const toggleDebounceTimerRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
   async function fetchAll() {
     if (!userId) return;
@@ -466,13 +470,39 @@ export const useHomeData = (userId: string | undefined) => {
   }
 
   async function toggleMealCompletion(mealId: string, currentStatus: boolean) {
+    // #407: 250ms debounce — 既存タイマーをキャンセルして再スケジュール
+    if (toggleDebounceTimerRef.current[mealId]) {
+      clearTimeout(toggleDebounceTimerRef.current[mealId]);
+      delete toggleDebounceTimerRef.current[mealId];
+    }
+
+    // 同一 mealId のリクエストが進行中の場合はスキップ
+    if (pendingToggleRef.current.has(mealId)) return;
+
+    // 250ms 後に実際の処理を実行
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        delete toggleDebounceTimerRef.current[mealId];
+        resolve();
+      }, 250);
+      toggleDebounceTimerRef.current[mealId] = timer;
+    });
+
+    // debounce 待機後、再度 pending チェック
+    if (pendingToggleRef.current.has(mealId)) return;
+    pendingToggleRef.current.add(mealId);
+
     const newStatus = !currentStatus;
+
+    // 楽観的 UI 更新
     setTodayMeals((prev) =>
       prev.map((m) => (m.id === mealId ? { ...m, is_completed: newStatus } : m))
     );
     setDailySummary((prev) => ({
       ...prev,
-      completedCount: newStatus ? prev.completedCount + 1 : prev.completedCount - 1,
+      completedCount: newStatus
+        ? Math.min(prev.completedCount + 1, prev.totalCount)
+        : Math.max(prev.completedCount - 1, 0),
     }));
 
     const { error } = await supabase
@@ -482,9 +512,31 @@ export const useHomeData = (userId: string | undefined) => {
 
     if (error) {
       console.error("Toggle completion error:", error);
+      // ロールバック: 楽観的更新を元に戻す
+      setTodayMeals((prev) =>
+        prev.map((m) => (m.id === mealId ? { ...m, is_completed: currentStatus } : m))
+      );
+      setDailySummary((prev) => ({
+        ...prev,
+        completedCount: newStatus
+          ? Math.max(prev.completedCount - 1, 0)
+          : Math.min(prev.completedCount + 1, prev.totalCount),
+      }));
+      // サーバー真値に再同期
       fetchAll();
     }
+
+    // PATCH 完了後に pending を解除
+    pendingToggleRef.current.delete(mealId);
   }
+
+  // #407: アンマウント時にデバウンスタイマーをクリア（メモリリーク防止）
+  useEffect(() => {
+    const timers = toggleDebounceTimerRef.current;
+    return () => {
+      Object.values(timers).forEach(clearTimeout);
+    };
+  }, []);
 
   useEffect(() => {
     fetchAll();


### PR DESCRIPTION
Closes #381

## 概要

- `Insight` 型の `summary` フィールドを `content` に修正（DBカラム名と一致、常に空表示バグを解消）
- AIインサイト生成ボタン (POST /api/health/insights) を追加
- カード押下で詳細BottomSheet (Modal) を表示、`recommendations` を一覧表示
- `analysis_date`・`priority` をカードおよびモーダルに表示