### PR TITLE
fix(mobile): 栄養フィードバック API に weekData コンテキストを送信 (#537)

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -289,9 +289,10 @@ interface NutritionSheetProps {
   day: DayRow | null;
   dateLabel: string;
   radarKeys: (keyof DayNutritionTotals)[];
+  weekDays: DayRow[];
 }
 
-function NutritionBottomSheet({ visible, onClose, day, dateLabel, radarKeys }: NutritionSheetProps) {
+function NutritionBottomSheet({ visible, onClose, day, dateLabel, radarKeys, weekDays }: NutritionSheetProps) {
   const meals = day?.planned_meals ?? [];
   const totals = useMemo(() => calcDayTotals(meals), [meals]);
   const [praiseComment, setPraiseComment]         = useState<string | null>(null);
@@ -313,9 +314,16 @@ function NutritionBottomSheet({ visible, onClose, day, dateLabel, radarKeys }: N
 
   async function fetchFeedback(dateStr: string, nutrition: DayNutritionTotals, mealCount: number, forceRefresh = false) {
     setIsLoadingFeedback(true);
+    const weekData = weekDays.map((d) => ({
+      date: d.day_date,
+      meals: d.planned_meals.map((m) => ({
+        title: m.dish_name,
+        calories: m.calories_kcal,
+      })),
+    }));
     try {
       const api = getApi();
-      const res = await api.post<any>("/api/ai/nutrition/feedback", { date: dateStr, nutrition, mealCount, forceRefresh });
+      const res = await api.post<any>("/api/ai/nutrition/feedback", { date: dateStr, nutrition, mealCount, forceRefresh, weekData });
       if (res.cached && (res.feedback || res.praiseComment)) {
         setPraiseComment(res.praiseComment ?? null);
         setAdviceText(res.advice ?? res.feedback ?? null);
@@ -1534,6 +1542,7 @@ export default function WeeklyMenuPage() {
         day={nutritionSheetDay}
         dateLabel={nutritionSheetLabel}
         radarKeys={DEFAULT_RADAR_KEYS}
+        weekDays={days}
       />
     </View>
   );


### PR DESCRIPTION
Closes #537

## Summary

- `NutritionSheetProps` に `weekDays: DayRow[]` プロパティを追加
- `NutritionBottomSheet` の `fetchFeedback` 内で `weekData` を組み立て、`/api/ai/nutrition/feedback` POST に含めるよう修正
- 親コンポーネントから `days` state を `weekDays` prop として渡すよう JSX を更新

## Test plan

- [ ] 週間メニュー画面で任意の日の栄養分析ボトムシートを開く
- [ ] ネットワークタブで `/api/ai/nutrition/feedback` の POST body に `weekData` 配列が含まれることを確認
- [ ] キャッシュ済み・生成中どちらのフローでもフィードバックが正常表示されることを確認