### PR TITLE
feat(mobile): Google OAuth ログイン・サインアップ (#439)

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -1,16 +1,56 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Link, router } from "expo-router";
+import * as WebBrowser from "expo-web-browser";
+import * as Linking from "expo-linking";
 import { useState } from "react";
 import { Alert, KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import Svg, { Path } from "react-native-svg";
 
 import { colors, spacing, radius, shadows } from "../../src/theme";
 import { supabase } from "../../src/lib/supabase";
+
+function GoogleIcon() {
+  return (
+    <Svg width={20} height={20} viewBox="0 0 24 24">
+      <Path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+      <Path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+      <Path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+      <Path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </Svg>
+  );
+}
 
 export default function LoginScreen() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+
+  async function onGoogleLogin() {
+    setIsSubmitting(true);
+    try {
+      const redirectTo = Linking.createURL("/auth/verify");
+      const { data, error } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo,
+          skipBrowserRedirect: true,
+        },
+      });
+      if (error) throw error;
+      if (!data?.url) throw new Error("OAuth URL が取得できませんでした。");
+
+      const result = await WebBrowser.openAuthSessionAsync(data.url, redirectTo);
+      if (result.type === "success" && result.url) {
+        // verify ページがディープリンクを処理するためルーティング
+        router.replace("/auth/verify");
+      }
+    } catch (e: any) {
+      Alert.alert("Googleログイン失敗", e?.message ?? "Googleログインに失敗しました。");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
 
   async function onSubmit() {
     const trimmedEmail = email.trim();
@@ -142,6 +182,33 @@ export default function LoginScreen() {
           >
             <Text style={{ color: "#fff", fontSize: 16, fontWeight: "800" }}>
               {isSubmitting ? "ログイン中..." : "ログイン"}
+            </Text>
+          </Pressable>
+
+          {/* 区切り線 */}
+          <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+            <View style={{ flex: 1, height: 1, backgroundColor: colors.border }} />
+            <Text style={{ fontSize: 12, color: colors.textMuted }}>または</Text>
+            <View style={{ flex: 1, height: 1, backgroundColor: colors.border }} />
+          </View>
+
+          {/* Google ログインボタン */}
+          <Pressable
+            onPress={onGoogleLogin}
+            disabled={isSubmitting}
+            style={({ pressed }) => ({
+              flexDirection: "row", alignItems: "center", justifyContent: "center",
+              gap: spacing.sm,
+              backgroundColor: colors.card,
+              borderRadius: radius.lg, paddingVertical: 14,
+              borderWidth: 1, borderColor: colors.border,
+              ...shadows.sm,
+              opacity: pressed || isSubmitting ? 0.7 : 1,
+            })}
+          >
+            <GoogleIcon />
+            <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>
+              Googleでログイン
             </Text>
           </Pressable>
         </View>

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -1,17 +1,56 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Link, router } from "expo-router";
 import * as Linking from "expo-linking";
+import * as WebBrowser from "expo-web-browser";
 import { useState } from "react";
 import { Alert, KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import Svg, { Path } from "react-native-svg";
 
 import { colors, spacing, radius, shadows } from "../../src/theme";
 import { supabase } from "../../src/lib/supabase";
+
+function GoogleIcon() {
+  return (
+    <Svg width={20} height={20} viewBox="0 0 24 24">
+      <Path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
+      <Path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+      <Path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+      <Path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </Svg>
+  );
+}
 
 export default function SignupScreen() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+
+  async function onGoogleSignup() {
+    setIsSubmitting(true);
+    try {
+      const redirectTo = Linking.createURL("/auth/verify");
+      const { data, error } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo,
+          skipBrowserRedirect: true,
+        },
+      });
+      if (error) throw error;
+      if (!data?.url) throw new Error("OAuth URL が取得できませんでした。");
+
+      const result = await WebBrowser.openAuthSessionAsync(data.url, redirectTo);
+      if (result.type === "success" && result.url) {
+        // verify ページがディープリンクを処理するためルーティング
+        router.replace("/auth/verify");
+      }
+    } catch (e: any) {
+      Alert.alert("Google登録失敗", e?.message ?? "Google登録に失敗しました。");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
 
   async function onSubmit() {
     const trimmedEmail = email.trim();
@@ -145,6 +184,33 @@ export default function SignupScreen() {
           >
             <Text style={{ color: "#fff", fontSize: 16, fontWeight: "800" }}>
               {isSubmitting ? "登録中..." : "アカウント作成"}
+            </Text>
+          </Pressable>
+
+          {/* 区切り線 */}
+          <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+            <View style={{ flex: 1, height: 1, backgroundColor: colors.border }} />
+            <Text style={{ fontSize: 12, color: colors.textMuted }}>または</Text>
+            <View style={{ flex: 1, height: 1, backgroundColor: colors.border }} />
+          </View>
+
+          {/* Google 登録ボタン */}
+          <Pressable
+            onPress={onGoogleSignup}
+            disabled={isSubmitting}
+            style={({ pressed }) => ({
+              flexDirection: "row", alignItems: "center", justifyContent: "center",
+              gap: spacing.sm,
+              backgroundColor: colors.card,
+              borderRadius: radius.lg, paddingVertical: 14,
+              borderWidth: 1, borderColor: colors.border,
+              ...shadows.sm,
+              opacity: pressed || isSubmitting ? 0.7 : 1,
+            })}
+          >
+            <GoogleIcon />
+            <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>
+              Googleで登録
             </Text>
           </Pressable>
         </View>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -22,6 +22,7 @@
     "expo-linear-gradient": "~14.0.2",
     "expo-notifications": "~0.29.9",
     "expo-router": "~4.0.0",
+    "expo-web-browser": "~14.0.2",
     "react": "18.3.1",
     "react-native": "0.76.9",
     "react-native-safe-area-context": "4.12.0",


### PR DESCRIPTION
Closes #439

## 概要

- `expo-web-browser` を `apps/mobile/package.json` に追加 (`~14.0.2`)
- `app/(auth)/login.tsx` に「Googleでログイン」ボタンを実装
- `app/(auth)/signup.tsx` に「Googleで登録」ボタンを実装
- `supabase.auth.signInWithOAuth({ provider: 'google', skipBrowserRedirect: true })` で OAuth URL を取得
- `WebBrowser.openAuthSessionAsync(url, redirectTo)` でブラウザを開き OAuth フローを実行
- コールバック先 `homegohan://auth/verify` は既存の `verify.tsx` が処理してセッション確立 → ホームへ遷移
- Google アイコンは `react-native-svg` (既存依存) で描画