### PR TITLE
test(mobile): AI チャットのテスト追加

### DIFF
--- a/apps/mobile/__tests__/ai/action-execute.test.tsx
+++ b/apps/mobile/__tests__/ai/action-execute.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * action-execute.test.tsx
+ * actionExecuted フラグの単一実行保証テスト
+ * - 「実行」ボタン押下で POST /api/ai/consultation/actions/:id/execute が1回だけ呼ばれる
+ * - 「却下」ボタン押下で DELETE /api/ai/consultation/actions/:id/execute が1回だけ呼ばれる
+ * - 実行後に同じメッセージのアクションボタンが非表示になる（二重実行防止）
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+// --- モック設定 ---
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+const mockDel = jest.fn();
+
+jest.mock('../../src/lib/api', () => ({
+  getApi: () => ({
+    get: mockGet,
+    post: mockPost,
+    del: mockDel,
+  }),
+  getApiBaseUrl: () => 'http://localhost:3000',
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ sessionId: 'test-session-id' }),
+  router: { back: jest.fn() },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('expo-image-picker', () => ({
+  requestMediaLibraryPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// --- コンポーネント import (モック設定後) ---
+import React from 'react';
+import { Alert } from 'react-native';
+import AiSessionPage from '../../app/ai/[sessionId]';
+import { supabase } from '../../src/lib/supabase';
+
+const MSG_WITH_ACTION = {
+  id: 'ai-msg-action',
+  role: 'assistant' as const,
+  content: 'カレーを献立に追加しましょうか？',
+  proposedActions: { type: 'add_meal', meal: 'カレー' },
+  createdAt: '2026-04-01T10:00:00.000Z',
+};
+
+let mockAlertSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (supabase.auth.getSession as jest.Mock).mockResolvedValue({
+    data: { session: { access_token: 'test-token' } },
+  });
+  global.fetch = jest.fn();
+  mockAlertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  mockAlertSpy.mockRestore();
+});
+
+describe('AiSessionPage — アクション実行ボタン', () => {
+  it('提案アクションが存在するとき「実行」「却下」ボタンが表示される', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] });
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('実行')).toBeTruthy();
+      expect(screen.getByText('却下')).toBeTruthy();
+    });
+  });
+
+  it('提案アクションがない場合はボタンが表示されない', async () => {
+    const msgNoAction = { ...MSG_WITH_ACTION, proposedActions: null };
+    mockGet.mockResolvedValueOnce({ messages: [msgNoAction] });
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('カレーを献立に追加しましょうか？')).toBeTruthy();
+    });
+
+    expect(screen.queryByText('実行')).toBeNull();
+    expect(screen.queryByText('却下')).toBeNull();
+  });
+});
+
+describe('AiSessionPage — アクション「実行」', () => {
+  it('「実行」ボタン押下で POST エンドポイントが1回だけ呼ばれる', async () => {
+    mockGet
+      .mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] })
+      .mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] }); // 実行後のリロード
+    mockPost.mockResolvedValueOnce({ success: true });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('実行')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('実行'));
+    });
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledTimes(1);
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/ai/consultation/actions/ai-msg-action/execute',
+        {}
+      );
+    });
+  });
+
+  it('「実行」後はアクションボタンが非表示になる (executedMessageIds に記録)', async () => {
+    mockGet
+      .mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] })
+      .mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] }); // 実行後のリロードでも proposedActions は残る
+    mockPost.mockResolvedValueOnce({ success: true });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('実行')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('実行'));
+    });
+
+    await waitFor(() => {
+      // リロード後も executedMessageIds によりボタンが非表示
+      expect(screen.queryByText('実行')).toBeNull();
+      expect(screen.queryByText('却下')).toBeNull();
+    });
+  });
+
+  it('「実行」が失敗した場合でもボタンは非表示にならない', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] });
+    mockPost.mockRejectedValueOnce(new Error('実行失敗'));
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('実行')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('実行'));
+    });
+
+    // エラー時はアクションが executedMessageIds に追加されない
+    // ただし現実装では executeActionByMessageId の catch 内で追加しないため
+    // ボタンが再表示されるはず（リロードなし）
+    await waitFor(() => {
+      expect(mockAlertSpy).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('AiSessionPage — アクション「却下」', () => {
+  it('「却下」ボタン押下で DELETE エンドポイントが1回だけ呼ばれる', async () => {
+    mockGet
+      .mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] })
+      .mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] }); // 却下後のリロード
+    mockDel.mockResolvedValueOnce({ success: true });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('却下')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('却下'));
+    });
+
+    await waitFor(() => {
+      expect(mockDel).toHaveBeenCalledTimes(1);
+      expect(mockDel).toHaveBeenCalledWith(
+        '/api/ai/consultation/actions/ai-msg-action/execute'
+      );
+    });
+  });
+
+  it('「却下」後はアクションボタンが非表示になる (executedMessageIds に記録)', async () => {
+    mockGet
+      .mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] })
+      .mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] });
+    mockDel.mockResolvedValueOnce({ success: true });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('却下')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('却下'));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('実行')).toBeNull();
+      expect(screen.queryByText('却下')).toBeNull();
+    });
+  });
+});
+
+describe('AiSessionPage — 単一実行保証 (executedMessageIds による重複排除)', () => {
+  it('実行成功後に GET が再取得されても同じメッセージのボタンは表示されない', async () => {
+    // POST 成功 → executedMessageIds に記録 → load() 再取得
+    // 再取得後も proposedActions が返ってくるが、executedMessageIds により非表示
+    mockGet
+      .mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] })
+      .mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] }); // リロード後も同じ
+    mockPost.mockResolvedValueOnce({ success: true });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('実行')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('実行'));
+    });
+
+    // 実行後: ボタンが非表示、POST は1回だけ呼ばれている
+    await waitFor(() => {
+      expect(screen.queryByText('実行')).toBeNull();
+    });
+    expect(mockPost).toHaveBeenCalledTimes(1);
+
+    // 追加で GET が呼ばれても同じ ID なのでボタンは表示されない
+    expect(screen.queryByText('実行')).toBeNull();
+    expect(screen.queryByText('却下')).toBeNull();
+  });
+
+  it('実行成功後にアクションボタンが再表示されない (ref による追跡)', async () => {
+    mockGet
+      .mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] })
+      .mockResolvedValueOnce({ messages: [MSG_WITH_ACTION] });
+    mockPost.mockResolvedValueOnce({ success: true });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('実行')).toBeTruthy();
+    });
+
+    // 実行
+    await act(async () => {
+      fireEvent.press(screen.getByText('実行'));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('実行')).toBeNull();
+      expect(screen.queryByText('却下')).toBeNull();
+    });
+
+    // load() で同一メッセージが再取得されてもボタンは出てこない
+    await act(async () => {}); // flush
+    expect(screen.queryByText('実行')).toBeNull();
+  });
+});

