### PR TITLE
test(mobile-e2e): pantry/recipes/badges に testID 追加

### DIFF
--- a/apps/mobile/app/badges/index.tsx
+++ b/apps/mobile/app/badges/index.tsx
@@ -41,15 +41,17 @@ export default function BadgesPage() {
     };
   }, []);
 
+  const earnedCount = badges.filter((b) => b.earned).length;
+
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="badges-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader
         title="バッジ"
         right={
           <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.xs }}>
             <Ionicons name="trophy" size={20} color={colors.accent} />
-            <Text style={{ fontSize: 13, fontWeight: "700", color: colors.textMuted }}>
-              {badges.filter((b) => b.earned).length}/{badges.length}
+            <Text testID="badges-earned-count" style={{ fontSize: 13, fontWeight: "700", color: colors.textMuted }}>
+              {earnedCount}/{badges.length}
             </Text>
           </View>
         }
@@ -67,6 +69,7 @@ export default function BadgesPage() {
         </Card>
       ) : badges.length === 0 ? (
         <EmptyState
+          testID="badges-empty"
           icon={<Ionicons name="trophy-outline" size={48} color={colors.textMuted} />}
           message="バッジがありません。"
         />
@@ -74,6 +77,7 @@ export default function BadgesPage() {
         <View style={{ gap: spacing.sm }}>
           {badges.map((b) => (
             <Card
+              testID={`badges-badge-${b.code}`}
               key={b.id}
               variant={b.earned ? "success" : "default"}
             >

--- a/apps/mobile/app/pantry/index.tsx
+++ b/apps/mobile/app/pantry/index.tsx
@@ -35,9 +35,11 @@ const CATEGORY_OPTIONS: { code: string; label: string }[] = [
 function CategoryPicker({
   value,
   onChange,
+  testIDPrefix,
 }: {
   value: string;
   onChange: (code: string) => void;
+  testIDPrefix?: string;
 }) {
   return (
     <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
@@ -46,6 +48,7 @@ function CategoryPicker({
         return (
           <Pressable
             key={opt.code}
+            testID={testIDPrefix ? `${testIDPrefix}-${opt.code}` : undefined}
             onPress={() => onChange(opt.code)}
             style={{
               paddingHorizontal: 12,
@@ -380,7 +383,7 @@ export default function PantryPage() {
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="pantry-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader title="冷蔵庫" subtitle="食材を管理しましょう" />
       <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.md }}>
 
@@ -403,11 +406,11 @@ export default function PantryPage() {
       <Card>
         <View style={{ gap: spacing.sm }}>
           <SectionHeader title="追加" />
-          <Input value={name} onChangeText={setName} placeholder="例: キャベツ" />
-          <Input value={amount} onChangeText={setAmount} placeholder="量（任意）" />
-          <CategoryPicker value={category} onChange={setCategory} />
-          <Input value={expirationDate} onChangeText={setExpirationDate} placeholder="期限 YYYY-MM-DD（任意）" />
-          <Button onPress={add} disabled={isSubmitting} loading={isSubmitting}>
+          <Input testID="pantry-name-input" value={name} onChangeText={setName} placeholder="例: キャベツ" />
+          <Input testID="pantry-amount-input" value={amount} onChangeText={setAmount} placeholder="量（任意）" />
+          <CategoryPicker value={category} onChange={setCategory} testIDPrefix="pantry-category" />
+          <Input testID="pantry-expiration-input" value={expirationDate} onChangeText={setExpirationDate} placeholder="期限 YYYY-MM-DD（任意）" />
+          <Button testID="pantry-add-button" onPress={add} disabled={isSubmitting} loading={isSubmitting}>
             {isSubmitting ? "追加中..." : "追加"}
           </Button>
         </View>
@@ -421,6 +424,7 @@ export default function PantryPage() {
             right={<Ionicons name="camera-outline" size={20} color={colors.accent} />}
           />
           <Button
+            testID="pantry-fridge-photo-button"
             onPress={analyzeFridge}
             disabled={isAnalyzing}
             loading={isAnalyzing}
@@ -565,11 +569,12 @@ export default function PantryPage() {
         <Card variant="error">
           <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
             <Ionicons name="alert-circle" size={20} color={colors.error} />
-            <Text style={{ color: colors.error, flex: 1 }}>{error}</Text>
+            <Text testID="pantry-error-text" style={{ color: colors.error, flex: 1 }}>{error}</Text>
           </View>
         </Card>
       ) : items.length === 0 ? (
         <EmptyState
+          testID="pantry-empty"
           icon={<Ionicons name="nutrition-outline" size={48} color={colors.textMuted} />}
           message="冷蔵庫は空です。"
           actionLabel="写真で追加"
@@ -579,7 +584,7 @@ export default function PantryPage() {
         <View style={{ gap: spacing.sm }}>
           <SectionHeader title={`食材一覧（${items.length}件）`} />
           {items.map((it) => (
-            <Card key={it.id}>
+            <Card testID={`pantry-item-${it.id}`} key={it.id}>
               <View style={{ gap: spacing.sm }}>
                 {/* Item header */}
                 <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
@@ -596,7 +601,7 @@ export default function PantryPage() {
                     </View>
                   )}
                   {!isExpired(it.expirationDate) && isExpiringSoon(it.expirationDate) && (
-                    <View style={{ backgroundColor: "#FFEBEE", borderRadius: 10, paddingHorizontal: 8, paddingVertical: 2 }}>
+                    <View testID={`pantry-expiring-badge-${it.id}`} style={{ backgroundColor: "#FFEBEE", borderRadius: 10, paddingHorizontal: 8, paddingVertical: 2 }}>
                       <Text style={{ fontSize: 11, color: colors.error, fontWeight: "600" }}>期限間近</Text>
                     </View>
                   )}
@@ -619,12 +624,12 @@ export default function PantryPage() {
                 {/* Edit form (inline) */}
                 {editingId === it.id ? (
                   <View style={{ gap: spacing.sm, marginTop: spacing.xs }}>
-                    <Input value={editName} onChangeText={setEditName} placeholder="食材名" />
+                    <Input testID="pantry-edit-name-input" value={editName} onChangeText={setEditName} placeholder="食材名" />
                     <Input value={editAmount} onChangeText={setEditAmount} placeholder="量（任意）" />
                     <CategoryPicker value={editCategory} onChange={setEditCategory} />
                     <Input value={editExpirationDate} onChangeText={setEditExpirationDate} placeholder="期限 YYYY-MM-DD（任意）" />
                     <View style={{ flexDirection: "row", gap: spacing.sm, flexWrap: "wrap" }}>
-                      <Button onPress={saveEdit} disabled={isSavingEdit} loading={isSavingEdit} size="sm">
+                      <Button testID="pantry-edit-save-button" onPress={saveEdit} disabled={isSavingEdit} loading={isSavingEdit} size="sm">
                         <Ionicons name="checkmark-outline" size={16} color="#FFFFFF" />
                         <Text style={{ color: "#FFFFFF", fontWeight: "700", fontSize: 13 }}>
                           {isSavingEdit ? "保存中..." : "保存"}
@@ -637,11 +642,11 @@ export default function PantryPage() {
                   </View>
                 ) : (
                   <View style={{ flexDirection: "row", gap: spacing.sm, flexWrap: "wrap", marginTop: spacing.xs }}>
-                    <Button onPress={() => startEdit(it)} variant="secondary" size="sm">
+                    <Button testID={`pantry-item-edit-${it.id}`} onPress={() => startEdit(it)} variant="secondary" size="sm">
                       <Ionicons name="create-outline" size={16} color={colors.text} />
                       <Text style={{ color: colors.text, fontWeight: "700", fontSize: 13 }}>編集</Text>
                     </Button>
-                    <Button onPress={() => remove(it.id)} variant="destructive" size="sm">
+                    <Button testID={`pantry-item-delete-${it.id}`} onPress={() => remove(it.id)} variant="destructive" size="sm">
                       <Ionicons name="trash-outline" size={16} color="#FFFFFF" />
                       <Text style={{ color: "#FFFFFF", fontWeight: "700", fontSize: 13 }}>削除</Text>
                     </Button>

--- a/apps/mobile/app/recipes/[id].tsx
+++ b/apps/mobile/app/recipes/[id].tsx
@@ -149,7 +149,7 @@ export default function RecipeDetailPage() {
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="recipe-detail-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader title="レシピ詳細" />
       <ScrollView style={styles.screen} contentContainerStyle={styles.container}>
 
@@ -185,7 +185,7 @@ export default function RecipeDetailPage() {
             {recipe.description ? <Text style={typography.body}>{recipe.description}</Text> : null}
 
             <View style={styles.actionRow}>
-              <Button onPress={toggleLike} variant={recipe.isLiked ? "destructive" : "secondary"} size="sm">
+              <Button testID="recipe-detail-like-button" onPress={toggleLike} variant={recipe.isLiked ? "destructive" : "secondary"} size="sm">
                 <Ionicons name={recipe.isLiked ? "heart" : "heart-outline"} size={16} color={recipe.isLiked ? "#FFF" : colors.text} />
                 <Text style={{ color: recipe.isLiked ? "#FFF" : colors.text, fontWeight: "700", fontSize: 13 }}>
                   {recipe.isLiked ? "解除" : "いいね"}

--- a/apps/mobile/app/recipes/index.tsx
+++ b/apps/mobile/app/recipes/index.tsx
@@ -69,11 +69,13 @@ type FilterChipProps = {
   label: string;
   selected: boolean;
   onPress: () => void;
+  testID?: string;
 };
 
-function FilterChip({ label, selected, onPress }: FilterChipProps) {
+function FilterChip({ label, selected, onPress, testID }: FilterChipProps) {
   return (
     <TouchableOpacity
+      testID={testID}
       onPress={onPress}
       style={{
         paddingHorizontal: spacing.md,
@@ -139,7 +141,7 @@ export default function RecipesPage() {
   const hasActiveFilters = !!(category || cuisineType || difficulty || maxTime);
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="recipes-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader
         title="レシピ"
         right={
@@ -164,6 +166,7 @@ export default function RecipesPage() {
             <View style={{ flexDirection: "row", gap: spacing.sm }}>
               <View style={{ flex: 1 }}>
                 <Input
+                  testID="recipes-search-input"
                   value={q}
                   onChangeText={setQ}
                   placeholder="検索（例: からあげ）"
@@ -196,6 +199,7 @@ export default function RecipesPage() {
                     {CATEGORY_OPTIONS.map((opt) => (
                       <FilterChip
                         key={opt.value}
+                        testID={`recipes-category-filter-${opt.value === "" ? "all" : opt.value}`}
                         label={opt.label}
                         selected={category === opt.value}
                         onPress={() => setCategory(opt.value)}
@@ -229,6 +233,7 @@ export default function RecipesPage() {
                   {DIFFICULTY_OPTIONS.map((opt) => (
                     <FilterChip
                       key={opt.value}
+                      testID={`recipes-difficulty-filter-${opt.value === "" ? "all" : opt.value}`}
                       label={opt.label}
                       selected={difficulty === opt.value}
                       onPress={() => setDifficulty(opt.value)}
@@ -238,7 +243,7 @@ export default function RecipesPage() {
               </View>
 
               {/* 調理時間 */}
-              <View style={{ gap: spacing.xs }}>
+              <View testID="recipes-time-filter" style={{ gap: spacing.xs }}>
                 <Text style={{ fontSize: 12, fontWeight: "700", color: colors.textLight }}>調理時間</Text>
                 <ScrollView horizontal showsHorizontalScrollIndicator={false}>
                   <View style={{ flexDirection: "row", gap: spacing.xs }}>
@@ -286,6 +291,7 @@ export default function RecipesPage() {
           </Card>
         ) : items.length === 0 ? (
           <EmptyState
+            testID="recipes-empty"
             icon={<Ionicons name="restaurant-outline" size={48} color={colors.textMuted} />}
             message="レシピがありません。"
           />
@@ -293,7 +299,7 @@ export default function RecipesPage() {
           <View style={{ gap: spacing.sm }}>
             <Text style={{ fontSize: 12, color: colors.textMuted }}>{items.length}件</Text>
             {items.map((r) => (
-              <Card key={r.id} onPress={() => router.push(`/recipes/${r.id}`)}>
+              <Card testID={`recipes-item-${r.id}`} key={r.id} onPress={() => router.push(`/recipes/${r.id}`)}>
                 <View style={{ gap: spacing.sm }}>
                   <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>{r.name}</Text>
 
@@ -351,6 +357,7 @@ export default function RecipesPage() {
 
                   <View style={{ flexDirection: "row", gap: spacing.sm, marginTop: spacing.xs }}>
                     <Button
+                      testID={`recipes-like-${r.id}`}
                       onPress={() => {
                         toggleLike(r.id, !r.isLiked).catch(() => {});
                       }}

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -39,7 +39,6 @@ export function Button({ children, onPress, variant = 'primary', disabled, loadi
       testID={testID}
       onPress={onPress}
       disabled={isDisabled}
-      testID={testID}
       style={({ pressed }) => {
         const base: ViewStyle = {
           backgroundColor: isDisabled ? colors.textMuted : pressed ? v.bgPressed : v.bg,


### PR DESCRIPTION
## 概要

E2E テスト用の `testID` を pantry・recipes・badges 画面に網羅追加。

## 変更内容

- `apps/mobile/src/components/ui/Button.tsx` — `testID` prop を追加し `Pressable` に転送
- `apps/mobile/src/components/ui/Card.tsx` — `testID` prop を追加し `Pressable`/`View` に転送
- `apps/mobile/src/components/ui/EmptyState.tsx` — `testID` prop を追加しルート `View` に転送
- `apps/mobile/app/pantry/index.tsx` — `pantry-screen`, `pantry-*-input`, `pantry-category-{code}`, `pantry-add-button`, `pantry-item-{id}`, `pantry-item-edit/delete-{id}`, `pantry-edit-name-input`, `pantry-edit-save-button`, `pantry-fridge-photo-button`, `pantry-expiring-badge-{id}`, `pantry-error-text`, `pantry-empty`
- `apps/mobile/app/recipes/index.tsx` — `recipes-screen`, `recipes-search-input`, `recipes-category-filter-{value}`, `recipes-difficulty-filter-{value}`, `recipes-time-filter`, `recipes-item-{id}`, `recipes-like-{id}`, `recipes-empty`
- `apps/mobile/app/recipes/[id].tsx` — `recipe-detail-screen`, `recipe-detail-like-button`
- `apps/mobile/app/badges/index.tsx` — `badges-screen`, `badges-badge-{code}`, `badges-earned-count`, `badges-empty`

## テスト計画

- [ ] `npx tsc --noEmit` でエラーなし（既存の pre-existing エラーのみ）
- [ ] E2E テストで各 testID が取得可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)