### PR TITLE
fix(mobile): メール確認 deep link の token_hash 処理 (#438)

### DIFF
--- a/apps/mobile/app/(auth)/auth/verify.tsx
+++ b/apps/mobile/app/(auth)/auth/verify.tsx
@@ -27,7 +27,10 @@ export default function VerifyPage() {
           return;
         }
 
-        // code or token が付いている場合はセッション確立を試みる
+        // 3 種類の Supabase auth リンク形式に対応:
+        //   1. PKCE/OAuth: code パラメータ
+        //   2. OTP: token_hash + type パラメータ (#438)
+        //   3. Legacy: access_token + refresh_token フラグメント
         if (params?.code) {
           const { error } = await supabase.auth.exchangeCodeForSession(params.code);
           if (error) throw error;


### PR DESCRIPTION
## 概要

Supabase OTP flow で発行される `token_hash + type` 形式のメール確認 deep link が mobile で無音失敗していた問題を修正する。

## 変更内容

- `apps/mobile/src/lib/deeplink.ts`: `SupabaseLinkParams` に `token_hash` フィールドを追加し `extractSupabaseLinkParams()` で抽出
- `apps/mobile/app/(auth)/auth/verify.tsx`: `token_hash + type` がある場合に `supabase.auth.verifyOtp()` を呼ぶ分岐を追加、`useEffect` 依存配列に `token_hash` / `type` を追加
- Web 側 `src/app/(auth)/auth/callback/route.ts` の実装に倣い、3 形式（PKCE/OAuth・OTP・Legacy）の対応コメントを追記

## テスト方法

- Supabase ダッシュボードで「Email OTP」フローを有効にし、確認メールの deep link を mobile で開く
- `token_hash` + `type=signup` 形式のリンクが正常に処理され、ホーム画面へ遷移することを確認

Closes #438