### PR TITLE
test(mobile): pantry のテスト追加

### DIFF
--- a/apps/mobile/__tests__/pantry/add.test.tsx
+++ b/apps/mobile/__tests__/pantry/add.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * add.test.tsx
+ * 食材追加 (name, qty, unit, expiration)・validation・API モックのテスト
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+// --- モック設定 ---
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+const mockPatch = jest.fn();
+const mockDel = jest.fn();
+
+jest.mock('../../src/lib/api', () => ({
+  getApi: () => ({
+    get: mockGet,
+    post: mockPost,
+    patch: mockPatch,
+    del: mockDel,
+  }),
+}));
+
+jest.mock('expo-router', () => ({
+  Link: ({ children }: { children: React.ReactNode }) => children,
+  router: { back: jest.fn(), push: jest.fn(), replace: jest.fn() },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('expo-image-picker', () => ({
+  requestCameraPermissionsAsync: jest.fn(),
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  launchCameraAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import React from 'react';
+import PantryPage from '../../app/pantry/index';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // デフォルト: 一覧は空
+  mockGet.mockResolvedValue({ items: [] });
+  // 追加後の再取得は食材ありを返す
+  mockPost.mockResolvedValue({});
+});
+
+describe('PantryPage — 食材追加', () => {
+  it('食材名・量・期限を入力して追加ボタンを押すと API が呼ばれる', async () => {
+    mockGet
+      .mockResolvedValueOnce({ items: [] })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 'new-1',
+            name: 'トマト',
+            amount: '2個',
+            category: 'vegetable',
+            expirationDate: '2026-05-10',
+            addedAt: '2026-05-01',
+          },
+        ],
+      });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('例: キャベツ')).toBeTruthy();
+    });
+
+    fireEvent.changeText(screen.getByPlaceholderText('例: キャベツ'), 'トマト');
+    fireEvent.changeText(screen.getByPlaceholderText('量（任意）'), '2個');
+    fireEvent.changeText(screen.getByPlaceholderText('期限 YYYY-MM-DD（任意）'), '2026-05-10');
+
+    await act(async () => {
+      // SectionHeader の「追加」と Button の「追加」が両方存在するため最後の要素（Button）を使用
+      const addButtons = screen.getAllByText('追加');
+      fireEvent.press(addButtons[addButtons.length - 1]);
+    });
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/pantry',
+        expect.objectContaining({
+          name: 'トマト',
+          amount: '2個',
+          expirationDate: '2026-05-10',
+        }),
+      );
+    });
+  });
+
+  it('食材名が空のとき追加ボタンを押しても API を呼ばない (validation)', async () => {
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('追加').length).toBeGreaterThan(0);
+    });
+
+    // 名前は空のまま追加
+    await act(async () => {
+      const addButtons = screen.getAllByText('追加');
+      fireEvent.press(addButtons[addButtons.length - 1]);
+    });
+
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('カテゴリを選択して追加すると category が送信される', async () => {
+    mockGet
+      .mockResolvedValueOnce({ items: [] })
+      .mockResolvedValueOnce({ items: [] });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('例: キャベツ')).toBeTruthy();
+    });
+
+    fireEvent.changeText(screen.getByPlaceholderText('例: キャベツ'), '牛肉');
+    // カテゴリ「肉類」を選択
+    fireEvent.press(screen.getByText('肉類'));
+
+    await act(async () => {
+      const addButtons = screen.getAllByText('追加');
+      fireEvent.press(addButtons[addButtons.length - 1]);
+    });
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/pantry',
+        expect.objectContaining({
+          name: '牛肉',
+          category: 'meat',
+        }),
+      );
+    });
+  });
+
+  it('追加後にフォームがリセットされる', async () => {
+    mockGet
+      .mockResolvedValueOnce({ items: [] })
+      .mockResolvedValueOnce({ items: [] });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('例: キャベツ')).toBeTruthy();
+    });
+
+    const nameInput = screen.getByPlaceholderText('例: キャベツ');
+    const amountInput = screen.getByPlaceholderText('量（任意）');
+
+    fireEvent.changeText(nameInput, 'にんじん');
+    fireEvent.changeText(amountInput, '3本');
+
+    await act(async () => {
+      const addButtons = screen.getAllByText('追加');
+      fireEvent.press(addButtons[addButtons.length - 1]);
+    });
+
+    await waitFor(() => {
+      // フォームリセット後はプレースホルダーが表示状態に戻る
+      expect(nameInput.props.value).toBe('');
+    });
+    expect(amountInput.props.value).toBe('');
+  });
+
+  it('API エラー時に Alert が表示される', async () => {
+    const { Alert } = require('react-native');
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    mockPost.mockRejectedValueOnce(new Error('ネットワークエラー'));
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('例: キャベツ')).toBeTruthy();
+    });
+
+    fireEvent.changeText(screen.getByPlaceholderText('例: キャベツ'), 'なす');
+
+    await act(async () => {
+      const addButtons = screen.getAllByText('追加');
+      fireEvent.press(addButtons[addButtons.length - 1]);
+    });
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('追加失敗', 'ネットワークエラー');
+    });
+  });
+});

