### PR TITLE
fix(test): jest.config.js の絶対パスを排除し CI 移植性を確保

### DIFF
--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -1,23 +1,21 @@
 const path = require('path');
 
-// test-auth worktree has no local node_modules; reuse mobile-test-infra's installs.
-// __dirname = /Users/horidaisuke/homegohan/.claude/worktrees/test-auth/apps/mobile
-// mobile-test-infra is a sibling worktree under .claude/worktrees/
-const MOBILE_TEST_INFRA = '/Users/horidaisuke/homegohan/.claude/worktrees/mobile-test-infra/apps/mobile';
-const mobileNodeModules = path.resolve(MOBILE_TEST_INFRA, 'node_modules');
-const worktreeNodeModules = path.resolve(MOBILE_TEST_INFRA, '../../node_modules');
+// __dirname = <repo-root>/apps/mobile
+// モノレポルートの node_modules を基準に解決する。
+// worktree の絶対パスには依存しない。
+const repoRoot = path.resolve(__dirname, '../..');
+const worktreeNodeModules = path.join(repoRoot, 'node_modules');
+const mobileNodeModules = path.join(__dirname, 'node_modules');
 
 /** @type {import('jest-expo').JestExpoConfig} */
 module.exports = {
-  // Point preset to the absolute path where jest-expo is installed
-  preset: path.join(worktreeNodeModules, 'jest-expo'),
-  // resolve all modules from mobile-test-infra's node_modules
+  preset: 'jest-expo',
   modulePaths: [mobileNodeModules, worktreeNodeModules],
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg))',
   ],
-  // Force all react-related modules to resolve from apps/mobile/node_modules
-  // This prevents the monorepo root react@18 from leaking in via react-test-renderer.
+  // react 系モジュールを apps/mobile/node_modules から優先解決し、
+  // モノレポルートの react@18 が react-test-renderer 経由で漏れ込むのを防ぐ。
   moduleNameMapper: {
     '^react$': path.join(mobileNodeModules, 'react'),
     '^react/(.*)$': path.join(mobileNodeModules, 'react', '$1'),


### PR DESCRIPTION
## Summary
- 複数のモバイルテスト PR (#592 #595-#603) が短時間にマージされた際、worktree の絶対パス (`/Users/horidaisuke/homegohan/.claude/worktrees/mobile-test-infra/...`) が `jest.config.js` に混入
- CI および別マシンでの checkout 時に path not found となる問題を修正
- `__dirname`（`apps/mobile`）起点の `path.resolve` でモノレポルートを算出し、worktree 名・ユーザーホームに依存しない汎用設定に統一
- `preset` を文字列 `'jest-expo'` に戻し、インストール済みパッケージを正しく参照

## Test plan
- [x] `/tmp/jest-fix-verify/apps/mobile` で `npm test` 実行 — 40 suites, 333 passed, 1 skipped, 0 failed
- [x] 絶対パス (`/Users/`) がファイル内に存在しないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)