### PR TITLE
feat(mobile): 今週のベスト料理カード (#430)

### DIFF
--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -93,6 +93,7 @@ export default function HomeScreen() {
     shoppingRemaining,
     badgeCount,
     latestBadge,
+    bestMealThisWeek,
     activityLevel,
     suggestion,
     performanceAnalysis,
@@ -944,6 +945,39 @@ export default function HomeScreen() {
               </View>
             )}
           </Pressable>
+
+          {/* ========== 今週のベスト料理 ========== */}
+          {bestMealThisWeek && bestMealThisWeek.image_url && (
+            <View style={{
+              borderRadius: radius.xl, overflow: "hidden",
+              borderWidth: 1, borderColor: colors.border, ...shadows.sm,
+            }}>
+              <View style={{ height: 128 }}>
+                <Image
+                  source={{ uri: bestMealThisWeek.image_url }}
+                  style={{ width: "100%", height: "100%" }}
+                  resizeMode="cover"
+                />
+                <LinearGradient
+                  colors={["transparent", "rgba(0,0,0,0.65)"]}
+                  style={{
+                    position: "absolute", left: 0, right: 0, bottom: 0, top: 0,
+                  }}
+                />
+                <View style={{
+                  position: "absolute", bottom: 0, left: 0, right: 0, padding: spacing.md,
+                }}>
+                  <View style={{ flexDirection: "row", alignItems: "center", gap: 4, marginBottom: 4 }}>
+                    <Ionicons name="ribbon" size={12} color="#FFD700" />
+                    <Text style={{ fontSize: 10, fontWeight: "800", color: "#FFD700" }}>今週のベスト</Text>
+                  </View>
+                  <Text style={{ fontSize: 14, fontWeight: "800", color: "#fff" }} numberOfLines={1}>
+                    {bestMealThisWeek.dish_name ?? ""}
+                  </Text>
+                </View>
+              </View>
+            </View>
+          )}
         </View>
       </ScrollView>
 

--- a/apps/mobile/src/hooks/useHomeData.ts
+++ b/apps/mobile/src/hooks/useHomeData.ts
@@ -52,6 +52,13 @@ interface TodayMeal {
   image_url: string | null;
 }
 
+interface BestMeal {
+  id: string;
+  dish_name: string | null;
+  image_url: string;
+  veg_score: number | null;
+}
+
 const DOW = ["日", "月", "火", "水", "木", "金", "土"];
 // todayStr is computed fresh on each fetchAll call, not cached at module level
 function getTodayStr() { return formatLocalDate(new Date()); }
@@ -79,6 +86,7 @@ export const useHomeData = (userId: string | undefined) => {
   const [shoppingRemaining, setShoppingRemaining] = useState(0);
   const [badgeCount, setBadgeCount] = useState(0);
   const [latestBadge, setLatestBadge] = useState<{ name: string; code: string; obtainedAt: string } | null>(null);
+  const [bestMealThisWeek, setBestMealThisWeek] = useState<BestMeal | null>(null);
 
   // ─── Announcements ───
   const [announcements, setAnnouncements] = useState<{ id: string; title: string; content: string }[]>([]);
@@ -103,6 +111,7 @@ export const useHomeData = (userId: string | undefined) => {
         fetchBadgeInfo(userId),
         fetchActivityLevel(userId),
         fetchAnnouncements(),
+        fetchBestMealThisWeek(userId),
       ]);
 
       // Heavier fetches — async
@@ -364,6 +373,46 @@ export const useHomeData = (userId: string | undefined) => {
     }
   }
 
+  async function fetchBestMealThisWeek(uid: string) {
+    try {
+      const sevenDaysAgo = new Date();
+      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 6);
+
+      const { data } = await supabase
+        .from("planned_meals")
+        .select(`
+          id,
+          dish_name,
+          image_url,
+          veg_score,
+          user_daily_meals!inner(
+            day_date,
+            user_id
+          )
+        `)
+        .eq("user_daily_meals.user_id", uid)
+        .gte("user_daily_meals.day_date", formatLocalDate(sevenDaysAgo))
+        .eq("is_completed", true)
+        .not("image_url", "is", null)
+        .order("veg_score", { ascending: false, nullsFirst: false })
+        .limit(1);
+
+      if (data && data.length > 0 && (data[0] as any).image_url) {
+        const row = data[0] as any;
+        setBestMealThisWeek({
+          id: row.id,
+          dish_name: row.dish_name,
+          image_url: row.image_url,
+          veg_score: row.veg_score,
+        });
+      } else {
+        setBestMealThisWeek(null);
+      }
+    } catch (e) {
+      console.error("Best meal fetch error:", e);
+    }
+  }
+
   async function fetchNutritionAnalysis() {
     try {
       setNutritionAnalysis((prev) => ({ ...prev, loading: true }));
@@ -604,6 +653,7 @@ export const useHomeData = (userId: string | undefined) => {
     shoppingRemaining,
     badgeCount,
     latestBadge,
+    bestMealThisWeek,
     activityLevel,
     suggestion,
     performanceAnalysis,


### PR DESCRIPTION
## Summary

- `useHomeData` に `bestMealThisWeek` ステートと `fetchBestMealThisWeek` 関数を追加
- `planned_meals` を当週日付範囲・`veg_score` 降順・`image_url` 存在条件でクエリ（web 参照実装に準拠）
- `home.tsx` に高さ 128 の画像カード + `LinearGradient` オーバーレイ + `ribbon` アイコン + 料理名を実装
- `image_url` がない週はカードを非表示

## Test plan

- [ ] 今週に `image_url` 付き・`is_completed=true` の `planned_meals` が存在する場合、ホーム画面最下部に画像カードが表示される
- [ ] カードに `ribbon` アイコンと「今週のベスト」ラベル、料理名が表示される
- [ ] グラデーションオーバーレイが適用されている
- [ ] `image_url` がない週はカードが表示されない

Closes #430