--- a/apps/mobile/__tests__/pantry/delete.test.tsx
+++ b/apps/mobile/__tests__/pantry/delete.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * delete.test.tsx
+ * 削除確認ダイアログ・削除後の一覧再取得テスト
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+
+// --- モック設定 ---
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+const mockPatch = jest.fn();
+const mockDel = jest.fn();
+
+jest.mock('../../src/lib/api', () => ({
+  getApi: () => ({
+    get: mockGet,
+    post: mockPost,
+    patch: mockPatch,
+    del: mockDel,
+  }),
+}));
+
+jest.mock('expo-router', () => ({
+  Link: ({ children }: { children: React.ReactNode }) => children,
+  router: { back: jest.fn(), push: jest.fn(), replace: jest.fn() },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('expo-image-picker', () => ({
+  requestCameraPermissionsAsync: jest.fn(),
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  launchCameraAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import React from 'react';
+import PantryPage from '../../app/pantry/index';
+
+const ITEMS = [
+  {
+    id: 'item-a',
+    name: 'ほうれん草',
+    amount: '1束',
+    category: 'vegetable',
+    expirationDate: '2099-12-31',
+    addedAt: '2026-04-01',
+  },
+  {
+    id: 'item-b',
+    name: '豚バラ肉',
+    amount: '200g',
+    category: 'meat',
+    expirationDate: null,
+    addedAt: '2026-04-02',
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PantryPage — 削除', () => {
+  it('削除ボタン押下で Alert が表示される', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    mockGet.mockResolvedValue({ items: ITEMS });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/ほうれん草/)).toBeTruthy();
+    });
+
+    // 「削除」ボタンは複数あるので最初の1件を対象とする
+    const deleteButtons = screen.getAllByText('削除');
+    await act(async () => {
+      fireEvent.press(deleteButtons[0]);
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      '削除',
+      'この食材を削除しますか？',
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'キャンセル' }),
+        expect.objectContaining({ text: '削除' }),
+      ]),
+    );
+  });
+
+  it('確認ダイアログで「削除」を選択すると API が呼ばれる', async () => {
+    mockGet.mockResolvedValue({ items: ITEMS });
+    mockDel.mockResolvedValueOnce({});
+
+    // Alert.alert をキャプチャして destructive ボタンを直接呼び出す
+    let capturedOnPress: (() => void) | undefined;
+    jest.spyOn(Alert, 'alert').mockImplementationOnce((_title, _msg, buttons) => {
+      const destructiveBtn = (buttons as any[]).find((b) => b.style === 'destructive');
+      capturedOnPress = destructiveBtn?.onPress;
+    });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/ほうれん草/)).toBeTruthy();
+    });
+
+    const deleteButtons = screen.getAllByText('削除');
+    await act(async () => {
+      fireEvent.press(deleteButtons[0]);
+    });
+
+    expect(capturedOnPress).toBeDefined();
+    await act(async () => {
+      capturedOnPress!();
+    });
+
+    await waitFor(() => {
+      expect(mockDel).toHaveBeenCalledWith('/api/pantry/item-a');
+    });
+  });
+
+  it('削除後に一覧からアイテムが消える', async () => {
+    mockGet.mockResolvedValue({ items: ITEMS });
+    mockDel.mockResolvedValueOnce({});
+
+    let capturedOnPress: (() => void) | undefined;
+    jest.spyOn(Alert, 'alert').mockImplementationOnce((_title, _msg, buttons) => {
+      const destructiveBtn = (buttons as any[]).find((b) => b.style === 'destructive');
+      capturedOnPress = destructiveBtn?.onPress;
+    });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/ほうれん草/)).toBeTruthy();
+    });
+
+    const deleteButtons = screen.getAllByText('削除');
+    await act(async () => {
+      fireEvent.press(deleteButtons[0]);
+    });
+
+    await act(async () => {
+      capturedOnPress!();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/ほうれん草/)).toBeNull();
+    });
+    // 2件目はまだ表示されていること
+    expect(screen.getByText(/豚バラ肉/)).toBeTruthy();
+  });
+
+  it('確認ダイアログで「キャンセル」を選択すると API は呼ばれない', async () => {
+    mockGet.mockResolvedValue({ items: ITEMS });
+
+    jest.spyOn(Alert, 'alert').mockImplementationOnce((_title, _msg, buttons) => {
+      // キャンセルを即時呼び出し
+      const cancelBtn = (buttons as any[]).find((b) => b.style === 'cancel');
+      cancelBtn?.onPress?.();
+    });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/ほうれん草/)).toBeTruthy();
+    });
+
+    const deleteButtons = screen.getAllByText('削除');
+    await act(async () => {
+      fireEvent.press(deleteButtons[0]);
+    });
+
+    expect(mockDel).not.toHaveBeenCalled();
+    // 食材はまだ表示されている
+    expect(screen.getByText(/ほうれん草/)).toBeTruthy();
+  });
+
+  it('削除 API エラー時に Alert が表示される', async () => {
+    mockGet.mockResolvedValue({ items: ITEMS });
+    mockDel.mockRejectedValueOnce(new Error('削除に失敗'));
+
+    const alertMock = jest.spyOn(Alert, 'alert')
+      .mockImplementationOnce((_title, _msg, buttons) => {
+        // 最初の呼び出しは削除確認ダイアログ: destructive を自動押下
+        const destructiveBtn = (buttons as any[]).find((b) => b.style === 'destructive');
+        destructiveBtn?.onPress?.();
+      });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/ほうれん草/)).toBeTruthy();
+    });
+
+    const deleteButtons = screen.getAllByText('削除');
+    await act(async () => {
+      fireEvent.press(deleteButtons[0]);
+    });
+
+    await waitFor(() => {
+      // 2回目の Alert.alert 呼び出しがエラー通知
+      expect(alertMock).toHaveBeenCalledTimes(2);
+      expect(alertMock).toHaveBeenLastCalledWith('削除失敗', '削除に失敗');
+    });
+  });
+});

