### PR TITLE
feat(mobile): 買い物リスト再生成に Realtime 購読を追加 (#449)

### DIFF
--- a/apps/mobile/app/ai/[sessionId].tsx
+++ b/apps/mobile/app/ai/[sessionId].tsx
@@ -1,7 +1,8 @@
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
+import * as ImagePicker from "expo-image-picker";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Alert, KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { Alert, Image, KeyboardAvoidingView, Platform, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 
 import { LoadingState, PageHeader } from "../../src/components/ui";
 import { colors, spacing, radius, shadows } from "../../src/theme";
@@ -16,6 +17,7 @@ type Message = {
   isImportant?: boolean;
   importanceReason?: string | null;
   createdAt: string;
+  imageUri?: string; // ローカル表示用（楽観的UI）
 };
 
 export default function AiSessionPage() {
@@ -26,6 +28,7 @@ export default function AiSessionPage() {
   const [error, setError] = useState<string | null>(null);
   const [text, setText] = useState("");
   const [streamingContent, setStreamingContent] = useState<string | null>(null);
+  const [attachedImage, setAttachedImage] = useState<{ uri: string; base64: string } | null>(null);
   // 自動実行済みのメッセージID集合。GET レスポンスは proposed_actions を返し続けるため、
   // クライアント側でアクションボタンを非表示にするためのトラッキングに使用する。
   const executedMessageIds = useRef<Set<string>>(new Set());
@@ -60,21 +63,45 @@ export default function AiSessionPage() {
     return () => clearTimeout(t);
   }, [messages.length]);
 
+  async function pickImage() {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== "granted") {
+      Alert.alert("権限が必要です", "画像を添付するにはカメラロールへのアクセスを許可してください。");
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: "images",
+      allowsEditing: true,
+      quality: 0.7,
+      base64: true,
+    });
+    if (!result.canceled && result.assets.length > 0) {
+      const asset = result.assets[0];
+      if (asset.base64) {
+        setAttachedImage({ uri: asset.uri, base64: asset.base64 });
+      }
+    }
+  }
+
   async function send() {
     const trimmed = text.trim();
-    if (!trimmed || isSending) return;
+    if ((!trimmed && !attachedImage) || isSending) return;
     setIsSending(true);
     setError(null);
     setStreamingContent(null);
+
+    const imageSnapshot = attachedImage;
 
     const optimistic: Message = {
       id: `local-${Date.now()}`,
       role: "user",
       content: trimmed,
       createdAt: new Date().toISOString(),
+      imageUri: imageSnapshot?.uri,
     };
     setMessages((prev) => [...prev, optimistic]);
     setText("");
+    setAttachedImage(null);
 
     try {
       const { data: sessionData } = await supabase.auth.getSession();
@@ -85,6 +112,11 @@ export default function AiSessionPage() {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 26000);
 
+      const body: Record<string, any> = { message: trimmed };
+      if (imageSnapshot) {
+        body.imageBase64 = imageSnapshot.base64;
+      }
+
       let res: Response;
       try {
         res = await fetch(url, {
@@ -93,7 +125,7 @@ export default function AiSessionPage() {
             "Content-Type": "application/json",
             ...(token ? { Authorization: `Bearer ${token}` } : {}),
           },
-          body: JSON.stringify({ message: trimmed }),
+          body: JSON.stringify(body),
           signal: controller.signal,
         });
       } finally {
@@ -395,15 +427,25 @@ export default function AiSessionPage() {
                         borderBottomLeftRadius: isUser ? radius.lg : 4,
                       }}
                     >
-                      <Text
-                        style={{
-                          color: isUser ? "#fff" : colors.text,
-                          fontSize: 14,
-                          lineHeight: 21,
-                        }}
-                      >
-                        {m.content}
-                      </Text>
+                      {/* 添付画像（楽観的UI: ローカル URI を使用） */}
+                      {isUser && m.imageUri && (
+                        <Image
+                          source={{ uri: m.imageUri }}
+                          style={{ width: 180, height: 180, borderRadius: radius.md, marginBottom: spacing.xs }}
+                          resizeMode="cover"
+                        />
+                      )}
+                      {m.content ? (
+                        <Text
+                          style={{
+                            color: isUser ? "#fff" : colors.text,
+                            fontSize: 14,
+                            lineHeight: 21,
+                          }}
+                        >
+                          {m.content}
+                        </Text>
+                      ) : null}
 
                       {/* アクションボタン */}
                       {m.role === "assistant" && renderActionButtons(m.id, m.proposedActions)}
@@ -462,49 +504,97 @@ export default function AiSessionPage() {
             <View
               style={{
                 paddingHorizontal: spacing.md,
-                paddingVertical: spacing.sm,
+                paddingTop: spacing.sm,
+                paddingBottom: spacing.sm,
                 borderTopWidth: 1,
                 borderColor: colors.border,
                 backgroundColor: colors.card,
-                flexDirection: "row",
-                gap: spacing.sm,
-                alignItems: "flex-end",
               }}
             >
-              <TextInput
-                value={text}
-                onChangeText={setText}
-                placeholder="相談内容を入力..."
-                placeholderTextColor={colors.textMuted}
-                multiline
-                style={{
-                  flex: 1,
-                  maxHeight: 100,
-                  borderWidth: 1,
-                  borderColor: colors.border,
-                  backgroundColor: colors.bg,
-                  padding: spacing.md,
-                  borderRadius: radius.lg,
-                  fontSize: 14,
-                  color: colors.text,
-                }}
-              />
-              <Pressable
-                onPress={send}
-                disabled={isSending || !text.trim()}
-                style={({ pressed }) => ({
-                  width: 44,
-                  height: 44,
-                  borderRadius: 22,
-                  backgroundColor: text.trim() ? colors.accent : colors.border,
-                  alignItems: "center",
-                  justifyContent: "center",
-                  ...shadows.sm,
-                  ...(pressed ? { opacity: 0.9 } : {}),
-                })}
-              >
-                <Ionicons name="send" size={20} color="#fff" />
-              </Pressable>
+              {/* 添付画像プレビュー */}
+              {attachedImage && (
+                <View style={{ marginBottom: spacing.sm }}>
+                  <View style={{ position: "relative", alignSelf: "flex-start" }}>
+                    <Image
+                      source={{ uri: attachedImage.uri }}
+                      style={{ width: 80, height: 80, borderRadius: radius.md }}
+                      resizeMode="cover"
+                    />
+                    <Pressable
+                      onPress={() => setAttachedImage(null)}
+                      style={{
+                        position: "absolute",
+                        top: -6,
+                        right: -6,
+                        width: 20,
+                        height: 20,
+                        borderRadius: 10,
+                        backgroundColor: colors.error,
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <Ionicons name="close" size={12} color="#fff" />
+                    </Pressable>
+                  </View>
+                </View>
+              )}
+
+              <View style={{ flexDirection: "row", gap: spacing.sm, alignItems: "flex-end" }}>
+                {/* 画像添付ボタン */}
+                <Pressable
+                  onPress={pickImage}
+                  disabled={isSending}
+                  style={({ pressed }) => ({
+                    width: 44,
+                    height: 44,
+                    borderRadius: 22,
+                    backgroundColor: attachedImage ? colors.accent : colors.bg,
+                    borderWidth: attachedImage ? 0 : 1,
+                    borderColor: colors.border,
+                    alignItems: "center",
+                    justifyContent: "center",
+                    ...(pressed ? { opacity: 0.7 } : {}),
+                  })}
+                >
+                  <Ionicons name="image-outline" size={20} color={attachedImage ? "#fff" : colors.textMuted} />
+                </Pressable>
+
+                <TextInput
+                  value={text}
+                  onChangeText={setText}
+                  placeholder="相談内容を入力..."
+                  placeholderTextColor={colors.textMuted}
+                  multiline
+                  style={{
+                    flex: 1,
+                    maxHeight: 100,
+                    borderWidth: 1,
+                    borderColor: colors.border,
+                    backgroundColor: colors.bg,
+                    padding: spacing.md,
+                    borderRadius: radius.lg,
+                    fontSize: 14,
+                    color: colors.text,
+                  }}
+                />
+                <Pressable
+                  onPress={send}
+                  disabled={isSending || (!text.trim() && !attachedImage)}
+                  style={({ pressed }) => ({
+                    width: 44,
+                    height: 44,
+                    borderRadius: 22,
+                    backgroundColor: (text.trim() || attachedImage) ? colors.accent : colors.border,
+                    alignItems: "center",
+                    justifyContent: "center",
+                    ...shadows.sm,
+                    ...(pressed ? { opacity: 0.9 } : {}),
+                  })}
+                >
+                  <Ionicons name="send" size={20} color="#fff" />
+                </Pressable>
+              </View>
             </View>
           </>
         )}

--- a/apps/mobile/app/health/goals.tsx
+++ b/apps/mobile/app/health/goals.tsx
@@ -3,9 +3,14 @@ import { Link } from "expo-router";
 import { useEffect, useState } from "react";
 import { Alert, ScrollView, StyleSheet, Text, View } from "react-native";
 
-import { Button, Card, EmptyState, Input, LoadingState, PageHeader, ProgressBar, SectionHeader } from "../../src/components/ui";
+import { Button, Card, ChipSelector, EmptyState, Input, LoadingState, PageHeader, ProgressBar, SectionHeader } from "../../src/components/ui";
 import { colors, spacing } from "../../src/theme";
 import { getApi } from "../../src/lib/api";
+
+type Milestone = {
+  value: number;
+  achieved_at: string;
+};
 
 type Goal = {
   id: string;
@@ -16,27 +21,42 @@ type Goal = {
   current_value: number | null;
   progress_percentage: number | null;
   status: string;
+  milestones?: Milestone[];
   created_at: string;
 };
 
+const GOAL_TYPES = [
+  { value: "weight", label: "体重", unit: "kg" },
+  { value: "body_fat", label: "体脂肪率", unit: "%" },
+  { value: "steps", label: "歩数", unit: "歩" },
+] as const;
+
+type GoalTypeValue = (typeof GOAL_TYPES)[number]["value"];
+
+function getGoalConfig(type: string) {
+  return GOAL_TYPES.find((t) => t.value === type) ?? GOAL_TYPES[0];
+}
+
 export default function HealthGoalsPage() {
-  const [items, setItems] = useState<Goal[]>([]);
+  const [allItems, setAllItems] = useState<Goal[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const [goalType, setGoalType] = useState("weight");
+  const [goalType, setGoalType] = useState<GoalTypeValue>("weight");
   const [targetValue, setTargetValue] = useState("");
-  const [targetUnit, setTargetUnit] = useState("kg");
   const [targetDate, setTargetDate] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const activeItems = allItems.filter((g) => g.status === "active");
+  const achievedItems = allItems.filter((g) => g.status === "achieved");
 
   async function load() {
     setIsLoading(true);
     setError(null);
     try {
       const api = getApi();
-      const res = await api.get<{ goals: Goal[] }>("/api/health/goals?status=active");
-      setItems((res.goals ?? []) as any);
+      const res = await api.get<{ goals: Goal[] }>("/api/health/goals?status=all");
+      setAllItems((res.goals ?? []) as any);
     } catch (e: any) {
       setError(e?.message ?? "取得に失敗しました。");
     } finally {
@@ -57,13 +77,14 @@ export default function HealthGoalsPage() {
       Alert.alert("入力エラー", "目標値は正の数値を入力してください。");
       return;
     }
+    const config = getGoalConfig(goalType);
     setIsSubmitting(true);
     try {
       const api = getApi();
       await api.post("/api/health/goals", {
         goal_type: goalType,
         target_value: numTv,
-        target_unit: targetUnit || "kg",
+        target_unit: config.unit,
         target_date: targetDate.trim() || null,
       });
       setTargetValue("");
@@ -117,112 +138,165 @@ export default function HealthGoalsPage() {
       />
       <ScrollView contentContainerStyle={styles.container}>
 
-      <Card>
-        <SectionHeader
-          title="新しい目標を作成"
-          right={<Ionicons name="add-circle-outline" size={20} color={colors.accent} />}
-        />
-        <View style={styles.formFields}>
-          <Input
-            label="タイプ"
-            value={goalType}
-            onChangeText={setGoalType}
-            placeholder="weight / body_fat 等"
+        {/* 目標作成フォーム */}
+        <Card>
+          <SectionHeader
+            title="新しい目標を作成"
+            right={<Ionicons name="add-circle-outline" size={20} color={colors.accent} />}
           />
-          <Input
-            label="目標値"
-            value={targetValue}
-            onChangeText={setTargetValue}
-            placeholder="目標値を入力"
-            keyboardType="decimal-pad"
-          />
-          <Input
-            label="単位"
-            value={targetUnit}
-            onChangeText={setTargetUnit}
-            placeholder="kg / % 等"
-          />
-          <Input
-            label="期限（任意）"
-            value={targetDate}
-            onChangeText={setTargetDate}
-            placeholder="YYYY-MM-DD"
-          />
-          <Button onPress={create} disabled={isSubmitting} loading={isSubmitting}>
-            {isSubmitting ? "作成中..." : "作成"}
-          </Button>
-        </View>
-      </Card>
-
-      <SectionHeader title="アクティブな目標" />
-
-      {isLoading ? (
-        <LoadingState message="目標を読み込み中..." />
-      ) : error ? (
-        <Card variant="error">
-          <View style={styles.errorRow}>
-            <Ionicons name="alert-circle" size={20} color={colors.error} />
-            <Text style={styles.errorText}>{error}</Text>
+          <View style={styles.formFields}>
+            <View>
+              <Text style={styles.fieldLabel}>ゴールタイプ</Text>
+              <ChipSelector
+                options={GOAL_TYPES.map((t) => ({ value: t.value, label: t.label }))}
+                selected={goalType}
+                onSelect={(v) => setGoalType(v as GoalTypeValue)}
+                style={styles.chipSelector}
+              />
+            </View>
+            <Input
+              label={`目標値（${getGoalConfig(goalType).unit}）`}
+              value={targetValue}
+              onChangeText={setTargetValue}
+              placeholder="目標値を入力"
+              keyboardType="decimal-pad"
+            />
+            <Input
+              label="期限（任意）"
+              value={targetDate}
+              onChangeText={setTargetDate}
+              placeholder="YYYY-MM-DD"
+            />
+            <Button onPress={create} disabled={isSubmitting} loading={isSubmitting}>
+              {isSubmitting ? "作成中..." : "作成"}
+            </Button>
           </View>
         </Card>
-      ) : items.length === 0 ? (
-        <EmptyState
-          icon={<Ionicons name="flag-outline" size={40} color={colors.textMuted} />}
-          message="目標がありません。"
-        />
-      ) : (
-        <View style={styles.list}>
-          {items.map((g) => {
-            const progress = g.progress_percentage ? Math.round(g.progress_percentage) : 0;
-            return (
-              <Card key={g.id}>
-                <View style={styles.goalHeader}>
-                  <Ionicons name="flag" size={18} color={colors.accent} />
-                  <Text style={styles.goalTitle}>
-                    {g.goal_type}: {g.current_value ?? "-"} → {g.target_value}
-                    {g.target_unit}
-                  </Text>
-                </View>
-                <ProgressBar
-                  value={progress}
-                  max={100}
-                  label="進捗"
-                  showPercentage
-                  color={progress >= 100 ? colors.success : colors.accent}
-                  style={styles.progressBar}
-                />
-                <View style={styles.goalActions}>
-                  <Button
-                    onPress={() => {
-                      if (g.current_value == null) {
-                        Alert.alert("データなし", "現在の値がまだ記録されていません。先に健康記録を入力してください。");
-                        return;
-                      }
-                      updateCurrent(g.id, g.current_value as number);
-                    }}
-                    variant="secondary"
-                    size="sm"
-                    disabled={g.current_value == null}
-                  >
-                    <Ionicons name="refresh-outline" size={14} color={colors.text} />
-                    <Text style={{ fontSize: 13, fontWeight: "700", color: colors.text }}>最新値で再計算</Text>
-                  </Button>
-                  <Button onPress={() => remove(g.id)} variant="destructive" size="sm">
-                    <Ionicons name="trash-outline" size={14} color="#FFFFFF" />
-                    <Text style={{ fontSize: 13, fontWeight: "700", color: "#FFFFFF" }}>削除</Text>
-                  </Button>
-                </View>
-              </Card>
-            );
-          })}
-        </View>
-      )}
 
-      <Button onPress={load} variant="ghost" size="sm">
-        <Ionicons name="refresh-outline" size={16} color={colors.textLight} />
-        <Text style={{ color: colors.textLight, fontWeight: "700", fontSize: 13 }}>更新</Text>
-      </Button>
-    </ScrollView>
+        {/* アクティブな目標 */}
+        <SectionHeader title="アクティブな目標" />
+
+        {isLoading ? (
+          <LoadingState message="目標を読み込み中..." />
+        ) : error ? (
+          <Card variant="error">
+            <View style={styles.errorRow}>
+              <Ionicons name="alert-circle" size={20} color={colors.error} />
+              <Text style={styles.errorText}>{error}</Text>
+            </View>
+          </Card>
+        ) : activeItems.length === 0 ? (
+          <EmptyState
+            icon={<Ionicons name="flag-outline" size={40} color={colors.textMuted} />}
+            message="アクティブな目標がありません。"
+          />
+        ) : (
+          <View style={styles.list}>
+            {activeItems.map((g) => {
+              const progress = g.progress_percentage ? Math.round(g.progress_percentage) : 0;
+              const config = getGoalConfig(g.goal_type);
+              return (
+                <Card key={g.id}>
+                  <View style={styles.goalHeader}>
+                    <Ionicons name="flag" size={18} color={colors.accent} />
+                    <Text style={styles.goalTitle}>
+                      {config.label}: {g.current_value ?? "-"} → {g.target_value}
+                      {g.target_unit}
+                    </Text>
+                  </View>
+                  <ProgressBar
+                    value={progress}
+                    max={100}
+                    label="進捗"
+                    showPercentage
+                    color={progress >= 100 ? colors.success : colors.accent}
+                    style={styles.progressBar}
+                  />
+                  {g.target_date && (
+                    <View style={styles.dateRow}>
+                      <Ionicons name="calendar-outline" size={13} color={colors.textMuted} />
+                      <Text style={styles.dateText}>
+                        期限: {new Date(g.target_date).toLocaleDateString("ja-JP")}
+                      </Text>
+                    </View>
+                  )}
+
+                  {/* マイルストーン */}
+                  {g.milestones && g.milestones.length > 0 && (
+                    <View style={styles.milestonesContainer}>
+                      <Text style={styles.milestonesLabel}>達成マイルストーン</Text>
+                      <View style={styles.milestonesList}>
+                        {g.milestones.map((m, i) => (
+                          <View key={i} style={styles.milestoneChip}>
+                            <Ionicons name="checkmark-circle" size={12} color={colors.success} />
+                            <Text style={styles.milestoneText}>
+                              {m.value}{g.target_unit}
+                            </Text>
+                          </View>
+                        ))}
+                      </View>
+                    </View>
+                  )}
+
+                  <View style={styles.goalActions}>
+                    <Button
+                      onPress={() => {
+                        if (g.current_value == null) {
+                          Alert.alert("データなし", "現在の値がまだ記録されていません。先に健康記録を入力してください。");
+                          return;
+                        }
+                        updateCurrent(g.id, g.current_value as number);
+                      }}
+                      variant="secondary"
+                      size="sm"
+                      disabled={g.current_value == null}
+                    >
+                      <Ionicons name="refresh-outline" size={14} color={colors.text} />
+                      <Text style={{ fontSize: 13, fontWeight: "700", color: colors.text }}>最新値で再計算</Text>
+                    </Button>
+                    <Button onPress={() => remove(g.id)} variant="destructive" size="sm">
+                      <Ionicons name="trash-outline" size={14} color="#FFFFFF" />
+                      <Text style={{ fontSize: 13, fontWeight: "700", color: "#FFFFFF" }}>削除</Text>
+                    </Button>
+                  </View>
+                </Card>
+              );
+            })}
+          </View>
+        )}
+
+        {/* 達成済み目標 */}
+        {!isLoading && !error && achievedItems.length > 0 && (
+          <>
+            <SectionHeader title="達成済みの目標" />
+            <View style={styles.list}>
+              {achievedItems.map((g) => {
+                const config = getGoalConfig(g.goal_type);
+                return (
+                  <Card key={g.id} variant="success">
+                    <View style={styles.achievedRow}>
+                      <View style={styles.achievedIcon}>
+                        <Ionicons name="trophy" size={20} color={colors.success} />
+                      </View>
+                      <View style={styles.achievedInfo}>
+                        <Text style={styles.achievedLabel}>{config.label} 目標達成！</Text>
+                        <Text style={styles.achievedSub}>
+                          {g.target_value}{g.target_unit} を達成
+                        </Text>
+                      </View>
+                    </View>
+                  </Card>
+                );
+              })}
+            </View>
+          </>
+        )}
+
+        <Button onPress={load} variant="ghost" size="sm">
+          <Ionicons name="refresh-outline" size={16} color={colors.textLight} />
+          <Text style={{ color: colors.textLight, fontWeight: "700", fontSize: 13 }}>更新</Text>
+        </Button>
+      </ScrollView>
     </View>
   );
 }
@@ -245,6 +319,15 @@ const styles = StyleSheet.create({
   formFields: {
     gap: spacing.md,
     marginTop: spacing.sm,
+  },
+  fieldLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: colors.textLight,
+    marginBottom: spacing.sm,
+  },
+  chipSelector: {
+    flexWrap: "wrap",
   },
   errorRow: {
     flexDirection: "row",
@@ -273,11 +356,78 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   progressBar: {
-    marginBottom: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  dateRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    marginBottom: spacing.sm,
+  },
+  dateText: {
+    fontSize: 12,
+    color: colors.textMuted,
+  },
+  milestonesContainer: {
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    paddingTop: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  milestonesLabel: {
+    fontSize: 11,
+    fontWeight: "600",
+    color: colors.textMuted,
+    marginBottom: spacing.xs,
+  },
+  milestonesList: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  milestoneChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 4,
+    borderRadius: 99,
+    backgroundColor: colors.successLight,
+  },
+  milestoneText: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: colors.success,
   },
   goalActions: {
     flexDirection: "row",
     gap: spacing.sm,
     flexWrap: "wrap",
+  },
+  achievedRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.md,
+  },
+  achievedIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: colors.successLight,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  achievedInfo: {
+    flex: 1,
+  },
+  achievedLabel: {
+    fontSize: 14,
+    fontWeight: "800",
+    color: colors.success,
+  },
+  achievedSub: {
+    fontSize: 12,
+    color: colors.success,
+    marginTop: 2,
   },
 });

--- a/apps/mobile/app/shopping-list/index.tsx
+++ b/apps/mobile/app/shopping-list/index.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Link } from "expo-router";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Alert, Modal, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 
 import { Button } from "../../src/components/ui/Button";
@@ -75,6 +75,27 @@ export default function ShoppingListPage() {
   const [servings, setServings] = useState(2);
   const [isTodayExpanded, setIsTodayExpanded] = useState(false);
   const [daysCountInput, setDaysCountInput] = useState('3');
+
+  // Realtime subscription refs for regeneration progress
+  const regenChannelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
+  const regenPollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  function cleanupRegenSubscription() {
+    if (regenPollingRef.current) {
+      clearInterval(regenPollingRef.current);
+      regenPollingRef.current = null;
+    }
+    if (regenChannelRef.current) {
+      supabase.removeChannel(regenChannelRef.current);
+      regenChannelRef.current = null;
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      cleanupRegenSubscription();
+    };
+  }, []);
 
   async function load() {
     setIsLoading(true);
@@ -342,53 +363,87 @@ export default function ShoppingListPage() {
 
       const response = await api.post<{ requestId?: string }>("/api/shopping-list/regenerate", body);
 
-      // 非同期処理：requestIdが返ってくるのでポーリング
+      // 非同期処理：requestIdが返ってくるので Realtime 購読 + ポーリングフォールバック
       if (response.requestId) {
+        const requestId = response.requestId;
         let attempts = 0;
         const maxAttempts = 60; // 最大2分
 
-        const poll = async () => {
-          try {
-            const statusRes = await api.get<{ status: string; result?: any }>(`/api/shopping-list/regenerate/status?requestId=${response.requestId}`);
-            if (statusRes.status === 'completed') {
-              if (statusRes.result?.stats?.totalServings) {
-                setTotalServings(statusRes.result.stats.totalServings);
-              }
-              await load();
-              const stats = statusRes.result?.stats;
-              const servingsText = stats?.totalServings ? ` (${stats.totalServings}食分)` : '';
-              Alert.alert("完了", `${stats?.outputCount ?? 0}件の材料を整理しました${servingsText}`);
-              return true;
-            } else if (statusRes.status === 'failed') {
-              throw new Error(statusRes.result?.error || '再生成に失敗しました');
-            }
-            return false;
-          } catch (e) {
-            throw e;
+        const handleCompleted = async (result?: any) => {
+          cleanupRegenSubscription();
+          if (result?.stats?.totalServings) {
+            setTotalServings(result.stats.totalServings);
           }
+          await load();
+          const stats = result?.stats;
+          const servingsText = stats?.totalServings ? ` (${stats.totalServings}食分)` : '';
+          Alert.alert("完了", `${stats?.outputCount ?? 0}件の材料を整理しました${servingsText}`);
+          setIsRegenerating(false);
         };
 
-        const pollInterval = setInterval(async () => {
+        const handleFailed = (errorMsg: string) => {
+          cleanupRegenSubscription();
+          setIsRegenerating(false);
+          Alert.alert("再生成失敗", errorMsg);
+        };
+
+        // ポーリング（Realtime 未接続時のフォールバック）
+        regenPollingRef.current = setInterval(async () => {
           attempts++;
           if (attempts > maxAttempts) {
-            clearInterval(pollInterval);
+            cleanupRegenSubscription();
             setIsRegenerating(false);
             Alert.alert("タイムアウト", "処理に時間がかかっています。後で確認してください。");
             return;
           }
           try {
-            const done = await poll();
-            if (done) {
-              clearInterval(pollInterval);
-              setIsRegenerating(false);
+            const statusRes = await api.get<{ status: string; result?: any }>(`/api/shopping-list/regenerate/status?requestId=${requestId}`);
+            if (statusRes.status === 'completed') {
+              await handleCompleted(statusRes.result);
+            } else if (statusRes.status === 'failed') {
+              handleFailed(statusRes.result?.error || '再生成に失敗しました');
             }
           } catch (e: any) {
-            clearInterval(pollInterval);
+            cleanupRegenSubscription();
             setIsRegenerating(false);
             Alert.alert("再生成失敗", e?.message ?? "再生成に失敗しました。");
           }
         }, 2000);
 
+        // Realtime 購読（接続成功時にポーリングを停止）
+        regenChannelRef.current = supabase
+          .channel(`shopping-list-request-${requestId}`)
+          .on(
+            'postgres_changes',
+            {
+              event: 'UPDATE',
+              schema: 'public',
+              table: 'shopping_list_requests',
+              filter: `id=eq.${requestId}`,
+            },
+            async (payload) => {
+              const newData = payload.new as {
+                status: string;
+                result?: { stats?: { outputCount: number; totalServings?: number }; error?: string };
+              };
+              if (newData.status === 'completed') {
+                await handleCompleted(newData.result);
+              } else if (newData.status === 'failed') {
+                handleFailed(newData.result?.error || '再生成に失敗しました');
+              }
+            }
+          )
+          .subscribe((status) => {
+            if (status === 'SUBSCRIBED') {
+              // Realtime 接続成功でポーリング停止
+              if (regenPollingRef.current) {
+                clearInterval(regenPollingRef.current);
+                regenPollingRef.current = null;
+              }
+            }
+          });
+
+        // Realtime/ポーリング中は return（setIsRegenerating(false) は各ハンドラ内で処理）
         return;
       }
 


### PR DESCRIPTION
## Summary

- `shopping_list_requests` テーブルへの Supabase Realtime 購読を追加
- Realtime 接続成功 (`SUBSCRIBED`) 時にポーリングを停止
- Realtime 未接続時は 2 秒ポーリングをフォールバックとして継続
- アンマウント時に `cleanupRegenSubscription()` でチャンネル・インターバル両方を解放

## Test plan

- [ ] 再生成ボタン押下後、Realtime チャンネルが `shopping-list-request-<requestId>` で購読されること
- [ ] Realtime 接続成功後にポーリングが停止すること
- [ ] 再生成完了時にリストが更新され完了アラートが表示されること
- [ ] 画面離脱時にチャンネルが削除されること（メモリリークなし）

Closes #449