### PR TITLE
test(mobile-e2e): menus weekly に testID 追加

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -362,20 +362,20 @@ function NutritionBottomSheet({ visible, onClose, day, dateLabel, radarKeys, wee
   return (
     <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
       <Pressable style={{ flex: 1, backgroundColor: "rgba(0,0,0,0.4)" }} onPress={onClose} />
-      <View style={{ backgroundColor: colors.bg, borderTopLeftRadius: radius["2xl"], borderTopRightRadius: radius["2xl"], maxHeight: "85%", ...shadows.lg }}>
+      <View testID="weekly-nutrition-sheet" style={{ backgroundColor: colors.bg, borderTopLeftRadius: radius["2xl"], borderTopRightRadius: radius["2xl"], maxHeight: "85%", ...shadows.lg }}>
         {/* Header */}
         <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", padding: spacing.lg, borderBottomWidth: 1, borderBottomColor: colors.border }}>
           <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
             <Ionicons name="bar-chart" size={18} color={colors.accent} />
             <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>{dateLabel} の栄養分析</Text>
           </View>
-          <Pressable onPress={onClose} hitSlop={8}>
+          <Pressable testID="weekly-nutrition-sheet-close" onPress={onClose} hitSlop={8}>
             <Ionicons name="close" size={22} color={colors.textMuted} />
           </Pressable>
         </View>
         <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
           {/* Radar Chart */}
-          <View style={{ alignItems: "center" }}>
+          <View testID="weekly-radar-chart" style={{ alignItems: "center" }}>
             <NutritionRadarChartSvg totals={totals} nutrientKeys={radarKeys} size={220} />
           </View>
           {/* AI Feedback */}
@@ -1188,12 +1188,13 @@ export default function WeeklyMenuPage() {
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="weekly-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader title="週間献立" />
       <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
       {/* ヘッダー: 週ナビゲーション */}
       <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
         <Pressable
+          testID="weekly-prev-button"
           onPress={() => shiftWeek(-1)}
           style={{
             width: 40,
@@ -1216,6 +1217,7 @@ export default function WeeklyMenuPage() {
           {plan && <Text style={{ fontSize: 12, color: colors.textMuted }}>{plan.title}</Text>}
         </View>
         <Pressable
+          testID="weekly-next-button"
           onPress={() => shiftWeek(1)}
           style={{
             width: 40,
@@ -1235,6 +1237,7 @@ export default function WeeklyMenuPage() {
 
       {/* 月カレンダー展開バー */}
       <Pressable
+        testID="weekly-calendar-toggle"
         onPress={() => setIsCalendarExpanded(prev => !prev)}
         style={{
           flexDirection: "row",
@@ -1314,6 +1317,7 @@ export default function WeeklyMenuPage() {
               return (
                 <Pressable
                   key={i}
+                  testID={`weekly-day-cell-${dateStr}`}
                   onPress={() => handleCalendarDateClick(day)}
                   style={{
                     width: "14.28%",
@@ -1368,7 +1372,7 @@ export default function WeeklyMenuPage() {
       {isLoading ? (
         <LoadingState />
       ) : error ? (
-        <Card variant="error">
+        <Card testID="weekly-error-banner" variant="error">
           <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
             <Ionicons name="alert-circle" size={20} color={colors.error} />
             <Text style={{ flex: 1, color: colors.error, fontSize: 13 }}>{error}</Text>
@@ -1381,7 +1385,7 @@ export default function WeeklyMenuPage() {
             icon={<Ionicons name="restaurant-outline" size={48} color={colors.textMuted} />}
             message="この週の献立がまだありません"
           />
-          <Button onPress={() => router.push("/menus/weekly/request")}>
+          <Button testID="weekly-request-button" onPress={() => router.push("/menus/weekly/request")}>
             AIで週間献立を作成
           </Button>
         </View>
@@ -1389,11 +1393,13 @@ export default function WeeklyMenuPage() {
         <>
           {/* AI生成中プログレス */}
           {pendingRequestId && (
-            <ProgressTodoCard
-              progress={pendingProgress}
-              phases={pendingIsUltimate ? ULTIMATE_PROGRESS_PHASES : PROGRESS_PHASES}
-              defaultMessage={pendingIsUltimate ? "究極モードで献立を生成中..." : "AIが献立を生成中..."}
-            />
+            <View testID="weekly-generating-indicator">
+              <ProgressTodoCard
+                progress={pendingProgress}
+                phases={pendingIsUltimate ? ULTIMATE_PROGRESS_PHASES : PROGRESS_PHASES}
+                defaultMessage={pendingIsUltimate ? "究極モードで献立を生成中..." : "AIが献立を生成中..."}
+              />
+            </View>
           )}
 
           {/* 日付セレクタ — 横並び丸型ピル */}
@@ -1414,6 +1420,7 @@ export default function WeeklyMenuPage() {
               return (
                 <Pressable
                   key={d.id}
+                  testID={`weekly-day-tab-${d.day_date}`}
                   onPress={() => setSelectedDate(d.day_date)}
                   style={({ pressed }) => ({
                     alignItems: "center",
@@ -1465,7 +1472,7 @@ export default function WeeklyMenuPage() {
                   <Ionicons name="bar-chart" size={13} color={colors.accent} />
                   <Text style={{ fontSize: 12, fontWeight: "600", color: colors.accent }}>栄養</Text>
                 </Pressable>
-                <Button size="sm" variant="ghost" onPress={() => router.push("/menus/weekly/request")}>
+                <Button testID="weekly-request-button" size="sm" variant="ghost" onPress={() => router.push("/menus/weekly/request")}>
                   <View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
                     <Ionicons name="sparkles" size={14} color={colors.accent} />
                     <Text style={{ fontSize: 12, fontWeight: "600", color: colors.accent }}>AIで再生成</Text>
@@ -1485,6 +1492,7 @@ export default function WeeklyMenuPage() {
                 return (
                   <Pressable
                     key={m.id}
+                    testID={`weekly-meal-card-${m.id}`}
                     onPress={() => toggleMealCompletion(m.id, m.is_completed)}
                     style={({ pressed }) => ({
                       flexDirection: "row",
@@ -1543,7 +1551,7 @@ export default function WeeklyMenuPage() {
                     </View>
 
                     {/* ステータス & アクション */}
-                    <View style={{ alignItems: "center", gap: 4 }}>
+                    <View testID={`weekly-meal-toggle-${m.id}`} style={{ alignItems: "center", gap: 4 }}>
                       {m.is_completed ? (
                         <StatusBadge variant="completed" label="完了" />
                       ) : isGenerating ? (

--- a/apps/mobile/app/menus/weekly/request/index.tsx
+++ b/apps/mobile/app/menus/weekly/request/index.tsx
@@ -197,7 +197,7 @@ export default function WeeklyRequestPage() {
   const themeOptions = themes.map((t) => ({ value: t, label: t }));
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="weekly-request-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader
         title="AIで週間献立を作成"
         subtitle="食材や好みに合わせた1週間の献立を自動生成"
@@ -211,6 +211,7 @@ export default function WeeklyRequestPage() {
         />
         <View style={{ marginTop: spacing.sm }}>
           <Input
+            testID="weekly-request-start-date-input"
             label={weekStartDay === 'sunday' ? "週の日曜日推奨" : "週の月曜日推奨"}
             value={startDate}
             onChangeText={setStartDate}
@@ -226,6 +227,7 @@ export default function WeeklyRequestPage() {
         />
         <View style={{ gap: spacing.md, marginTop: spacing.sm }}>
           <Button
+            testID="weekly-request-fridge-photo-button"
             onPress={uploadFridgePhotoAndAnalyze}
             disabled={isUploading || isSubmitting}
             loading={isUploading}
@@ -239,7 +241,7 @@ export default function WeeklyRequestPage() {
             </View>
           </Button>
           {fridgeImageUri ? (
-            <Image source={{ uri: fridgeImageUri }} style={{ width: "100%", height: 160, borderRadius: radius.md }} />
+            <Image testID="weekly-request-fridge-image-preview" source={{ uri: fridgeImageUri }} style={{ width: "100%", height: 160, borderRadius: radius.md }} />
           ) : null}
           {fridgeSummary ? (
             <View style={{ flexDirection: "row", alignItems: "flex-start", gap: spacing.sm }}>
@@ -271,12 +273,14 @@ export default function WeeklyRequestPage() {
         />
         <View style={{ gap: spacing.md, marginTop: spacing.sm }}>
           <Input
+            testID="weekly-request-family-size-input"
             label="家族人数"
             value={familySize}
             onChangeText={setFamilySize}
             keyboardType="number-pad"
           />
           <Input
+            testID="weekly-request-cheat-day-toggle"
             label="チートデイ（任意）"
             value={cheatDay}
             onChangeText={setCheatDay}
@@ -290,6 +294,7 @@ export default function WeeklyRequestPage() {
               selected={selectedThemes}
               onSelect={toggleTheme}
               multiple
+              testIDPrefix="weekly-request-theme"
             />
           </View>
         </View>
@@ -302,6 +307,7 @@ export default function WeeklyRequestPage() {
         />
         <View style={{ marginTop: spacing.sm }}>
           <Input
+            testID="weekly-request-note-input"
             value={note}
             onChangeText={setNote}
             placeholder="例: 野菜多め、魚を増やしたい"
@@ -313,6 +319,7 @@ export default function WeeklyRequestPage() {
 
       {/* 究極モードトグル */}
       <Pressable
+        testID="weekly-request-ultimate-toggle"
         onPress={() => setIsUltimateMode((prev) => !prev)}
         style={{
           flexDirection: "row",
@@ -361,7 +368,7 @@ export default function WeeklyRequestPage() {
         </View>
       </Pressable>
 
-      <Button onPress={submit} disabled={isSubmitting || isUploading} loading={isSubmitting} size="lg">
+      <Button testID="weekly-request-submit-button" onPress={submit} disabled={isSubmitting || isUploading} loading={isSubmitting} size="lg">
         <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
           <Ionicons name={isUltimateMode ? "flash" : "sparkles"} size={18} color="#FFFFFF" />
           <Text style={{ color: "#FFFFFF", fontWeight: "700", fontSize: 16 }}>

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -12,6 +12,7 @@ type ButtonProps = {
   loading?: boolean;
   size?: 'sm' | 'md' | 'lg';
   style?: ViewStyle;
+  testID?: string;
 };
 
 const VARIANT_STYLES: Record<ButtonVariant, { bg: string; bgPressed: string; text: string; border?: string }> = {
@@ -28,7 +29,7 @@ const SIZE_STYLES: Record<string, { paddingV: number; paddingH: number; fontSize
   lg: { paddingV: 16, paddingH: 20, fontSize: 16 },
 };
 
-export function Button({ children, onPress, variant = 'primary', disabled, loading, size = 'md', style }: ButtonProps) {
+export function Button({ children, onPress, variant = 'primary', disabled, loading, size = 'md', style, testID }: ButtonProps) {
   const v = VARIANT_STYLES[variant];
   const s = SIZE_STYLES[size];
   const isDisabled = disabled || loading;
@@ -37,6 +38,7 @@ export function Button({ children, onPress, variant = 'primary', disabled, loadi
     <Pressable
       onPress={onPress}
       disabled={isDisabled}
+      testID={testID}
       style={({ pressed }) => {
         const base: ViewStyle = {
           backgroundColor: isDisabled ? colors.textMuted : pressed ? v.bgPressed : v.bg,

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -8,6 +8,7 @@ type CardProps = {
   style?: ViewStyle;
   variant?: 'default' | 'accent' | 'success' | 'warning' | 'error' | 'purple';
   padding?: keyof typeof spacing;
+  testID?: string;
 };
 
 const BORDER_COLORS: Record<string, string> = {
@@ -19,7 +20,7 @@ const BORDER_COLORS: Record<string, string> = {
   purple: '#D1C4E9',
 };
 
-export function Card({ children, onPress, style, variant = 'default', padding = 'lg' }: CardProps) {
+export function Card({ children, onPress, style, variant = 'default', padding = 'lg', testID }: CardProps) {
   const cardStyle: ViewStyle = {
     backgroundColor: colors.card,
     borderRadius: radius.lg,
@@ -32,11 +33,11 @@ export function Card({ children, onPress, style, variant = 'default', padding = 
 
   if (onPress) {
     return (
-      <Pressable onPress={onPress} style={({ pressed }) => [cardStyle, pressed && { opacity: 0.9, transform: [{ scale: 0.99 }] }]}>
+      <Pressable testID={testID} onPress={onPress} style={({ pressed }) => [cardStyle, pressed && { opacity: 0.9, transform: [{ scale: 0.99 }] }]}>
         {children}
       </Pressable>
     );
   }
 
-  return <View style={cardStyle}>{children}</View>;
+  return <View testID={testID} style={cardStyle}>{children}</View>;
 }

--- a/apps/mobile/src/components/ui/ChipSelector.tsx
+++ b/apps/mobile/src/components/ui/ChipSelector.tsx
@@ -13,6 +13,7 @@ type ChipSelectorProps<T extends string = string> = {
   multiple?: boolean;
   scrollable?: boolean;
   style?: ViewStyle;
+  testIDPrefix?: string;
 };
 
 export function ChipSelector<T extends string = string>({
@@ -21,6 +22,7 @@ export function ChipSelector<T extends string = string>({
   onSelect,
   scrollable,
   style,
+  testIDPrefix,
 }: ChipSelectorProps<T>) {
   const isSelected = (value: T) => (Array.isArray(selected) ? selected.includes(value) : selected === value);
 
@@ -30,6 +32,7 @@ export function ChipSelector<T extends string = string>({
       <Pressable
         key={opt.value}
         onPress={() => onSelect(opt.value)}
+        testID={testIDPrefix ? `${testIDPrefix}-${opt.value}` : undefined}
         style={{
           paddingVertical: 8,
           paddingHorizontal: 14,


### PR DESCRIPTION
## 概要

E2E テスト用に `apps/mobile` の menus weekly 画面群へ testID を網羅追加。

### weekly/index.tsx（14 件）

- `weekly-screen` — 画面ルート View
- `weekly-prev-button` / `weekly-next-button` — 週移動ボタン
- `weekly-calendar-toggle` — カレンダー展開/折りたたみ
- `weekly-day-cell-{date}` — 月カレンダー日付セル（動的）
- `weekly-day-tab-{date}` — 週タブ（動的）
- `weekly-generating-indicator` — AI 生成中プログレスカード
- `weekly-request-button` — AI 献立生成リクエストボタン
- `weekly-error-banner` — エラー表示カード
- `weekly-meal-card-{id}` — 食事カード（動的）
- `weekly-meal-toggle-{id}` — 完了トグル領域（動的）
- `weekly-nutrition-sheet` — 栄養分析ボトムシート
- `weekly-nutrition-sheet-close` — ボトムシート閉じるボタン
- `weekly-radar-chart` — レーダーチャートラッパー

### weekly/request/index.tsx（10 件）

- `weekly-request-screen` — 画面ルート View
- `weekly-request-start-date-input` — 開始日入力
- `weekly-request-family-size-input` — 家族人数入力
- `weekly-request-fridge-photo-button` — 冷蔵庫写真ボタン
- `weekly-request-fridge-image-preview` — 冷蔵庫画像プレビュー
- `weekly-request-cheat-day-toggle` — チートデイ入力
- `weekly-request-theme-{theme}` — テーマ ChipSelector（動的）
- `weekly-request-note-input` — メモ入力
- `weekly-request-ultimate-toggle` — 究極モードトグル
- `weekly-request-submit-button` — 生成ボタン

### 共通コンポーネント変更

- `Button` — `testID` prop 追加
- `Card` — `testID` prop 追加
- `ChipSelector` — `testIDPrefix` prop 追加（chip ごとに `${prefix}-${value}` を付与）

### スキップした testID（実装に対応要素なし）

- `weekly-shopping-list-button` / `weekly-shopping-modal` / `weekly-shopping-modal-close` / `weekly-shopping-item-{id}` / `weekly-shopping-check-{id}` — shopping 機能が weekly/index.tsx に存在しない
- `weekly-request-ingredient-add-button` / `weekly-request-ingredient-input` — 食材は冷蔵庫解析で自動追加のみ。テキスト入力 UI なし
- `weekly-request-generating-view` — 送信中は Button の loading 状態で制御。独立した View なし
- `weekly-request-error-text` — エラーは Alert で表示。JSX に error Text なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)