### PR TITLE
fix: analyze-weight-scale で mimeType を Edge Function に転送 (#431)

### DIFF
--- a/src/app/api/ai/analyze-weight-scale/route.ts
+++ b/src/app/api/ai/analyze-weight-scale/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: Request) {
 
   try {
     const body = await request.json();
-    const { image } = body;
+    const { image, mimeType } = body;
 
     if (!image) {
       return NextResponse.json({ error: 'Image is required' }, { status: 400 });
@@ -21,6 +21,9 @@ export async function POST(request: Request) {
     const formData = new FormData();
     formData.append('image_base64', image);
     formData.append('device_type', 'weight_scale');
+    if (mimeType) {
+      formData.append('mime_type', mimeType);
+    }
 
     const invokePromise = supabase.functions.invoke('analyze-health-photo', {
       body: formData,

--- a/supabase/functions/analyze-health-photo/index.ts
+++ b/supabase/functions/analyze-health-photo/index.ts
@@ -115,6 +115,7 @@ Deno.serve(async (req) => {
     const imageFile = formData.get("image") as File | null;
     const imageBase64 = formData.get("image_base64") as string | null;
     const deviceType = formData.get("device_type") as string || "auto";
+    const mimeTypeField = formData.get("mime_type") as string | null;
 
     let base64Image: string;
     let mimeType: string;
@@ -125,7 +126,7 @@ Deno.serve(async (req) => {
       mimeType = imageFile.type || "image/jpeg";
     } else if (imageBase64) {
       base64Image = imageBase64.replace(/^data:image\/\w+;base64,/, "");
-      mimeType = "image/jpeg";
+      mimeType = mimeTypeField || "image/jpeg";
     } else {
       return new Response(
         JSON.stringify({ error: "Image is required" }),


### PR DESCRIPTION
## Summary

- `route.ts` で `body` から `mimeType` を抽出し、FormData に `mime_type` フィールドとして追加
- `analyze-health-photo` Edge Function で `mime_type` フォームフィールドを読み取り、`image_base64` 経由のリクエストでハードコードの `image/jpeg` を動的な mimeType に置換
- mobile 側 (`apps/mobile/app/meals/new.tsx:394`) はすでに `mimeType` を送信済みのため変更不要

## Test plan

- [ ] 体重計写真（JPEG）を送信して正常に解析されることを確認
- [ ] HEIC 等の異なる mimeType でも正常に転送・解析されることを確認
- [ ] `mime_type` フィールドを含まないリクエストでも `image/jpeg` フォールバックが機能することを確認

Closes #431