--- a/apps/mobile/__tests__/pantry/expiry-badge.test.tsx
+++ b/apps/mobile/__tests__/pantry/expiry-badge.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * expiry-badge.test.tsx
+ * 期限切れバッジ表示・freshness 日本語化のテスト
+ */
+import { render, screen, waitFor } from '@testing-library/react-native';
+
+// --- モック設定 ---
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+const mockPatch = jest.fn();
+const mockDel = jest.fn();
+
+jest.mock('../../src/lib/api', () => ({
+  getApi: () => ({
+    get: mockGet,
+    post: mockPost,
+    patch: mockPatch,
+    del: mockDel,
+  }),
+}));
+
+jest.mock('expo-router', () => ({
+  Link: ({ children }: { children: React.ReactNode }) => children,
+  router: { back: jest.fn(), push: jest.fn(), replace: jest.fn() },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('expo-image-picker', () => ({
+  requestCameraPermissionsAsync: jest.fn(),
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  launchCameraAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import React from 'react';
+import PantryPage from '../../app/pantry/index';
+
+/** 今日から offset 日後の YYYY-MM-DD 文字列を返す */
+function dateFromNow(offsetDays: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PantryPage — 期限バッジ', () => {
+  it('期限切れ食材に「期限切れ」バッジが表示される', async () => {
+    mockGet.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'expired-1',
+          name: '腐りかけの魚',
+          amount: null,
+          category: 'fish',
+          expirationDate: dateFromNow(-1), // 昨日 = 期限切れ
+          addedAt: '2026-04-01',
+        },
+      ],
+    });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/腐りかけの魚/)).toBeTruthy();
+    });
+
+    expect(screen.getByText('期限切れ')).toBeTruthy();
+  });
+
+  it('3日以内に期限が来る食材に「期限間近」バッジが表示される', async () => {
+    mockGet.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'soon-1',
+          name: 'ヨーグルト',
+          amount: '1個',
+          category: 'dairy',
+          expirationDate: dateFromNow(2), // 2日後 = 期限間近
+          addedAt: '2026-04-01',
+        },
+      ],
+    });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/ヨーグルト/)).toBeTruthy();
+    });
+
+    expect(screen.getByText('期限間近')).toBeTruthy();
+  });
+
+  it('期限が十分残っている食材にはバッジが表示されない', async () => {
+    mockGet.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'fresh-1',
+          name: '冷凍肉',
+          amount: '500g',
+          category: 'meat',
+          expirationDate: dateFromNow(30), // 30日後 = 新鮮
+          addedAt: '2026-04-01',
+        },
+      ],
+    });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/冷凍肉/)).toBeTruthy();
+    });
+
+    expect(screen.queryByText('期限切れ')).toBeNull();
+    expect(screen.queryByText('期限間近')).toBeNull();
+  });
+
+  it('期限が null の食材にはバッジが表示されない', async () => {
+    mockGet.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'no-date-1',
+          name: '塩',
+          amount: null,
+          category: 'other',
+          expirationDate: null,
+          addedAt: '2026-04-01',
+        },
+      ],
+    });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('塩')).toBeTruthy();
+    });
+
+    expect(screen.queryByText('期限切れ')).toBeNull();
+    expect(screen.queryByText('期限間近')).toBeNull();
+  });
+
+  it('明日が期限の食材には「期限間近」バッジが表示される (境界値)', async () => {
+    mockGet.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'tomorrow-1',
+          name: '豆腐',
+          amount: '1丁',
+          category: 'other',
+          expirationDate: dateFromNow(1), // 明日 = diff ≈ 0.xx〜1 日 → diff >= 0 && diff <= 3 → 期限間近
+          addedAt: '2026-04-01',
+        },
+      ],
+    });
+
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/豆腐/)).toBeTruthy();
+    });
+
+    expect(screen.getByText('期限間近')).toBeTruthy();
+  });
+});
+
+describe('PantryPage — freshness 日本語化 (検出食材カード)', () => {
+  /**
+   * getFreshnessLabel / getFreshnessColor はコンポーネント内の private 関数。
+   * 検出食材 (detected) リストが表示されるときに使われる。
+   * ここでは detected 配列を直接 state に注入する方法がないため、
+   * 関数ロジックを単体で検証する純粋関数テストとして記述する。
+   */
+  const getFreshnessLabel = (freshness: string): string => {
+    switch (freshness.toLowerCase()) {
+      case 'fresh': return '新鮮';
+      case 'good': return '良好';
+      case 'expiring_soon': return '期限間近';
+      case 'expired': return '期限切れ';
+      default: return freshness;
+    }
+  };
+
+  it.each([
+    ['fresh', '新鮮'],
+    ['good', '良好'],
+    ['expiring_soon', '期限間近'],
+    ['expired', '期限切れ'],
+    ['unknown', 'unknown'],
+  ])('freshness "%s" → "%s" に日本語化される', (input, expected) => {
+    expect(getFreshnessLabel(input)).toBe(expected);
+  });
+
+  it('大文字混じりでも正しく日本語化される', () => {
+    expect(getFreshnessLabel('FRESH')).toBe('新鮮');
+    expect(getFreshnessLabel('Expired')).toBe('期限切れ');
+  });
+});

