### PR TITLE
feat(mobile): health 目標タイプに sleep_hours/step_count を追加 (#559)

### DIFF
--- a/apps/mobile/app/health/goals.tsx
+++ b/apps/mobile/app/health/goals.tsx
@@ -28,7 +28,8 @@ type Goal = {
 const GOAL_TYPES = [
   { value: "weight", label: "体重", unit: "kg" },
   { value: "body_fat", label: "体脂肪率", unit: "%" },
-  { value: "steps", label: "歩数", unit: "歩" },
+  { value: "sleep_hours", label: "睡眠時間", unit: "時間" },
+  { value: "step_count", label: "歩数", unit: "歩" },
 ] as const;
 
 type GoalTypeValue = (typeof GOAL_TYPES)[number]["value"];


### PR DESCRIPTION
## Summary

- `apps/mobile/app/health/goals.tsx` の `GOAL_TYPES` 配列に `sleep_hours`（睡眠時間・時間）と `step_count`（歩数・歩）を追加
- 既存の `steps` エントリを削除し `step_count` に統一（`(tabs)/health.tsx` の `GOAL_LABELS` と整合）

## Test plan

- [ ] 目標作成フォームのゴールタイプ ChipSelector に「睡眠時間」「歩数」が表示される
- [ ] 各タイプ選択時に目標値ラベルの単位が正しく表示される（時間 / 歩）
- [ ] ダッシュボードの目標進捗カードで `GOAL_LABELS` のラベルが正しく表示される

Closes #559