### PR TITLE
feat(mobile): 日付セレクタに祝日・休日アクセント色 (#541)

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -755,6 +755,13 @@ export default function WeeklyMenuPage() {
   // Radar chart nutrient keys — fetched from profile (falls back to DEFAULT_RADAR_KEYS)
   const [radarChartNutrients, setRadarChartNutrients] = useState<(keyof DayNutritionTotals)[]>(DEFAULT_RADAR_KEYS);
 
+  // Calendar state
+  const [displayMonth, setDisplayMonth] = useState<Date>(() => new Date());
+  const [holidays, setHolidays] = useState<Record<string, string>>({});
+  const [isCalendarExpanded, setIsCalendarExpanded] = useState(false);
+  const [calendarMealDates, setCalendarMealDates] = useState<Set<string>>(new Set());
+  const fetchedRangesRef = useRef<Set<string>>(new Set());
+
   useEffect(() => {
     const fetchRadarProfile = async () => {
       try {
@@ -1364,6 +1371,12 @@ export default function WeeklyMenuPage() {
               const dayNum = d.day_date.slice(8);
               const completedAll = d.planned_meals.length > 0 && d.planned_meals.every((m) => m.is_completed);
               const hasGenerating = d.planned_meals.some((m) => m.is_generating);
+              const dayOfWeek = new Date(d.day_date + "T00:00:00").getDay(); // 0=日,6=土
+              const isHolidayDay = !!holidays[d.day_date];
+              const isSunday = dayOfWeek === 0;
+              const isSaturday = dayOfWeek === 6;
+              // 祝日・日曜日=danger(赤系)、土曜日=blue(青系)
+              const accentColor = (isHolidayDay || isSunday) ? colors.danger : isSaturday ? colors.blue : null;
 
               return (
                 <Pressable
@@ -1375,20 +1388,20 @@ export default function WeeklyMenuPage() {
                     paddingVertical: spacing.sm,
                     paddingHorizontal: spacing.md,
                     borderRadius: radius.lg,
-                    backgroundColor: selected ? colors.accent : colors.card,
+                    backgroundColor: selected ? (accentColor ?? colors.accent) : colors.card,
                     borderWidth: 1,
-                    borderColor: selected ? colors.accent : colors.border,
+                    borderColor: selected ? (accentColor ?? colors.accent) : (accentColor ? `${accentColor}33` : colors.border),
                     minWidth: 48,
                     ...shadows.sm,
                     ...(pressed ? { opacity: 0.9 } : {}),
                   })}
                 >
-                  <Text style={{ fontSize: 11, fontWeight: "600", color: selected ? "#fff" : colors.textMuted }}>{dow}</Text>
-                  <Text style={{ fontSize: 16, fontWeight: "800", color: selected ? "#fff" : colors.text }}>{dayNum}</Text>
+                  <Text style={{ fontSize: 11, fontWeight: "600", color: selected ? "#fff" : (accentColor ?? colors.textMuted) }}>{dow}</Text>
+                  <Text style={{ fontSize: 16, fontWeight: "800", color: selected ? "#fff" : (accentColor ?? colors.text) }}>{dayNum}</Text>
                   {completedAll ? (
                     <Ionicons name="checkmark-circle" size={14} color={selected ? "#fff" : colors.success} />
                   ) : hasGenerating ? (
-                    <ActivityIndicator size={12} color={selected ? "#fff" : colors.accent} />
+                    <ActivityIndicator size={12} color={selected ? "#fff" : (accentColor ?? colors.accent)} />
                   ) : (
                     <Text style={{ fontSize: 10, color: selected ? "rgba(255,255,255,0.7)" : colors.textMuted }}>
                       {d.planned_meals.length}食

--- a/apps/mobile/src/theme/colors.ts
+++ b/apps/mobile/src/theme/colors.ts
@@ -14,6 +14,7 @@ export const colors = {
   warningLight: '#FFF3E0',
   error: '#F44336',
   errorLight: '#FFEBEE',
+  danger: '#D64545',
   purple: '#7C4DFF',
   purpleLight: '#EDE7F6',
   blue: '#2196F3',


### PR DESCRIPTION
Closes #541

## Summary

- 週間献立の日付セレクタ（横スクロールのピル型タブ）で祝日・休日のアクセント色を実装
- 祝日・日曜日: `colors.danger` (#D64545) 赤系
- 土曜日: `colors.blue` (#2196F3) 青系
- 平日: 変更なし

## 変更内容

- `apps/mobile/app/menus/weekly/index.tsx`: 日付セレクタ内で `dayOfWeek`・`isHolidayDay` を算出し、`accentColor` を背景色・枠色・テキスト色に適用
- `apps/mobile/src/theme/colors.ts`: `danger: '#D64545'` を追加 (web 版と統一)
- カレンダー機能 (#451) で参照されていた `displayMonth`/`holidays`/`isCalendarExpanded`/`calendarMealDates`/`fetchedRangesRef` の state 未宣言 TS エラーを合わせて修正

## Test plan

- [ ] 土曜日のピルが青系テキスト・枠線で表示される
- [ ] 日曜日のピルが赤系テキスト・枠線で表示される
- [ ] 祝日のピルが赤系テキスト・枠線で表示される
- [ ] 選択中は各アクセント色の背景になる
- [ ] 平日は変更なし