### PR TITLE
refactor(mobile): デザインシステムを web に揃える (C)

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -56,7 +56,7 @@ export default function TabsLayout() {
         name="menus"
         options={{
           title: "献立",
-          tabBarIcon: ({ color, size }) => <Ionicons name="restaurant" size={size} color={color} />,
+          tabBarIcon: ({ color, size }) => <Ionicons name="book-outline" size={size} color={color} />,
         }}
       />
       <Tabs.Screen

--- a/apps/mobile/src/theme/colors.ts
+++ b/apps/mobile/src/theme/colors.ts
@@ -1,12 +1,12 @@
 // Web版と同じカラーパレット (src/app/(main)/home/page.tsx L17-37)
 export const colors = {
-  bg: '#FAF9F7',
+  bg: '#FFFFFF',
   card: '#FFFFFF',
   text: '#1A1A1A',
   textLight: '#4A4A4A',
-  textMuted: '#9A9A9A',
-  accent: '#E07A5F',
-  accentLight: '#FDF0ED',
+  textMuted: '#666666',
+  accent: '#FF8A65',
+  accentLight: '#FFCCBC',
   accentDark: '#C4634C',
   success: '#4CAF50',
   successLight: '#E8F5E9',


### PR DESCRIPTION
## 概要

mobile のデザインシステムトークンを web 版に揃える。

## 変更内容

- accent #E07A5F → #FF8A65 (web の `--accent` CSS 変数値)
- accentLight #FDF0ED → #FFCCBC (web の `--accent-soft`)
- bg #FAF9F7 → #FFFFFF (web の純白)
- textMuted #9A9A9A → #666666 (web の `--text-muted`)
- タブアイコン restaurant → book-outline で web の Menu 形と意味整合

## 別 issue 化

- fontFamily (Noto Sans JP 導入) は別 issue
- web 側 success/error/warning のトークン化は別 issue (B 起票分)