### PR TITLE
feat(mobile): 買い物リストの全削除ボタンを追加 (#448)

### DIFF
--- a/apps/mobile/app/shopping-list/index.tsx
+++ b/apps/mobile/app/shopping-list/index.tsx
@@ -11,7 +11,7 @@ import { LoadingState } from "../../src/components/ui/LoadingState";
 import { PageHeader } from "../../src/components/ui/PageHeader";
 import { SectionHeader } from "../../src/components/ui/SectionHeader";
 import { StatusBadge } from "../../src/components/ui/StatusBadge";
-import { getApi } from "../../src/lib/api";
+import { getApi, getApiBaseUrl } from "../../src/lib/api";
 import { getActiveShoppingListId } from "../../src/lib/mealPlan";
 import { supabase } from "../../src/lib/supabase";
 import { colors, radius, spacing } from "../../src/theme";
@@ -39,6 +39,7 @@ export default function ShoppingListPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isRegenerating, setIsRegenerating] = useState(false);
+  const [isClearingAll, setIsClearingAll] = useState(false);
 
   const [newName, setNewName] = useState("");
   const [newCategory, setNewCategory] = useState("その他");
@@ -161,6 +162,45 @@ export default function ShoppingListPage() {
     ]);
   }
 
+  async function deleteAllItems() {
+    if (items.length === 0) return;
+
+    Alert.alert(
+      "全削除",
+      `${items.length}件のアイテムをすべて削除しますか？`,
+      [
+        { text: "キャンセル", style: "cancel" },
+        {
+          text: "全削除",
+          style: "destructive",
+          onPress: async () => {
+            setIsClearingAll(true);
+            const itemIds = items.map((i) => i.id);
+            try {
+              const { data } = await supabase.auth.getSession();
+              const token = data.session?.access_token ?? null;
+              const baseUrl = getApiBaseUrl();
+              const res = await fetch(`${baseUrl}/api/shopping-list`, {
+                method: "DELETE",
+                headers: {
+                  "Content-Type": "application/json",
+                  ...(token ? { Authorization: `Bearer ${token}` } : {}),
+                },
+                body: JSON.stringify({ itemIds }),
+              });
+              if (!res.ok) throw new Error("全削除に失敗しました");
+              setItems([]);
+            } catch (e: any) {
+              Alert.alert("削除失敗", e?.message ?? "全削除に失敗しました。");
+            } finally {
+              setIsClearingAll(false);
+            }
+          },
+        },
+      ]
+    );
+  }
+
   async function regenerate() {
     if (isRegenerating) return;
     Alert.alert(
@@ -250,6 +290,23 @@ export default function ShoppingListPage() {
               <View style={{ backgroundColor: colors.accentLight, paddingHorizontal: spacing.sm, paddingVertical: 2, borderRadius: radius.sm }}>
                 <Text style={{ fontSize: 12, fontWeight: "700", color: colors.accent }}>{totalServings}食分</Text>
               </View>
+            )}
+            {items.length > 0 && (
+              <Pressable
+                onPress={deleteAllItems}
+                disabled={isClearingAll}
+                hitSlop={8}
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: 14,
+                  backgroundColor: colors.bg,
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <Ionicons name="trash-outline" size={14} color="#ef4444" />
+              </Pressable>
             )}
             <Button
               onPress={regenerate}


### PR DESCRIPTION
## Summary

- PageHeader の right 領域に赤いゴミ箱アイコンボタンを追加（アイテムが 1 件以上ある場合のみ表示）
- タップ時に件数を示す確認ダイアログ（Alert.alert）を表示し、誤操作を防止
- 確認後は DELETE /api/shopping-list に itemIds を一括送信して全削除

## Test plan

- [ ] 買い物リストにアイテムを追加し、ヘッダー右にゴミ箱アイコンが表示されること
- [ ] リストが空のときアイコンが非表示になること
- [ ] ゴミ箱アイコンをタップすると件数入りの確認ダイアログが出ること
- [ ] 「キャンセル」でダイアログが閉じてリストが変わらないこと
- [ ] 「全削除」でリストが空になり API が成功すること

Closes #448