### PR TITLE
feat(mobile): プロフィール編集に 12 フィールドを追加 (#557)

### DIFF
--- a/apps/mobile/app/profile/index.tsx
+++ b/apps/mobile/app/profile/index.tsx
@@ -36,6 +36,39 @@ const FITNESS_GOALS = [
 
 const HEALTH_CONDITIONS = ["高血圧", "糖尿病", "脂質異常症", "貧血", "痛風", "骨粗しょう症", "睡眠障害", "ストレス"];
 
+const SPORT_OPTIONS = [
+  { value: "soccer", label: "サッカー", icon: "⚽" },
+  { value: "basketball", label: "バスケットボール", icon: "🏀" },
+  { value: "volleyball", label: "バレーボール", icon: "🏐" },
+  { value: "baseball", label: "野球", icon: "⚾" },
+  { value: "tennis", label: "テニス", icon: "🎾" },
+  { value: "swimming", label: "水泳", icon: "🏊" },
+  { value: "track_and_field", label: "陸上競技", icon: "🏃" },
+  { value: "road_cycling", label: "自転車", icon: "🚴" },
+  { value: "martial_arts_general", label: "格闘技", icon: "🥊" },
+  { value: "weightlifting", label: "ウェイトリフティング", icon: "🏋️" },
+  { value: "custom", label: "その他", icon: "🎯" },
+  { value: "none", label: "特になし", icon: "❌" },
+];
+
+const EXPERIENCE_OPTIONS = [
+  { value: "beginner", label: "初心者（1年未満）", icon: "🔰" },
+  { value: "intermediate", label: "中級者（1〜3年）", icon: "📈" },
+  { value: "advanced", label: "上級者（3年以上）", icon: "🏆" },
+];
+
+const PHASE_OPTIONS = [
+  { value: "training", label: "トレーニング期", icon: "🏋️", desc: "体力・技術向上中" },
+  { value: "competition", label: "試合期", icon: "🏆", desc: "大会・試合シーズン" },
+  { value: "cut", label: "減量期", icon: "⚖️", desc: "体重調整中" },
+  { value: "recovery", label: "回復期", icon: "🛌", desc: "オフシーズン" },
+];
+
+const KITCHEN_APPLIANCES = [
+  "電子レンジ", "オーブン", "トースター", "炊飯器", "圧力鍋",
+  "フードプロセッサー", "ミキサー", "ホットクック", "低温調理器", "グリル",
+];
+
 const WORK_STYLES = [
   { value: "sedentary", label: "デスクワーク" },
   { value: "light_active", label: "オフィス" },
@@ -154,11 +187,40 @@ export default function ProfilePage() {
     }
   }
 
+  function updatePerformanceProfile(path: string, value: any) {
+    setEditForm((prev: any) => {
+      const pp = { ...(prev.performanceProfile || {}) };
+      const keys = path.split(".");
+      if (keys.length === 2) {
+        pp[keys[0]] = { ...(pp[keys[0]] || {}), [keys[1]]: value };
+      } else {
+        pp[keys[0]] = value;
+      }
+      return { ...prev, performanceProfile: pp };
+    });
+  }
+
   async function handleSave() {
     setIsSaving(true);
     try {
       const api = getApi();
-      const updated = await api.put<any>("/api/profile", editForm);
+      const payload = {
+        ...editForm,
+        goalText: editForm.goalText ?? null,
+        targetDate: editForm.targetDate ?? null,
+        sleepQuality: editForm.sleepQuality ?? null,
+        stressLevel: editForm.stressLevel ?? null,
+        coldSensitivity: editForm.coldSensitivity ?? false,
+        swellingProne: editForm.swellingProne ?? false,
+        dietStyle: editForm.dietStyle ?? null,
+        kitchenAppliances: editForm.kitchenAppliances ?? [],
+        mealPrepOk: editForm.mealPrepOk ?? true,
+        weekendCookingMinutes: editForm.weekendCookingMinutes ?? null,
+        weeklyFoodBudget: editForm.weeklyFoodBudget ?? null,
+        hobbies: editForm.hobbies ?? [],
+        performanceProfile: editForm.performanceProfile ?? null,
+      };
+      const updated = await api.patch<any>("/api/profile", payload);
       setProfileData(updated);
       setEditForm(updated);
       setIsEditing(false);
@@ -291,6 +353,8 @@ export default function ProfilePage() {
               })}
             </View>
             <Field label="目標体重 (kg)" value={editForm.targetWeight?.toString()} editing={isEditing} onChange={(v) => updateField("targetWeight", v ? parseFloat(v) : null)} keyboardType="decimal-pad" />
+            <Field label="目標（テキスト）" value={editForm.goalText} editing={isEditing} onChange={(v) => updateField("goalText", v || null)} />
+            <Field label="目標期限（YYYY-MM-DD）" value={editForm.targetDate} editing={isEditing} onChange={(v) => updateField("targetDate", v || null)} />
           </Card>
         )}
 
