### PR TITLE
fix(mobile): ログイン成功後リダイレクトロジックを web と整合 (#531)

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
-import { Link, router } from "expo-router";
+import { Link, router, useLocalSearchParams } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 import * as Linking from "expo-linking";
 import { useState } from "react";
@@ -21,6 +21,7 @@ function GoogleIcon() {
 }
 
 export default function LoginScreen() {
+  const { next } = useLocalSearchParams<{ next?: string }>();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -66,7 +67,36 @@ export default function LoginScreen() {
         password,
       });
       if (error) throw error;
-      router.replace("/");
+
+      // ログイン成功: user_profiles から roles / onboarding 状態を取得して振り分け
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        const { data: profile } = await supabase
+          .from('user_profiles')
+          .select('roles, onboarding_started_at, onboarding_completed_at')
+          .eq('id', user.id)
+          .single();
+
+        const roles: string[] = profile?.roles ?? [];
+
+        // ?next= クエリパラメータがある場合はそのパスへ復帰 (/ 始まりのみ許可)
+        const safeNext = typeof next === 'string' && next.startsWith('/') ? next : null;
+
+        if (roles.includes('admin') || roles.includes('super_admin')) {
+          router.replace('/admin');
+        } else if (safeNext) {
+          router.replace(safeNext as any);
+        } else if (profile?.onboarding_completed_at) {
+          // オンボーディング完了済み → ホームへ
+          router.replace('/(tabs)/home');
+        } else if (profile?.onboarding_started_at) {
+          // オンボーディング進行中 → 再開ページへ
+          router.replace('/onboarding/resume');
+        } else {
+          // 未開始 → 初回ウェルカムへ
+          router.replace('/onboarding/welcome');
+        }
+      }
     } catch (e: any) {
       Alert.alert("ログイン失敗", e?.message ?? "ログインに失敗しました。");
     } finally {


### PR DESCRIPTION
Closes #531

## Summary
- `user_profiles` テーブルから `roles` / `onboarding_started_at` / `onboarding_completed_at` を取得し、ログイン後のルーティングを判定
- admin/super_admin ユーザー → `/admin`、onboarding 進行中 → `/onboarding/resume`、未開始 → `/onboarding/welcome`、完了済み → `/(tabs)/home`
- `?next=` クエリパラメータ指定時はそのパスへ復帰（`/` 始まりのみ許可）
- `web` の `src/app/(auth)/login/page.tsx:112-140` と同等のロジックを実装

## Test plan
- [ ] admin ユーザーでログインすると `/admin` に遷移する
- [ ] onboarding 未完了ユーザーが `/onboarding/resume` または `/onboarding/welcome` に遷移する
- [ ] 通常ユーザーが `/(tabs)/home` に遷移する
- [ ] `?next=/some/path` 付きでログインするとそのパスへ遷移する
- [ ] `?next=` なしの通常ログインフローが壊れていないことを確認