### PR TITLE
feat: モバイル ストリーク画面で内部キーを日本語ラベルに変換 (#561)

### DIFF
--- a/apps/mobile/app/health/streaks.tsx
+++ b/apps/mobile/app/health/streaks.tsx
@@ -7,6 +7,13 @@ import { Button, Card, EmptyState, LoadingState, PageHeader, ProgressBar, Sectio
 import { colors, spacing } from "../../src/theme";
 import { getApi } from "../../src/lib/api";
 
+const STREAK_TYPE_LABELS: Record<string, string> = {
+  daily_record: "毎日の記録",
+  meal_record: "食事記録",
+  health_record: "健康記録",
+  exercise_record: "運動記録",
+};
+
 type Streak = {
   id?: string;
   streak_type: string;
@@ -134,7 +141,7 @@ export default function HealthStreaksPage() {
 
           <Card>
             <SectionHeader
-              title="daily_record"
+              title={STREAK_TYPE_LABELS[data.streak.streak_type] ?? data.streak.streak_type}
               right={<Ionicons name="stats-chart-outline" size={18} color={colors.accent} />}
             />
             <View style={styles.detailGrid}>


### PR DESCRIPTION
## Summary

- `STREAK_TYPE_LABELS` 辞書を `apps/mobile/app/health/streaks.tsx` 上部に定義
- `SectionHeader title="daily_record"` の raw キー渡しを `STREAK_TYPE_LABELS[data.streak.streak_type] ?? data.streak.streak_type` に変換
- 対応キー: `daily_record` → 毎日の記録、`meal_record` → 食事記録、`health_record` → 健康記録、`exercise_record` → 運動記録

## Test plan

- [ ] ストリーク画面でセクションヘッダーが「daily_record」ではなく「毎日の記録」と表示されることを確認
- [ ] 未知のキーが来た場合はそのまま raw キーが表示されることを確認（フォールバック `?? type`）
- [ ] `npx tsc --noEmit` で streaks.tsx に関する型エラーがないことを確認済み

Closes #561