### PR TITLE
fix(mobile): サインアップ重複メール (silent-success) 検知 (#533)

### DIFF
--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -82,12 +82,22 @@ export default function SignupScreen() {
     setIsSubmitting(true);
     try {
       const emailRedirectTo = Linking.createURL("/auth/verify");
-      const { error } = await supabase.auth.signUp({
+      const { data, error } = await supabase.auth.signUp({
         email: trimmedEmail,
         password,
         options: { emailRedirectTo },
       });
       if (error) throw error;
+      // Supabase の email confirmation 有効時、重複メールアドレスは
+      // silent-success を返し identities が空配列になる (#533)
+      if (data.user?.identities?.length === 0) {
+        Alert.alert(
+          "登録できませんでした",
+          "このメールアドレスは既に登録されています。ログインへ進んでください。",
+          [{ text: "ログインへ", onPress: () => router.replace("/(auth)/login") }]
+        );
+        return;
+      }
       Alert.alert("確認してください", "確認メールを送信しました。メール内のリンクから認証してください。", [
         { text: "OK", onPress: () => router.replace("/(auth)/login") },
       ]);


### PR DESCRIPTION
Closes #533

## 概要

Supabase の email confirmation が有効な環境で、既存メールアドレスを使って signUp を試みると silent-success（エラーなし・成功レスポンス）が返る。このとき `data.user.identities` が空配列になる。

- `data.user?.identities?.length === 0` を判定条件として追加
- 重複検知時は `Alert` で「このメールアドレスは既に登録されています」を表示しログイン画面へ誘導
- 参照実装: `src/app/(auth)/signup/page.tsx:97-103` (#286)

## テスト手順

1. Supabase ダッシュボードで email confirmation を有効にする
2. 既登録のメールアドレスでサインアップを試みる
3. Alert「登録できませんでした」が表示されることを確認
4. 「ログインへ」タップでログイン画面に遷移することを確認