--- a/apps/mobile/__tests__/ai/chat-stream.test.tsx
+++ b/apps/mobile/__tests__/ai/chat-stream.test.tsx
@@ -1,0 +1,376 @@
+/**
+ * chat-stream.test.tsx
+ * メッセージ送信・ストリーミング受信・executedMessageIds 重複防止のテスト
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+// --- モック設定 ---
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+const mockDel = jest.fn();
+
+jest.mock('../../src/lib/api', () => ({
+  getApi: () => ({
+    get: mockGet,
+    post: mockPost,
+    del: mockDel,
+  }),
+  getApiBaseUrl: () => 'http://localhost:3000',
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ sessionId: 'test-session-id' }),
+  router: {
+    back: jest.fn(),
+    push: jest.fn(),
+  },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('expo-image-picker', () => ({
+  requestMediaLibraryPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// fetch SSE モックユーティリティ
+function makeSseResponse(lines: string[]): Response {
+  const text = lines.join('\n') + '\n';
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(text);
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoded);
+      controller.close();
+    },
+  });
+  return {
+    ok: true,
+    status: 200,
+    body: stream,
+    text: () => Promise.resolve(text),
+  } as unknown as Response;
+}
+
+/** テキスト入力欄を見つけて文字を入力し、送信ボタンを押す */
+async function typeAndSend(inputText: string) {
+  const input = screen.getByPlaceholderText('相談内容を入力...');
+  fireEvent.changeText(input, inputText);
+  // 送信ボタンは入力バー内の最後の Pressable。
+  // UNSAFE_getAllByType で Pressable をすべて取得し最後を押す。
+  const pressables = screen.UNSAFE_getAllByType(Pressable);
+  await act(async () => {
+    fireEvent.press(pressables[pressables.length - 1]);
+  });
+}
+
+// --- コンポーネント import (モック設定後) ---
+import React from 'react';
+import { Pressable } from 'react-native';
+import AiSessionPage from '../../app/ai/[sessionId]';
+import { supabase } from '../../src/lib/supabase';
+
+const INITIAL_MESSAGES = [
+  {
+    id: 'msg-1',
+    role: 'user' as const,
+    content: 'こんにちは',
+    createdAt: '2026-04-01T10:00:00.000Z',
+  },
+  {
+    id: 'msg-2',
+    role: 'assistant' as const,
+    content: 'はじめまして！何かご相談がありますか？',
+    createdAt: '2026-04-01T10:00:05.000Z',
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (supabase.auth.getSession as jest.Mock).mockResolvedValue({
+    data: { session: { access_token: 'test-token' } },
+  });
+  global.fetch = jest.fn();
+});
+
+describe('AiSessionPage — メッセージ一覧表示', () => {
+  it('既存のメッセージが表示される', async () => {
+    mockGet.mockResolvedValueOnce({ messages: INITIAL_MESSAGES });
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('こんにちは')).toBeTruthy();
+      expect(screen.getByText('はじめまして！何かご相談がありますか？')).toBeTruthy();
+    });
+  });
+
+  it('メッセージ 0 件のとき入力バーが表示される', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+  });
+
+  it('ローディング中は LoadingState が表示される', async () => {
+    // 解決しない promise でローディング状態を維持
+    let resolve!: (v: any) => void;
+    mockGet.mockReturnValueOnce(new Promise((res) => { resolve = res; }));
+    render(<AiSessionPage />);
+
+    // LoadingState は存在する (spinner or loading text)
+    // NOTE: LoadingState コンポーネントが何らかのテキストをレンダリングしていれば検出できる
+    // ここでは入力欄がまだない = ローディング中を確認
+    expect(screen.queryByPlaceholderText('相談内容を入力...')).toBeNull();
+
+    act(() => { resolve({ messages: [] }); });
+  });
+});
+
+describe('AiSessionPage — メッセージ送信 (ストリーミング)', () => {
+  it('テキスト入力後に送信ボタンが有効になる', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    const input = screen.getByPlaceholderText('相談内容を入力...');
+    // 初期状態では空なので送信ボタンは無効色
+    // テキスト入力後、ボタンの背景色が変わるが RNTL では style の変化で確認するより
+    // 実際に送信が呼ばれるかで確認する
+    fireEvent.changeText(input, '今日の夕食を教えて');
+    expect(input.props.value).toBe('今日の夕食を教えて');
+  });
+
+  it('テキスト送信後、楽観的メッセージが表示される', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+
+    // fetch を delay させて楽観的 UI の確認中を維持
+    let resolveFetch!: (v: Response) => void;
+    (global.fetch as jest.Mock).mockReturnValueOnce(
+      new Promise((res) => { resolveFetch = res; })
+    );
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await typeAndSend('今日の夕食を教えて');
+
+    // 楽観的メッセージが表示される
+    await waitFor(() => {
+      expect(screen.getByText('今日の夕食を教えて')).toBeTruthy();
+    });
+
+    // クリーンアップ: fetch を失敗させて終了
+    act(() => {
+      resolveFetch({ ok: false, status: 500, text: () => Promise.resolve(''), body: null } as any);
+    });
+    await waitFor(() => {
+      // エラー後、楽観的メッセージが削除される
+      expect(screen.queryByText('今日の夕食を教えて')).toBeNull();
+    });
+  });
+
+  it('SSE ストリームのチャンクが最終メッセージとして表示される', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+
+    const sseLines = [
+      'data: {"choices":[{"delta":{"content":"今日"}}]}',
+      'data: {"choices":[{"delta":{"content":"の夕食"}}]}',
+      'data: {"choices":[{"delta":{"content":"はカレーです"}}]}',
+      'data: {"aiMessage":{"id":"ai-resp-1","content":"今日の夕食はカレーです","createdAt":"2026-04-01T11:00:00.000Z"},"userMessage":{"id":"user-sent-1","content":"今日の夕食を教えて","createdAt":"2026-04-01T10:59:00.000Z"}}',
+      'data: [DONE]',
+    ];
+    (global.fetch as jest.Mock).mockResolvedValueOnce(makeSseResponse(sseLines));
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await typeAndSend('今日の夕食を教えて');
+
+    await waitFor(() => {
+      expect(screen.getByText('今日の夕食はカレーです')).toBeTruthy();
+    });
+  });
+
+  it('SSE 完了後、入力欄がクリアされる', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+
+    const sseLines = [
+      'data: {"aiMessage":{"id":"ai-resp-2","content":"応答テキスト","createdAt":"2026-04-01T11:00:00.000Z"},"userMessage":{"id":"user-sent-2","content":"テスト送信","createdAt":"2026-04-01T10:59:00.000Z"}}',
+      'data: [DONE]',
+    ];
+    (global.fetch as jest.Mock).mockResolvedValueOnce(makeSseResponse(sseLines));
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    const input = screen.getByPlaceholderText('相談内容を入力...');
+    fireEvent.changeText(input, 'テスト送信');
+    expect(input.props.value).toBe('テスト送信');
+
+    await typeAndSend('テスト送信');
+
+    await waitFor(() => {
+      // 入力欄がクリアされていること
+      const inputAfter = screen.getByPlaceholderText('相談内容を入力...');
+      expect(inputAfter.props.value).toBe('');
+    });
+  });
+
+  it('fetch が HTTP エラーを返したとき、エラーメッセージを表示しオプティミスティックメッセージを削除する', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('Internal Server Error'),
+      body: null,
+    } as any);
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await typeAndSend('エラーテスト');
+
+    await waitFor(() => {
+      expect(screen.getByText(/HTTP 500/)).toBeTruthy();
+    });
+    // 楽観的メッセージが削除されていること
+    expect(screen.queryByText('エラーテスト')).toBeNull();
+  });
+
+  it('fetch が呼ばれる際に Authorization ヘッダーが含まれる', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+
+    const sseLines = [
+      'data: {"aiMessage":{"id":"ai-auth-test","content":"認証テスト応答","createdAt":"2026-04-01T11:00:00.000Z"},"userMessage":{"id":"user-auth","content":"認証テスト","createdAt":"2026-04-01T10:59:00.000Z"}}',
+      'data: [DONE]',
+    ];
+    (global.fetch as jest.Mock).mockResolvedValueOnce(makeSseResponse(sseLines));
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await typeAndSend('認証テスト');
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    const fetchCall = (global.fetch as jest.Mock).mock.calls[0];
+    expect(fetchCall[1].headers['Authorization']).toBe('Bearer test-token');
+    expect(fetchCall[0]).toContain('/api/ai/consultation/sessions/test-session-id/messages?stream=true');
+  });
+});
+
+describe('AiSessionPage — executedMessageIds 重複防止', () => {
+  it('actionExecuted=true の SSE 受信後、アクションボタンが非表示になる', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+
+    // actionExecuted=true を含む SSE
+    const sseLines = [
+      'data: {"aiMessage":{"id":"ai-action-msg","content":"アクションを実行しました","proposedActions":{"type":"add_meal"},"createdAt":"2026-04-01T11:00:00.000Z"},"userMessage":{"id":"user-1","content":"追加して","createdAt":"2026-04-01T10:59:00.000Z"},"actionExecuted":true}',
+      'data: [DONE]',
+    ];
+    (global.fetch as jest.Mock).mockResolvedValueOnce(makeSseResponse(sseLines));
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await typeAndSend('追加して');
+
+    await waitFor(() => {
+      expect(screen.getByText('アクションを実行しました')).toBeTruthy();
+    });
+
+    // actionExecuted=true で記録されたメッセージのアクションボタンが非表示
+    // (executedMessageIds に 'ai-action-msg' が追加されているので renderActionButtons が null を返す)
+    expect(screen.queryByText('実行')).toBeNull();
+    expect(screen.queryByText('却下')).toBeNull();
+  });
+
+  it('actionExecuted=false の SSE では proposedActions がありアクションボタンが表示される', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+
+    // actionExecuted なし（フラグなし）= アクションボタン表示
+    const sseLines = [
+      'data: {"aiMessage":{"id":"ai-propose-msg","content":"献立を追加しましょうか？","proposedActions":{"type":"add_meal"},"createdAt":"2026-04-01T11:00:00.000Z"},"userMessage":{"id":"user-2","content":"提案して","createdAt":"2026-04-01T10:59:00.000Z"}}',
+      'data: [DONE]',
+    ];
+    (global.fetch as jest.Mock).mockResolvedValueOnce(makeSseResponse(sseLines));
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await typeAndSend('提案して');
+
+    await waitFor(() => {
+      expect(screen.getByText('献立を追加しましょうか？')).toBeTruthy();
+    });
+
+    // アクションボタンが表示される
+    expect(screen.getByText('実行')).toBeTruthy();
+    expect(screen.getByText('却下')).toBeTruthy();
+  });
+
+  it('初回ロード時に proposedActions があり executedMessageIds に未記録なら表示', async () => {
+    const msgWithAction = {
+      id: 'existing-action-msg',
+      role: 'assistant' as const,
+      content: 'この献立でよろしいですか？',
+      proposedActions: { type: 'confirm_meal' },
+      createdAt: '2026-04-01T10:00:00.000Z',
+    };
+    mockGet.mockResolvedValueOnce({ messages: [msgWithAction] });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('この献立でよろしいですか？')).toBeTruthy();
+    });
+
+    // 初期ロード時は executedMessageIds が空なのでボタンが表示される
+    expect(screen.getByText('実行')).toBeTruthy();
+    expect(screen.getByText('却下')).toBeTruthy();
+  });
+});

