### PR TITLE
fix(mobile): pantry freshness を日本語化 (#386)

### DIFF
--- a/apps/mobile/app/pantry/index.tsx
+++ b/apps/mobile/app/pantry/index.tsx
@@ -300,12 +300,22 @@ export default function PantryPage() {
     ]);
   }
 
+  function getFreshnessLabel(freshness: string): string {
+    switch (freshness.toLowerCase()) {
+      case "fresh": return "新鮮";
+      case "good": return "良好";
+      case "expiring_soon": return "期限間近";
+      case "expired": return "期限切れ";
+      default: return freshness;
+    }
+  }
+
   function getFreshnessColor(freshness: string): string {
     switch (freshness.toLowerCase()) {
       case "fresh": return colors.success;
       case "good": return colors.success;
-      case "ok": return colors.warning;
-      case "old": return colors.error;
+      case "expiring_soon": return colors.warning;
+      case "expired": return colors.error;
       default: return colors.textMuted;
     }
   }
@@ -427,7 +437,7 @@ export default function PantryPage() {
                           borderRadius: 4,
                           backgroundColor: getFreshnessColor(i.freshness),
                         }} />
-                        <Text style={{ fontSize: 12, color: colors.textMuted }}>{i.freshness}</Text>
+                        <Text style={{ fontSize: 12, color: colors.textMuted }}>{getFreshnessLabel(i.freshness)}</Text>
                       </View>
                     </View>
                     <View style={{ flexDirection: "row", gap: spacing.sm, flexWrap: "wrap" }}>


### PR DESCRIPTION
## Summary

- `getFreshnessLabel()` を追加: `fresh` → 新鮮, `good` → 良好, `expiring_soon` → 期限間近, `expired` → 期限切れ
- `getFreshnessColor()` のキーを `ok`/`old` から `expiring_soon`/`expired` に修正（`image-recognition.ts` の `FRESHNESS_VALUES` と整合）
- freshness 表示テキストを `getFreshnessLabel()` 経由に変更

Closes #386

## Test plan

- [ ] 冷蔵庫解析後、各食材の freshness が日本語（新鮮/良好/期限間近/期限切れ）で表示される
- [ ] `expiring_soon` の食材が警告色（黄）で表示される
- [ ] `expired` の食材が赤色で表示される