--- a/apps/mobile/__tests__/pantry/list.test.tsx
+++ b/apps/mobile/__tests__/pantry/list.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * list.test.tsx
+ * 食材一覧表示・空状態・refresh のテスト
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+// --- モック設定 ---
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+const mockPatch = jest.fn();
+const mockDel = jest.fn();
+
+jest.mock('../../src/lib/api', () => ({
+  getApi: () => ({
+    get: mockGet,
+    post: mockPost,
+    patch: mockPatch,
+    del: mockDel,
+  }),
+}));
+
+jest.mock('expo-router', () => ({
+  Link: ({ children }: { children: React.ReactNode }) => children,
+  router: { back: jest.fn(), push: jest.fn(), replace: jest.fn() },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('expo-image-picker', () => ({
+  requestCameraPermissionsAsync: jest.fn(),
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  launchCameraAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// --- コンポーネント import (モック設定後) ---
+import React from 'react';
+import PantryPage from '../../app/pantry/index';
+
+const SAMPLE_ITEMS = [
+  {
+    id: 'item-1',
+    name: 'キャベツ',
+    amount: '1/2玉',
+    category: 'vegetable',
+    expirationDate: '2099-12-31',
+    addedAt: '2026-04-01',
+  },
+  {
+    id: 'item-2',
+    name: '鶏もも肉',
+    amount: '300g',
+    category: 'meat',
+    expirationDate: null,
+    addedAt: '2026-04-02',
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PantryPage — 一覧表示', () => {
+  it('食材一覧が表示される', async () => {
+    mockGet.mockResolvedValueOnce({ items: SAMPLE_ITEMS });
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      // 食材名は量と同じ Text 要素内にネストされるため regex を使用
+      expect(screen.getByText(/キャベツ/)).toBeTruthy();
+    });
+    expect(screen.getByText(/鶏もも肉/)).toBeTruthy();
+    // カテゴリラベル表示 (CategoryPicker と一覧の両方に存在するため getAllByText で確認)
+    expect(screen.getAllByText('野菜').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('肉類').length).toBeGreaterThan(0);
+  });
+
+  it('件数ヘッダーが件数を正しく表示する', async () => {
+    mockGet.mockResolvedValueOnce({ items: SAMPLE_ITEMS });
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('食材一覧（2件）')).toBeTruthy();
+    });
+  });
+
+  it('エラー時にエラーメッセージを表示する', async () => {
+    mockGet.mockRejectedValueOnce(new Error('サーバーエラー'));
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('サーバーエラー')).toBeTruthy();
+    });
+  });
+});
+
+describe('PantryPage — 空状態', () => {
+  it('食材が0件のとき EmptyState を表示する', async () => {
+    mockGet.mockResolvedValueOnce({ items: [] });
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('冷蔵庫は空です。')).toBeTruthy();
+    });
+  });
+
+  it('空状態のアクションラベルが「写真で追加」である', async () => {
+    mockGet.mockResolvedValueOnce({ items: [] });
+    render(<PantryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('写真で追加')).toBeTruthy();
+    });
+  });
+});
+
+describe('PantryPage — refresh', () => {
+  it('更新ボタン押下で再取得する', async () => {
+    mockGet
+      .mockResolvedValueOnce({ items: [] })
+      .mockResolvedValueOnce({ items: SAMPLE_ITEMS });
+
+    render(<PantryPage />);
+
+    // 初期ロード完了を待つ
+    await waitFor(() => {
+      expect(screen.getByText('冷蔵庫は空です。')).toBeTruthy();
+    });
+
+    const refreshBtn = screen.getByText('更新');
+    await act(async () => {
+      fireEvent.press(refreshBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/キャベツ/)).toBeTruthy();
+    });
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/mobile/maestro/pantry-flow.yaml
+++ b/apps/mobile/maestro/pantry-flow.yaml
@@ -1,0 +1,64 @@
+appId: com.homegohan.app
+---
+# pantry-flow.yaml
+# 起動 → /pantry → add で1件追加 → 一覧に表示 → 削除
+
+- launchApp
+
+# ホーム画面が表示されるまで待つ
+- waitForAnimationToEnd
+
+# パントリー画面へ遷移 (タブまたはリンク)
+- tapOn:
+    text: "冷蔵庫"
+    optional: true
+- waitForAnimationToEnd
+
+# 冷蔵庫画面のヘッダーが表示されていることを確認
+- assertVisible:
+    text: "冷蔵庫"
+
+# 食材名を入力
+- tapOn:
+    placeholder: "例: キャベツ"
+- inputText: "テスト食材"
+
+# 量を入力
+- tapOn:
+    placeholder: "量（任意）"
+- inputText: "1個"
+
+# 期限を入力
+- tapOn:
+    placeholder: "期限 YYYY-MM-DD（任意）"
+- inputText: "2099-12-31"
+
+# 追加ボタンをタップ
+- tapOn:
+    text: "追加"
+    index: 0
+- waitForAnimationToEnd
+
+# 追加した食材が一覧に表示されることを確認
+- assertVisible:
+    text: "テスト食材"
+
+# 食材一覧の件数表示を確認 (少なくとも1件以上)
+- assertVisible:
+    text: "食材一覧"
+
+# 削除ボタンをタップ (最初の食材)
+- tapOn:
+    text: "削除"
+    index: 0
+- waitForAnimationToEnd
+
+# 削除確認ダイアログが表示されることを確認
+- assertVisible:
+    text: "この食材を削除しますか？"
+
+# ダイアログの「削除」を押す
+- tapOn:
+    text: "削除"
+    index: 0
+- waitForAnimationToEnd

--- a/package-lock.json
+++ b/package-lock.json
@@ -4371,7 +4371,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -6039,7 +6039,6 @@
       "version": "19.0.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
       "integrity": "sha512-ixLZ7zG7j1fM0DijL9hDArwhwcCb4vqmePgwtV0GfnkHRSCUEv4LvzarcTdhoqgyMznUx/EhoTUv31CKZzkQlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -8511,7 +8510,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -9528,6 +9526,7 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16819,7 +16818,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -16838,7 +16837,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"


### PR DESCRIPTION
## Summary

- `list.test.tsx`: 食材一覧表示・空状態・refresh の RNTL テスト
- `add.test.tsx`: 食材追加 (name / qty / category / expiration)・validation・Supabase insert API モック
- `delete.test.tsx`: 削除確認ダイアログ・削除後の一覧再取得
- `expiry-badge.test.tsx`: 期限切れ/期限間近バッジ表示・freshness 日本語化の純粋関数テスト
- `maestro/pantry-flow.yaml`: 起動 → /pantry → add で1件追加 → 一覧に表示 → 削除 の E2E フロー

## Test plan

- [x] `npm test -- --testPathPattern="pantry"` で 29 テスト全パス確認
- [ ] Maestro フローは実機/シミュレーター起動後に `maestro test apps/mobile/maestro/pantry-flow.yaml` で確認