### PR TITLE
feat(mobile): お知らせバナー(Announcement)を home に追加 (#416)

### DIFF
--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -86,6 +86,8 @@ export default function HomeScreen() {
     activityLevel,
     suggestion,
     performanceAnalysis,
+    announcements,
+    dismissAnnouncement,
     toggleMealCompletion,
     updateActivityLevel,
     setSuggestion,
@@ -199,6 +201,38 @@ export default function HomeScreen() {
             />
           </View>
         </View>
+
+        {/* ========== お知らせバナー ========== */}
+        {announcements.length > 0 && (
+          <View style={{ paddingHorizontal: spacing.lg, paddingTop: spacing.md, gap: spacing.sm }}>
+            {announcements.map((ann) => (
+              <View
+                key={ann.id}
+                style={{
+                  backgroundColor: "#EFF6FF",
+                  borderWidth: 1,
+                  borderColor: "#BFDBFE",
+                  borderRadius: radius.xl,
+                  padding: spacing.md,
+                  flexDirection: "row",
+                  alignItems: "flex-start",
+                  gap: spacing.sm,
+                }}
+              >
+                <Text style={{ fontSize: 16 }}>📢</Text>
+                <View style={{ flex: 1 }}>
+                  <Text style={{ fontSize: 13, fontWeight: "700", color: "#1E3A8A" }}>{ann.title}</Text>
+                  {ann.content ? (
+                    <Text style={{ fontSize: 12, color: "#1D4ED8", marginTop: 2, lineHeight: 17 }}>{ann.content}</Text>
+                  ) : null}
+                </View>
+                <Pressable onPress={() => dismissAnnouncement(ann.id)} hitSlop={12}>
+                  <Ionicons name="close" size={16} color="#93C5FD" />
+                </Pressable>
+              </View>
+            ))}
+          </View>
+        )}
 
         <View style={{ paddingHorizontal: spacing.lg, paddingTop: spacing.lg, gap: spacing.lg }}>
 

--- a/apps/mobile/src/hooks/useHomeData.ts
+++ b/apps/mobile/src/hooks/useHomeData.ts
@@ -80,6 +80,9 @@ export const useHomeData = (userId: string | undefined) => {
   const [badgeCount, setBadgeCount] = useState(0);
   const [latestBadge, setLatestBadge] = useState<{ name: string; code: string; obtainedAt: string } | null>(null);
 
+  // ─── Announcements ───
+  const [announcements, setAnnouncements] = useState<{ id: string; title: string; content: string }[]>([]);
+
   // #407: meal toggle debounce — pending mealId set + 250ms debounce timer
   const pendingToggleRef = useRef<Set<string>>(new Set());
   const toggleDebounceTimerRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
@@ -99,6 +102,7 @@ export const useHomeData = (userId: string | undefined) => {
         fetchShoppingRemaining(userId),
         fetchBadgeInfo(userId),
         fetchActivityLevel(userId),
+        fetchAnnouncements(),
       ]);
 
       // Heavier fetches — async
@@ -342,6 +346,24 @@ export const useHomeData = (userId: string | undefined) => {
     }
   }
 
+  async function fetchAnnouncements() {
+    try {
+      const api = getApi();
+      const data = await api.get<any>("/api/announcements?mode=public");
+      if (data?.announcements && Array.isArray(data.announcements)) {
+        setAnnouncements(
+          data.announcements.map((a: any) => ({
+            id: String(a.id ?? a.announcement_id ?? Math.random()),
+            title: a.title ?? "",
+            content: a.content ?? "",
+          }))
+        );
+      }
+    } catch (e) {
+      console.error("Announcements fetch error:", e);
+    }
+  }
+
   async function fetchNutritionAnalysis() {
     try {
       setNutritionAnalysis((prev) => ({ ...prev, loading: true }));
@@ -553,6 +575,10 @@ export const useHomeData = (userId: string | undefined) => {
     pendingToggleRef.current.delete(mealId);
   }
 
+  function dismissAnnouncement(id: string) {
+    setAnnouncements((prev) => prev.filter((a) => a.id !== id));
+  }
+
   // #407: アンマウント時にデバウンスタイマーをクリア（メモリリーク防止）
   useEffect(() => {
     const timers = toggleDebounceTimerRef.current;
@@ -581,6 +607,8 @@ export const useHomeData = (userId: string | undefined) => {
     activityLevel,
     suggestion,
     performanceAnalysis,
+    announcements,
+    dismissAnnouncement,
     toggleMealCompletion,
     updateActivityLevel,
     setSuggestion,


### PR DESCRIPTION
## Summary

- `useHomeData` に `fetchAnnouncements` を追加し `/api/announcements?mode=public` からお知らせ一覧を取得
- `announcements` state と `dismissAnnouncement` 関数を hook から公開
- `home.tsx` のヒーローセクション直下に青背景バナーを表示（`title` + `content`）
- X ボタンで個別に閉じると `dismissAnnouncement` でセッション内から除去（再表示なし）

## Test plan

- [ ] お知らせが存在する場合、ヒーローセクション直下に青バナーが表示される
- [ ] `title` と `content` が正しく表示される
- [ ] X ボタンをタップするとそのバナーが消える
- [ ] 複数件のお知らせがある場合、それぞれ独立して閉じられる
- [ ] お知らせが 0 件の場合、バナーは表示されない

Closes #416