### PR TITLE
feat(mobile): 究極モード (V4 Ultimate) 献立生成を実装 (#445)

### DIFF
--- a/apps/mobile/app/health/record/[date].tsx
+++ b/apps/mobile/app/health/record/[date].tsx
@@ -1,10 +1,10 @@
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
-import { Alert, ScrollView, Text, View } from "react-native";
+import { Alert, Pressable, ScrollView, Text, View } from "react-native";
 
-import { Button, Card, Input, LoadingState, PageHeader, SectionHeader } from "../../../src/components/ui";
-import { colors, spacing } from "../../../src/theme";
+import { Button, Card, Input, LoadingState, PageHeader } from "../../../src/components/ui";
+import { colors, spacing, radius } from "../../../src/theme";
 import { getApi } from "../../../src/lib/api";
 
 type HealthRecord = {
@@ -14,9 +14,17 @@ type HealthRecord = {
   body_fat_percentage: number | null;
   systolic_bp: number | null;
   diastolic_bp: number | null;
+  heart_rate: number | null;
+  body_temp: number | null;
   sleep_hours: number | null;
-  step_count: number | null;
+  sleep_quality: number | null;
   water_intake: number | null;
+  step_count: number | null;
+  bowel_movement: number | null;
+  overall_condition: number | null;
+  mood_score: number | null;
+  energy_level: number | null;
+  stress_level: number | null;
   daily_note: string | null;
 };
 
@@ -55,6 +63,92 @@ function DiffIndicator({ current, previous, unit, lower }: { current: string; pr
   );
 }
 
+const SCORE_OPTIONS: { value: number; emoji: string }[][] = [
+  // overall_condition
+  [
+    { value: 1, emoji: "😫" },
+    { value: 2, emoji: "😔" },
+    { value: 3, emoji: "😐" },
+    { value: 4, emoji: "🙂" },
+    { value: 5, emoji: "😄" },
+  ],
+  // mood_score
+  [
+    { value: 1, emoji: "😢" },
+    { value: 2, emoji: "😔" },
+    { value: 3, emoji: "😐" },
+    { value: 4, emoji: "😊" },
+    { value: 5, emoji: "🥰" },
+  ],
+  // energy_level
+  [
+    { value: 1, emoji: "🪫" },
+    { value: 2, emoji: "🔋" },
+    { value: 3, emoji: "⚡" },
+    { value: 4, emoji: "💪" },
+    { value: 5, emoji: "🚀" },
+  ],
+  // stress_level
+  [
+    { value: 1, emoji: "😌" },
+    { value: 2, emoji: "🙂" },
+    { value: 3, emoji: "😐" },
+    { value: 4, emoji: "😰" },
+    { value: 5, emoji: "🤯" },
+  ],
+  // sleep_quality
+  [
+    { value: 1, emoji: "😵" },
+    { value: 2, emoji: "😪" },
+    { value: 3, emoji: "😴" },
+    { value: 4, emoji: "😌" },
+    { value: 5, emoji: "🌟" },
+  ],
+];
+
+function ScoreSelector({
+  label,
+  value,
+  onChange,
+  options,
+  selectedColor,
+}: {
+  label: string;
+  value: number | null;
+  onChange: (v: number | null) => void;
+  options: { value: number; emoji: string }[];
+  selectedColor: string;
+}) {
+  return (
+    <View style={{ gap: spacing.sm }}>
+      <Text style={{ fontSize: 13, color: colors.textLight }}>{label}</Text>
+      <View style={{ flexDirection: "row", gap: spacing.xs ?? 4, justifyContent: "space-around" }}>
+        {options.map((opt) => {
+          const selected = value === opt.value;
+          return (
+            <Pressable
+              key={opt.value}
+              onPress={() => onChange(selected ? null : opt.value)}
+              style={{
+                flex: 1,
+                alignItems: "center",
+                gap: 2,
+                paddingVertical: spacing.sm,
+                borderRadius: radius.md,
+                backgroundColor: selected ? colors.accentLight : "transparent",
+                borderWidth: 2,
+                borderColor: selected ? colors.accent : "transparent",
+              }}
+            >
+              <Text style={{ fontSize: 22 }}>{opt.emoji}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
 export default function HealthRecordDetailPage() {
   const params = useLocalSearchParams<{ date?: string | string[] }>();
   const date = useMemo(() => {
@@ -68,13 +162,26 @@ export default function HealthRecordDetailPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // 体組成
   const [weight, setWeight] = useState("");
   const [bodyFat, setBodyFat] = useState("");
+  // バイタル
   const [sys, setSys] = useState("");
   const [dia, setDia] = useState("");
+  const [heartRate, setHeartRate] = useState("");
+  const [bodyTemp, setBodyTemp] = useState("");
+  // 生活習慣
   const [sleepHours, setSleepHours] = useState("");
-  const [steps, setSteps] = useState("");
+  const [sleepQuality, setSleepQuality] = useState<number | null>(null);
   const [water, setWater] = useState("");
+  const [steps, setSteps] = useState("");
+  const [bowelMovement, setBowelMovement] = useState("");
+  // 体調・メンタル
+  const [overallCondition, setOverallCondition] = useState<number | null>(null);
+  const [moodScore, setMoodScore] = useState<number | null>(null);
+  const [energyLevel, setEnergyLevel] = useState<number | null>(null);
+  const [stressLevel, setStressLevel] = useState<number | null>(null);
+  // メモ
   const [note, setNote] = useState("");
   const [isSaving, setIsSaving] = useState(false);
 
@@ -83,9 +190,17 @@ export default function HealthRecordDetailPage() {
     setBodyFat(r?.body_fat_percentage == null ? "" : String(r.body_fat_percentage));
     setSys(r?.systolic_bp == null ? "" : String(r.systolic_bp));
     setDia(r?.diastolic_bp == null ? "" : String(r.diastolic_bp));
+    setHeartRate(r?.heart_rate == null ? "" : String(r.heart_rate));
+    setBodyTemp(r?.body_temp == null ? "" : String(r.body_temp));
     setSleepHours(r?.sleep_hours == null ? "" : String(r.sleep_hours));
-    setSteps(r?.step_count == null ? "" : String(r.step_count));
+    setSleepQuality(r?.sleep_quality ?? null);
     setWater(r?.water_intake == null ? "" : String(r.water_intake));
+    setSteps(r?.step_count == null ? "" : String(r.step_count));
+    setBowelMovement(r?.bowel_movement == null ? "" : String(r.bowel_movement));
+    setOverallCondition(r?.overall_condition ?? null);
+    setMoodScore(r?.mood_score ?? null);
+    setEnergyLevel(r?.energy_level ?? null);
+    setStressLevel(r?.stress_level ?? null);
     setNote(r?.daily_note ?? "");
   }
 
@@ -119,17 +234,28 @@ export default function HealthRecordDetailPage() {
       const vBodyFat = toNum(bodyFat);
       const vSys = toInt(sys);
       const vDia = toInt(dia);
+      const vHeartRate = toInt(heartRate);
+      const vBodyTemp = toNum(bodyTemp);
       const vSleep = toNum(sleepHours);
-      const vSteps = toInt(steps);
       const vWater = toInt(water);
+      const vSteps = toInt(steps);
+      const vBowel = toInt(bowelMovement);
 
       if (vWeight !== undefined) body.weight = vWeight;
       if (vBodyFat !== undefined) body.body_fat_percentage = vBodyFat;
       if (vSys !== undefined) body.systolic_bp = vSys;
       if (vDia !== undefined) body.diastolic_bp = vDia;
+      if (vHeartRate !== undefined) body.heart_rate = vHeartRate;
+      if (vBodyTemp !== undefined) body.body_temp = vBodyTemp;
       if (vSleep !== undefined) body.sleep_hours = vSleep;
-      if (vSteps !== undefined) body.step_count = vSteps;
+      if (sleepQuality !== null) body.sleep_quality = sleepQuality;
       if (vWater !== undefined) body.water_intake = vWater;
+      if (vSteps !== undefined) body.step_count = vSteps;
+      if (vBowel !== undefined) body.bowel_movement = vBowel;
+      if (overallCondition !== null) body.overall_condition = overallCondition;
+      if (moodScore !== null) body.mood_score = moodScore;
+      if (energyLevel !== null) body.energy_level = energyLevel;
+      if (stressLevel !== null) body.stress_level = stressLevel;
 
       const noteTrimmed = note.trim();
       if (noteTrimmed) body.daily_note = noteTrimmed;
@@ -227,56 +353,125 @@ export default function HealthRecordDetailPage() {
             </Card>
           )}
 
-          {/* 身体データ */}
+          {/* 体組成 */}
           <Card>
             <View style={{ gap: spacing.md }}>
-              <SectionHeader title="身体データ" />
+              <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+                <View style={{ width: 36, height: 36, borderRadius: radius.sm, backgroundColor: colors.accentLight, alignItems: "center", justifyContent: "center" }}>
+                  <Ionicons name="scale" size={18} color={colors.accent} />
+                </View>
+                <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>体組成</Text>
+              </View>
               <View style={{ flexDirection: "row", gap: spacing.md }}>
                 <View style={{ flex: 1 }}>
                   <Input label="体重 (kg)" value={weight} onChangeText={setWeight} keyboardType="decimal-pad" placeholder="60.2" />
                 </View>
                 <View style={{ flex: 1 }}>
-                  <Input label="体脂肪 (%)" value={bodyFat} onChangeText={setBodyFat} keyboardType="decimal-pad" placeholder="20.5" />
+                  <Input label="体脂肪率 (%)" value={bodyFat} onChangeText={setBodyFat} keyboardType="decimal-pad" placeholder="20.5" />
                 </View>
               </View>
             </View>
           </Card>
 
-          {/* 血圧 */}
+          {/* バイタル */}
           <Card>
             <View style={{ gap: spacing.md }}>
-              <SectionHeader title="血圧" />
+              <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+                <View style={{ width: 36, height: 36, borderRadius: radius.sm, backgroundColor: colors.errorLight, alignItems: "center", justifyContent: "center" }}>
+                  <Ionicons name="heart" size={18} color={colors.error} />
+                </View>
+                <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>バイタル</Text>
+              </View>
               <View style={{ flexDirection: "row", gap: spacing.md }}>
                 <View style={{ flex: 1 }}>
-                  <Input label="収縮期 (mmHg)" value={sys} onChangeText={setSys} keyboardType="number-pad" placeholder="120" />
+                  <Input label="収縮期血圧 (mmHg)" value={sys} onChangeText={setSys} keyboardType="number-pad" placeholder="120" />
                 </View>
                 <View style={{ flex: 1 }}>
-                  <Input label="拡張期 (mmHg)" value={dia} onChangeText={setDia} keyboardType="number-pad" placeholder="80" />
+                  <Input label="拡張期血圧 (mmHg)" value={dia} onChangeText={setDia} keyboardType="number-pad" placeholder="80" />
+                </View>
+              </View>
+              <View style={{ flexDirection: "row", gap: spacing.md }}>
+                <View style={{ flex: 1 }}>
+                  <Input label="脈拍 (bpm)" value={heartRate} onChangeText={setHeartRate} keyboardType="number-pad" placeholder="70" />
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Input label="体温 (℃)" value={bodyTemp} onChangeText={setBodyTemp} keyboardType="decimal-pad" placeholder="36.5" />
                 </View>
               </View>
             </View>
           </Card>
 
-          {/* 生活データ */}
+          {/* 生活習慣 */}
           <Card>
             <View style={{ gap: spacing.md }}>
-              <SectionHeader title="生活データ" />
+              <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+                <View style={{ width: 36, height: 36, borderRadius: radius.sm, backgroundColor: colors.purpleLight, alignItems: "center", justifyContent: "center" }}>
+                  <Ionicons name="bed" size={18} color={colors.purple} />
+                </View>
+                <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>生活習慣</Text>
+              </View>
+              <Input label="睡眠時間 (時間)" value={sleepHours} onChangeText={setSleepHours} keyboardType="decimal-pad" placeholder="7.5" />
+              <ScoreSelector
+                label="睡眠の質"
+                value={sleepQuality}
+                onChange={setSleepQuality}
+                options={SCORE_OPTIONS[4]}
+                selectedColor={colors.purple}
+              />
               <View style={{ flexDirection: "row", gap: spacing.md }}>
                 <View style={{ flex: 1 }}>
-                  <Input label="睡眠 (時間)" value={sleepHours} onChangeText={setSleepHours} keyboardType="decimal-pad" placeholder="7.5" />
+                  <Input label="水分摂取 (ml)" value={water} onChangeText={setWater} keyboardType="number-pad" placeholder="2000" />
                 </View>
                 <View style={{ flex: 1 }}>
                   <Input label="歩数" value={steps} onChangeText={setSteps} keyboardType="number-pad" placeholder="8000" />
                 </View>
-                <View style={{ flex: 1 }}>
-                  <Input label="水 (ml)" value={water} onChangeText={setWater} keyboardType="number-pad" placeholder="2000" />
-                </View>
               </View>
+              <Input label="便通 (回)" value={bowelMovement} onChangeText={setBowelMovement} keyboardType="number-pad" placeholder="1" />
+            </View>
+          </Card>
+
+          {/* 体調・メンタル */}
+          <Card>
+            <View style={{ gap: spacing.md }}>
+              <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+                <View style={{ width: 36, height: 36, borderRadius: radius.sm, backgroundColor: colors.successLight, alignItems: "center", justifyContent: "center" }}>
+                  <Ionicons name="sparkles-outline" size={18} color={colors.success} />
+                </View>
+                <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>体調・メンタル</Text>
+              </View>
+              <ScoreSelector
+                label="全体的な体調"
+                value={overallCondition}
+                onChange={setOverallCondition}
+                options={SCORE_OPTIONS[0]}
+                selectedColor={colors.success}
+              />
+              <ScoreSelector
+                label="気分"
+                value={moodScore}
+                onChange={setMoodScore}
+                options={SCORE_OPTIONS[1]}
+                selectedColor={colors.success}
+              />
+              <ScoreSelector
+                label="エネルギーレベル"
+                value={energyLevel}
+                onChange={setEnergyLevel}
+                options={SCORE_OPTIONS[2]}
+                selectedColor={colors.warning}
+              />
+              <ScoreSelector
+                label="ストレスレベル"
+                value={stressLevel}
+                onChange={setStressLevel}
+                options={SCORE_OPTIONS[3]}
+                selectedColor={colors.blue}
+              />
             </View>
           </Card>
 
           {/* メモ */}
-          <Input label="メモ" value={note} onChangeText={setNote} placeholder="今日の体調など" multiline />
+          <Input label="今日のメモ" value={note} onChangeText={setNote} placeholder="今日の気づきや出来事を記録..." multiline />
 
           {/* アクション */}
           <Button onPress={save} loading={isSaving}>

--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -278,6 +278,7 @@ export default function WeeklyMenuPage() {
   const [pendingRequestId, setPendingRequestId] = useState<string | null>(null);
   const [pendingStatus, setPendingStatus] = useState<string | null>(null);
   const [pendingProgress, setPendingProgress] = useState<PendingProgress | null>(null);
+  const [pendingIsUltimate, setPendingIsUltimate] = useState(false);
 
   useEffect(() => {
     setWeekStart(getWeekStart(new Date(), weekStartDay));
@@ -346,19 +347,22 @@ export default function WeeklyMenuPage() {
   async function checkPending() {
     try {
       const api = getApi();
-      const res = await api.get<{ hasPending: boolean; requestId?: string; status?: string; startDate?: string }>(
+      const res = await api.get<{ hasPending: boolean; requestId?: string; status?: string; startDate?: string; mode?: string }>(
         `/api/ai/menu/weekly/pending?date=${weekStartStr}`
       );
       if (res.hasPending && res.requestId && res.startDate === weekStartStr) {
         setPendingRequestId(res.requestId);
         setPendingStatus(res.status ?? "processing");
+        setPendingIsUltimate(res.mode === "v4" || res.mode === "v5");
         return;
       }
       setPendingRequestId(null);
       setPendingStatus(null);
+      setPendingIsUltimate(false);
     } catch {
       setPendingRequestId(null);
       setPendingStatus(null);
+      setPendingIsUltimate(false);
     }
   }
 
@@ -397,12 +401,14 @@ export default function WeeklyMenuPage() {
             setPendingRequestId(null);
             setPendingStatus(null);
             setPendingProgress(null);
+            setPendingIsUltimate(false);
             Alert.alert("完了", "週間献立の生成が完了しました。");
           }
           if (newRecord.status === "failed") {
             setPendingRequestId(null);
             setPendingStatus(null);
             setPendingProgress(null);
+            setPendingIsUltimate(false);
             setError(newRecord.error_message ?? "週間献立の生成に失敗しました。");
           }
         }
@@ -436,10 +442,12 @@ export default function WeeklyMenuPage() {
           setPendingRequestId(null);
           setPendingStatus(null);
           setPendingProgress(null);
+          setPendingIsUltimate(false);
         } else if (res.status === "failed") {
           setPendingRequestId(null);
           setPendingStatus(null);
           setPendingProgress(null);
+          setPendingIsUltimate(false);
           setError(res.errorMessage ?? "週間献立の生成に失敗しました。");
         }
       } catch {
@@ -590,7 +598,11 @@ export default function WeeklyMenuPage() {
         <>
           {/* AI生成中プログレス */}
           {pendingRequestId && (
-            <ProgressTodoCard progress={pendingProgress} />
+            <ProgressTodoCard
+              progress={pendingProgress}
+              phases={pendingIsUltimate ? ULTIMATE_PROGRESS_PHASES : PROGRESS_PHASES}
+              defaultMessage={pendingIsUltimate ? "究極モードで献立を生成中..." : "AIが献立を生成中..."}
+            />
           )}
 
           {/* 日付セレクタ — 横並び丸型ピル */}

--- a/apps/mobile/app/menus/weekly/request/index.tsx
+++ b/apps/mobile/app/menus/weekly/request/index.tsx
@@ -2,13 +2,28 @@ import { Ionicons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
 import { router } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
-import { Alert, Image, ScrollView, Text, View } from "react-native";
+import { Alert, Image, Pressable, ScrollView, Text, View } from "react-native";
 
 import { Button, Card, ChipSelector, Input, PageHeader, SectionHeader } from "../../../../src/components/ui";
 import { getApi } from "../../../../src/lib/api";
 import { colors, radius, spacing } from "../../../../src/theme";
 import { useProfile } from "../../../../src/providers/ProfileProvider";
 import type { WeekStartDay } from "../../../../src/providers/ProfileProvider";
+
+const MEAL_TYPES = ["breakfast", "lunch", "dinner"] as const;
+
+function buildWeekTargetSlots(weekStartStr: string): { date: string; mealType: string }[] {
+  const slots: { date: string; mealType: string }[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(weekStartStr + "T00:00:00");
+    d.setDate(d.getDate() + i);
+    const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    for (const mealType of MEAL_TYPES) {
+      slots.push({ date: dateStr, mealType });
+    }
+  }
+  return slots;
+}
 
 const formatLocalDate = (date: Date): string => {
   const y = date.getFullYear();
@@ -45,6 +60,7 @@ export default function WeeklyRequestPage() {
     setStartDate(formatLocalDate(getWeekStart(new Date(), weekStartDay)));
   }, [weekStartDay]);
 
+  const [isUltimateMode, setIsUltimateMode] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -136,15 +152,40 @@ export default function WeeklyRequestPage() {
       const noteForApi = [note.trim(), ...extraLines].filter(Boolean).join("\n");
 
       const api = getApi();
-      await api.post("/api/ai/menu/weekly/request", {
-        startDate: weekStartStr,
-        note: noteForApi,
-        familySize: Math.max(1, Math.min(10, parseInt(familySize || "1") || 1)),
-        cheatDay: cheatDay.trim() || null,
-        preferences: { useFridgeFirst, quickMeals, japaneseStyle, healthy, ingredients },
-      });
 
-      Alert.alert("生成開始", "週間献立の生成を開始しました。生成中は「生成中...」と表示されます。");
+      if (isUltimateMode) {
+        // 究極モード: /api/ai/menu/v4/generate に ultimateMode: true で送信
+        const targetSlots = buildWeekTargetSlots(weekStartStr);
+        await api.post("/api/ai/menu/v4/generate", {
+          targetSlots,
+          resolveExistingMeals: true,
+          note: noteForApi,
+          ultimateMode: true,
+          familySize: Math.max(1, Math.min(10, parseInt(familySize || "1") || 1)),
+          constraints: {
+            useFridgeFirst,
+            quickMeals,
+            japaneseStyle,
+            healthy,
+            ingredients,
+          },
+        });
+        Alert.alert(
+          "究極モード生成開始",
+          "6ステップの栄養バランス分析で究極の献立を生成します。完了まで数分かかります。"
+        );
+      } else {
+        // 通常モード
+        await api.post("/api/ai/menu/weekly/request", {
+          startDate: weekStartStr,
+          note: noteForApi,
+          familySize: Math.max(1, Math.min(10, parseInt(familySize || "1") || 1)),
+          cheatDay: cheatDay.trim() || null,
+          preferences: { useFridgeFirst, quickMeals, japaneseStyle, healthy, ingredients },
+        });
+        Alert.alert("生成開始", "週間献立の生成を開始しました。生成中は「生成中...」と表示されます。");
+      }
+
       router.replace("/menus/weekly");
     } catch (e: any) {
       Alert.alert("生成失敗", e?.message ?? "生成に失敗しました。");
@@ -270,11 +311,61 @@ export default function WeeklyRequestPage() {
         </View>
       </Card>
 
+      {/* 究極モードトグル */}
+      <Pressable
+        onPress={() => setIsUltimateMode((prev) => !prev)}
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          gap: spacing.md,
+          padding: spacing.lg,
+          backgroundColor: isUltimateMode ? "#FFF8E7" : colors.card,
+          borderRadius: radius.lg,
+          borderWidth: 2,
+          borderColor: isUltimateMode ? "#F59E0B" : colors.border,
+        }}
+      >
+        <View
+          style={{
+            width: 44,
+            height: 44,
+            borderRadius: radius.md,
+            backgroundColor: isUltimateMode ? "#F59E0B" : colors.bg,
+            alignItems: "center",
+            justifyContent: "center",
+            borderWidth: isUltimateMode ? 0 : 1,
+            borderColor: colors.border,
+          }}
+        >
+          <Ionicons name="flash" size={22} color={isUltimateMode ? "#fff" : colors.textMuted} />
+        </View>
+        <View style={{ flex: 1, gap: 3 }}>
+          <Text style={{ fontSize: 15, fontWeight: "700", color: isUltimateMode ? "#B45309" : colors.text }}>
+            究極モード (V4 Ultimate)
+          </Text>
+          <Text style={{ fontSize: 12, color: isUltimateMode ? "#92400E" : colors.textMuted }}>
+            6ステップ栄養バランス分析＋改善（生成に数分かかります）
+          </Text>
+        </View>
+        <View
+          style={{
+            width: 26,
+            height: 26,
+            borderRadius: 13,
+            backgroundColor: isUltimateMode ? "#F59E0B" : colors.border,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          {isUltimateMode && <Ionicons name="checkmark" size={16} color="#fff" />}
+        </View>
+      </Pressable>
+
       <Button onPress={submit} disabled={isSubmitting || isUploading} loading={isSubmitting} size="lg">
         <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
-          <Ionicons name="sparkles" size={18} color="#FFFFFF" />
+          <Ionicons name={isUltimateMode ? "flash" : "sparkles"} size={18} color="#FFFFFF" />
           <Text style={{ color: "#FFFFFF", fontWeight: "700", fontSize: 16 }}>
-            {isSubmitting ? "生成中..." : "生成する"}
+            {isSubmitting ? "生成中..." : isUltimateMode ? "究極モードで生成" : "生成する"}
           </Text>
         </View>
       </Button>


### PR DESCRIPTION
Closes #445

## 概要

- `apps/mobile/app/menus/weekly/request/index.tsx` に究極モードトグル UI を追加
- トグル ON 時は `/api/ai/menu/v4/generate` に `ultimateMode: true` と週 7 日分 (朝・昼・夕 × 7 = 21 スロット) の `targetSlots` を送信
- トグル OFF 時は従来通り `/api/ai/menu/weekly/request` を使用
- `apps/mobile/app/menus/weekly/index.tsx` で `pendingIsUltimate` フラグを追加し、究極モード生成中は `ULTIMATE_PROGRESS_PHASES` (6 ステップ) の進捗表示に切り替える

## 受け入れ基準

- [x] 究極モード起動ボタン (タップでトグル ON/OFF)
- [x] 6 ステップ進捗表示 (ULTIMATE_PROGRESS_PHASES)