### PR TITLE
fix(mobile): onboarding の health_conditions を 14 種に揃える (#417)

### DIFF
--- a/apps/mobile/app/onboarding/questions.tsx
+++ b/apps/mobile/app/onboarding/questions.tsx
@@ -302,6 +302,12 @@ const QUESTIONS: Question[] = [
       { label: "骨粗しょう症", value: "骨粗しょう症" },
       { label: "貧血", value: "貧血" },
       { label: "痛風", value: "痛風" },
+      { label: "便秘・下痢", value: "消化器系" },
+      { label: "不眠・睡眠障害", value: "睡眠障害" },
+      { label: "花粉症・アレルギー", value: "アレルギー" },
+      { label: "甲状腺疾患", value: "甲状腺疾患" },
+      { label: "自律神経失調", value: "自律神経" },
+      { label: "うつ・不安障害", value: "メンタル" },
     ],
   },
   {


### PR DESCRIPTION
Closes #417

## 概要

- モバイル版 `apps/mobile/app/onboarding/questions.tsx` の `health_conditions` 選択肢が 8 種のみだった
- Web 版 (`src/app/onboarding/questions/page.tsx`) と同じ 14 種に揃えた
- 追加した 6 項目: 便秘・下痢（消化器系）、不眠・睡眠障害、花粉症・アレルギー、甲状腺疾患、自律神経失調、うつ・不安障害（メンタル）

## 変更ファイル

- `apps/mobile/app/onboarding/questions.tsx`: `health_conditions.options` に 6 項目追記