### PR TITLE
feat(mobile): pantry カテゴリをプリセット選択 UI に変更 (#382)

### DIFF
--- a/apps/mobile/app/pantry/index.tsx
+++ b/apps/mobile/app/pantry/index.tsx
@@ -24,6 +24,54 @@ type PantryItem = {
   addedAt: string | null;
 };
 
+const CATEGORY_OPTIONS: { code: string; label: string }[] = [
+  { code: "vegetable", label: "野菜" },
+  { code: "meat", label: "肉類" },
+  { code: "fish", label: "魚介" },
+  { code: "dairy", label: "乳製品・卵" },
+  { code: "other", label: "その他" },
+];
+
+function CategoryPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (code: string) => void;
+}) {
+  return (
+    <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
+      {CATEGORY_OPTIONS.map((opt) => {
+        const selected = value === opt.code;
+        return (
+          <Pressable
+            key={opt.code}
+            onPress={() => onChange(opt.code)}
+            style={{
+              paddingHorizontal: 12,
+              paddingVertical: 6,
+              borderRadius: 20,
+              borderWidth: 1.5,
+              borderColor: selected ? colors.accent : colors.border,
+              backgroundColor: selected ? colors.accentLight : colors.card,
+            }}
+          >
+            <Text
+              style={{
+                fontSize: 13,
+                fontWeight: selected ? "700" : "400",
+                color: selected ? colors.accent : colors.textLight,
+              }}
+            >
+              {opt.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
 type FridgeIngredient = {
   name: string;
   category: string;
@@ -347,7 +395,7 @@ export default function PantryPage() {
           <SectionHeader title="追加" />
           <Input value={name} onChangeText={setName} placeholder="例: キャベツ" />
           <Input value={amount} onChangeText={setAmount} placeholder="量（任意）" />
-          <Input value={category} onChangeText={setCategory} placeholder="category（例: vegetable）" />
+          <CategoryPicker value={category} onChange={setCategory} />
           <Input value={expirationDate} onChangeText={setExpirationDate} placeholder="期限 YYYY-MM-DD（任意）" />
           <Button onPress={add} disabled={isSubmitting} loading={isSubmitting}>
             {isSubmitting ? "追加中..." : "追加"}
@@ -548,7 +596,9 @@ export default function PantryPage() {
                 <View style={{ flexDirection: "row", gap: spacing.md, flexWrap: "wrap" }}>
                   <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.xs }}>
                     <Ionicons name="pricetag-outline" size={14} color={colors.textMuted} />
-                    <Text style={{ fontSize: 13, color: colors.textMuted }}>{it.category ?? "-"}</Text>
+                    <Text style={{ fontSize: 13, color: colors.textMuted }}>
+                      {CATEGORY_OPTIONS.find((o) => o.code === it.category)?.label ?? it.category ?? "-"}
+                    </Text>
                   </View>
                   <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.xs }}>
                     <Ionicons name="calendar-outline" size={14} color={(isExpired(it.expirationDate) || isExpiringSoon(it.expirationDate)) ? colors.error : colors.textMuted} />
@@ -561,7 +611,7 @@ export default function PantryPage() {
                   <View style={{ gap: spacing.sm, marginTop: spacing.xs }}>
                     <Input value={editName} onChangeText={setEditName} placeholder="食材名" />
                     <Input value={editAmount} onChangeText={setEditAmount} placeholder="量（任意）" />
-                    <Input value={editCategory} onChangeText={setEditCategory} placeholder="category（例: vegetable）" />
+                    <CategoryPicker value={editCategory} onChange={setEditCategory} />
                     <Input value={editExpirationDate} onChangeText={setEditExpirationDate} placeholder="期限 YYYY-MM-DD（任意）" />
                     <View style={{ flexDirection: "row", gap: spacing.sm, flexWrap: "wrap" }}>
                       <Button onPress={saveEdit} disabled={isSavingEdit} loading={isSavingEdit} size="sm">


### PR DESCRIPTION
## Summary

- `apps/mobile/app/pantry/index.tsx` のカテゴリ入力欄をプレーンテキスト `Input` からチップ選択 UI (`CategoryPicker`) に変更
- `CATEGORY_OPTIONS` 定数で内部コードと日本語ラベルをマッピング（vegetable→野菜、meat→肉類、fish→魚介、dairy→乳製品・卵、other→その他）
- 新規追加フォーム・インライン編集フォームの両方に適用
- 食材一覧のカテゴリ表示も同マッピングで日本語ラベル化し、内部コードを UI に露出させない

## Test plan

- [ ] 追加フォームでカテゴリチップをタップして選択状態が反映されることを確認
- [ ] 選択したカテゴリで食材を追加し、一覧に日本語ラベルで表示されることを確認
- [ ] 編集フォームを開いたとき既存カテゴリが選択状態で表示されることを確認
- [ ] 編集フォームでカテゴリを変更して保存できることを確認
- [ ] 内部コード文字列（"vegetable" など）が UI に一切露出しないことを確認

Closes #382