### PR TITLE
feat: モバイル週間メニューの MODE_CONFIG に ai_creative を追加 (#552)

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -724,6 +724,7 @@ const MODE_CONFIG: Record<string, { label: string; color: string; bg: string }> 
   buy: { label: "買う", color: colors.purple, bg: colors.purpleLight },
   out: { label: "外食", color: colors.warning, bg: colors.warningLight },
   skip: { label: "なし", color: colors.textMuted, bg: colors.bg },
+  ai_creative: { label: "AI献立", color: colors.accent, bg: colors.accentLight },
 };
 
 export default function WeeklyMenuPage() {


### PR DESCRIPTION
## Summary

- `apps/mobile/app/menus/weekly/index.tsx` の `MODE_CONFIG` に `ai_creative` エントリが欠落していた
- Web 版 (`src/app/(main)/menus/weekly/page.tsx`) と同様に `label: "AI献立"`、`color: colors.accent`、`bg: colors.accentLight` を追加
- 変更は MODE_CONFIG への 1 行追加のみで、他の修正 PR (祝日色/day selector/meal toggle) との競合なし

## Test plan

- [ ] AI 献立モード (`mode = "ai_creative"`) の食事カードに「AI献立」ラベルとアクセントカラーが正しく表示される
- [ ] 他のモード (cook / quick / buy / out / skip) の表示が変わっていないことを確認

Closes #552