### PR TITLE
feat(mobile): health 目標画面の機能拡充 (#383)

### DIFF
--- a/apps/mobile/app/health/goals.tsx
+++ b/apps/mobile/app/health/goals.tsx
@@ -3,9 +3,14 @@ import { Link } from "expo-router";
 import { useEffect, useState } from "react";
 import { Alert, ScrollView, StyleSheet, Text, View } from "react-native";
 
-import { Button, Card, EmptyState, Input, LoadingState, PageHeader, ProgressBar, SectionHeader } from "../../src/components/ui";
+import { Button, Card, ChipSelector, EmptyState, Input, LoadingState, PageHeader, ProgressBar, SectionHeader } from "../../src/components/ui";
 import { colors, spacing } from "../../src/theme";
 import { getApi } from "../../src/lib/api";
+
+type Milestone = {
+  value: number;
+  achieved_at: string;
+};
 
 type Goal = {
   id: string;
@@ -16,27 +21,42 @@ type Goal = {
   current_value: number | null;
   progress_percentage: number | null;
   status: string;
+  milestones?: Milestone[];
   created_at: string;
 };
 
+const GOAL_TYPES = [
+  { value: "weight", label: "体重", unit: "kg" },
+  { value: "body_fat", label: "体脂肪率", unit: "%" },
+  { value: "steps", label: "歩数", unit: "歩" },
+] as const;
+
+type GoalTypeValue = (typeof GOAL_TYPES)[number]["value"];
+
+function getGoalConfig(type: string) {
+  return GOAL_TYPES.find((t) => t.value === type) ?? GOAL_TYPES[0];
+}
+
 export default function HealthGoalsPage() {
-  const [items, setItems] = useState<Goal[]>([]);
+  const [allItems, setAllItems] = useState<Goal[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const [goalType, setGoalType] = useState("weight");
+  const [goalType, setGoalType] = useState<GoalTypeValue>("weight");
   const [targetValue, setTargetValue] = useState("");
-  const [targetUnit, setTargetUnit] = useState("kg");
   const [targetDate, setTargetDate] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const activeItems = allItems.filter((g) => g.status === "active");
+  const achievedItems = allItems.filter((g) => g.status === "achieved");
 
   async function load() {
     setIsLoading(true);
     setError(null);
     try {
       const api = getApi();
-      const res = await api.get<{ goals: Goal[] }>("/api/health/goals?status=active");
-      setItems((res.goals ?? []) as any);
+      const res = await api.get<{ goals: Goal[] }>("/api/health/goals?status=all");
+      setAllItems((res.goals ?? []) as any);
     } catch (e: any) {
       setError(e?.message ?? "取得に失敗しました。");
     } finally {
@@ -57,13 +77,14 @@ export default function HealthGoalsPage() {
       Alert.alert("入力エラー", "目標値は正の数値を入力してください。");
       return;
     }
+    const config = getGoalConfig(goalType);
     setIsSubmitting(true);
     try {
       const api = getApi();
       await api.post("/api/health/goals", {
         goal_type: goalType,
         target_value: numTv,
-        target_unit: targetUnit || "kg",
+        target_unit: config.unit,
         target_date: targetDate.trim() || null,
       });
       setTargetValue("");
@@ -117,112 +138,165 @@ export default function HealthGoalsPage() {
       />
       <ScrollView contentContainerStyle={styles.container}>
 
-      <Card>
-        <SectionHeader
-          title="新しい目標を作成"
-          right={<Ionicons name="add-circle-outline" size={20} color={colors.accent} />}
-        />
-        <View style={styles.formFields}>
-          <Input
-            label="タイプ"
-            value={goalType}
-            onChangeText={setGoalType}
-            placeholder="weight / body_fat 等"
+        {/* 目標作成フォーム */}
+        <Card>
+          <SectionHeader
+            title="新しい目標を作成"
+            right={<Ionicons name="add-circle-outline" size={20} color={colors.accent} />}
           />
-          <Input
-            label="目標値"
-            value={targetValue}
-            onChangeText={setTargetValue}
-            placeholder="目標値を入力"
-            keyboardType="decimal-pad"
-          />
-          <Input
-            label="単位"
-            value={targetUnit}
-            onChangeText={setTargetUnit}
-            placeholder="kg / % 等"
-          />
-          <Input
-            label="期限（任意）"
-            value={targetDate}
-            onChangeText={setTargetDate}
-            placeholder="YYYY-MM-DD"
-          />
-          <Button onPress={create} disabled={isSubmitting} loading={isSubmitting}>
-            {isSubmitting ? "作成中..." : "作成"}
-          </Button>
-        </View>
-      </Card>
-
-      <SectionHeader title="アクティブな目標" />
-
-      {isLoading ? (
-        <LoadingState message="目標を読み込み中..." />
-      ) : error ? (
-        <Card variant="error">
-          <View style={styles.errorRow}>
-            <Ionicons name="alert-circle" size={20} color={colors.error} />
-            <Text style={styles.errorText}>{error}</Text>
+          <View style={styles.formFields}>
+            <View>
+              <Text style={styles.fieldLabel}>ゴールタイプ</Text>
+              <ChipSelector
+                options={GOAL_TYPES.map((t) => ({ value: t.value, label: t.label }))}
+                selected={goalType}
+                onSelect={(v) => setGoalType(v as GoalTypeValue)}
+                style={styles.chipSelector}
+              />
+            </View>
+            <Input
+              label={`目標値（${getGoalConfig(goalType).unit}）`}
+              value={targetValue}
+              onChangeText={setTargetValue}
+              placeholder="目標値を入力"
+              keyboardType="decimal-pad"
+            />
+            <Input
+              label="期限（任意）"
+              value={targetDate}
+              onChangeText={setTargetDate}
+              placeholder="YYYY-MM-DD"
+            />
+            <Button onPress={create} disabled={isSubmitting} loading={isSubmitting}>
+              {isSubmitting ? "作成中..." : "作成"}
+            </Button>
           </View>
         </Card>
-      ) : items.length === 0 ? (
-        <EmptyState
-          icon={<Ionicons name="flag-outline" size={40} color={colors.textMuted} />}
-          message="目標がありません。"
-        />
-      ) : (
-        <View style={styles.list}>
-          {items.map((g) => {
-            const progress = g.progress_percentage ? Math.round(g.progress_percentage) : 0;
-            return (
-              <Card key={g.id}>
-                <View style={styles.goalHeader}>
-                  <Ionicons name="flag" size={18} color={colors.accent} />
-                  <Text style={styles.goalTitle}>
-                    {g.goal_type}: {g.current_value ?? "-"} → {g.target_value}
-                    {g.target_unit}
-                  </Text>
-                </View>
-                <ProgressBar
-                  value={progress}
-                  max={100}
-                  label="進捗"
-                  showPercentage
-                  color={progress >= 100 ? colors.success : colors.accent}
-                  style={styles.progressBar}
-                />
-                <View style={styles.goalActions}>
-                  <Button
-                    onPress={() => {
-                      if (g.current_value == null) {
-                        Alert.alert("データなし", "現在の値がまだ記録されていません。先に健康記録を入力してください。");
-                        return;
-                      }
-                      updateCurrent(g.id, g.current_value as number);
-                    }}
-                    variant="secondary"
-                    size="sm"
-                    disabled={g.current_value == null}
-                  >
-                    <Ionicons name="refresh-outline" size={14} color={colors.text} />
-                    <Text style={{ fontSize: 13, fontWeight: "700", color: colors.text }}>最新値で再計算</Text>
-                  </Button>
-                  <Button onPress={() => remove(g.id)} variant="destructive" size="sm">
-                    <Ionicons name="trash-outline" size={14} color="#FFFFFF" />
-                    <Text style={{ fontSize: 13, fontWeight: "700", color: "#FFFFFF" }}>削除</Text>
-                  </Button>
-                </View>
-              </Card>
-            );
-          })}
-        </View>
-      )}
 
-      <Button onPress={load} variant="ghost" size="sm">
-        <Ionicons name="refresh-outline" size={16} color={colors.textLight} />
-        <Text style={{ color: colors.textLight, fontWeight: "700", fontSize: 13 }}>更新</Text>
-      </Button>
-    </ScrollView>
+        {/* アクティブな目標 */}
+        <SectionHeader title="アクティブな目標" />
+
+        {isLoading ? (
+          <LoadingState message="目標を読み込み中..." />
+        ) : error ? (
+          <Card variant="error">
+            <View style={styles.errorRow}>
+              <Ionicons name="alert-circle" size={20} color={colors.error} />
+              <Text style={styles.errorText}>{error}</Text>
+            </View>
+          </Card>
+        ) : activeItems.length === 0 ? (
+          <EmptyState
+            icon={<Ionicons name="flag-outline" size={40} color={colors.textMuted} />}
+            message="アクティブな目標がありません。"
+          />
+        ) : (
+          <View style={styles.list}>
+            {activeItems.map((g) => {
+              const progress = g.progress_percentage ? Math.round(g.progress_percentage) : 0;
+              const config = getGoalConfig(g.goal_type);
+              return (
+                <Card key={g.id}>
+                  <View style={styles.goalHeader}>
+                    <Ionicons name="flag" size={18} color={colors.accent} />
+                    <Text style={styles.goalTitle}>
+                      {config.label}: {g.current_value ?? "-"} → {g.target_value}
+                      {g.target_unit}
+                    </Text>
+                  </View>
+                  <ProgressBar
+                    value={progress}
+                    max={100}
+                    label="進捗"
+                    showPercentage
+                    color={progress >= 100 ? colors.success : colors.accent}
+                    style={styles.progressBar}
+                  />
+                  {g.target_date && (
+                    <View style={styles.dateRow}>
+                      <Ionicons name="calendar-outline" size={13} color={colors.textMuted} />
+                      <Text style={styles.dateText}>
+                        期限: {new Date(g.target_date).toLocaleDateString("ja-JP")}
+                      </Text>
+                    </View>
+                  )}
+
+                  {/* マイルストーン */}
+                  {g.milestones && g.milestones.length > 0 && (
+                    <View style={styles.milestonesContainer}>
+                      <Text style={styles.milestonesLabel}>達成マイルストーン</Text>
+                      <View style={styles.milestonesList}>
+                        {g.milestones.map((m, i) => (
+                          <View key={i} style={styles.milestoneChip}>
+                            <Ionicons name="checkmark-circle" size={12} color={colors.success} />
+                            <Text style={styles.milestoneText}>
+                              {m.value}{g.target_unit}
+                            </Text>
+                          </View>
+                        ))}
+                      </View>
+                    </View>
+                  )}
+
+                  <View style={styles.goalActions}>
+                    <Button
+                      onPress={() => {
+                        if (g.current_value == null) {
+                          Alert.alert("データなし", "現在の値がまだ記録されていません。先に健康記録を入力してください。");
+                          return;
+                        }
+                        updateCurrent(g.id, g.current_value as number);
+                      }}
+                      variant="secondary"
+                      size="sm"
+                      disabled={g.current_value == null}
+                    >
+                      <Ionicons name="refresh-outline" size={14} color={colors.text} />
+                      <Text style={{ fontSize: 13, fontWeight: "700", color: colors.text }}>最新値で再計算</Text>
+                    </Button>
+                    <Button onPress={() => remove(g.id)} variant="destructive" size="sm">
+                      <Ionicons name="trash-outline" size={14} color="#FFFFFF" />
+                      <Text style={{ fontSize: 13, fontWeight: "700", color: "#FFFFFF" }}>削除</Text>
+                    </Button>
+                  </View>
+                </Card>
+              );
+            })}
+          </View>
+        )}
+
+        {/* 達成済み目標 */}
+        {!isLoading && !error && achievedItems.length > 0 && (
+          <>
+            <SectionHeader title="達成済みの目標" />
+            <View style={styles.list}>
+              {achievedItems.map((g) => {
+                const config = getGoalConfig(g.goal_type);
+                return (
+                  <Card key={g.id} variant="success">
+                    <View style={styles.achievedRow}>
+                      <View style={styles.achievedIcon}>
+                        <Ionicons name="trophy" size={20} color={colors.success} />
+                      </View>
+                      <View style={styles.achievedInfo}>
+                        <Text style={styles.achievedLabel}>{config.label} 目標達成！</Text>
+                        <Text style={styles.achievedSub}>
+                          {g.target_value}{g.target_unit} を達成
+                        </Text>
+                      </View>
+                    </View>
+                  </Card>
+                );
+              })}
+            </View>
+          </>
+        )}
+
+        <Button onPress={load} variant="ghost" size="sm">
+          <Ionicons name="refresh-outline" size={16} color={colors.textLight} />
+          <Text style={{ color: colors.textLight, fontWeight: "700", fontSize: 13 }}>更新</Text>
+        </Button>
+      </ScrollView>
     </View>
   );
 }
@@ -245,6 +319,15 @@ const styles = StyleSheet.create({
   formFields: {
     gap: spacing.md,
     marginTop: spacing.sm,
+  },
+  fieldLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: colors.textLight,
+    marginBottom: spacing.sm,
+  },
+  chipSelector: {
+    flexWrap: "wrap",
   },
   errorRow: {
     flexDirection: "row",
@@ -273,11 +356,78 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   progressBar: {
-    marginBottom: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  dateRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    marginBottom: spacing.sm,
+  },
+  dateText: {
+    fontSize: 12,
+    color: colors.textMuted,
+  },
+  milestonesContainer: {
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    paddingTop: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  milestonesLabel: {
+    fontSize: 11,
+    fontWeight: "600",
+    color: colors.textMuted,
+    marginBottom: spacing.xs,
+  },
+  milestonesList: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  milestoneChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    borderRadius: 99,
+    backgroundColor: colors.successLight,
+  },
+  milestoneText: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: colors.success,
   },
   goalActions: {
     flexDirection: "row",
     gap: spacing.sm,
     flexWrap: "wrap",
+  },
+  achievedRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.md,
+  },
+  achievedIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: colors.successLight,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  achievedInfo: {
+    flex: 1,
+  },
+  achievedLabel: {
+    fontSize: 14,
+    fontWeight: "800",
+    color: colors.success,
+  },
+  achievedSub: {
+    fontSize: 12,
+    color: colors.success,
+    marginTop: 2,
   },
 });


### PR DESCRIPTION
## Summary

- `goal_type` のフリーテキスト入力を `ChipSelector` による 3 択（体重 / 体脂肪率 / 歩数）に変更
- 選択タイプに応じて単位（kg / % / 歩）を自動セット。フォームから単位入力欄を削除
- API を `?status=all` に変更し、アクティブ目標と達成済み目標を同一リクエストで取得
- アクティブ目標カードに達成マイルストーンチップ一覧を表示（`milestones` フィールド対応）
- 達成済み目標セクションを画面下部に追加（trophy アイコン・成功カード）
- goal_type の日本語ラベルをカード表示に反映（`weight` → 「体重」等）

## Test plan

- [ ] 目標作成フォームでゴールタイプ選択チップが 3 種（体重/体脂肪率/歩数）表示される
- [ ] タイプ選択で目標値ラベルの単位が変わる
- [ ] 目標作成後にアクティブ一覧に反映される
- [ ] ゴールカードのタイトルが日本語ラベルで表示される
- [ ] マイルストーンがある目標でチップが表示される
- [ ] 達成済み目標がある場合に画面下部にセクションが表示される

Closes #383