--- a/apps/mobile/__tests__/ai/image-attach.test.tsx
+++ b/apps/mobile/__tests__/ai/image-attach.test.tsx
@@ -1,0 +1,280 @@
+/**
+ * image-attach.test.tsx
+ * 画像添付機能のテスト (expo-image-picker モック)
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+// --- モック設定 ---
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+const mockDel = jest.fn();
+
+jest.mock('../../src/lib/api', () => ({
+  getApi: () => ({
+    get: mockGet,
+    post: mockPost,
+    del: mockDel,
+  }),
+  getApiBaseUrl: () => 'http://localhost:3000',
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ sessionId: 'test-session-id' }),
+  router: {
+    back: jest.fn(),
+    push: jest.fn(),
+  },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('expo-image-picker', () => ({
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// --- コンポーネント import (モック設定後) ---
+import React from 'react';
+import { Alert, Pressable } from 'react-native';
+import AiSessionPage from '../../app/ai/[sessionId]';
+import { supabase } from '../../src/lib/supabase';
+import * as ImagePicker from 'expo-image-picker';
+
+// モック関数への型付きエイリアス
+const mockRequestPermissions = ImagePicker.requestMediaLibraryPermissionsAsync as jest.Mock;
+const mockLaunchLibrary = ImagePicker.launchImageLibraryAsync as jest.Mock;
+
+let mockAlertSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (supabase.auth.getSession as jest.Mock).mockResolvedValue({
+    data: { session: { access_token: 'test-token' } },
+  });
+  global.fetch = jest.fn();
+  mockAlertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+  mockGet.mockResolvedValue({ messages: [] });
+});
+
+afterEach(() => {
+  mockAlertSpy.mockRestore();
+});
+
+/** 入力バーの画像添付ボタンを押す (最後から2番目の Pressable) */
+async function pressImageAttachButton() {
+  const pressables = screen.UNSAFE_getAllByType(Pressable);
+  // PageHeader: back(0), summarize(1), close(2)
+  // Input bar: image(last-1), send(last)
+  const imageBtn = pressables[pressables.length - 2];
+  await act(async () => {
+    fireEvent.press(imageBtn);
+  });
+}
+
+describe('AiSessionPage — 画像添付 (expo-image-picker)', () => {
+  it('画像添付ボタン(入力バー内の最後から2番目の Pressable)が存在する', async () => {
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    const pressables = screen.UNSAFE_getAllByType(Pressable);
+    // 最低でも PageHeader×3 + 画像ボタン + 送信ボタン = 5 つ以上
+    expect(pressables.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('権限が granted のとき、launchImageLibraryAsync が呼ばれる', async () => {
+    mockRequestPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockLaunchLibrary.mockResolvedValueOnce({ canceled: true });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await pressImageAttachButton();
+
+    expect(mockRequestPermissions).toHaveBeenCalledTimes(1);
+    expect(mockLaunchLibrary).toHaveBeenCalledTimes(1);
+    expect(mockLaunchLibrary).toHaveBeenCalledWith({
+      mediaTypes: 'images',
+      allowsEditing: true,
+      quality: 0.7,
+      base64: true,
+    });
+  });
+
+  it('権限が denied のとき、Alert が表示され launchImageLibraryAsync は呼ばれない', async () => {
+    mockRequestPermissions.mockResolvedValueOnce({ status: 'denied' });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await pressImageAttachButton();
+
+    expect(mockAlertSpy).toHaveBeenCalledWith(
+      '権限が必要です',
+      '画像を添付するにはカメラロールへのアクセスを許可してください。'
+    );
+    expect(mockLaunchLibrary).not.toHaveBeenCalled();
+  });
+
+  it('画像選択がキャンセルされた場合、添付プレビューは表示されない', async () => {
+    mockRequestPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockLaunchLibrary.mockResolvedValueOnce({ canceled: true });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await pressImageAttachButton();
+
+    // キャンセルなので launchImageLibraryAsync は呼ばれるが
+    // attachedImage は設定されない
+    expect(mockLaunchLibrary).toHaveBeenCalledTimes(1);
+    // エラーや Alert は発生しない
+    expect(mockAlertSpy).not.toHaveBeenCalled();
+    // 入力欄は空のまま
+    const input = screen.getByPlaceholderText('相談内容を入力...');
+    expect(input.props.value).toBe('');
+  });
+
+  it('画像選択成功時、Pressable の数が増える (プレビューの削除ボタンが追加される)', async () => {
+    mockRequestPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockLaunchLibrary.mockResolvedValueOnce({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///tmp/test-image.jpg',
+          base64: 'base64encodeddata==',
+          width: 800,
+          height: 600,
+        },
+      ],
+    });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    const pressablesBefore = screen.UNSAFE_getAllByType(Pressable);
+    const countBefore = pressablesBefore.length;
+
+    await pressImageAttachButton();
+
+    // 画像が選択されると削除ボタン(×)が追加される → Pressable が増える
+    await waitFor(() => {
+      const pressablesAfter = screen.UNSAFE_getAllByType(Pressable);
+      expect(pressablesAfter.length).toBeGreaterThan(countBefore);
+    });
+  });
+
+  it('添付画像の削除ボタン(×)を押すと Pressable の数が元に戻る', async () => {
+    mockRequestPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockLaunchLibrary.mockResolvedValueOnce({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///tmp/test-image.jpg',
+          base64: 'base64encodeddata==',
+        },
+      ],
+    });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    const pressablesBefore = screen.UNSAFE_getAllByType(Pressable);
+    const countBefore = pressablesBefore.length;
+
+    // 画像を添付
+    await pressImageAttachButton();
+
+    // 添付後は Pressable が増えている
+    await waitFor(() => {
+      expect(screen.UNSAFE_getAllByType(Pressable).length).toBeGreaterThan(countBefore);
+    });
+
+    // 削除ボタン(×)を押す
+    // 添付プレビュー追加後、Pressable の順序:
+    // [0]: back, [1]: summarize, [2]: close, [3]: 削除ボタン(×), [4]: image, [5]: send
+    const pressablesAfterAttach = screen.UNSAFE_getAllByType(Pressable);
+    // 削除ボタンは送信・画像添付より前、CloseSession より後
+    const removeBtn = pressablesAfterAttach[pressablesAfterAttach.length - 3];
+    await act(async () => {
+      fireEvent.press(removeBtn);
+    });
+
+    // 削除後は Pressable の数が元に戻る
+    await waitFor(() => {
+      expect(screen.UNSAFE_getAllByType(Pressable).length).toBe(countBefore);
+    });
+  });
+
+  it('base64 がない asset は attachedImage が設定されない (Pressable 数が変わらない)', async () => {
+    mockRequestPermissions.mockResolvedValueOnce({ status: 'granted' });
+    mockLaunchLibrary.mockResolvedValueOnce({
+      canceled: false,
+      assets: [
+        {
+          uri: 'file:///tmp/no-base64.jpg',
+          base64: null, // base64 なし
+        },
+      ],
+    });
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    const pressablesBefore = screen.UNSAFE_getAllByType(Pressable);
+    const countBefore = pressablesBefore.length;
+
+    await pressImageAttachButton();
+
+    // base64 がないので attachedImage は設定されない
+    // → 削除ボタンが追加されない (Pressable の数が変わらない)
+    await act(async () => {}); // 非同期更新を flush
+    expect(screen.UNSAFE_getAllByType(Pressable).length).toBe(countBefore);
+  });
+});
+
+// TODO: 画像添付付きメッセージの送信テスト
+// 現在 apps/mobile/app/ai/[sessionId].tsx では imageBase64 を body に含めて送信している。
+// 送信時のフルフロー (image picker -> attach -> send with imageBase64) のテストは
+// Maestro E2E テストでカバー予定。
+describe.skip('TODO: 画像付きメッセージ送信の統合テスト', () => {
+  it('imageBase64 を含むリクエストボディで fetch が呼ばれる', () => {
+    // Maestro E2E テストでカバー予定
+  });
+});

