### PR TITLE
test(mobile-e2e): onboarding ドメインに testID 追加

### DIFF
--- a/apps/mobile/app/onboarding/questions.tsx
+++ b/apps/mobile/app/onboarding/questions.tsx
@@ -953,6 +953,7 @@ export default function OnboardingQuestions() {
   }
 
   const canSkip = (currentQuestion as any)?.allowSkip;
+  const isLastStep = getNextQuestion(currentStep, answers) === -1;
 
   if (isLoading) {
     return <LoadingState message="前回の進捗を読み込み中..." style={{ backgroundColor: "#FFF7ED" }} />;
@@ -978,13 +979,13 @@ export default function OnboardingQuestions() {
   }
 
   return (
-    <View style={[styles.screenContainer, { paddingTop: insets.top }]}>
+    <View testID="onboarding-questions-screen" style={[styles.screenContainer, { paddingTop: insets.top }]}>
       {/* ── Header: back + progress ── */}
       <View style={styles.headerSection}>
         <View style={styles.headerRow}>
           <View style={styles.headerLeft}>
             {stepHistory.length > 0 && (
-              <Pressable onPress={handleBack} style={styles.backButton} hitSlop={12}>
+              <Pressable testID="onboarding-back-button" onPress={handleBack} style={styles.backButton} hitSlop={12}>
                 <Ionicons name="chevron-back" size={18} color="#666" />
               </Pressable>
             )}
@@ -995,7 +996,7 @@ export default function OnboardingQuestions() {
           <Text style={styles.headerCounter}>{progress.current} / {progress.total}</Text>
         </View>
         {/* Progress bar */}
-        <View style={styles.progressTrack}>
+        <View testID="onboarding-progress-bar" style={styles.progressTrack}>
           <View style={[styles.progressFill, { width: `${(progress.current / progress.total) * 100}%` }]} />
         </View>
       </View>
@@ -1011,7 +1012,7 @@ export default function OnboardingQuestions() {
         </View>
 
         {/* Question text */}
-        <View style={styles.questionSection}>
+        <View testID="onboarding-question-text" style={styles.questionSection}>
           {getQuestionText()
             .split("\n")
             .map((line, i) => (
@@ -1029,6 +1030,7 @@ export default function OnboardingQuestions() {
         {currentQuestion.type === "text" && (
           <View style={styles.inputRow}>
             <TextInput
+              testID="onboarding-text-input"
               autoFocus
               placeholder={currentQuestion.placeholder}
               placeholderTextColor={colors.textMuted}
@@ -1049,24 +1051,32 @@ export default function OnboardingQuestions() {
 
         {/* Number input */}
         {currentQuestion.type === "number" && (
-          <View style={styles.inputRow}>
-            <TextInput
-              autoFocus
-              keyboardType="number-pad"
-              placeholder={currentQuestion.placeholder}
-              placeholderTextColor={colors.textMuted}
-              value={inputValue}
-              onChangeText={(v) => setInputValue(v.replace(/[^0-9]/g, ""))}
-              onSubmitEditing={() => { if (isNumberValid) handleAnswer(numberValue); }}
-              style={[styles.textInput, { flex: 1 }]}
-            />
-            <Pressable
-              onPress={() => { if (isNumberValid) handleAnswer(numberValue); }}
-              disabled={!isNumberValid}
-              style={[styles.arrowButton, !isNumberValid && styles.arrowButtonDisabled]}
-            >
-              <Ionicons name="arrow-forward" size={20} color="#fff" />
-            </Pressable>
+          <View style={{ gap: spacing.xs }}>
+            <View style={styles.inputRow}>
+              <TextInput
+                testID="onboarding-number-input"
+                autoFocus
+                keyboardType="number-pad"
+                placeholder={currentQuestion.placeholder}
+                placeholderTextColor={colors.textMuted}
+                value={inputValue}
+                onChangeText={(v) => setInputValue(v.replace(/[^0-9]/g, ""))}
+                onSubmitEditing={() => { if (isNumberValid) handleAnswer(numberValue); }}
+                style={[styles.textInput, { flex: 1 }]}
+              />
+              <Pressable
+                onPress={() => { if (isNumberValid) handleAnswer(numberValue); }}
+                disabled={!isNumberValid}
+                style={[styles.arrowButton, !isNumberValid && styles.arrowButtonDisabled]}
+              >
+                <Ionicons name="arrow-forward" size={20} color="#fff" />
+              </Pressable>
+            </View>
+            {inputValue.length > 0 && !isNumberValid && (
+              <Text testID="onboarding-error-text" style={styles.errorText}>
+                {numberMin}〜{numberMax} の範囲で入力してください
+              </Text>
+            )}
           </View>
         )}
 
@@ -1076,6 +1086,7 @@ export default function OnboardingQuestions() {
             {(currentQuestion.options || []).map((opt) => (
               <Pressable
                 key={opt.value}
+                testID={`onboarding-choice-option-${opt.value}`}
                 onPress={() => handleAnswer(opt.value)}
                 style={({ pressed }) => [styles.choiceButton, pressed && { backgroundColor: colors.accent, borderColor: colors.accent }]}
               >
@@ -1101,6 +1112,7 @@ export default function OnboardingQuestions() {
                 return (
                   <Pressable
                     key={opt.value}
+                    testID={`onboarding-multi-choice-option-${opt.value}`}
                     onPress={() => handleMultiSelect(opt.value)}
                     style={[styles.multiButton, selected && styles.multiButtonSelected]}
                   >
@@ -1113,11 +1125,12 @@ export default function OnboardingQuestions() {
             </View>
             <View style={styles.actionRow}>
               {canSkip && (
-                <Pressable onPress={() => handleAnswer(null)} style={styles.skipButton}>
+                <Pressable testID="onboarding-skip-question-button" onPress={() => handleAnswer(null)} style={styles.skipButton}>
                   <Text style={styles.skipButtonText}>スキップ</Text>
                 </Pressable>
               )}
               <Pressable
+                testID={isLastStep ? "onboarding-submit-button" : "onboarding-next-button"}
                 onPress={() => { if (isMultiReady) handleAnswer(selectedMulti); }}
                 disabled={!isMultiReady}
                 style={[styles.nextButton, !isMultiReady && styles.nextButtonDisabled]}
@@ -1168,11 +1181,12 @@ export default function OnboardingQuestions() {
 
             <View style={styles.actionRow}>
               {canSkip && (
-                <Pressable onPress={() => handleAnswer(null)} style={styles.skipButton}>
+                <Pressable testID="onboarding-skip-question-button" onPress={() => handleAnswer(null)} style={styles.skipButton}>
                   <Text style={styles.skipButtonText}>スキップ</Text>
                 </Pressable>
               )}
               <Pressable
+                testID={isLastStep ? "onboarding-submit-button" : "onboarding-next-button"}
                 onPress={() => { if (hasTags) handleAnswer(tags); }}
                 disabled={!hasTags}
                 style={[styles.nextButton, !hasTags && styles.nextButtonDisabled]}
@@ -1215,6 +1229,7 @@ export default function OnboardingQuestions() {
               </View>
             </View>
             <Pressable
+              testID={isLastStep ? "onboarding-submit-button" : "onboarding-next-button"}
               onPress={() => handleAnswer("completed")}
               disabled={!answers.age || !answers.height || !answers.weight}
               style={[styles.nextButton, (!answers.age || !answers.height || !answers.weight) && styles.nextButtonDisabled]}
@@ -1254,7 +1269,7 @@ export default function OnboardingQuestions() {
             </Pressable>
           </View>
           {canSkip && (
-            <Pressable onPress={() => handleAnswer(null)} style={styles.skipButton}>
+            <Pressable testID="onboarding-skip-question-button" onPress={() => handleAnswer(null)} style={styles.skipButton}>
               <Text style={styles.skipButtonText}>スキップ</Text>
             </Pressable>
           )}
@@ -1362,6 +1377,7 @@ export default function OnboardingQuestions() {
           </View>
 
           <Pressable
+            testID={isLastStep ? "onboarding-submit-button" : "onboarding-next-button"}
             onPress={() => {
               const familySize = parseInt(answers.family_size) || 2;
               const config = answers.servings_config || createDefaultServingsConfig(familySize);
@@ -1632,6 +1648,11 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     color: "#4B5563",
     fontSize: 12,
+  },
+  errorText: {
+    color: colors.error,
+    fontSize: 12,
+    textAlign: "center",
   },
   /* ── Stats ── */
   statsRow: {

--- a/apps/mobile/app/onboarding/resume.tsx
+++ b/apps/mobile/app/onboarding/resume.tsx
@@ -58,6 +58,7 @@ export default function OnboardingResume() {
 
   return (
     <ScrollView
+      testID="onboarding-resume-screen"
       contentContainerStyle={styles.container}
       style={styles.scroll}
     >
@@ -84,6 +85,7 @@ export default function OnboardingResume() {
           <Text style={styles.progressPercent}>{progressPercent}%</Text>
         </View>
         <ProgressBar
+          testID="onboarding-resume-progress-bar"
           value={progress?.currentStep || 0}
           max={progress?.totalQuestions || 1}
           height={8}
@@ -96,6 +98,7 @@ export default function OnboardingResume() {
       {/* Buttons */}
       <View style={styles.buttonGroup}>
         <Pressable
+          testID="onboarding-resume-continue-button"
           onPress={() => router.push("/onboarding/questions?resume=true")}
           style={({ pressed }) => [
             styles.primaryButton,
@@ -107,6 +110,7 @@ export default function OnboardingResume() {
         </Pressable>
 
         <Pressable
+          testID="onboarding-resume-reset-button"
           onPress={handleReset}
           disabled={isResetting}
           style={({ pressed }) => [
@@ -122,6 +126,7 @@ export default function OnboardingResume() {
         </Pressable>
 
         <Pressable
+          testID="onboarding-resume-skip-button"
           onPress={() => router.replace("/(tabs)/home")}
           style={styles.skipButton}
         >

--- a/apps/mobile/app/onboarding/welcome.tsx
+++ b/apps/mobile/app/onboarding/welcome.tsx
@@ -27,6 +27,7 @@ export default function OnboardingWelcome() {
 
   return (
     <ScrollView
+      testID="onboarding-welcome-screen"
       contentContainerStyle={styles.container}
       style={styles.scroll}
     >
@@ -90,6 +91,7 @@ export default function OnboardingWelcome() {
       {/* Buttons */}
       <View style={styles.buttonGroup}>
         <Pressable
+          testID="onboarding-start-button"
           onPress={() => router.push("/onboarding/questions")}
           style={({ pressed }) => [
             styles.primaryButton,
@@ -101,6 +103,7 @@ export default function OnboardingWelcome() {
         </Pressable>
 
         <Pressable
+          testID="onboarding-skip-button"
           onPress={handleSkip}
           style={styles.skipButton}
           disabled={isSkipping}

--- a/apps/mobile/src/components/ui/ProgressBar.tsx
+++ b/apps/mobile/src/components/ui/ProgressBar.tsx
@@ -10,6 +10,7 @@ type ProgressBarProps = {
   label?: string;
   showPercentage?: boolean;
   style?: ViewStyle;
+  testID?: string;
 };
 
 export function ProgressBar({
@@ -21,11 +22,12 @@ export function ProgressBar({
   label,
   showPercentage,
   style,
+  testID,
 }: ProgressBarProps) {
   const pct = max > 0 ? Math.min(Math.round((value / max) * 100), 100) : 0;
 
   return (
-    <View style={[{ gap: 4 }, style]}>
+    <View testID={testID} style={[{ gap: 4 }, style]}>
       {(label || showPercentage) && (
         <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
           {label ? <Text style={{ fontSize: 12, fontWeight: '600', color: colors.textLight }}>{label}</Text> : null}


### PR DESCRIPTION
## 変更内容

onboarding ドメイン画面 3 ファイルに Maestro E2E テスト用 testID を追加。

### 追加 testID 一覧

**welcome.tsx** (3件)
- `onboarding-welcome-screen` (ScrollView)
- `onboarding-start-button` ("はじめる")
- `onboarding-skip-button` ("あとで設定する")

**resume.tsx** (5件)
- `onboarding-resume-screen` (ScrollView)
- `onboarding-resume-progress-bar` (ProgressBar)
- `onboarding-resume-continue-button` ("続きから再開")
- `onboarding-resume-reset-button` ("最初からやり直す")
- `onboarding-resume-skip-button` ("あとで設定する")

**questions.tsx** (動的 ID 含む)
- `onboarding-questions-screen` (ルート View)
- `onboarding-question-text` (質問テキスト View)
- `onboarding-text-input`
- `onboarding-number-input`
- `onboarding-choice-option-{value}` (動的)
- `onboarding-multi-choice-option-{value}` (動的)
- `onboarding-next-button` / `onboarding-submit-button` (最終ステップ切替)
- `onboarding-back-button`
- `onboarding-skip-question-button` (allowSkip 時のみ)
- `onboarding-progress-bar`
- `onboarding-error-text` (number バリデーション失敗時)

### 副次変更

`ProgressBar` コンポーネント (`src/components/ui/ProgressBar.tsx`) に `testID?: string` props を追加。

## Test plan

- [ ] tsc --noEmit で対象ファイルに新規型エラーがないことを確認 (済)
- [ ] Maestro で各 testID を使った E2E フローを実行