### PR TITLE
fix(mobile): 買い物リスト再生成に範囲選択 UI を追加 (#446)

### DIFF
--- a/apps/mobile/app/shopping-list/index.tsx
+++ b/apps/mobile/app/shopping-list/index.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Link } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
-import { Alert, Pressable, ScrollView, Text, View } from "react-native";
+import { Alert, Modal, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 
 import { Button } from "../../src/components/ui/Button";
 import { Card } from "../../src/components/ui/Card";
@@ -33,6 +33,23 @@ type Item = {
   selected_variant_index?: number;
 };
 
+type RangeType = 'today' | 'tomorrow' | 'dayAfterTomorrow' | 'days' | 'week';
+type MealType = 'breakfast' | 'lunch' | 'dinner';
+type RangeStep = 'range' | 'servings';
+
+type ShoppingRange = {
+  type: RangeType;
+  todayMeals: MealType[];
+  daysCount: number;
+};
+
+function formatLocalDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
 export default function ShoppingListPage() {
   const [shoppingListId, setShoppingListId] = useState<string | null>(null);
   const [items, setItems] = useState<Item[]>([]);
@@ -45,6 +62,18 @@ export default function ShoppingListPage() {
   const [newQuantity, setNewQuantity] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [totalServings, setTotalServings] = useState<number | null>(null);
+
+  // Range selection modal state
+  const [showRangeModal, setShowRangeModal] = useState(false);
+  const [rangeStep, setRangeStep] = useState<RangeStep>('range');
+  const [shoppingRange, setShoppingRange] = useState<ShoppingRange>({
+    type: 'week',
+    todayMeals: ['breakfast', 'lunch', 'dinner'],
+    daysCount: 3,
+  });
+  const [servings, setServings] = useState(2);
+  const [isTodayExpanded, setIsTodayExpanded] = useState(false);
+  const [daysCountInput, setDaysCountInput] = useState('3');
 
   async function load() {
     setIsLoading(true);
@@ -161,84 +190,162 @@ export default function ShoppingListPage() {
     ]);
   }
 
-  async function regenerate() {
-    if (isRegenerating) return;
-    Alert.alert(
-      "献立から再生成",
-      "AIが材料を整理します。手動追加した項目は残ります。",
-      [
-        { text: "キャンセル", style: "cancel" },
-        {
-          text: "再生成",
-          onPress: async () => {
-            setIsRegenerating(true);
-            try {
-              const api = getApi();
-              const response = await api.post<{ requestId?: string }>("/api/shopping-list/regenerate", {});
+  function calculateDateRange() {
+    const today = new Date();
+    const todayStr = formatLocalDate(today);
 
-              // 非同期処理：requestIdが返ってくるのでポーリング
-              if (response.requestId) {
-                // ポーリングで完了を待つ
-                let attempts = 0;
-                const maxAttempts = 60; // 最大2分
-                const poll = async () => {
-                  try {
-                    const statusRes = await api.get<{ status: string; result?: any }>(`/api/shopping-list/regenerate/status?requestId=${response.requestId}`);
-                    if (statusRes.status === 'completed') {
-                      if (statusRes.result?.stats?.totalServings) {
-                        setTotalServings(statusRes.result.stats.totalServings);
-                      }
-                      await load();
-                      const stats = statusRes.result?.stats;
-                      const servingsText = stats?.totalServings ? ` (${stats.totalServings}食分)` : '';
-                      Alert.alert("完了", `${stats?.outputCount ?? 0}件の材料を整理しました${servingsText}`);
-                      return true;
-                    } else if (statusRes.status === 'failed') {
-                      throw new Error(statusRes.result?.error || '再生成に失敗しました');
-                    }
-                    return false;
-                  } catch (e) {
-                    throw e;
-                  }
-                };
-
-                const pollInterval = setInterval(async () => {
-                  attempts++;
-                  if (attempts > maxAttempts) {
-                    clearInterval(pollInterval);
-                    setIsRegenerating(false);
-                    Alert.alert("タイムアウト", "処理に時間がかかっています。後で確認してください。");
-                    return;
-                  }
-                  try {
-                    const done = await poll();
-                    if (done) {
-                      clearInterval(pollInterval);
-                      setIsRegenerating(false);
-                    }
-                  } catch (e: any) {
-                    clearInterval(pollInterval);
-                    setIsRegenerating(false);
-                    Alert.alert("再生成失敗", e?.message ?? "再生成に失敗しました。");
-                  }
-                }, 2000);
-
-                // ポーリング中は return して finally に行かせない
-                // (setIsRegenerating(false) はポーリング内で処理)
-                return;
-              }
-
-              await load();
-              setIsRegenerating(false);
-            } catch (e: any) {
-              setIsRegenerating(false);
-              Alert.alert("再生成失敗", e?.message ?? "再生成に失敗しました。");
-            }
-          },
-        },
-      ]
-    );
+    switch (shoppingRange.type) {
+      case 'today':
+        return {
+          startDate: todayStr,
+          endDate: todayStr,
+          mealTypes: shoppingRange.todayMeals,
+        };
+      case 'tomorrow': {
+        const tomorrow = new Date(today);
+        tomorrow.setDate(tomorrow.getDate() + 1);
+        return {
+          startDate: formatLocalDate(tomorrow),
+          endDate: formatLocalDate(tomorrow),
+          mealTypes: ['breakfast', 'lunch', 'dinner'] as MealType[],
+        };
+      }
+      case 'dayAfterTomorrow': {
+        const dayAfter = new Date(today);
+        dayAfter.setDate(dayAfter.getDate() + 2);
+        return {
+          startDate: formatLocalDate(dayAfter),
+          endDate: formatLocalDate(dayAfter),
+          mealTypes: ['breakfast', 'lunch', 'dinner'] as MealType[],
+        };
+      }
+      case 'week': {
+        const weekEnd = new Date(today);
+        weekEnd.setDate(weekEnd.getDate() + 6);
+        return {
+          startDate: todayStr,
+          endDate: formatLocalDate(weekEnd),
+          mealTypes: ['breakfast', 'lunch', 'dinner'] as MealType[],
+        };
+      }
+      case 'days': {
+        const count = Math.max(1, Math.min(14, shoppingRange.daysCount));
+        const endDay = new Date(today);
+        endDay.setDate(endDay.getDate() + count - 1);
+        return {
+          startDate: todayStr,
+          endDate: formatLocalDate(endDay),
+          mealTypes: ['breakfast', 'lunch', 'dinner'] as MealType[],
+        };
+      }
+      default:
+        return {
+          startDate: todayStr,
+          endDate: todayStr,
+          mealTypes: ['breakfast', 'lunch', 'dinner'] as MealType[],
+        };
+    }
   }
+
+  async function executeRegenerate() {
+    if (isRegenerating) return;
+    setShowRangeModal(false);
+    setIsRegenerating(true);
+
+    const dateRange = calculateDateRange();
+
+    try {
+      const api = getApi();
+      const body: Record<string, any> = {
+        startDate: dateRange.startDate,
+        endDate: dateRange.endDate,
+        mealTypes: dateRange.mealTypes,
+      };
+
+      // 人数設定を送信（デフォルト以外の場合）
+      if (servings !== 2) {
+        body.servingsConfig = { default: servings };
+      }
+
+      const response = await api.post<{ requestId?: string }>("/api/shopping-list/regenerate", body);
+
+      // 非同期処理：requestIdが返ってくるのでポーリング
+      if (response.requestId) {
+        let attempts = 0;
+        const maxAttempts = 60; // 最大2分
+
+        const poll = async () => {
+          try {
+            const statusRes = await api.get<{ status: string; result?: any }>(`/api/shopping-list/regenerate/status?requestId=${response.requestId}`);
+            if (statusRes.status === 'completed') {
+              if (statusRes.result?.stats?.totalServings) {
+                setTotalServings(statusRes.result.stats.totalServings);
+              }
+              await load();
+              const stats = statusRes.result?.stats;
+              const servingsText = stats?.totalServings ? ` (${stats.totalServings}食分)` : '';
+              Alert.alert("完了", `${stats?.outputCount ?? 0}件の材料を整理しました${servingsText}`);
+              return true;
+            } else if (statusRes.status === 'failed') {
+              throw new Error(statusRes.result?.error || '再生成に失敗しました');
+            }
+            return false;
+          } catch (e) {
+            throw e;
+          }
+        };
+
+        const pollInterval = setInterval(async () => {
+          attempts++;
+          if (attempts > maxAttempts) {
+            clearInterval(pollInterval);
+            setIsRegenerating(false);
+            Alert.alert("タイムアウト", "処理に時間がかかっています。後で確認してください。");
+            return;
+          }
+          try {
+            const done = await poll();
+            if (done) {
+              clearInterval(pollInterval);
+              setIsRegenerating(false);
+            }
+          } catch (e: any) {
+            clearInterval(pollInterval);
+            setIsRegenerating(false);
+            Alert.alert("再生成失敗", e?.message ?? "再生成に失敗しました。");
+          }
+        }, 2000);
+
+        return;
+      }
+
+      await load();
+      setIsRegenerating(false);
+    } catch (e: any) {
+      setIsRegenerating(false);
+      Alert.alert("再生成失敗", e?.message ?? "再生成に失敗しました。");
+    }
+  }
+
+  function openRangeModal() {
+    if (isRegenerating) return;
+    setRangeStep('range');
+    setIsTodayExpanded(false);
+    setShowRangeModal(true);
+  }
+
+  const rangeLabel = (type: RangeType) => {
+    switch (type) {
+      case 'today': return '今日の分';
+      case 'tomorrow': return '明日の分';
+      case 'dayAfterTomorrow': return '明後日の分';
+      case 'days': return `${shoppingRange.daysCount}日分`;
+      case 'week': return '1週間分';
+    }
+  };
+
+  const mealLabel = (meal: MealType) =>
+    meal === 'breakfast' ? '朝食' : meal === 'lunch' ? '昼食' : '夕食';
 
   return (
     <View style={{ flex: 1, backgroundColor: colors.bg }}>
@@ -252,7 +359,7 @@ export default function ShoppingListPage() {
               </View>
             )}
             <Button
-              onPress={regenerate}
+              onPress={openRangeModal}
               disabled={isRegenerating}
               loading={isRegenerating}
               size="sm"
@@ -270,6 +377,368 @@ export default function ShoppingListPage() {
           </View>
         }
       />
+
+      {/* Range Selection Modal */}
+      <Modal
+        visible={showRangeModal}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowRangeModal(false)}
+      >
+        <Pressable
+          style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', justifyContent: 'flex-end' }}
+          onPress={() => setShowRangeModal(false)}
+        >
+          <Pressable
+            style={{
+              backgroundColor: colors.card,
+              borderTopLeftRadius: radius['2xl'],
+              borderTopRightRadius: radius['2xl'],
+              padding: spacing.lg,
+              paddingBottom: spacing['3xl'],
+              maxHeight: '80%',
+            }}
+            onPress={(e) => e.stopPropagation()}
+          >
+            <ScrollView showsVerticalScrollIndicator={false}>
+
+              {/* Step 1: 範囲選択 */}
+              {rangeStep === 'range' && (
+                <>
+                  <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: spacing.lg }}>
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.sm }}>
+                      <Text style={{ fontSize: 15, fontWeight: '700', color: colors.text }}>買い物の範囲を選択</Text>
+                      <View style={{ backgroundColor: colors.bg, paddingHorizontal: 6, paddingVertical: 2, borderRadius: 6 }}>
+                        <Text style={{ fontSize: 11, color: colors.textMuted }}>ステップ 1/2</Text>
+                      </View>
+                    </View>
+                    <Pressable
+                      onPress={() => setShowRangeModal(false)}
+                      hitSlop={8}
+                      style={{ width: 28, height: 28, borderRadius: 14, backgroundColor: colors.bg, alignItems: 'center', justifyContent: 'center' }}
+                    >
+                      <Ionicons name="close" size={14} color={colors.textLight} />
+                    </Pressable>
+                  </View>
+
+                  <View style={{ gap: spacing.sm }}>
+                    {/* 今日の分 */}
+                    <View>
+                      <Pressable
+                        onPress={() => {
+                          if (shoppingRange.type === 'today') {
+                            setIsTodayExpanded(!isTodayExpanded);
+                          } else {
+                            setShoppingRange({ ...shoppingRange, type: 'today' });
+                            setIsTodayExpanded(true);
+                          }
+                        }}
+                        style={{
+                          padding: spacing.md,
+                          borderRadius: radius.md,
+                          flexDirection: 'row',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          backgroundColor: shoppingRange.type === 'today' ? colors.accent : colors.bg,
+                          borderWidth: 1,
+                          borderColor: shoppingRange.type === 'today' ? colors.accent : colors.border,
+                        }}
+                      >
+                        <Text style={{ fontSize: 14, fontWeight: '500', color: shoppingRange.type === 'today' ? '#fff' : colors.text }}>
+                          今日の分
+                        </Text>
+                        {shoppingRange.type === 'today' && (
+                          <Ionicons
+                            name={isTodayExpanded ? "chevron-up" : "chevron-down"}
+                            size={16}
+                            color="#fff"
+                          />
+                        )}
+                      </Pressable>
+
+                      {/* 食事タイプ選択（今日のみ） */}
+                      {shoppingRange.type === 'today' && isTodayExpanded && (
+                        <View style={{ paddingLeft: spacing.lg, paddingTop: spacing.sm, gap: spacing.xs }}>
+                          {(['breakfast', 'lunch', 'dinner'] as MealType[]).map((mealType) => {
+                            const isSelected = shoppingRange.todayMeals.includes(mealType);
+                            return (
+                              <Pressable
+                                key={mealType}
+                                onPress={() => {
+                                  const newMeals = isSelected
+                                    ? shoppingRange.todayMeals.filter(m => m !== mealType)
+                                    : [...shoppingRange.todayMeals, mealType];
+                                  setShoppingRange({ ...shoppingRange, todayMeals: newMeals });
+                                }}
+                                style={{
+                                  padding: spacing.sm,
+                                  borderRadius: radius.sm,
+                                  flexDirection: 'row',
+                                  alignItems: 'center',
+                                  gap: spacing.sm,
+                                  backgroundColor: isSelected ? `${colors.accent}18` : 'transparent',
+                                }}
+                              >
+                                <View
+                                  style={{
+                                    width: 20,
+                                    height: 20,
+                                    borderRadius: 4,
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    backgroundColor: isSelected ? colors.accent : 'transparent',
+                                    borderWidth: 2,
+                                    borderColor: isSelected ? colors.accent : colors.border,
+                                  }}
+                                >
+                                  {isSelected && <Ionicons name="checkmark" size={12} color="#fff" />}
+                                </View>
+                                <Text style={{ fontSize: 13, color: colors.text }}>{mealLabel(mealType)}</Text>
+                              </Pressable>
+                            );
+                          })}
+                        </View>
+                      )}
+                    </View>
+
+                    {/* 明日の分 */}
+                    <Pressable
+                      onPress={() => setShoppingRange({ ...shoppingRange, type: 'tomorrow' })}
+                      style={{
+                        padding: spacing.md,
+                        borderRadius: radius.md,
+                        backgroundColor: shoppingRange.type === 'tomorrow' ? colors.accent : colors.bg,
+                        borderWidth: 1,
+                        borderColor: shoppingRange.type === 'tomorrow' ? colors.accent : colors.border,
+                      }}
+                    >
+                      <Text style={{ fontSize: 14, fontWeight: '500', color: shoppingRange.type === 'tomorrow' ? '#fff' : colors.text }}>
+                        明日の分
+                      </Text>
+                    </Pressable>
+
+                    {/* 明後日の分 */}
+                    <Pressable
+                      onPress={() => setShoppingRange({ ...shoppingRange, type: 'dayAfterTomorrow' })}
+                      style={{
+                        padding: spacing.md,
+                        borderRadius: radius.md,
+                        backgroundColor: shoppingRange.type === 'dayAfterTomorrow' ? colors.accent : colors.bg,
+                        borderWidth: 1,
+                        borderColor: shoppingRange.type === 'dayAfterTomorrow' ? colors.accent : colors.border,
+                      }}
+                    >
+                      <Text style={{ fontSize: 14, fontWeight: '500', color: shoppingRange.type === 'dayAfterTomorrow' ? '#fff' : colors.text }}>
+                        明後日の分
+                      </Text>
+                    </Pressable>
+
+                    {/* ○○日分 */}
+                    <View>
+                      <Pressable
+                        onPress={() => setShoppingRange({ ...shoppingRange, type: 'days' })}
+                        style={{
+                          padding: spacing.md,
+                          borderRadius: radius.md,
+                          backgroundColor: shoppingRange.type === 'days' ? colors.accent : colors.bg,
+                          borderWidth: 1,
+                          borderColor: shoppingRange.type === 'days' ? colors.accent : colors.border,
+                        }}
+                      >
+                        <Text style={{ fontSize: 14, fontWeight: '500', color: shoppingRange.type === 'days' ? '#fff' : colors.text }}>
+                          {shoppingRange.daysCount}日分
+                        </Text>
+                      </Pressable>
+
+                      {shoppingRange.type === 'days' && (
+                        <View style={{ paddingLeft: spacing.lg, paddingTop: spacing.sm, flexDirection: 'row', alignItems: 'center', gap: spacing.sm }}>
+                          <TextInput
+                            value={daysCountInput}
+                            onChangeText={(v) => {
+                              setDaysCountInput(v);
+                              const n = parseInt(v);
+                              if (!isNaN(n) && n >= 1 && n <= 14) {
+                                setShoppingRange({ ...shoppingRange, daysCount: n });
+                              }
+                            }}
+                            keyboardType="number-pad"
+                            style={{
+                              width: 64,
+                              padding: spacing.sm,
+                              borderRadius: radius.sm,
+                              backgroundColor: colors.bg,
+                              borderWidth: 1,
+                              borderColor: colors.border,
+                              textAlign: 'center',
+                              fontSize: 14,
+                              color: colors.text,
+                            }}
+                          />
+                          <Text style={{ fontSize: 13, color: colors.textMuted }}>日分（今日から・最大14日）</Text>
+                        </View>
+                      )}
+                    </View>
+
+                    {/* 1週間分 */}
+                    <Pressable
+                      onPress={() => setShoppingRange({ ...shoppingRange, type: 'week' })}
+                      style={{
+                        padding: spacing.md,
+                        borderRadius: radius.md,
+                        backgroundColor: shoppingRange.type === 'week' ? colors.accent : colors.bg,
+                        borderWidth: 1,
+                        borderColor: shoppingRange.type === 'week' ? colors.accent : colors.border,
+                      }}
+                    >
+                      <Text style={{ fontSize: 14, fontWeight: '500', color: shoppingRange.type === 'week' ? '#fff' : colors.text }}>
+                        1週間分
+                      </Text>
+                    </Pressable>
+                  </View>
+
+                  {/* 次へボタン */}
+                  <Pressable
+                    onPress={() => setRangeStep('servings')}
+                    disabled={shoppingRange.type === 'today' && shoppingRange.todayMeals.length === 0}
+                    style={({ pressed }) => ({
+                      marginTop: spacing.lg,
+                      padding: spacing.md,
+                      borderRadius: radius.md,
+                      backgroundColor: (shoppingRange.type === 'today' && shoppingRange.todayMeals.length === 0)
+                        ? colors.textMuted
+                        : pressed ? colors.accentDark : colors.accent,
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: spacing.sm,
+                    })}
+                  >
+                    <Text style={{ color: '#fff', fontWeight: '700', fontSize: 14 }}>次へ（人数確認）</Text>
+                    <Ionicons name="chevron-forward" size={18} color="#fff" />
+                  </Pressable>
+                </>
+              )}
+
+              {/* Step 2: 人数設定 */}
+              {rangeStep === 'servings' && (
+                <>
+                  <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: spacing.lg }}>
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.sm }}>
+                      <Pressable
+                        onPress={() => setRangeStep('range')}
+                        hitSlop={8}
+                        style={{ width: 28, height: 28, borderRadius: 14, backgroundColor: colors.bg, alignItems: 'center', justifyContent: 'center' }}
+                      >
+                        <Ionicons name="chevron-back" size={14} color={colors.textLight} />
+                      </Pressable>
+                      <Text style={{ fontSize: 15, fontWeight: '700', color: colors.text }}>人数を確認</Text>
+                      <View style={{ backgroundColor: colors.bg, paddingHorizontal: 6, paddingVertical: 2, borderRadius: 6 }}>
+                        <Text style={{ fontSize: 11, color: colors.textMuted }}>ステップ 2/2</Text>
+                      </View>
+                    </View>
+                    <Pressable
+                      onPress={() => setShowRangeModal(false)}
+                      hitSlop={8}
+                      style={{ width: 28, height: 28, borderRadius: 14, backgroundColor: colors.bg, alignItems: 'center', justifyContent: 'center' }}
+                    >
+                      <Ionicons name="close" size={14} color={colors.textLight} />
+                    </Pressable>
+                  </View>
+
+                  {/* 選択した範囲の表示 */}
+                  <View style={{
+                    backgroundColor: colors.accentLight,
+                    padding: spacing.md,
+                    borderRadius: radius.md,
+                    marginBottom: spacing.lg,
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: spacing.sm,
+                  }}>
+                    <Ionicons name="calendar-outline" size={16} color={colors.accent} />
+                    <Text style={{ fontSize: 13, color: colors.accent, fontWeight: '600' }}>
+                      {rangeLabel(shoppingRange.type)}
+                      {shoppingRange.type === 'today' && shoppingRange.todayMeals.length < 3
+                        ? ` (${shoppingRange.todayMeals.map(mealLabel).join('・')})`
+                        : ''}
+                    </Text>
+                  </View>
+
+                  <Text style={{ fontSize: 13, color: colors.textLight, marginBottom: spacing.md }}>
+                    何人分の材料を計算しますか？
+                  </Text>
+
+                  {/* 人数セレクター */}
+                  <View style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: spacing.xl,
+                    backgroundColor: colors.bg,
+                    padding: spacing.lg,
+                    borderRadius: radius.md,
+                    marginBottom: spacing.lg,
+                  }}>
+                    <Pressable
+                      onPress={() => setServings(Math.max(1, servings - 1))}
+                      style={{
+                        width: 44,
+                        height: 44,
+                        borderRadius: 22,
+                        backgroundColor: colors.card,
+                        borderWidth: 1,
+                        borderColor: colors.border,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <Text style={{ fontSize: 20, fontWeight: '700', color: colors.text }}>−</Text>
+                    </Pressable>
+                    <View style={{ alignItems: 'center' }}>
+                      <Text style={{ fontSize: 36, fontWeight: '700', color: colors.text }}>{servings}</Text>
+                      <Text style={{ fontSize: 12, color: colors.textMuted }}>人分</Text>
+                    </View>
+                    <Pressable
+                      onPress={() => setServings(Math.min(10, servings + 1))}
+                      style={{
+                        width: 44,
+                        height: 44,
+                        borderRadius: 22,
+                        backgroundColor: colors.card,
+                        borderWidth: 1,
+                        borderColor: colors.border,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}
+                    >
+                      <Text style={{ fontSize: 20, fontWeight: '700', color: colors.text }}>+</Text>
+                    </Pressable>
+                  </View>
+
+                  {/* 生成ボタン */}
+                  <Pressable
+                    onPress={executeRegenerate}
+                    style={({ pressed }) => ({
+                      padding: spacing.md,
+                      borderRadius: radius.md,
+                      backgroundColor: pressed ? colors.accentDark : colors.accent,
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: spacing.sm,
+                    })}
+                  >
+                    <Ionicons name="sparkles" size={18} color="#fff" />
+                    <Text style={{ color: '#fff', fontWeight: '700', fontSize: 14 }}>この設定で買い物リストを生成</Text>
+                  </Pressable>
+                </>
+              )}
+
+            </ScrollView>
+          </Pressable>
+        </Pressable>
+      </Modal>
+
       <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.md }}>
 
       <View style={{ flexDirection: "row", gap: spacing.md }}>