@@ -300,6 +364,87 @@ export default function ProfilePage() {
             <Field label="主要スポーツ" value={editForm.primarySport} editing={isEditing} onChange={(v) => updateField("primarySport", v)} />
             <Field label="週の運動回数" value={editForm.exerciseFrequency?.toString()} editing={isEditing} onChange={(v) => updateField("exerciseFrequency", v ? parseInt(v) : null)} keyboardType="number-pad" />
             <Field label="運動強度" value={editForm.exerciseIntensity} editing={isEditing} onChange={(v) => updateField("exerciseIntensity", v)} />
+
+            <Text style={[s.cardTitle, { marginTop: spacing.md }]}>競技プロフィール</Text>
+            <Text style={s.fieldLabel}>競技種目</Text>
+            <View style={s.chipWrap}>
+              {SPORT_OPTIONS.map((sport) => {
+                const currentSportId = editForm.performanceProfile?.sport?.id;
+                const selected = currentSportId === sport.value || (sport.value === "none" && !currentSportId);
+                return (
+                  <Pressable
+                    key={sport.value}
+                    onPress={() => isEditing && updatePerformanceProfile("sport.id", sport.value === "none" ? null : sport.value)}
+                    style={[s.chip, selected && s.chipSelected]}
+                  >
+                    <Text style={{ fontSize: 14 }}>{sport.icon}</Text>
+                    <Text style={[s.chipText, selected && { color: "#fff" }]}>{sport.label}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+
+            {editForm.performanceProfile?.sport?.id === "custom" && (
+              <Field
+                label="競技名を入力"
+                value={editForm.performanceProfile?.sport?.name}
+                editing={isEditing}
+                onChange={(v) => updatePerformanceProfile("sport.name", v)}
+              />
+            )}
+
+            {editForm.performanceProfile?.sport?.id && editForm.performanceProfile?.sport?.id !== "none" && (
+              <>
+                <Text style={[s.fieldLabel, { marginTop: spacing.sm }]}>競技経験</Text>
+                <View style={s.chipWrap}>
+                  {EXPERIENCE_OPTIONS.map((exp) => {
+                    const selected = editForm.performanceProfile?.sport?.experience === exp.value;
+                    return (
+                      <Pressable
+                        key={exp.value}
+                        onPress={() => isEditing && updatePerformanceProfile("sport.experience", exp.value)}
+                        style={[s.chip, selected && s.chipSelected]}
+                      >
+                        <Text style={{ fontSize: 14 }}>{exp.icon}</Text>
+                        <Text style={[s.chipText, selected && { color: "#fff" }]}>{exp.label}</Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+
+                <Text style={[s.fieldLabel, { marginTop: spacing.sm }]}>トレーニング期</Text>
+                <View style={s.chipWrap}>
+                  {PHASE_OPTIONS.map((phase) => {
+                    const selected = editForm.performanceProfile?.sport?.phase === phase.value;
+                    return (
+                      <Pressable
+                        key={phase.value}
+                        onPress={() => isEditing && updatePerformanceProfile("sport.phase", phase.value)}
+                        style={[s.chip, selected && s.chipSelected]}
+                      >
+                        <Text style={{ fontSize: 14 }}>{phase.icon}</Text>
+                        <Text style={[s.chipText, selected && { color: "#fff" }]}>{phase.label}</Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+
+                {(editForm.performanceProfile?.sport?.phase === "competition" ||
+                  editForm.performanceProfile?.sport?.phase === "cut") && (
+                  <Field
+                    label="次の大会・試合日（YYYY-MM-DD）"
+                    value={editForm.performanceProfile?.cut?.targetDate}
+                    editing={isEditing}
+                    onChange={(v) => updatePerformanceProfile("cut.targetDate", v || null)}
+                  />
+                )}
+              </>
+            )}
+
+            <View style={{ backgroundColor: "#F5F3FF", borderRadius: 12, padding: spacing.md, marginTop: spacing.md }}>
+              <Text style={{ fontSize: 13, fontWeight: "700", color: "#7C3AED", marginBottom: 4 }}>🏆 競技プロフィールとは？</Text>
+              <Text style={{ fontSize: 12, color: "#7C3AED" }}>競技に取り組んでいる方向けの機能です。トレーニング期や競技特性に合わせて、最適な栄養提案を行います。</Text>
+            </View>
           </Card>
         )}
 
@@ -321,12 +466,101 @@ export default function ProfilePage() {
                 );
               })}
             </View>
+
+            <Text style={[s.fieldLabel, { marginTop: spacing.sm }]}>睡眠の質</Text>
+            {isEditing ? (
+              <View style={{ flexDirection: "row", gap: spacing.xs, marginBottom: spacing.sm }}>
+                {[
+                  { value: "good", label: "良好" },
+                  { value: "average", label: "普通" },
+                  { value: "poor", label: "悪い" },
+                ].map((opt) => {
+                  const selected = editForm.sleepQuality === opt.value;
+                  return (
+                    <Pressable key={opt.value} onPress={() => updateField("sleepQuality", opt.value)} style={[s.chip, selected && s.chipSelected]}>
+                      <Text style={[s.chipText, selected && { color: "#fff" }]}>{opt.label}</Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            ) : (
+              <Text style={[s.fieldValue, { marginBottom: spacing.sm }]}>
+                {editForm.sleepQuality === "good" ? "良好" : editForm.sleepQuality === "average" ? "普通" : editForm.sleepQuality === "poor" ? "悪い" : "未設定"}
+              </Text>
+            )}
+
+            <Text style={[s.fieldLabel, { marginTop: spacing.xs }]}>ストレスレベル</Text>
+            {isEditing ? (
+              <View style={{ flexDirection: "row", gap: spacing.xs, marginBottom: spacing.sm }}>
+                {[
+                  { value: "low", label: "低い" },
+                  { value: "medium", label: "普通" },
+                  { value: "high", label: "高い" },
+                ].map((opt) => {
+                  const selected = editForm.stressLevel === opt.value;
+                  return (
+                    <Pressable key={opt.value} onPress={() => updateField("stressLevel", opt.value)} style={[s.chip, selected && s.chipSelected]}>
+                      <Text style={[s.chipText, selected && { color: "#fff" }]}>{opt.label}</Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            ) : (
+              <Text style={[s.fieldValue, { marginBottom: spacing.sm }]}>
+                {editForm.stressLevel === "low" ? "低い" : editForm.stressLevel === "medium" ? "普通" : editForm.stressLevel === "high" ? "高い" : "未設定"}
+              </Text>
+            )}
+
+            <Text style={[s.fieldLabel, { marginTop: spacing.xs }]}>その他</Text>
+            <View style={{ flexDirection: "row", gap: spacing.xs, flexWrap: "wrap" }}>
+              <Pressable
+                onPress={() => isEditing && updateField("coldSensitivity", !editForm.coldSensitivity)}
+                style={[s.chip, editForm.coldSensitivity && s.chipSelected]}
+              >
+                <Text style={{ fontSize: 14 }}>🥶</Text>
+                <Text style={[s.chipText, editForm.coldSensitivity && { color: "#fff" }]}>冷え性</Text>
+              </Pressable>
+              <Pressable
+                onPress={() => isEditing && updateField("swellingProne", !editForm.swellingProne)}
+                style={[s.chip, editForm.swellingProne && s.chipSelected]}
+              >
+                <Text style={{ fontSize: 14 }}>💧</Text>
+                <Text style={[s.chipText, editForm.swellingProne && { color: "#fff" }]}>むくみやすい</Text>
+              </Pressable>
+            </View>
           </Card>
         )}
 
         {activeTab === "diet" && (
           <Card>
             <Text style={s.cardTitle}>食事</Text>
+            <Text style={s.fieldLabel}>食事スタイル</Text>
+            {isEditing ? (
+              <View style={{ flexDirection: "row", gap: spacing.xs, flexWrap: "wrap", marginBottom: spacing.sm }}>
+                {[
+                  { value: "normal", label: "通常" },
+                  { value: "vegetarian", label: "ベジタリアン" },
+                  { value: "vegan", label: "ヴィーガン" },
+                  { value: "pescatarian", label: "ペスカタリアン" },
+                  { value: "gluten_free", label: "グルテンフリー" },
+                  { value: "keto", label: "ケトジェニック" },
+                ].map((opt) => {
+                  const selected = (editForm.dietStyle || "normal") === opt.value;
+                  return (
+                    <Pressable key={opt.value} onPress={() => updateField("dietStyle", opt.value)} style={[s.chip, selected && s.chipSelected]}>
+                      <Text style={[s.chipText, selected && { color: "#fff" }]}>{opt.label}</Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            ) : (
+              <Text style={[s.fieldValue, { marginBottom: spacing.sm }]}>
+                {(() => {
+                  const map: Record<string, string> = { normal: "通常", vegetarian: "ベジタリアン", vegan: "ヴィーガン", pescatarian: "ペスカタリアン", gluten_free: "グルテンフリー", keto: "ケトジェニック" };
+                  return map[editForm.dietStyle] || "未設定";
+                })()}
+              </Text>
+            )}
             <Field
               label="アレルギー（カンマ区切り）"
               value={(editForm.dietFlags?.allergies || []).join("、")}
@@ -373,6 +607,33 @@ export default function ProfilePage() {
               })}
             </View>
             <Field label="平日の調理時間 (分)" value={editForm.weekdayCookingMinutes?.toString()} editing={isEditing} onChange={(v) => updateField("weekdayCookingMinutes", v ? parseInt(v) : null)} keyboardType="number-pad" />
+            <Field label="休日の調理時間 (分)" value={editForm.weekendCookingMinutes?.toString()} editing={isEditing} onChange={(v) => updateField("weekendCookingMinutes", v ? parseInt(v) : null)} keyboardType="number-pad" />
+
+            <Text style={[s.fieldLabel, { marginTop: spacing.sm }]}>持っている調理器具</Text>
+            <View style={s.chipWrap}>
+              {KITCHEN_APPLIANCES.map((appliance) => {
+                const selected = (editForm.kitchenAppliances || []).includes(appliance);
+                return (
+                  <Pressable
+                    key={appliance}
+                    onPress={() => isEditing && toggleArrayItem("kitchenAppliances", appliance)}
+                    style={[s.chip, selected && s.chipSelected]}
+                  >
+                    <Text style={[s.chipText, selected && { color: "#fff" }]}>{appliance}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+
+            <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", paddingVertical: spacing.sm, borderTopWidth: 1, borderTopColor: "#F3F4F6", marginTop: spacing.xs }}>
+              <Text style={s.fieldLabel}>作り置きOK</Text>
+              <Switch
+                value={editForm.mealPrepOk ?? true}
+                onValueChange={(v) => { if (isEditing) updateField("mealPrepOk", v); }}
+                disabled={!isEditing}
+                trackColor={{ true: colors.accent }}
+              />
+            </View>
           </Card>
         )}
 
@@ -395,6 +656,13 @@ export default function ProfilePage() {
               })}
             </View>
             <Field label="家族人数" value={editForm.familySize?.toString()} editing={isEditing} onChange={(v) => updateField("familySize", v ? parseInt(v) : null)} keyboardType="number-pad" />
+            <Field label="週間食費予算 (円)" value={editForm.weeklyFoodBudget?.toString()} editing={isEditing} onChange={(v) => updateField("weeklyFoodBudget", v ? parseInt(v) : null)} keyboardType="number-pad" />
+            <Field
+              label="趣味（カンマ区切り）"
+              value={(editForm.hobbies || []).join("、")}
+              editing={isEditing}
+              onChange={(v) => updateField("hobbies", v.split(/[,、]/).map((s: string) => s.trim()).filter(Boolean))}
+            />
           </Card>
         )}
 


### PR DESCRIPTION
## Summary

- goals タブに `goalText`（目標テキスト）と `targetDate`（目標期限）を追加
- sports タブに performanceProfile セクション（`sport.id` / `sport.experience` / `sport.phase` / `cut.targetDate`）を追加
- health タブに `sleepQuality`、`stressLevel`、`coldSensitivity`、`swellingProne` を追加
- diet タブに `dietStyle`（食事スタイル選択）を追加
- cooking タブに `weekendCookingMinutes`、`kitchenAppliances`、`mealPrepOk` を追加
- lifestyle タブに `weeklyFoodBudget`、`hobbies` を追加
- `handleSave` を `PUT` → `PATCH /api/profile` に変更し全フィールドを送信

## Test plan

- [ ] 各タブを開き、追加フィールドが表示されることを確認
- [ ] 編集モードで各フィールドを変更し、「保存」で PATCH /api/profile が呼ばれることを確認
- [ ] sports タブの performanceProfile で競技を選択し、experience / phase が表示されることを確認
- [ ] phase が competition / cut の場合のみ cut.targetDate フィールドが表示されることを確認
- [ ] web の `src/app/(main)/profile/page.tsx:792-1221` と同等の挙動であることを確認

Closes #557