--- a/apps/mobile/__tests__/ai/session-list.test.tsx
+++ b/apps/mobile/__tests__/ai/session-list.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * session-list.test.tsx
+ * AI セッション一覧・新規作成のテスト
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+// --- モック設定 ---
+// jest.mock はホイストされるため、ファクトリー内で参照する変数は var か jest.fn() 直書きにする
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+
+jest.mock('../../src/lib/api', () => ({
+  getApi: () => ({
+    get: mockGet,
+    post: mockPost,
+  }),
+}));
+
+jest.mock('expo-router', () => ({
+  Link: ({ children }: { children: React.ReactNode }) => children,
+  router: {
+    push: jest.fn(),
+    back: jest.fn(),
+    replace: jest.fn(),
+  },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// --- コンポーネント import (モック設定後) ---
+import React from 'react';
+import AiSessionsPage from '../../app/ai/index';
+import { router } from 'expo-router';
+
+const SAMPLE_SESSIONS = [
+  {
+    id: 'session-1',
+    // ページタイトル「AI相談」と重複しないようにユニークなタイトルを使用
+    title: '夕食についての相談',
+    status: 'active',
+    summary: null,
+    messageCount: 3,
+    createdAt: '2026-04-01T10:00:00.000Z',
+    updatedAt: '2026-04-01T10:30:00.000Z',
+  },
+  {
+    id: 'session-2',
+    title: '食事相談',
+    status: 'active',
+    summary: 'まとめ',
+    messageCount: 7,
+    createdAt: '2026-04-02T09:00:00.000Z',
+    updatedAt: '2026-04-02T09:45:00.000Z',
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('AiSessionsPage — セッション一覧', () => {
+  it('セッション一覧が表示される', async () => {
+    mockGet.mockResolvedValueOnce({ sessions: SAMPLE_SESSIONS });
+    render(<AiSessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('夕食についての相談')).toBeTruthy();
+    });
+    expect(screen.getByText('食事相談')).toBeTruthy();
+  });
+
+  it('セッション一覧が空のとき EmptyState を表示する', async () => {
+    mockGet.mockResolvedValueOnce({ sessions: [] });
+    render(<AiSessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('アクティブなセッションがありません。')).toBeTruthy();
+    });
+  });
+
+  it('エラー時にエラーメッセージを表示する', async () => {
+    mockGet.mockRejectedValueOnce(new Error('サーバーエラー'));
+    render(<AiSessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('サーバーエラー')).toBeTruthy();
+    });
+  });
+
+  it('セッションをタップすると対応する sessionId の画面に遷移する', async () => {
+    mockGet.mockResolvedValueOnce({ sessions: SAMPLE_SESSIONS });
+    render(<AiSessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('夕食についての相談')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByText('夕食についての相談'));
+    expect(router.push).toHaveBeenCalledWith('/ai/session-1');
+  });
+
+  it('API が /api/ai/consultation/sessions?status=active を呼ぶ', async () => {
+    mockGet.mockResolvedValueOnce({ sessions: [] });
+    render(<AiSessionsPage />);
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/api/ai/consultation/sessions?status=active');
+    });
+  });
+});
+
+describe('AiSessionsPage — 新規作成', () => {
+  it('「新規」ボタン押下で createSession を呼び、新セッション画面へ遷移する', async () => {
+    mockGet.mockResolvedValueOnce({ sessions: [] });
+    mockPost.mockResolvedValueOnce({ success: true, session: { id: 'new-session-123' } });
+
+    render(<AiSessionsPage />);
+
+    // 初期ロード完了を待つ
+    await waitFor(() => {
+      expect(screen.getByText('アクティブなセッションがありません。')).toBeTruthy();
+    });
+
+    const newBtn = screen.getByText('新規');
+    await act(async () => {
+      fireEvent.press(newBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/api/ai/consultation/sessions', { title: 'AI相談' });
+      expect(router.push).toHaveBeenCalledWith('/ai/new-session-123');
+    });
+  });
+
+  it('新規作成中は「作成中...」テキストが表示される', async () => {
+    mockGet.mockResolvedValueOnce({ sessions: [] });
+
+    // post を delay させて非同期状態を確認
+    let resolvePost!: (v: any) => void;
+    mockPost.mockReturnValueOnce(new Promise((res) => { resolvePost = res; }));
+
+    render(<AiSessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('アクティブなセッションがありません。')).toBeTruthy();
+    });
+
+    const newBtn = screen.getByText('新規');
+    act(() => {
+      fireEvent.press(newBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('作成中...')).toBeTruthy();
+    });
+
+    // クリーンアップ
+    act(() => {
+      resolvePost({ success: true, session: { id: 'x' } });
+    });
+  });
+
+  it('新規作成が失敗したときエラーメッセージを表示する', async () => {
+    mockGet.mockResolvedValueOnce({ sessions: [] });
+    mockPost.mockRejectedValueOnce(new Error('作成エラー'));
+
+    render(<AiSessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('アクティブなセッションがありません。')).toBeTruthy();
+    });
+
+    const newBtn = screen.getByText('新規');
+    await act(async () => {
+      fireEvent.press(newBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('作成エラー')).toBeTruthy();
+    });
+  });
+
+  it('「新しい相談を始める」ボタン (EmptyState action) でも新規作成できる', async () => {
+    mockGet.mockResolvedValueOnce({ sessions: [] });
+    mockPost.mockResolvedValueOnce({ success: true, session: { id: 'empty-new-456' } });
+
+    render(<AiSessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('新しい相談を始める')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(screen.getByText('新しい相談を始める'));
+    });
+
+    await waitFor(() => {
+      expect(router.push).toHaveBeenCalledWith('/ai/empty-new-456');
+    });
+  });
+});
+
+describe('AiSessionsPage — 更新', () => {
+  it('「更新」ボタン押下で再取得する', async () => {
+    mockGet
+      .mockResolvedValueOnce({ sessions: [] })
+      .mockResolvedValueOnce({ sessions: SAMPLE_SESSIONS });
+
+    render(<AiSessionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('アクティブなセッションがありません。')).toBeTruthy();
+    });
+
+    const refreshBtn = screen.getByText('更新');
+    await act(async () => {
+      fireEvent.press(refreshBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('夕食についての相談')).toBeTruthy();
+    });
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/mobile/maestro/ai-chat-flow.yaml
+++ b/apps/mobile/maestro/ai-chat-flow.yaml
@@ -1,0 +1,58 @@
+appId: com.homegohan.app
+---
+# AI チャット E2E フロー
+# 前提: ユーザーがログイン済みの状態でアプリを起動していること
+
+- launchApp:
+    clearState: false
+
+# AI 相談タブへ移動
+- tapOn:
+    text: "AI相談"
+    optional: true
+
+# セッション一覧が表示されることを確認
+- assertVisible: "AI相談"
+
+# 新規セッション作成
+- tapOn:
+    text: "新規"
+
+# チャット画面が開くのを待つ
+- waitForAnimationToEnd
+
+# チャット画面のタイトルを確認
+- assertVisible: "AIチャット"
+
+# 入力欄が表示されることを確認
+- assertVisible:
+    text: "相談内容を入力..."
+    optional: true
+
+# メッセージを入力
+- tapOn:
+    text: "相談内容を入力..."
+    optional: true
+- inputText: "今日の夕食のおすすめを教えてください"
+
+# 送信ボタンをタップ
+- tapOn:
+    id: "send-button"
+    optional: true
+
+# 応答を待つ (タイムアウト: 30秒)
+- waitForAnimationToEnd:
+    timeout: 30000
+
+# 送信したメッセージが表示されていることを確認
+- assertVisible: "今日の夕食のおすすめを教えてください"
+
+# セッション一覧に戻る
+- tapOn:
+    text: "戻る"
+    optional: true
+- back:
+    optional: true
+
+# セッション一覧に戻っていることを確認
+- assertVisible: "AI相談"


### PR DESCRIPTION
## Summary

- `apps/mobile/__tests__/ai/session-list.test.tsx`: セッション一覧表示・新規作成・更新 (10 テスト)
- `apps/mobile/__tests__/ai/chat-stream.test.tsx`: メッセージ送信・SSE ストリーミング受信・executedMessageIds 重複防止 (12 テスト)
- `apps/mobile/__tests__/ai/action-execute.test.tsx`: actionExecuted フラグによる単一実行保証・実行/却下ボタン動作 (9 テスト)
- `apps/mobile/__tests__/ai/image-attach.test.tsx`: expo-image-picker モックを使った画像添付フロー (7 テスト + 1 skip TODO)
- `apps/mobile/maestro/ai-chat-flow.yaml`: AI チャット E2E Maestro フロー

## 技術メモ

- `jest.mock` ファクトリー内で参照するモック関数は `jest.fn()` をファクトリー内に直書きし、インポートした module 経由でアクセスするパターンで TDZ 問題を回避
- `Alert.alert` は `jest.spyOn(Alert, 'alert')` でモック
- `Pressable` の検索は `UNSAFE_getAllByType(Pressable)` を使用 (accessibilityRole="button" は自動付与されないため)
- SSE フェイクストリームは `ReadableStream` + `TextEncoder` で構築

## Test plan

- [ ] `cd apps/mobile && npm test -- --testPathPattern="__tests__/ai/"` で全テストがグリーンであることを確認
- [ ] 実機での Maestro: `maestro test maestro/ai-chat-flow.yaml`