### PR TITLE
feat(mobile): ProgressTodoCard にグラデーション背景・エラー色を実装 (#538)

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
 import { router } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -583,17 +584,25 @@ function ProgressTodoCard({ progress, phases = PROGRESS_PHASES, defaultMessage =
     return "pending";
   };
 
+  const isError = currentPhase === "failed";
+
   const headerMessage =
     totalDays > 0
       ? `献立を生成中...（${progress?.completedSlots ?? 0}/${totalSlots}食、${totalDays}日分）`
       : (progress?.message ?? defaultMessage);
 
   return (
-    <View
+    <LinearGradient
+      colors={
+        isError
+          ? ["#ef4444", "#dc2626"]
+          : [colors.accent, colors.purple]
+      }
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
       style={{
         borderRadius: radius.lg,
         overflow: "hidden",
-        backgroundColor: colors.accent,
       }}
     >
       {/* ヘッダー */}
@@ -685,7 +694,7 @@ function ProgressTodoCard({ progress, phases = PROGRESS_PHASES, defaultMessage =
           })}
         </View>
       )}
-    </View>
+    </LinearGradient>
   );
 }
 


### PR DESCRIPTION
Closes #538

## Summary
- `expo-linear-gradient` の `LinearGradient` コンポーネントを import
- `ProgressTodoCard` の背景を単色 (`colors.accent`) からグラデーションに変更
- 通常時: `colors.accent` → `colors.purple` (135deg 相当、start/end で実装)
- エラー時 (`phase === "failed"`): `#ef4444` → `#dc2626` の赤系グラデーション
- web の `src/app/(main)/menus/weekly/page.tsx:355-358` と同等のビジュアル

## Test plan
- [ ] 献立生成中に ProgressTodoCard が accent → purple のグラデーション背景で表示される
- [ ] 生成失敗時 (phase = "failed") に赤系グラデーション背景が表示される
- [ ] iOS / Android 両環境で LinearGradient が正常にレンダリングされる