### PR TITLE
fix(mobile): onboarding skip 時に /api/onboarding/complete を呼び出す (#406)

### DIFF
--- a/apps/mobile/app/onboarding/welcome.tsx
+++ b/apps/mobile/app/onboarding/welcome.tsx
@@ -1,12 +1,30 @@
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
+import { useState } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 
 import { Card } from "../../src/components/ui";
+import { getApi } from "../../src/lib/api";
 import { colors, radius, shadows, spacing } from "../../src/theme";
 
 // モバイル版: 初回ウェルカム画面 (OB-UI-06)
 export default function OnboardingWelcome() {
+  const [isSkipping, setIsSkipping] = useState(false);
+
+  const handleSkip = async () => {
+    if (isSkipping) return;
+    setIsSkipping(true);
+    try {
+      const api = getApi();
+      await api.post("/api/onboarding/complete");
+    } catch (error) {
+      // エラーでもホームへ遷移する
+      console.error("[onboarding] skip complete API failed:", error);
+    } finally {
+      router.replace("/(tabs)/home");
+    }
+  };
+
   return (
     <ScrollView
       contentContainerStyle={styles.container}
@@ -83,8 +101,9 @@ export default function OnboardingWelcome() {
         </Pressable>
 
         <Pressable
-          onPress={() => router.replace("/(tabs)/home")}
+          onPress={handleSkip}
           style={styles.skipButton}
+          disabled={isSkipping}
         >
           <Text style={styles.skipButtonText}>あとで設定する</Text>
         </Pressable>


### PR DESCRIPTION
Closes #406

## 概要

- `apps/mobile/app/onboarding/welcome.tsx` のスキップボタンハンドラで `POST /api/onboarding/complete` を呼び出すよう修正
- API 呼び出し後にホームへ遷移することで `onboarding_completed_at` が DB に書き込まれる
- エラー発生時も `finally` でホームへ遷移し、ユーザー体験を損なわない
- 二重タップ防止のため `isSkipping` フラグを追加し `disabled` 属性をセット