### PR TITLE
refactor(mobile): formatLocalDate を packages/core に集約 (#390)

### DIFF
--- a/apps/mobile/src/hooks/useHomeData.ts
+++ b/apps/mobile/src/hooks/useHomeData.ts
@@ -1,13 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { supabase } from "../lib/supabase";
 import { getApi } from "../lib/api";
-
-const formatLocalDate = (date: Date): string => {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-};
+import { formatLocalDate } from "@homegohan/core";
 
 interface DailySummary {
   totalCalories: number;


### PR DESCRIPTION
Closes #390

## 概要

- `apps/mobile/src/hooks/useHomeData.ts` に独自定義されていた `formatLocalDate` 関数を削除
- `@homegohan/core` からの `import { formatLocalDate }` に置き換え
- これにより `packages/core/src/utils/week-utils.ts` の実装が single source of truth となり、core 版の変更が mobile に自動追従される