### PR TITLE
test(mobile-e2e): AI chat に testID 追加

### DIFF
--- a/apps/mobile/app/ai/[sessionId].tsx
+++ b/apps/mobile/app/ai/[sessionId].tsx
@@ -328,6 +328,7 @@ export default function AiSessionPage() {
     return (
       <View style={{ flexDirection: "row", gap: spacing.sm, flexWrap: "wrap", marginTop: spacing.sm }}>
         <Pressable
+          testID={`ai-chat-action-${messageId}-execute`}
           onPress={() => executeActionByMessageId(messageId)}
           style={({ pressed }) => ({
             flexDirection: "row",
@@ -344,6 +345,7 @@ export default function AiSessionPage() {
           <Text style={{ color: "#fff", fontWeight: "700", fontSize: 13 }}>実行</Text>
         </Pressable>
         <Pressable
+          testID={`ai-chat-action-${messageId}-reject`}
           onPress={() => rejectActionByMessageId(messageId)}
           style={({ pressed }) => ({
             flexDirection: "row",
@@ -367,7 +369,7 @@ export default function AiSessionPage() {
 
   return (
     <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined} style={{ flex: 1, backgroundColor: colors.bg }}>
-      <View style={{ flex: 1 }}>
+      <View testID="ai-chat-screen" style={{ flex: 1 }}>
         <PageHeader
           title="AIチャット"
           right={
@@ -398,7 +400,7 @@ export default function AiSessionPage() {
               {error && (
                 <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm, padding: spacing.md, backgroundColor: colors.errorLight, borderRadius: radius.md }}>
                   <Ionicons name="alert-circle" size={16} color={colors.error} />
-                  <Text style={{ color: colors.error, fontSize: 13, flex: 1 }}>{error}</Text>
+                  <Text testID="ai-chat-error-text" style={{ color: colors.error, fontSize: 13, flex: 1 }}>{error}</Text>
                 </View>
               )}
               {messages.map((m) => {
@@ -408,12 +410,14 @@ export default function AiSessionPage() {
                 return (
                   <View
                     key={m.id}
+                    testID={`ai-chat-message-${m.id}`}
                     style={{
                       alignSelf: isUser ? "flex-end" : "flex-start",
                       maxWidth: "85%",
                     }}
                   >
                     <View
+                      testID={isUser ? `ai-chat-message-user-${m.id}` : `ai-chat-message-assistant-${m.id}`}
                       style={{
                         padding: spacing.md,
                         borderRadius: radius.lg,
@@ -456,7 +460,7 @@ export default function AiSessionPage() {
                           {new Date(m.createdAt).toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" })}
                         </Text>
                         {!isSystem && (
-                          <Pressable onPress={() => toggleImportant(m)} hitSlop={8}>
+                          <Pressable testID={`ai-chat-mark-important-${m.id}`} onPress={() => toggleImportant(m)} hitSlop={8}>
                             <Ionicons
                               name={m.isImportant ? "star" : "star-outline"}
                               size={16}
@@ -472,7 +476,7 @@ export default function AiSessionPage() {
 
               {/* ストリーミング中: リアルタイム表示 or ドットインジケータ */}
               {isSending && (
-                <View style={{ alignSelf: "flex-start", maxWidth: "85%" }}>
+                <View testID="ai-chat-streaming-view" style={{ alignSelf: "flex-start", maxWidth: "85%" }}>
                   <View
                     style={{
                       padding: spacing.md,
@@ -516,11 +520,13 @@ export default function AiSessionPage() {
                 <View style={{ marginBottom: spacing.sm }}>
                   <View style={{ position: "relative", alignSelf: "flex-start" }}>
                     <Image
+                      testID="ai-chat-image-preview"
                       source={{ uri: attachedImage.uri }}
                       style={{ width: 80, height: 80, borderRadius: radius.md }}
                       resizeMode="cover"
                     />
                     <Pressable
+                      testID="ai-chat-image-remove-button"
                       onPress={() => setAttachedImage(null)}
                       style={{
                         position: "absolute",
@@ -543,6 +549,7 @@ export default function AiSessionPage() {
               <View style={{ flexDirection: "row", gap: spacing.sm, alignItems: "flex-end" }}>
                 {/* 画像添付ボタン */}
                 <Pressable
+                  testID="ai-chat-image-attach-button"
                   onPress={pickImage}
                   disabled={isSending}
                   style={({ pressed }) => ({
@@ -561,6 +568,7 @@ export default function AiSessionPage() {
                 </Pressable>
 
                 <TextInput
+                  testID="ai-chat-input"
                   value={text}
                   onChangeText={setText}
                   placeholder="相談内容を入力..."
@@ -579,6 +587,7 @@ export default function AiSessionPage() {
                   }}
                 />
                 <Pressable
+                  testID="ai-chat-send-button"
                   onPress={send}
                   disabled={isSending || (!text.trim() && !attachedImage)}
                   style={({ pressed }) => ({

--- a/apps/mobile/app/ai/important.tsx
+++ b/apps/mobile/app/ai/important.tsx
@@ -40,7 +40,7 @@ export default function AiImportantMessagesPage() {
   }, []);
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="ai-important-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader
         title="重要メッセージ"
         right={
@@ -65,13 +65,14 @@ export default function AiImportantMessagesPage() {
         </Card>
       ) : items.length === 0 ? (
         <EmptyState
+          testID="ai-important-empty"
           icon={<Ionicons name="star-outline" size={48} color={colors.textMuted} />}
           message="重要メッセージがありません。"
         />
       ) : (
         <View style={{ gap: spacing.sm }}>
           {items.map((m) => (
-            <Card key={m.id} onPress={() => router.push(`/ai/${m.session.id}`)}>
+            <Card key={m.id} testID={`ai-important-item-${m.id}`} onPress={() => router.push(`/ai/${m.session.id}`)}>
               <View style={{ gap: spacing.sm }}>
                 <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
                   <View

--- a/apps/mobile/app/ai/index.tsx
+++ b/apps/mobile/app/ai/index.tsx
@@ -59,11 +59,11 @@ export default function AiSessionsPage() {
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="ai-sessions-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader
         title="AI相談"
         right={
-          <Button onPress={createSession} loading={isCreating} size="sm">
+          <Button testID="ai-new-session-button" onPress={createSession} loading={isCreating} size="sm">
             <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.xs }}>
               <Ionicons name="add" size={16} color="#FFFFFF" />
               <Text style={{ color: "#FFFFFF", fontWeight: "700", fontSize: 13 }}>
@@ -76,7 +76,7 @@ export default function AiSessionsPage() {
       <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.md }}>
 
       <View style={{ flexDirection: "row", gap: spacing.md }}>
-        <Link href="/ai/important" style={{ color: colors.accent, fontSize: 14, fontWeight: "600" }}>
+        <Link testID="ai-important-button" href="/ai/important" style={{ color: colors.accent, fontSize: 14, fontWeight: "600" }}>
           <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.xs }}>
             <Ionicons name="star-outline" size={16} color={colors.accent} />
             <Text style={{ color: colors.accent, fontSize: 14, fontWeight: "600" }}>重要メッセージ一覧</Text>
@@ -96,11 +96,12 @@ export default function AiSessionsPage() {
         <Card variant="error">
           <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
             <Ionicons name="alert-circle" size={20} color={colors.error} />
-            <Text style={{ color: colors.error, fontSize: 14, fontWeight: "600" }}>{error}</Text>
+            <Text testID="ai-sessions-error-text" style={{ color: colors.error, fontSize: 14, fontWeight: "600" }}>{error}</Text>
           </View>
         </Card>
       ) : sessions.length === 0 ? (
         <EmptyState
+          testID="ai-sessions-empty"
           icon={<Ionicons name="chatbubbles-outline" size={48} color={colors.textMuted} />}
           message="アクティブなセッションがありません。"
           actionLabel="新しい相談を始める"
@@ -111,6 +112,7 @@ export default function AiSessionsPage() {
           {sessions.map((s) => (
             <ListItem
               key={s.id}
+              testID={`ai-session-item-${s.id}`}
               title={s.title}
               subtitle={`${s.messageCount} messages / ${new Date(s.updatedAt).toLocaleString("ja-JP")}`}
               onPress={() => router.push(`/ai/${s.id}`)}
@@ -134,7 +136,7 @@ export default function AiSessionsPage() {
         </View>
       )}
 
-      <Button onPress={load} variant="ghost" size="sm">
+      <Button testID="ai-reload-button" onPress={load} variant="ghost" size="sm">
         <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.xs }}>
           <Ionicons name="reload-outline" size={16} color={colors.textLight} />
           <Text style={{ color: colors.textLight, fontWeight: "600", fontSize: 14 }}>更新</Text>

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -12,6 +12,7 @@ type ButtonProps = {
   loading?: boolean;
   size?: 'sm' | 'md' | 'lg';
   style?: ViewStyle;
+  testID?: string;
 };
 
 const VARIANT_STYLES: Record<ButtonVariant, { bg: string; bgPressed: string; text: string; border?: string }> = {
@@ -28,13 +29,14 @@ const SIZE_STYLES: Record<string, { paddingV: number; paddingH: number; fontSize
   lg: { paddingV: 16, paddingH: 20, fontSize: 16 },
 };
 
-export function Button({ children, onPress, variant = 'primary', disabled, loading, size = 'md', style }: ButtonProps) {
+export function Button({ children, onPress, variant = 'primary', disabled, loading, size = 'md', style, testID }: ButtonProps) {
   const v = VARIANT_STYLES[variant];
   const s = SIZE_STYLES[size];
   const isDisabled = disabled || loading;
 
   return (
     <Pressable
+      testID={testID}
       onPress={onPress}
       disabled={isDisabled}
       style={({ pressed }) => {

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -8,6 +8,7 @@ type CardProps = {
   style?: ViewStyle;
   variant?: 'default' | 'accent' | 'success' | 'warning' | 'error' | 'purple';
   padding?: keyof typeof spacing;
+  testID?: string;
 };
 
 const BORDER_COLORS: Record<string, string> = {
@@ -19,7 +20,7 @@ const BORDER_COLORS: Record<string, string> = {
   purple: '#D1C4E9',
 };
 
-export function Card({ children, onPress, style, variant = 'default', padding = 'lg' }: CardProps) {
+export function Card({ children, onPress, style, variant = 'default', padding = 'lg', testID }: CardProps) {
   const cardStyle: ViewStyle = {
     backgroundColor: colors.card,
     borderRadius: radius.lg,
@@ -32,11 +33,11 @@ export function Card({ children, onPress, style, variant = 'default', padding = 
 
   if (onPress) {
     return (
-      <Pressable onPress={onPress} style={({ pressed }) => [cardStyle, pressed && { opacity: 0.9, transform: [{ scale: 0.99 }] }]}>
+      <Pressable testID={testID} onPress={onPress} style={({ pressed }) => [cardStyle, pressed && { opacity: 0.9, transform: [{ scale: 0.99 }] }]}>
         {children}
       </Pressable>
     );
   }
 
-  return <View style={cardStyle}>{children}</View>;
+  return <View testID={testID} style={cardStyle}>{children}</View>;
 }

--- a/apps/mobile/src/components/ui/EmptyState.tsx
+++ b/apps/mobile/src/components/ui/EmptyState.tsx
@@ -9,11 +9,12 @@ type EmptyStateProps = {
   actionLabel?: string;
   onAction?: () => void;
   style?: ViewStyle;
+  testID?: string;
 };
 
-export function EmptyState({ icon, message, actionLabel, onAction, style }: EmptyStateProps) {
+export function EmptyState({ icon, message, actionLabel, onAction, style, testID }: EmptyStateProps) {
   return (
-    <View style={[{ alignItems: 'center', paddingVertical: spacing['3xl'], gap: spacing.md }, style]}>
+    <View testID={testID} style={[{ alignItems: 'center', paddingVertical: spacing['3xl'], gap: spacing.md }, style]}>
       {icon ?? null}
       <Text style={{ fontSize: 15, color: colors.textMuted, textAlign: 'center' }}>{message}</Text>
       {actionLabel && onAction ? (

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -10,9 +10,10 @@ type ListItemProps = {
   onPress?: () => void;
   style?: ViewStyle;
   highlighted?: boolean;
+  testID?: string;
 };
 
-export function ListItem({ title, subtitle, right, left, onPress, style, highlighted }: ListItemProps) {
+export function ListItem({ title, subtitle, right, left, onPress, style, highlighted, testID }: ListItemProps) {
   const content = (
     <View
       style={{
@@ -39,11 +40,11 @@ export function ListItem({ title, subtitle, right, left, onPress, style, highlig
 
   if (onPress) {
     return (
-      <Pressable onPress={onPress} style={({ pressed }) => (pressed ? { opacity: 0.9, transform: [{ scale: 0.99 }] } : {})}>
+      <Pressable testID={testID} onPress={onPress} style={({ pressed }) => (pressed ? { opacity: 0.9, transform: [{ scale: 0.99 }] } : {})}>
         {content}
       </Pressable>
     );
   }
 
-  return content;
+  return <View testID={testID}>{content}</View>;
 }


### PR DESCRIPTION
## 概要

`apps/mobile/app/ai/` 配下の 3 画面に E2E テスト用 testID を網羅追加。

- `ai/index.tsx` (セッション一覧画面)
- `ai/[sessionId].tsx` (チャット画面)
- `ai/important.tsx` (重要メッセージ画面)

## 追加した testID 一覧

### ai/index.tsx
- `ai-sessions-screen` — 画面ルート View
- `ai-new-session-button` — 新規セッション作成ボタン
- `ai-important-button` — 重要メッセージ一覧リンク
- `ai-session-item-{id}` — 各セッション行 (動的)
- `ai-sessions-empty` — 空状態
- `ai-sessions-error-text` — エラーテキスト
- `ai-reload-button` — 更新ボタン

### ai/[sessionId].tsx
- `ai-chat-screen` — 画面ルート View
- `ai-chat-message-{id}` — 各メッセージ外側コンテナ (動的)
- `ai-chat-message-user-{id}` — ユーザーメッセージ内側バブル (動的)
- `ai-chat-message-assistant-{id}` — アシスタントメッセージ内側バブル (動的)
- `ai-chat-input` — テキスト入力欄
- `ai-chat-send-button` — 送信ボタン
- `ai-chat-image-attach-button` — 画像添付ボタン
- `ai-chat-image-preview` — 添付画像プレビュー
- `ai-chat-image-remove-button` — 画像削除ボタン
- `ai-chat-streaming-view` — ストリーミング中インジケータ
- `ai-chat-error-text` — エラーテキスト
- `ai-chat-action-{messageId}-execute` — アクション実行ボタン (動的)
- `ai-chat-action-{messageId}-reject` — アクション却下ボタン (動的)
- `ai-chat-mark-important-{id}` — 重要マーク切り替えボタン (動的)

### ai/important.tsx
- `ai-important-screen` — 画面ルート View
- `ai-important-item-{id}` — 各重要メッセージカード (動的)
- `ai-important-empty` — 空状態

## 共通コンポーネントの変更

`Button`, `Card`, `EmptyState`, `ListItem` に `testID?: string` prop を追加し、
内部の `Pressable` / `View` へフォワードするよう型定義を拡張。

🤖 Generated with [Claude Code](https://claude.com/claude-code)