### PR TITLE
feat(mobile): MODE_CONFIG に ai_creative モード追加 (#552)

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -718,12 +718,13 @@ const MEAL_CONFIG: Record<string, { icon: keyof typeof Ionicons.glyphMap; label:
   midnight_snack: { icon: "cloudy-night", label: "夜食", color: "#3F51B5" },
 };
 
-const MODE_CONFIG: Record<string, { label: string; color: string; bg: string }> = {
+const MODE_CONFIG: Record<string, { icon?: string; label: string; color: string; bg: string }> = {
   cook: { label: "自炊", color: colors.success, bg: colors.successLight },
   quick: { label: "時短", color: colors.blue, bg: colors.blueLight },
   buy: { label: "買う", color: colors.purple, bg: colors.purpleLight },
   out: { label: "外食", color: colors.warning, bg: colors.warningLight },
   skip: { label: "なし", color: colors.textMuted, bg: colors.bg },
+  ai_creative: { icon: "sparkles", label: "AI献立", color: colors.accent, bg: colors.accentLight },
 };
 
 export default function WeeklyMenuPage() {


### PR DESCRIPTION
## Summary

- `apps/mobile/app/menus/weekly/index.tsx` の `MODE_CONFIG` に `ai_creative` エントリを追加
- `icon: "sparkles"`、`label: "AI献立"`、`color: colors.accent`、`bg: colors.accentLight` を設定
- web 側 `src/app/(main)/menus/weekly/page.tsx:138` の定義と整合
- `MODE_CONFIG` の型定義に optional な `icon` フィールドを追加（既存エントリへの影響なし）

Closes #552