### PR TITLE
feat(mobile): onboarding に favorite_ingredients・diet_style・hobbies 追加 (#423)

### DIFF
--- a/apps/mobile/app/onboarding/questions.tsx
+++ b/apps/mobile/app/onboarding/questions.tsx
@@ -333,6 +333,28 @@ const QUESTIONS: Question[] = [
     allowSkip: true,
   },
   {
+    id: "favorite_ingredients",
+    text: "好きな食材を教えてください\n（献立に積極的に入れます）",
+    type: "tags",
+    placeholder: "例: 鶏肉、ブロッコリー、アボカド",
+    suggestions: ["鶏肉", "豚肉", "牛肉", "魚", "エビ", "豆腐", "卵", "ブロッコリー", "ほうれん草", "トマト", "アボカド", "きのこ", "さつまいも", "キャベツ"],
+    allowSkip: true,
+  },
+  {
+    id: "diet_style",
+    text: "食事スタイルを教えてください",
+    type: "choice",
+    allowSkip: true,
+    options: [
+      { label: "通常", value: "normal", description: "特に制限なし" },
+      { label: "ベジタリアン", value: "vegetarian", description: "肉を食べない" },
+      { label: "ヴィーガン", value: "vegan", description: "動物性食品を食べない" },
+      { label: "ペスカタリアン", value: "pescatarian", description: "魚は食べる" },
+      { label: "グルテンフリー", value: "gluten_free", description: "小麦を避ける" },
+      { label: "ケトジェニック", value: "keto", description: "低糖質・高脂質" },
+    ],
+  },
+  {
     id: "cooking_experience",
     text: "料理の経験は？",
     type: "choice",
@@ -427,6 +449,14 @@ const QUESTIONS: Question[] = [
       { label: "IHコンロ", value: "stove:ih" },
     ],
   },
+  {
+    id: "hobbies",
+    text: "趣味を教えてください\n（献立提案の参考にします）",
+    type: "tags",
+    placeholder: "例: 読書、ヨガ、ランニング",
+    suggestions: ["読書", "料理", "ヨガ", "ランニング", "筋トレ", "サイクリング", "登山", "映画", "ゲーム", "旅行", "音楽", "カフェ巡り", "釣り", "キャンプ"],
+    allowSkip: true,
+  },
 ];
 
 function getNextQuestion(fromStep: number, ans: Record<string, any>) {
@@ -465,6 +495,9 @@ function transformAnswersToProfile(ans: Record<string, any>) {
   if (ans.health_conditions?.length && !ans.health_conditions.includes("none")) profile.healthConditions = ans.health_conditions;
   if (ans.medications?.length && !ans.medications.includes("none")) profile.medications = ans.medications;
   if (ans.allergies?.length) profile.dietFlags = { allergies: ans.allergies, dislikes: [] };
+  if (ans.favorite_ingredients?.length) profile.favoriteIngredients = ans.favorite_ingredients;
+  if (ans.diet_style) profile.dietStyle = ans.diet_style;
+  if (ans.hobbies?.length) profile.hobbies = ans.hobbies;
   if (ans.cooking_experience) profile.cookingExperience = ans.cooking_experience;
   if (ans.cooking_time) profile.weekdayCookingMinutes = parseInt(ans.cooking_time);
   if (ans.cuisine_preference?.length) {
@@ -537,6 +570,9 @@ function toDbProfileUpdates(body: any, userId: string) {
   if (body.healthConditions) updates.health_conditions = body.healthConditions;
   if (body.medications) updates.medications = body.medications;
   if (body.dietFlags) updates.diet_flags = body.dietFlags;
+  if (body.favoriteIngredients) updates.favorite_ingredients = body.favoriteIngredients;
+  if (body.dietStyle) updates.diet_style = body.dietStyle;
+  if (body.hobbies) updates.hobbies = body.hobbies;
   if (body.cookingExperience) updates.cooking_experience = body.cookingExperience;
   if (body.weekdayCookingMinutes !== undefined) updates.weekday_cooking_minutes = body.weekdayCookingMinutes;
   if (body.cuisinePreferences) updates.cuisine_preferences = body.cuisinePreferences;
@@ -686,6 +722,9 @@ export default function OnboardingQuestions() {
         updates.age = parseInt(ans.age);
         updates.age_group = `${Math.floor(parseInt(ans.age) / 10) * 10}s`;
       }
+      if (ans.favorite_ingredients?.length) updates.favorite_ingredients = ans.favorite_ingredients;
+      if (ans.diet_style) updates.diet_style = ans.diet_style;
+      if (ans.hobbies?.length) updates.hobbies = ans.hobbies;
       if (!updates.nickname) updates.nickname = "Guest";
       if (!updates.age_group && !updates.age) updates.age_group = "unspecified";
       if (!updates.gender) updates.gender = "unspecified";


### PR DESCRIPTION
## Summary

- `QUESTIONS` 配列に 3 質問を追加（`favorite_ingredients` / `diet_style` / `hobbies`）
- `transformAnswersToProfile` と `toDbProfileUpdates` に各フィールドのマッピングを追加
- `saveProgress` にリアルタイム保存用マッピングを追加（回答ごとに DB に即時反映）

## 変更詳細

| 質問ID | 型 | 位置 |
|---|---|---|
| `favorite_ingredients` | tags（サジェスト14種） | `allergies` の直後 |
| `diet_style` | choice（6種選択・スキップ可） | `favorite_ingredients` の直後 |
| `hobbies` | tags（サジェスト14種） | `stove_type` の直後（末尾） |

## Test plan

- [ ] オンボーディングフローで 3 質問が表示されること
- [ ] `favorite_ingredients` / `hobbies` でタグ追加・削除・スキップが動作すること
- [ ] `diet_style` で 6 種の選択肢が表示されスキップが動作すること
- [ ] 回答が `user_profiles` の対応カラムに保存されること

Closes #423