### PR TITLE
feat: モバイル オンボーディングに体の悩み/睡眠/ストレス/妊娠状態の4問追加 (#413)

### DIFF
--- a/apps/mobile/app/onboarding/questions.tsx
+++ b/apps/mobile/app/onboarding/questions.tsx
@@ -327,6 +327,53 @@ const QUESTIONS: Question[] = [
     ],
   },
   {
+    id: "body_concerns",
+    text: "体の悩みはありますか？（複数選択可、なければスキップ）",
+    type: "multi_choice",
+    allowSkip: true,
+    options: [
+      { label: "🥶 冷え性", value: "cold_sensitivity" },
+      { label: "🦵 むくみやすい", value: "swelling_prone" },
+      { label: "💤 疲れやすい", value: "fatigue" },
+      { label: "🤕 肩こり・腰痛", value: "stiff_shoulders" },
+      { label: "😵 頭痛持ち", value: "headache" },
+      { label: "🌡️ 汗をかきにくい", value: "low_sweating" },
+      { label: "🍂 肌荒れ", value: "skin_trouble" },
+      { label: "💇 髪のパサつき", value: "dry_hair" },
+    ],
+  },
+  {
+    id: "sleep_quality",
+    text: "睡眠の質はいかがですか？",
+    type: "choice",
+    options: [
+      { label: "😴 良好", value: "good", description: "よく眠れている" },
+      { label: "😐 普通", value: "average", description: "特に問題なし" },
+      { label: "😫 悪い", value: "poor", description: "睡眠に問題がある" },
+    ],
+  },
+  {
+    id: "stress_level",
+    text: "日々のストレスレベルは？",
+    type: "choice",
+    options: [
+      { label: "😌 低い", value: "low", description: "リラックスできている" },
+      { label: "😐 普通", value: "medium", description: "日常的なストレス" },
+      { label: "😰 高い", value: "high", description: "ストレスを感じている" },
+    ],
+  },
+  {
+    id: "pregnancy_status",
+    text: "妊娠・授乳の状況を教えてください",
+    type: "choice",
+    showIf: (answers) => answers.gender === "female",
+    options: [
+      { label: "🙅‍♀️ 該当なし", value: "none", description: "妊娠・授乳中ではない" },
+      { label: "🤰 妊娠中", value: "pregnant", description: "現在妊娠中" },
+      { label: "🤱 授乳中", value: "nursing", description: "現在授乳中" },
+    ],
+  },
+  {
     id: "medications",
     text: "服用中の薬はありますか？（なければスキップ）",
     type: "multi_choice",


### PR DESCRIPTION
## Summary

- `QUESTIONS` 配列の `health_conditions` 直後・`medications` 直前に 4 問を追加
  - `body_concerns`: 冷え性・むくみ・疲れやすい等の体の悩みを複数選択（スキップ可）
  - `sleep_quality`: 睡眠の質を良好/普通/悪い の3択
  - `stress_level`: 日々のストレスレベルを低/普通/高 の3択
  - `pregnancy_status`: 妊娠・授乳状況を3択（`answers.gender === "female"` の場合のみ表示）

## Test plan

- [ ] オンボーディングフローを通しで実行し、4問が正しい順序で表示される
- [ ] `pregnancy_status` が性別=女性の場合のみ表示され、男性の場合はスキップされる
- [ ] `body_concerns` でスキップボタンが表示され、回答なしで次に進める
- [ ] TypeScript エラーが `questions.tsx` に存在しない (`npx tsc --noEmit`)

Closes #413