### PR TITLE
fix(mobile): チェックイン睡眠時間をスライダー(3〜12, 0.5刻み)に変更 (#412)

### DIFF
--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -3,6 +3,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import { router } from "expo-router";
 import { useMemo, useState, useEffect, useRef } from "react";
 import { Animated, Image, Pressable, ScrollView, Text, View } from "react-native";
+import Slider from "@react-native-community/slider";
 import { Svg, Circle } from "react-native-svg";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -445,22 +446,21 @@ export default function HomeScreen() {
                   <View>
                     <View style={{ flexDirection: "row", justifyContent: "space-between", marginBottom: spacing.xs }}>
                       <Text style={{ fontSize: 12, fontWeight: "600", color: colors.textLight }}>😴 睡眠時間</Text>
-                      <Text style={{ fontSize: 13, fontWeight: "800", color: colors.text }}>{checkinForm.sleepHours}時間</Text>
+                      <Text style={{ fontSize: 13, fontWeight: "800", color: colors.text }}>
+                        {checkinForm.sleepHours}時間
+                      </Text>
                     </View>
-                    <View style={{ flexDirection: "row", gap: 4 }}>
-                      {[4, 5, 6, 7, 8, 9, 10].map((h) => (
-                        <Pressable
-                          key={h}
-                          onPress={() => setCheckinForm({ ...checkinForm, sleepHours: h })}
-                          style={{
-                            flex: 1, paddingVertical: 6, borderRadius: radius.md, alignItems: "center",
-                            backgroundColor: checkinForm.sleepHours === h ? colors.purple : colors.bg,
-                          }}
-                        >
-                          <Text style={{ fontSize: 11, fontWeight: "800", color: checkinForm.sleepHours === h ? "#fff" : colors.textMuted }}>{h}</Text>
-                        </Pressable>
-                      ))}
-                    </View>
+                    <Slider
+                      style={{ width: "100%", height: 40 }}
+                      minimumValue={3}
+                      maximumValue={12}
+                      step={0.5}
+                      value={checkinForm.sleepHours}
+                      onValueChange={(v) => setCheckinForm({ ...checkinForm, sleepHours: Math.round(v * 2) / 2 })}
+                      minimumTrackTintColor={colors.purple}
+                      maximumTrackTintColor={colors.border}
+                      thumbTintColor={colors.purple}
+                    />
                   </View>
 
                   {/* 各項目（5段階） */}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@homegohan/core": "*",
     "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-community/slider": "4.5.5",
     "@supabase/supabase-js": "^2.78.0",
     "expo": "~53.0.0",
     "expo-constants": "~17.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
       "dependencies": {
         "@homegohan/core": "*",
         "@react-native-async-storage/async-storage": "2.1.2",
+        "@react-native-community/slider": "4.5.5",
         "@supabase/supabase-js": "^2.78.0",
         "expo": "~53.0.0",
         "expo-constants": "~17.1.8",
@@ -4485,6 +4486,12 @@
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
+    },
+    "node_modules/@react-native-community/slider": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.5.tgz",
+      "integrity": "sha512-x2N415pg4ZxIltArOKczPwn7JEYh+1OxQ4+hTnafomnMsqs65HZuEWcX+Ch8c5r8V83DiunuQUf5hWGWlw8hQQ==",
+      "license": "MIT"
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.79.6",


### PR DESCRIPTION
## Summary

- `@react-native-community/slider` を導入し、離散ボタン(4〜10)をスライダーに置き換え
- min=3, max=12, step=0.5 でウェブ実装と仕様を統一
- 現在値を「N時間」形式でリアルタイム表示

## Test plan

- [ ] スライダーの最小値が 3、最大値が 12 であることを確認
- [ ] 0.5 刻みで値が変化することを確認
- [ ] 現在の値が「N時間」形式で表示されることを確認
- [ ] 従来の離散ボタンが削除されていることを確認

Closes #412