### PR TITLE
fix(mobile): onboarding saveProgress で全フィールドを DB 反映 (#408)

### DIFF
--- a/apps/mobile/app/onboarding/questions.tsx
+++ b/apps/mobile/app/onboarding/questions.tsx
@@ -648,6 +648,19 @@ export default function OnboardingQuestions() {
     setTags((prev) => prev.filter((x) => x !== t));
   }
 
+  // #408: XSS ペイロードを除去するサニタイズ関数（Web 版 route.ts と同等）
+  function sanitizeText(value: unknown): string {
+    if (typeof value !== "string") return "";
+    return value
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#x27;")
+      .replace(/\//g, "&#x2F;")
+      .trim()
+      .slice(0, 100);
+  }
+
   // リアルタイム保存
   async function saveProgress(step: number, ans: Record<string, any>) {
     try {
@@ -679,13 +692,100 @@ export default function OnboardingQuestions() {
         updates.onboarding_started_at = new Date().toISOString();
       }
 
-      // 回答内容も同時に保存
-      if (ans.nickname) updates.nickname = ans.nickname;
+      // #408: 回答内容を全カラムに反映（Web 版 route.ts L76-147 と同等）
+      if (ans.nickname) updates.nickname = sanitizeText(ans.nickname);
       if (ans.gender) updates.gender = ans.gender;
       if (ans.age) {
         updates.age = parseInt(ans.age);
         updates.age_group = `${Math.floor(parseInt(ans.age) / 10) * 10}s`;
       }
+      if (ans.occupation) updates.occupation = ans.occupation;
+      if (ans.height) updates.height = parseFloat(ans.height);
+      if (ans.weight) updates.weight = parseFloat(ans.weight);
+      if (ans.nutrition_goal) updates.nutrition_goal = ans.nutrition_goal;
+      if (ans.target_weight) updates.target_weight = parseFloat(ans.target_weight);
+      if (ans.target_date) updates.target_date = ans.target_date;
+      if (ans.weight_change_rate) updates.weight_change_rate = ans.weight_change_rate;
+      if (ans.exercise_types && !ans.exercise_types.includes("none")) {
+        updates.exercise_types = ans.exercise_types;
+      }
+      if (ans.exercise_frequency) updates.exercise_frequency = parseInt(ans.exercise_frequency);
+      if (ans.exercise_intensity) updates.exercise_intensity = ans.exercise_intensity;
+      if (ans.exercise_duration) updates.exercise_duration_per_session = parseInt(ans.exercise_duration);
+      if (ans.work_style) updates.work_style = ans.work_style;
+      if (ans.health_conditions && !ans.health_conditions.includes("none")) {
+        updates.health_conditions = ans.health_conditions;
+      }
+      if (ans.body_concerns?.length) {
+        updates.cold_sensitivity = ans.body_concerns.includes("cold_sensitivity");
+        updates.swelling_prone = ans.body_concerns.includes("swelling_prone");
+      }
+      if (ans.sleep_quality) updates.sleep_quality = ans.sleep_quality;
+      if (ans.stress_level) updates.stress_level = ans.stress_level;
+      if (ans.pregnancy_status) updates.pregnancy_status = ans.pregnancy_status;
+      if (ans.medications && !ans.medications.includes("none")) {
+        updates.medications = ans.medications;
+      }
+      if (ans.allergies?.length || ans.dislikes?.length) {
+        updates.diet_flags = {
+          allergies: ans.allergies || [],
+          dislikes: ans.dislikes || [],
+        };
+      }
+      if (ans.favorite_ingredients?.length) updates.favorite_ingredients = ans.favorite_ingredients;
+      if (ans.diet_style) updates.diet_style = ans.diet_style;
+      if (ans.cooking_experience) updates.cooking_experience = ans.cooking_experience;
+      if (ans.cooking_time) updates.weekday_cooking_minutes = parseInt(ans.cooking_time);
+      if (ans.cuisine_preference?.length) {
+        const prefs: Record<string, number> = {};
+        ans.cuisine_preference.forEach((c: string) => {
+          prefs[c] = 5;
+        });
+        updates.cuisine_preferences = prefs;
+      }
+      if (ans.family_size) updates.family_size = parseInt(ans.family_size);
+      if (ans.servings_config) updates.servings_config = ans.servings_config;
+      if (ans.shopping_frequency) updates.shopping_frequency = ans.shopping_frequency;
+      if (ans.weekly_food_budget && ans.weekly_food_budget !== "none") {
+        updates.weekly_food_budget = parseInt(ans.weekly_food_budget);
+      }
+      const appliances: string[] = [];
+      if (ans.kitchen_appliances?.length) appliances.push(...ans.kitchen_appliances);
+      if (ans.stove_type) appliances.push(ans.stove_type);
+      if (appliances.length > 0) updates.kitchen_appliances = appliances;
+      if (ans.hobbies?.length) updates.hobbies = ans.hobbies;
+      if (ans.nutrition_goal === "athlete_performance") {
+        const sportId = ans.sport_type === "custom" ? "custom" : ans.sport_type;
+        const sportName = ans.sport_type === "custom" ? ans.sport_custom_name : null;
+        updates.performance_profile = {
+          sport: {
+            id: sportId || null,
+            name: sportName || null,
+            role: null,
+            experience: ans.sport_experience || "intermediate",
+            phase: ans.training_phase || "training",
+            demandVector: null,
+          },
+          growth: {
+            isUnder18: ans.age ? parseInt(ans.age) < 18 : false,
+            heightChangeRecent: null,
+            growthProtectionEnabled: ans.age ? parseInt(ans.age) < 18 : false,
+          },
+          cut: {
+            enabled: ans.training_phase === "cut",
+            targetWeight: ans.target_weight ? parseFloat(ans.target_weight) : null,
+            targetDate: ans.competition_date || ans.target_date || null,
+            strategy: "gradual",
+          },
+          priorities: {
+            protein: "high",
+            carbs: ans.training_phase === "competition" ? "high" : "moderate",
+            fat: "moderate",
+            hydration: "high",
+          },
+        };
+      }
+
       if (!updates.nickname) updates.nickname = "Guest";
       if (!updates.age_group && !updates.age) updates.age_group = "unspecified";
       if (!updates.gender) updates.gender = "unspecified";


### PR DESCRIPTION
Closes #408

## 概要

- `saveProgress` が `nickname` / `gender` / `age` の 3 フィールドしか DB に書き込んでいなかった問題を修正
- Web 版 `src/app/api/onboarding/progress/route.ts` (L76-147) と同等のロジックを実装し、全回答フィールドを中間保存時に DB へ反映するよう拡張
- 追加されたフィールド: `occupation`, `height`, `weight`, `nutrition_goal`, `target_weight`, `target_date`, `weight_change_rate`, `exercise_types`, `exercise_frequency`, `exercise_intensity`, `exercise_duration_per_session`, `work_style`, `health_conditions`, `body_concerns` (cold_sensitivity / swelling_prone フラグ展開), `sleep_quality`, `stress_level`, `pregnancy_status`, `medications`, `diet_flags`, `favorite_ingredients`, `diet_style`, `cooking_experience`, `weekday_cooking_minutes`, `cuisine_preferences`, `family_size`, `servings_config`, `shopping_frequency`, `weekly_food_budget`, `kitchen_appliances`, `hobbies`, `performance_profile`
- `nickname` に XSS sanitize (`sanitizeText` ヘルパー) を適用