### PR TITLE
feat(mobile): 通知 toggle ON 時に OS 通知権限を要求 (#558)

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import * as FileSystem from "expo-file-system";
+import * as Notifications from "expo-notifications";
 import { router } from "expo-router";
 import * as Sharing from "expo-sharing";
 import React, { useEffect, useState } from "react";
@@ -93,6 +94,28 @@ export default function SettingsTab() {
     currentValue: boolean,
   ) {
     const newValue = !currentValue;
+
+    // 通知を ON にするときは OS の通知権限をリクエスト
+    if (key === "notifications_enabled" && newValue) {
+      const { status: existingStatus } = await Notifications.getPermissionsAsync();
+      let finalStatus = existingStatus;
+      if (existingStatus !== "granted") {
+        const { status } = await Notifications.requestPermissionsAsync();
+        finalStatus = status;
+      }
+      if (finalStatus !== "granted") {
+        Alert.alert(
+          "通知が許可されていません",
+          "通知を受け取るには、端末の設定からアプリの通知を許可してください。",
+          [
+            { text: "キャンセル", style: "cancel" },
+            { text: "設定を開く", onPress: () => Linking.openSettings() },
+          ],
+        );
+        return; // DB への保存も行わない
+      }
+    }
+
     setter(newValue);
     try {
       const api = getApi();


### PR DESCRIPTION
## Summary

- 通知 toggle を OFF → ON にした際に `expo-notifications` の `getPermissionsAsync()` / `requestPermissionsAsync()` を呼び出し OS 通知権限を確認・要求
- 権限付与済みの場合は重複ダイアログを表示しない
- 権限拒否時は `Alert` でユーザーに案内し DB 保存を行わない（toggle は ON にならない）
- 「設定を開く」ボタンから `Linking.openSettings()` で OS 設定へ誘導

Closes #558