@@ -331,7 +800,7 @@ export default function ShoppingListPage() {
           icon={<Ionicons name="cart-outline" size={48} color={colors.textMuted} />}
           message="買い物リストは空です。"
           actionLabel="献立から生成"
-          onAction={regenerate}
+          onAction={openRangeModal}
         />
       ) : (
         <View style={{ gap: spacing.md }}>


### PR DESCRIPTION
Closes #446

## 概要

- 再生成ボタンタップ時に 2 ステップのボトムシートモーダルを表示する
- ステップ 1: 買い物範囲の選択（今日 / 明日 / 明後日 / ○○日分 / 1週間）
  - 「今日の分」を選択した場合、朝食・昼食・夕食のチェックボックスで食事タイプを指定可能
  - 「○○日分」を選択した場合、数値入力で 1〜14 日を指定可能
- ステップ 2: 人数確認（± ボタンで 1〜10 人を選択）
- API (`/api/shopping-list/regenerate`) に `startDate` / `endDate` / `mealTypes` / `servingsConfig` を送信

## テスト計画

- [ ] 再生成ボタンをタップしてモーダルが表示されること
- [ ] 各範囲（今日/明日/明後日/○○日分/1週間）を選択できること
- [ ] 「今日の分」選択時に食事タイプのチェックボックスが展開されること
- [ ] 「○○日分」選択時に日数入力フィールドが表示されること
- [ ] 「次へ」ボタンで人数確認画面に遷移すること
- [ ] 人数を ± で変更できること
- [ ] 「この設定で買い物リストを生成」ボタンで再生成が実行されること