### PR TITLE
test(mobile): src/lib・theme・components の単体テスト追加

### DIFF
--- a/apps/mobile/__tests__/components/PageHeader.test.tsx
+++ b/apps/mobile/__tests__/components/PageHeader.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * PageHeader.test.tsx
+ * src/components/ui/PageHeader.tsx のレンダリングと戻るボタン動作を検証する
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+// ── expo-router モック ────────────────────────────────────────────────────────
+jest.mock('expo-router', () => ({
+  router: { back: jest.fn(), push: jest.fn() },
+}));
+
+import { router as mockRouter } from 'expo-router';
+const mockBack = mockRouter.back as jest.Mock;
+
+// ── @expo/vector-icons モック ─────────────────────────────────────────────────
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+// ── react-native-safe-area-context モック ─────────────────────────────────────
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+import { PageHeader } from '../../src/components/ui/PageHeader';
+
+beforeEach(() => {
+  mockBack.mockClear();
+});
+
+describe('PageHeader', () => {
+  it('title テキストをレンダリングする', () => {
+    const { getByText } = render(<PageHeader title="テストページ" />);
+    expect(getByText('テストページ')).toBeTruthy();
+  });
+
+  it('subtitle が渡されたとき表示される', () => {
+    const { getByText } = render(<PageHeader title="タイトル" subtitle="サブタイトル" />);
+    expect(getByText('サブタイトル')).toBeTruthy();
+  });
+
+  it('subtitle が省略されたとき表示されない', () => {
+    const { queryByText } = render(<PageHeader title="タイトル" />);
+    expect(queryByText('サブタイトル')).toBeNull();
+  });
+
+  it('showBack=true (デフォルト) のとき戻るボタンが存在し、タップで router.back() が呼ばれる', () => {
+    const { UNSAFE_getAllByType } = render(<PageHeader title="タイトル" />);
+    // Pressable が複数ある可能性があるので最初の Pressable をタップ
+    const { Pressable } = require('react-native');
+    const pressables = UNSAFE_getAllByType(Pressable);
+    // 最初の Pressable が戻るボタン
+    fireEvent.press(pressables[0]);
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('showBack=false のとき戻るボタンが表示されない', () => {
+    const { UNSAFE_queryAllByType } = render(<PageHeader title="タイトル" showBack={false} />);
+    const { Pressable } = require('react-native');
+    const pressables = UNSAFE_queryAllByType(Pressable);
+    expect(pressables).toHaveLength(0);
+  });
+
+  it('right スロットがレンダリングされる', () => {
+    const { Text } = require('react-native');
+    const { getByText } = render(
+      <PageHeader title="タイトル" right={<Text>rightContent</Text>} />,
+    );
+    expect(getByText('rightContent')).toBeTruthy();
+  });
+});

--- a/apps/mobile/__tests__/lib/api-client.test.ts
+++ b/apps/mobile/__tests__/lib/api-client.test.ts
@@ -1,0 +1,87 @@
+/**
+ * api-client.test.ts
+ * src/lib/api.ts の getApiBaseUrl() と getApi() をテストする
+ *
+ * supabase / @homegohan/core はモックで置換する。
+ * jest.isolateModules() を使って _api シングルトンをテストごとにリセットする。
+ */
+
+// ── supabase モック ──────────────────────────────────────────────────────────
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
+    },
+  },
+}));
+
+// ── @homegohan/core モック ─────────────────────────────────────────────────
+// ファクトリ内で jest.fn() を直接生成し、外部変数参照によるホイスティングエラーを避ける
+jest.mock('@homegohan/core', () => ({
+  createHttpClient: jest.fn((opts: any) => ({ _opts: opts, get: jest.fn(), post: jest.fn() })),
+}));
+
+describe('getApiBaseUrl()', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('EXPO_PUBLIC_API_BASE_URL が設定されていれば値を返す', () => {
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'https://api.example.com';
+    // isolateModules で新鮮なモジュールを取得
+    let result: string | undefined;
+    jest.isolateModules(() => {
+      const { getApiBaseUrl } = require('../../src/lib/api');
+      result = getApiBaseUrl();
+    });
+    expect(result).toBe('https://api.example.com');
+  });
+
+  it('EXPO_PUBLIC_API_BASE_URL が未設定なら Error をスロー', () => {
+    delete process.env.EXPO_PUBLIC_API_BASE_URL;
+    jest.isolateModules(() => {
+      const { getApiBaseUrl } = require('../../src/lib/api');
+      expect(() => getApiBaseUrl()).toThrow('[mobile] Missing env: EXPO_PUBLIC_API_BASE_URL');
+    });
+  });
+});
+
+describe('getApi()', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV, EXPO_PUBLIC_API_BASE_URL: 'https://api.example.com' };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('createHttpClient を baseUrl 付きで呼ぶ', () => {
+    jest.isolateModules(() => {
+      const { createHttpClient } = require('@homegohan/core');
+      const { getApi } = require('../../src/lib/api');
+      getApi();
+      expect(createHttpClient).toHaveBeenCalledWith(
+        expect.objectContaining({ baseUrl: 'https://api.example.com' }),
+      );
+    });
+  });
+
+  it('2 回目以降はキャッシュを返す (createHttpClient は 1 回だけ呼ばれる)', () => {
+    jest.isolateModules(() => {
+      const { createHttpClient } = require('@homegohan/core');
+      const { getApi } = require('../../src/lib/api');
+      const a = getApi();
+      const b = getApi();
+      expect(a).toBe(b);
+      expect(createHttpClient).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/mobile/__tests__/lib/deeplink.test.ts
+++ b/apps/mobile/__tests__/lib/deeplink.test.ts
@@ -1,0 +1,53 @@
+/**
+ * deeplink.test.ts
+ * src/lib/deeplink.ts の extractSupabaseLinkParams() をテストする
+ */
+
+import { extractSupabaseLinkParams } from '../../src/lib/deeplink';
+
+describe('extractSupabaseLinkParams()', () => {
+  it('フラグメント部の access_token を抽出できる', () => {
+    const url = 'myapp://callback#access_token=TOKEN123&token_type=bearer';
+    const result = extractSupabaseLinkParams(url);
+    expect(result.access_token).toBe('TOKEN123');
+  });
+
+  it('フラグメント部の refresh_token を抽出できる', () => {
+    const url = 'myapp://callback#access_token=A&refresh_token=REFRESH456';
+    const result = extractSupabaseLinkParams(url);
+    expect(result.refresh_token).toBe('REFRESH456');
+  });
+
+  it('クエリパラメータの code を抽出できる', () => {
+    const url = 'https://example.com/auth/callback?code=AUTHCODE789';
+    const result = extractSupabaseLinkParams(url);
+    expect(result.code).toBe('AUTHCODE789');
+  });
+
+  it('フラグメントがクエリより優先される', () => {
+    const url = 'https://example.com/auth?access_token=QUERY#access_token=FRAGMENT';
+    const result = extractSupabaseLinkParams(url);
+    expect(result.access_token).toBe('FRAGMENT');
+  });
+
+  it('error と error_description を抽出できる', () => {
+    const url = 'myapp://callback#error=access_denied&error_description=User+denied';
+    const result = extractSupabaseLinkParams(url);
+    expect(result.error).toBe('access_denied');
+    expect(result.error_description).toBe('User denied');
+  });
+
+  it('type フィールドを抽出できる', () => {
+    const url = 'myapp://callback#type=recovery&token_hash=HASH';
+    const result = extractSupabaseLinkParams(url);
+    expect(result.type).toBe('recovery');
+    expect(result.token_hash).toBe('HASH');
+  });
+
+  it('パラメータがない場合は undefined を返す', () => {
+    const result = extractSupabaseLinkParams('myapp://callback');
+    expect(result.access_token).toBeUndefined();
+    expect(result.code).toBeUndefined();
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/apps/mobile/__tests__/theme/colors.test.ts
+++ b/apps/mobile/__tests__/theme/colors.test.ts
@@ -1,0 +1,48 @@
+/**
+ * colors.test.ts
+ * src/theme/colors.ts の主要トークン値を検証する
+ */
+
+import { colors } from '../../src/theme/colors';
+
+describe('colors トークン', () => {
+  it('accent は #FF8A65', () => {
+    expect(colors.accent).toBe('#FF8A65');
+  });
+
+  it('accentDark は #C4634C', () => {
+    expect(colors.accentDark).toBe('#C4634C');
+  });
+
+  it('danger は #D64545', () => {
+    expect(colors.danger).toBe('#D64545');
+  });
+
+  it('bg は #FFFFFF', () => {
+    expect(colors.bg).toBe('#FFFFFF');
+  });
+
+  it('text は #1A1A1A', () => {
+    expect(colors.text).toBe('#1A1A1A');
+  });
+
+  it('success は #4CAF50', () => {
+    expect(colors.success).toBe('#4CAF50');
+  });
+
+  it('error は #F44336', () => {
+    expect(colors.error).toBe('#F44336');
+  });
+
+  it('border は #EEEEEE', () => {
+    expect(colors.border).toBe('#EEEEEE');
+  });
+
+  it('streak は #FF6B35', () => {
+    expect(colors.streak).toBe('#FF6B35');
+  });
+
+  it('purple は #7C4DFF', () => {
+    expect(colors.purple).toBe('#7C4DFF');
+  });
+});

--- a/apps/mobile/__tests__/theme/spacing.test.ts
+++ b/apps/mobile/__tests__/theme/spacing.test.ts
@@ -1,0 +1,42 @@
+/**
+ * spacing.test.ts
+ * src/theme/spacing.ts のスペーシング・ラジウストークンを検証する
+ */
+
+import { spacing, radius } from '../../src/theme/spacing';
+
+describe('spacing トークン', () => {
+  it('xs は 4', () => {
+    expect(spacing.xs).toBe(4);
+  });
+
+  it('sm は 8', () => {
+    expect(spacing.sm).toBe(8);
+  });
+
+  it('md は 12', () => {
+    expect(spacing.md).toBe(12);
+  });
+
+  it('lg は 16', () => {
+    expect(spacing.lg).toBe(16);
+  });
+
+  it('xl は 20', () => {
+    expect(spacing.xl).toBe(20);
+  });
+
+  it('2xl は 24', () => {
+    expect(spacing['2xl']).toBe(24);
+  });
+});
+
+describe('radius トークン', () => {
+  it('sm は 8', () => {
+    expect(radius.sm).toBe(8);
+  });
+
+  it('full は 999', () => {
+    expect(radius.full).toBe(999);
+  });
+});


### PR DESCRIPTION
## Summary
- colors.ts token 値検証 (accent, danger, success 等 10 ケース)
- spacing.ts / radius token 値検証 (8 ケース)
- api.ts getApiBaseUrl() / getApi() のモックを使った検証 (4 ケース)
- deeplink.ts extractSupabaseLinkParams() を境界値含めて検証 (7 ケース)
- PageHeader コンポーネントの title/subtitle/showBack/right レンダリング検証 (6 ケース)

合計 35 テストケース

## Test plan
- [x] npm test 全 pass (35 passed, 0 failed)