### PR TITLE
test(mobile-e2e): auth ドメインに testID 追加

### DIFF
--- a/apps/mobile/app/(auth)/auth/forgot-password.tsx
+++ b/apps/mobile/app/(auth)/auth/forgot-password.tsx
@@ -10,6 +10,7 @@ import { supabase } from "../../../src/lib/supabase";
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   async function onSubmit() {
     const trimmed = email.trim();
@@ -23,7 +24,9 @@ export default function ForgotPasswordPage() {
       const redirectTo = Linking.createURL("/auth/reset-password");
       const { error } = await supabase.auth.resetPasswordForEmail(trimmed, { redirectTo });
       if (error) throw error;
-      Alert.alert("送信しました", "パスワード再設定用のメールを送信しました。");
+      const successMsg = "パスワード再設定用のメールを送信しました。";
+      setSuccessMessage(successMsg);
+      Alert.alert("送信しました", successMsg);
     } catch (e: any) {
       Alert.alert("送信失敗", e?.message ?? "送信に失敗しました。");
     } finally {
@@ -33,6 +36,7 @@ export default function ForgotPasswordPage() {
 
   return (
     <KeyboardAvoidingView
+      testID="forgot-screen"
       style={{ flex: 1, backgroundColor: colors.bg }}
       behavior={Platform.OS === "ios" ? "padding" : undefined}
     >
@@ -77,6 +81,7 @@ export default function ForgotPasswordPage() {
             }}>
               <Ionicons name="mail-outline" size={18} color={colors.textMuted} />
               <TextInput
+                testID="forgot-email-input"
                 placeholder="email@example.com"
                 placeholderTextColor={colors.textMuted}
                 autoCapitalize="none"
@@ -92,8 +97,19 @@ export default function ForgotPasswordPage() {
             </View>
           </View>
 
+          {/* 送信成功メッセージ */}
+          {successMessage !== null && (
+            <Text
+              testID="forgot-success-text"
+              style={{ fontSize: 14, color: colors.success, textAlign: "center" }}
+            >
+              {successMessage}
+            </Text>
+          )}
+
           {/* 送信ボタン */}
           <Pressable
+            testID="forgot-submit-button"
             onPress={onSubmit}
             disabled={isSubmitting}
             style={({ pressed }) => ({

--- a/apps/mobile/app/(auth)/auth/reset-password.tsx
+++ b/apps/mobile/app/(auth)/auth/reset-password.tsx
@@ -100,6 +100,7 @@ export default function ResetPasswordPage() {
 
   return (
     <KeyboardAvoidingView
+      testID="reset-screen"
       style={{ flex: 1, backgroundColor: colors.bg }}
       behavior={Platform.OS === "ios" ? "padding" : undefined}
     >
@@ -142,11 +143,14 @@ export default function ResetPasswordPage() {
             <Text style={{ fontSize: 14, color: colors.blue, flex: 1 }}>セッション確認中...</Text>
           </View>
         ) : !sessionReady ? (
-          <View style={{
-            backgroundColor: colors.errorLight, borderRadius: radius.lg,
-            padding: spacing.md, marginBottom: spacing.md,
-            flexDirection: "row", alignItems: "center", gap: spacing.sm,
-          }}>
+          <View
+            testID="reset-error-text"
+            style={{
+              backgroundColor: colors.errorLight, borderRadius: radius.lg,
+              padding: spacing.md, marginBottom: spacing.md,
+              flexDirection: "row", alignItems: "center", gap: spacing.sm,
+            }}
+          >
             <Ionicons name="warning-outline" size={18} color={colors.error} />
             <Text style={{ fontSize: 14, color: colors.error, flex: 1 }}>
               セッションが確認できません。メールの再設定リンクから開き直してください。
@@ -167,6 +171,7 @@ export default function ResetPasswordPage() {
             }}>
               <Ionicons name="lock-closed-outline" size={18} color={colors.textMuted} />
               <TextInput
+                testID="reset-password-input"
                 placeholder="8文字以上"
                 placeholderTextColor={colors.textMuted}
                 secureTextEntry={!showPassword}
@@ -194,6 +199,7 @@ export default function ResetPasswordPage() {
             }}>
               <Ionicons name="lock-closed-outline" size={18} color={colors.textMuted} />
               <TextInput
+                testID="reset-confirm-input"
                 placeholder="もう一度入力"
                 placeholderTextColor={colors.textMuted}
                 secureTextEntry={!showConfirm}
@@ -212,6 +218,7 @@ export default function ResetPasswordPage() {
 
           {/* 更新ボタン */}
           <Pressable
+            testID="reset-submit-button"
             onPress={onSubmit}
             disabled={isSubmitting || isSettingSession}
             style={({ pressed }) => ({

--- a/apps/mobile/app/(auth)/auth/verify.tsx
+++ b/apps/mobile/app/(auth)/auth/verify.tsx
@@ -75,7 +75,7 @@ export default function VerifyPage() {
   if (hasSession && isDone && !hasError) return <Redirect href="/(tabs)/home" />;
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="verify-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       {/* 戻るボタン */}
       <Pressable
         onPress={() => router.back()}
@@ -110,7 +110,7 @@ export default function VerifyPage() {
             borderWidth: 1, borderColor: colors.border, ...shadows.sm,
             width: "100%",
           }}>
-            <ActivityIndicator size="large" color={colors.accent} />
+            <ActivityIndicator testID="verify-loading" size="large" color={colors.accent} />
             <Text style={{ fontSize: 15, color: colors.textMuted }}>確認中...</Text>
           </View>
         ) : (
@@ -132,11 +132,14 @@ export default function VerifyPage() {
                 </Text>
               </View>
             ) : (
-              <View style={{
-                backgroundColor: colors.errorLight, borderRadius: radius.lg,
-                padding: spacing.md, flexDirection: "row", alignItems: "center",
-                gap: spacing.sm, width: "100%",
-              }}>
+              <View
+                testID="verify-error-text"
+                style={{
+                  backgroundColor: colors.errorLight, borderRadius: radius.lg,
+                  padding: spacing.md, flexDirection: "row", alignItems: "center",
+                  gap: spacing.sm, width: "100%",
+                }}
+              >
                 <Ionicons name="warning-outline" size={20} color={colors.error} />
                 <Text style={{ fontSize: 14, color: colors.error, flex: 1 }}>
                   確認できませんでした。

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -31,6 +31,7 @@ export default function LoginScreen() {
   const [password, setPassword] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   // #532: rate limit 残り秒数 (0 = 制限なし)
   const [rateLimitRemaining, setRateLimitRemaining] = useState(0);
 
@@ -89,6 +90,7 @@ export default function LoginScreen() {
   }
 
   async function onSubmit() {
+    setErrorMessage(null);
     // #532: rate limit チェック
     if (rateLimitRemaining > 0) {
       Alert.alert("しばらくお待ちください", `再試行まであと ${rateLimitRemaining} 秒お待ちください。`);
@@ -124,14 +126,20 @@ export default function LoginScreen() {
           error.message.includes("For security purposes") ||
           error.message.includes("too many requests")
         ) {
-          Alert.alert("ログイン失敗", "しばらくしてから再度お試しください。");
+          const msg = "しばらくしてから再度お試しください。";
+          setErrorMessage(msg);
+          Alert.alert("ログイン失敗", msg);
         } else if (
           error.message.includes("Invalid login credentials") ||
           error.message.includes("Invalid email or password")
         ) {
-          Alert.alert("ログイン失敗", "メールアドレスまたはパスワードが正しくありません。");
+          const msg = "メールアドレスまたはパスワードが正しくありません。";
+          setErrorMessage(msg);
+          Alert.alert("ログイン失敗", msg);
         } else {
-          Alert.alert("ログイン失敗", "ログインに失敗しました。入力内容をご確認ください。");
+          const msg = "ログインに失敗しました。入力内容をご確認ください。";
+          setErrorMessage(msg);
+          Alert.alert("ログイン失敗", msg);
         }
         return;
       }
@@ -174,7 +182,9 @@ export default function LoginScreen() {
         }
       }
     } catch (e: any) {
-      Alert.alert("ログイン失敗", e?.message ?? "ログインに失敗しました。");
+      const msg = e?.message ?? "ログインに失敗しました。";
+      setErrorMessage(msg);
+      Alert.alert("ログイン失敗", msg);
     } finally {
       setIsSubmitting(false);
     }
@@ -211,6 +221,38 @@ export default function LoginScreen() {
           <Text style={{ fontSize: 28, fontWeight: "900", color: colors.text }}>ログイン</Text>
           <Text style={{ fontSize: 14, color: colors.textMuted, marginTop: 4 }}>おかえりなさい！</Text>
         </View>
+
+        {/* レート制限バナー */}
+        {rateLimitRemaining > 0 && (
+          <View
+            testID="login-rate-limit-banner"
+            style={{
+              backgroundColor: colors.errorLight, borderRadius: radius.lg,
+              padding: spacing.md, marginBottom: spacing.md,
+              flexDirection: "row", alignItems: "center", gap: spacing.sm,
+            }}
+          >
+            <Ionicons name="time-outline" size={18} color={colors.error} />
+            <Text style={{ fontSize: 14, color: colors.error, flex: 1 }}>
+              再試行まであと {rateLimitRemaining} 秒お待ちください。
+            </Text>
+          </View>
+        )}
+
+        {/* エラーバナー */}
+        {errorMessage !== null && (
+          <View
+            testID="login-error-banner"
+            style={{
+              backgroundColor: colors.errorLight, borderRadius: radius.lg,
+              padding: spacing.md, marginBottom: spacing.md,
+              flexDirection: "row", alignItems: "center", gap: spacing.sm,
+            }}
+          >
+            <Ionicons name="alert-circle-outline" size={18} color={colors.error} />
+            <Text style={{ fontSize: 14, color: colors.error, flex: 1 }}>{errorMessage}</Text>
+          </View>
+        )}
 
         {/* フォーム */}
         <View style={{ gap: spacing.md }}>
@@ -263,7 +305,7 @@ export default function LoginScreen() {
                   fontSize: 15, color: colors.text,
                 }}
               />
-              <Pressable onPress={() => setShowPassword(!showPassword)} hitSlop={8}>
+              <Pressable testID="login-show-password-button" onPress={() => setShowPassword(!showPassword)} hitSlop={8}>
                 <Ionicons name={showPassword ? "eye-off-outline" : "eye-outline"} size={20} color={colors.textMuted} />
               </Pressable>
             </View>
@@ -272,7 +314,7 @@ export default function LoginScreen() {
           {/* パスワード忘れた */}
           <View style={{ alignItems: "flex-end" }}>
             <Link href="/auth/forgot-password" asChild>
-              <Pressable>
+              <Pressable testID="login-forgot-password-link">
                 <Text style={{ fontSize: 13, color: colors.accent, fontWeight: "600" }}>パスワードを忘れた？</Text>
               </Pressable>
             </Link>
@@ -308,6 +350,7 @@ export default function LoginScreen() {
 
           {/* Google ログインボタン */}
           <Pressable
+            testID="login-google-button"
             onPress={onGoogleLogin}
             disabled={isSubmitting}
             style={({ pressed }) => ({
@@ -331,7 +374,7 @@ export default function LoginScreen() {
         <View style={{ flexDirection: "row", justifyContent: "center", marginTop: 24, gap: 4 }}>
           <Text style={{ fontSize: 14, color: colors.textMuted }}>アカウントをお持ちでない方は</Text>
           <Link href="/signup" asChild>
-            <Pressable>
+            <Pressable testID="login-signup-link">
               <Text style={{ fontSize: 14, color: colors.accent, fontWeight: "700" }}>新規登録</Text>
             </Pressable>
           </Link>

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -25,6 +25,7 @@ export default function SignupScreen() {
   const [password, setPassword] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   async function onGoogleSignup() {
     setIsSubmitting(true);
@@ -68,6 +69,7 @@ export default function SignupScreen() {
   }
 
   async function onSubmit() {
+    setErrorMessage(null);
     const trimmedEmail = email.trim().toLowerCase();
     if (!trimmedEmail || !password) {
       Alert.alert("入力エラー", "メールアドレスとパスワードを入力してください。");
@@ -102,7 +104,9 @@ export default function SignupScreen() {
         { text: "OK", onPress: () => router.replace("/(auth)/login") },
       ]);
     } catch (e: any) {
-      Alert.alert("登録失敗", e?.message ?? "登録に失敗しました。");
+      const msg = e?.message ?? "登録に失敗しました。";
+      setErrorMessage(msg);
+      Alert.alert("登録失敗", msg);
     } finally {
       setIsSubmitting(false);
     }
@@ -110,6 +114,7 @@ export default function SignupScreen() {
 
   return (
     <KeyboardAvoidingView
+      testID="signup-screen"
       style={{ flex: 1, backgroundColor: colors.bg }}
       behavior={Platform.OS === "ios" ? "padding" : undefined}
     >
@@ -139,6 +144,21 @@ export default function SignupScreen() {
           <Text style={{ fontSize: 14, color: colors.textMuted, marginTop: 4 }}>はじめまして！</Text>
         </View>
 
+        {/* エラーバナー */}
+        {errorMessage !== null && (
+          <View
+            testID="signup-error-banner"
+            style={{
+              backgroundColor: colors.errorLight, borderRadius: radius.lg,
+              padding: spacing.md, marginBottom: spacing.md,
+              flexDirection: "row", alignItems: "center", gap: spacing.sm,
+            }}
+          >
+            <Ionicons name="alert-circle-outline" size={18} color={colors.error} />
+            <Text style={{ fontSize: 14, color: colors.error, flex: 1 }}>{errorMessage}</Text>
+          </View>
+        )}
+
         {/* フォーム */}
         <View style={{ gap: spacing.md }}>
           <View>
@@ -152,6 +172,7 @@ export default function SignupScreen() {
             }}>
               <Ionicons name="mail-outline" size={18} color={colors.textMuted} />
               <TextInput
+                testID="signup-email-input"
                 placeholder="email@example.com"
                 placeholderTextColor={colors.textMuted}
                 autoCapitalize="none"
@@ -178,6 +199,7 @@ export default function SignupScreen() {
             }}>
               <Ionicons name="lock-closed-outline" size={18} color={colors.textMuted} />
               <TextInput
+                testID="signup-password-input"
                 placeholder="8文字以上・英字と数字を含む"
                 placeholderTextColor={colors.textMuted}
                 secureTextEntry={!showPassword}
@@ -188,7 +210,7 @@ export default function SignupScreen() {
                   fontSize: 15, color: colors.text,
                 }}
               />
-              <Pressable onPress={() => setShowPassword(!showPassword)} hitSlop={8}>
+              <Pressable testID="signup-show-password-button" onPress={() => setShowPassword(!showPassword)} hitSlop={8}>
                 <Ionicons name={showPassword ? "eye-off-outline" : "eye-outline"} size={20} color={colors.textMuted} />
               </Pressable>
             </View>
@@ -199,6 +221,7 @@ export default function SignupScreen() {
 
           {/* 登録ボタン */}
           <Pressable
+            testID="signup-button"
             onPress={onSubmit}
             disabled={isSubmitting}
             style={({ pressed }) => ({
@@ -222,6 +245,7 @@ export default function SignupScreen() {
 
           {/* Google 登録ボタン */}
           <Pressable
+            testID="signup-google-button"
             onPress={onGoogleSignup}
             disabled={isSubmitting}
             style={({ pressed }) => ({
@@ -245,7 +269,7 @@ export default function SignupScreen() {
         <View style={{ flexDirection: "row", justifyContent: "center", marginTop: 24, gap: 4 }}>
           <Text style={{ fontSize: 14, color: colors.textMuted }}>アカウントをお持ちの方は</Text>
           <Link href="/(auth)/login" asChild>
-            <Pressable>
+            <Pressable testID="signup-login-link">
               <Text style={{ fontSize: 14, color: colors.accent, fontWeight: "700" }}>ログイン</Text>
             </Pressable>
           </Link>

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -13,7 +13,7 @@ export default function Index() {
   if (authLoading || (session && profileLoading)) {
     return (
       <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.bg }}>
-        <ActivityIndicator color={colors.accent} size="large" />
+        <ActivityIndicator testID="welcome-loading" color={colors.accent} size="large" />
       </View>
     );
   }
@@ -22,7 +22,7 @@ export default function Index() {
   if (session && profile?.onboardingCompletedAt) return <Redirect href="/(tabs)/home" />;
 
   return (
-    <View style={{ flex: 1, backgroundColor: "#FFF7ED" }}>
+    <View testID="welcome-screen" style={{ flex: 1, backgroundColor: "#FFF7ED" }}>
       {/* ヒーロー */}
       <View style={{ flex: 1, justifyContent: "center", alignItems: "center", paddingHorizontal: spacing.xl }}>
         <View style={{
@@ -43,7 +43,7 @@ export default function Index() {
       {/* アクション */}
       <View style={{ paddingHorizontal: spacing.xl, paddingBottom: 60, gap: spacing.md }}>
         <Link href="/login" asChild>
-          <Pressable style={{
+          <Pressable testID="welcome-login-button" style={{
             backgroundColor: colors.accent, borderRadius: radius.lg,
             paddingVertical: 16, alignItems: "center", ...shadows.md,
           }}>
@@ -52,7 +52,7 @@ export default function Index() {
         </Link>
 
         <Link href="/signup" asChild>
-          <Pressable style={{
+          <Pressable testID="welcome-signup-button" style={{
             backgroundColor: colors.card, borderRadius: radius.lg,
             paddingVertical: 16, alignItems: "center",
             borderWidth: 1.5, borderColor: colors.accent,


### PR DESCRIPTION
## 概要

Maestro E2E シナリオ向けに auth ドメイン全画面へ testID を網羅的に付与。

- `index.tsx` (welcome): 4 件
- `login.tsx`: 6 件 (login-error-banner は inline View 新規追加、Alert ロジックは保持)
- `signup.tsx`: 8 件 (signup-error-banner は inline View 新規追加、Alert ロジックは保持)
- `forgot-password.tsx`: 4 件 (forgot-success-text は inline Text 新規追加、Alert ロジックは保持)
- `reset-password.tsx`: 5 件
- `verify.tsx`: 3 件

合計 **30 件** の testID を追加。

## 確認事項

- `npx tsc --noEmit` でエラー増加なし (既存の expo-linking 型解決エラーのみ)
- 既存の Alert ロジックはすべて保持