### PR TITLE
test(mobile-e2e): login/home に testID を追加 (Maestro 用)

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -182,6 +182,7 @@ export default function LoginScreen() {
 
   return (
     <KeyboardAvoidingView
+      testID="login-screen"
       style={{ flex: 1, backgroundColor: colors.bg }}
       behavior={Platform.OS === "ios" ? "padding" : undefined}
     >
@@ -224,6 +225,7 @@ export default function LoginScreen() {
             }}>
               <Ionicons name="mail-outline" size={18} color={colors.textMuted} />
               <TextInput
+                testID="email-input"
                 placeholder="email@example.com"
                 placeholderTextColor={colors.textMuted}
                 autoCapitalize="none"
@@ -250,6 +252,7 @@ export default function LoginScreen() {
             }}>
               <Ionicons name="lock-closed-outline" size={18} color={colors.textMuted} />
               <TextInput
+                testID="password-input"
                 placeholder="パスワード"
                 placeholderTextColor={colors.textMuted}
                 secureTextEntry={!showPassword}
@@ -277,6 +280,7 @@ export default function LoginScreen() {
 
           {/* ログインボタン */}
           <Pressable
+            testID="login-button"
             onPress={onSubmit}
             disabled={isSubmitting || rateLimitRemaining > 0}
             style={({ pressed }) => ({

--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -165,7 +165,7 @@ export default function HomeScreen() {
   });
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="home-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <ScrollView contentContainerStyle={{ paddingBottom: 32 }}>
         {/* ========== ヒーローセクション ========== */}
         <View style={{ backgroundColor: "#FFF7ED", paddingTop: insets.top + 8, paddingBottom: 20, paddingHorizontal: spacing.lg }}>

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -2,7 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ["babel-preset-expo"],
-    plugins: [require.resolve("expo-router/babel")],
   };
 };
 

--- a/apps/mobile/maestro/flows/01-login.yaml
+++ b/apps/mobile/maestro/flows/01-login.yaml
@@ -1,0 +1,35 @@
+appId: com.homegohan.app
+---
+# 01-login: アプリ起動 → ウェルカム画面 → ログイン画面 → メール+パスワード入力 → ホーム画面確認
+- launchApp:
+    clearState: true
+
+# ウェルカム画面で「ログイン」をタップして login.tsx に移動
+- tapOn:
+    text: "ログイン"
+
+# ログイン画面が表示されるまで待機
+- extendedWaitUntil:
+    visible:
+      id: "login-screen"
+    timeout: 10000
+
+# メールアドレス入力
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+
+# パスワード入力
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_PASSWORD}
+
+# ログインボタンタップ
+- tapOn:
+    id: "login-button"
+
+# ホーム画面が表示されることを確認
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 15000


### PR DESCRIPTION
## Summary

- \`apps/mobile/app/(auth)/login.tsx\`: Maestro flow が要求する testID を付与
  - \`testID="login-screen"\` → KeyboardAvoidingView (ルート)
  - \`testID="email-input"\` → メールアドレス TextInput
  - \`testID="password-input"\` → パスワード TextInput
  - \`testID="login-button"\` → ログインボタン Pressable
- \`apps/mobile/app/(tabs)/home.tsx\`: ルート View に \`testID="home-screen"\` を付与
- \`apps/mobile/maestro/flows/01-login.yaml\`: Maestro 2.5.1 互換に修正
  - \`assertVisible.timeout\` → \`extendedWaitUntil\` 形式に変換
  - clearState 後はウェルカム画面が表示されるため「ログイン」タップステップを追加
- \`apps/mobile/babel.config.js\`: SDK 50 以降 deprecated な expo-router/babel プラグインを除去

## Test plan

- [x] tsc --noEmit で login.tsx / home.tsx に新規エラーなし
- [x] Maestro 2.5.1 + iPhone 16 Pro (iOS 18.3) シミュレーターで 01-login.yaml を実行し全ステップ pass