### PR TITLE
test(mobile-e2e): profile/settings/comparison に testID 追加

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -23,9 +23,10 @@ type SettingRowProps = {
   right?: React.ReactNode;
   onPress?: () => void;
   last?: boolean;
+  testID?: string;
 };
 
-function SettingRow({ icon, iconBg, title, subtitle, right, onPress, last }: SettingRowProps) {
+function SettingRow({ icon, iconBg, title, subtitle, right, onPress, last, testID }: SettingRowProps) {
   const content = (
     <View style={[styles.settingRow, !last && styles.settingRowBorder]}>
       <View style={styles.settingLeft}>
@@ -42,9 +43,9 @@ function SettingRow({ icon, iconBg, title, subtitle, right, onPress, last }: Set
   );
 
   if (onPress) {
-    return <Pressable onPress={onPress}>{content}</Pressable>;
+    return <Pressable testID={testID} onPress={onPress}>{content}</Pressable>;
   }
-  return content;
+  return <View testID={testID}>{content}</View>;
 }
 
 export default function SettingsTab() {
@@ -243,7 +244,7 @@ export default function SettingsTab() {
   }
 
   return (
-    <View style={[styles.screen, { paddingTop: insets.top }]}>
+    <View testID="settings-screen" style={[styles.screen, { paddingTop: insets.top }]}>
       {/* Header */}
       <View style={styles.header}>
         <Text style={styles.headerTitle}>設定</Text>
@@ -259,12 +260,14 @@ export default function SettingsTab() {
               icon="🔔"
               iconBg="#EFF6FF"
               title="通知"
+              testID="settings-notifications-toggle"
               right={<Switch value={notifications} onValueChange={() => handleToggleNotificationPreference("notifications_enabled", setNotifications, notifications)} trackColor={{ true: colors.accent }} />}
             />
             <SettingRow
               icon="🤖"
               iconBg="#F3E8FF"
               title="自動解析"
+              testID="settings-auto-analyze-toggle"
               right={<Switch value={autoAnalyze} onValueChange={() => handleToggleNotificationPreference("auto_analyze_enabled", setAutoAnalyze, autoAnalyze)} trackColor={{ true: colors.accent }} />}
             />
             <SettingRow
@@ -276,6 +279,7 @@ export default function SettingsTab() {
               right={
                 <View style={styles.weekStartRow}>
                   <Pressable
+                    testID="settings-week-start-sunday"
                     onPress={() => handleWeekStartDayChange("sunday")}
                     disabled={savingWeekStart}
                     style={[styles.weekStartBtn, weekStartDay === "sunday" && styles.weekStartBtnActive]}
@@ -283,6 +287,7 @@ export default function SettingsTab() {
                     <Text style={[styles.weekStartText, weekStartDay === "sunday" && styles.weekStartTextActive]}>日曜</Text>
                   </Pressable>
                   <Pressable
+                    testID="settings-week-start-monday"
                     onPress={() => handleWeekStartDayChange("monday")}
                     disabled={savingWeekStart}
                     style={[styles.weekStartBtn, weekStartDay === "monday" && styles.weekStartBtnActive]}
@@ -304,6 +309,7 @@ export default function SettingsTab() {
               iconBg="#EFF6FF"
               title="プロフィール"
               subtitle="名前、年齢、身長・体重など"
+              testID="settings-profile-row"
               onPress={() => router.push("/profile")}
             />
             <SettingRow
@@ -311,6 +317,7 @@ export default function SettingsTab() {
               iconBg="#FEF2F2"
               title="健康診断"
               subtitle="検査結果の記録・分析"
+              testID="settings-blood-test-row"
               onPress={() => router.push("/health/blood-tests")}
             />
             <SettingRow
@@ -318,6 +325,7 @@ export default function SettingsTab() {
               iconBg="#FFF7ED"
               title="栄養目標を再設定"
               subtitle="計算根拠を見ながら目標カロリーを調整"
+              testID="settings-nutrition-targets-row"
               onPress={() => router.push("/profile/nutrition-targets")}
               last
             />
@@ -333,6 +341,7 @@ export default function SettingsTab() {
               iconBg="#F0FDF4"
               title="JSONでエクスポート"
               subtitle="全データを JSON 形式でダウンロード"
+              testID="settings-export-json-row"
               onPress={handleExportJson}
               right={exportingJson ? <Text style={{ fontSize: 12, color: "#6B7280" }}>処理中…</Text> : undefined}
             />
@@ -341,6 +350,7 @@ export default function SettingsTab() {
               iconBg="#F0FDF4"
               title="CSVでエクスポート"
               subtitle="食事記録を CSV 形式でダウンロード"
+              testID="settings-export-csv-row"
               onPress={handleExportCsv}
               right={exportingCsv ? <Text style={{ fontSize: 12, color: "#6B7280" }}>処理中…</Text> : undefined}
             />
@@ -363,12 +373,14 @@ export default function SettingsTab() {
               icon="📄"
               iconBg="#F9FAFB"
               title="利用規約"
+              testID="settings-tos-row"
               onPress={() => Linking.openURL("https://homegohan.app/terms")}
             />
             <SettingRow
               icon="🔒"
               iconBg="#F9FAFB"
               title="プライバシーポリシー"
+              testID="settings-privacy-row"
               onPress={() => Linking.openURL("https://homegohan.app/privacy")}
             />
             <SettingRow
@@ -390,6 +402,7 @@ export default function SettingsTab() {
               iconBg="#FEF2F2"
               title="アカウント管理"
               subtitle="アカウント削除"
+              testID="settings-account-row"
               onPress={() => router.push("/settings/account")}
               last
             />
@@ -397,7 +410,7 @@ export default function SettingsTab() {
         </View>
 
         {/* ── ログアウト ── */}
-        <Pressable onPress={() => setShowLogoutModal(true)} style={styles.logoutBtn}>
+        <Pressable testID="settings-logout-button" onPress={() => setShowLogoutModal(true)} style={styles.logoutBtn}>
           <Text style={styles.logoutText}>ログアウト</Text>
         </Pressable>
 
@@ -407,7 +420,7 @@ export default function SettingsTab() {
       </ScrollView>
 
       {/* ── ログアウト確認モーダル ── */}
-      <Modal visible={showLogoutModal} transparent animationType="fade">
+      <Modal visible={showLogoutModal} transparent animationType="fade" testID="settings-logout-confirm-modal">
         <View style={styles.modalOverlay}>
           <View style={styles.modalCard}>
             <View style={styles.modalIcon}>
@@ -417,10 +430,10 @@ export default function SettingsTab() {
             <Text style={styles.modalSub}>
               ログアウトしてもデータは保持されます。{"\n"}またすぐにお会いしましょう。
             </Text>
-            <Pressable onPress={handleLogout} style={styles.modalLogoutBtn}>
+            <Pressable testID="settings-logout-confirm-button" onPress={handleLogout} style={styles.modalLogoutBtn}>
               <Text style={styles.modalLogoutText}>ログアウト</Text>
             </Pressable>
-            <Pressable onPress={() => setShowLogoutModal(false)} style={styles.modalCancelBtn}>
+            <Pressable testID="settings-logout-cancel-button" onPress={() => setShowLogoutModal(false)} style={styles.modalCancelBtn}>
               <Text style={styles.modalCancelText}>キャンセル</Text>
             </Pressable>
           </View>

--- a/apps/mobile/app/comparison/index.tsx
+++ b/apps/mobile/app/comparison/index.tsx
@@ -68,11 +68,11 @@ export default function ComparisonPage() {
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="comparison-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader
         title="比較"
         right={
-          <Button onPress={trigger} variant="primary" size="sm">
+          <Button testID="comparison-recalculate-button" onPress={trigger} variant="primary" size="sm">
             <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.xs }}>
               <Ionicons name="refresh" size={16} color="#FFFFFF" />
               <Text style={{ color: "#FFFFFF", fontWeight: "700", fontSize: 13 }}>再計算</Text>
@@ -86,6 +86,7 @@ export default function ComparisonPage() {
         options={PERIOD_OPTIONS}
         selected={periodType}
         onSelect={setPeriodType}
+        testIDPrefix="comparison-period"
       />
 
       {isLoading ? (
@@ -94,11 +95,12 @@ export default function ComparisonPage() {
         <Card variant="error">
           <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
             <Ionicons name="alert-circle" size={20} color={colors.error} />
-            <Text style={{ color: colors.error, fontSize: 14, fontWeight: "600" }}>{error}</Text>
+            <Text testID="comparison-error-text" style={{ color: colors.error, fontSize: 14, fontWeight: "600" }}>{error}</Text>
           </View>
         </Card>
       ) : !data ? (
         <EmptyState
+          testID="comparison-empty"
           icon={<Ionicons name="bar-chart-outline" size={48} color={colors.textMuted} />}
           message="データがありません。"
         />
@@ -126,7 +128,7 @@ export default function ComparisonPage() {
 
           <View style={{ gap: spacing.md }}>
             {data.rankings?.map((m) => (
-              <Card key={m.metric.code}>
+              <Card key={m.metric.code} testID={`comparison-ranking-item-${m.metric.code}`}>
                 <SectionHeader title={m.metric.name} />
                 <View style={{ gap: spacing.md }}>
                   {m.segments.map((s) => (

--- a/apps/mobile/app/profile/index.tsx
+++ b/apps/mobile/app/profile/index.tsx
@@ -242,7 +242,7 @@ export default function ProfilePage() {
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="profile-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader
         title="マイページ"
         right={
@@ -251,7 +251,7 @@ export default function ProfilePage() {
               <Pressable onPress={() => { setEditForm(profileData); setIsEditing(false); }}>
                 <Text style={{ fontSize: 15, color: colors.textMuted, fontWeight: "600" }}>キャンセル</Text>
               </Pressable>
-              <Pressable onPress={handleSave} disabled={isSaving}>
+              <Pressable testID="profile-save-button" onPress={handleSave} disabled={isSaving}>
                 <Text style={{ fontSize: 15, color: colors.accent, fontWeight: "700" }}>
                   {isSaving ? "保存中..." : "保存"}
                 </Text>
@@ -287,6 +287,7 @@ export default function ProfilePage() {
           {TABS.map((tab) => (
             <Pressable
               key={tab.id}
+              testID={`profile-tab-${tab.id}`}
               onPress={() => setActiveTab(tab.id)}
               style={[s.tab, activeTab === tab.id && s.tabActive]}
             >
@@ -300,7 +301,7 @@ export default function ProfilePage() {
         {activeTab === "basic" && (
           <Card>
             <Text style={s.cardTitle}>基本情報</Text>
-            <Field label="ニックネーム" value={editForm.nickname} editing={isEditing} onChange={(v) => updateField("nickname", v)} />
+            <Field label="ニックネーム" value={editForm.nickname} editing={isEditing} onChange={(v) => updateField("nickname", v)} testID="profile-nickname-input" />
             <Field label="年齢" value={editForm.age?.toString()} editing={isEditing} onChange={(v) => updateField("age", v ? parseInt(v) : null)} keyboardType="number-pad" />
             {isEditing ? (
               <View style={s.field}>
@@ -315,6 +316,7 @@ export default function ProfilePage() {
                     return (
                       <Pressable
                         key={opt.value}
+                        testID={`profile-gender-${opt.value}`}
                         onPress={() => updateField("gender", opt.value)}
                         style={[s.chip, selected && s.chipSelected]}
                       >
@@ -327,8 +329,8 @@ export default function ProfilePage() {
             ) : (
               <Field label="性別" value={editForm.gender === "male" ? "男性" : editForm.gender === "female" ? "女性" : "未設定"} editing={false} />
             )}
-            <Field label="身長 (cm)" value={editForm.height?.toString()} editing={isEditing} onChange={(v) => updateField("height", v ? parseFloat(v) : null)} keyboardType="decimal-pad" />
-            <Field label="体重 (kg)" value={editForm.weight?.toString()} editing={isEditing} onChange={(v) => updateField("weight", v ? parseFloat(v) : null)} keyboardType="decimal-pad" />
+            <Field label="身長 (cm)" value={editForm.height?.toString()} editing={isEditing} onChange={(v) => updateField("height", v ? parseFloat(v) : null)} keyboardType="decimal-pad" testID="profile-height-input" />
+            <Field label="体重 (kg)" value={editForm.weight?.toString()} editing={isEditing} onChange={(v) => updateField("weight", v ? parseFloat(v) : null)} keyboardType="decimal-pad" testID="profile-weight-input" />
             <Field label="職業" value={editForm.occupation} editing={isEditing} onChange={(v) => updateField("occupation", v)} />
           </Card>
         )}
@@ -801,6 +803,7 @@ export default function ProfilePage() {
 
         {/* ── ログアウト ── */}
         <Pressable
+          testID="profile-logout-button"
           onPress={() => {
             Alert.alert(
               "ログアウトしますか？",
@@ -825,18 +828,20 @@ export default function ProfilePage() {
   );
 }
 
-function Field({ label, value, editing, onChange, keyboardType }: {
+function Field({ label, value, editing, onChange, keyboardType, testID }: {
   label: string;
   value?: string | null;
   editing: boolean;
   onChange?: (v: string) => void;
   keyboardType?: "default" | "number-pad" | "decimal-pad";
+  testID?: string;
 }) {
   return (
     <View style={s.field}>
       <Text style={s.fieldLabel}>{label}</Text>
       {editing && onChange ? (
         <TextInput
+          testID={testID}
           style={s.fieldInput}
           value={value ?? ""}
           onChangeText={onChange}

--- a/apps/mobile/app/profile/nutrition-targets.tsx
+++ b/apps/mobile/app/profile/nutrition-targets.tsx
@@ -132,7 +132,7 @@ export default function NutritionTargetsPage() {
   );
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="nutrition-targets-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader title="栄養目標" />
       <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
       {/* ヘッダー説明 */}
@@ -266,7 +266,7 @@ export default function NutritionTargetsPage() {
                 最終計算日: {new Date(targets.last_calculated_at).toLocaleDateString("ja-JP")}
               </Text>
             )}
-            <Button variant="secondary" onPress={recalculate} loading={isRecalculating}>
+            <Button testID="nutrition-targets-recalculate-button" variant="secondary" onPress={recalculate} loading={isRecalculating}>
               再計算する
             </Button>
           </View>

--- a/apps/mobile/app/settings/account.tsx
+++ b/apps/mobile/app/settings/account.tsx
@@ -32,7 +32,7 @@ export default function AccountSettingsPage() {
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="account-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader title="アカウント" />
       <ScrollView contentContainerStyle={styles.container}>
 
@@ -44,7 +44,7 @@ export default function AccountSettingsPage() {
         <Text style={typography.body}>
           アカウント削除は取り消しできません。必要なデータは事前に控えてください。
         </Text>
-        <Button onPress={deleteAccount} variant="destructive" size="lg">
+        <Button testID="account-delete-button" onPress={deleteAccount} variant="destructive" size="lg">
           <Ionicons name="trash-outline" size={18} color="#FFF" />
           <Text style={{ color: "#FFF", fontWeight: "700", fontSize: 16 }}>アカウント削除</Text>
         </Button>

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -12,6 +12,7 @@ type ButtonProps = {
   loading?: boolean;
   size?: 'sm' | 'md' | 'lg';
   style?: ViewStyle;
+  testID?: string;
 };
 
 const VARIANT_STYLES: Record<ButtonVariant, { bg: string; bgPressed: string; text: string; border?: string }> = {
@@ -28,7 +29,7 @@ const SIZE_STYLES: Record<string, { paddingV: number; paddingH: number; fontSize
   lg: { paddingV: 16, paddingH: 20, fontSize: 16 },
 };
 
-export function Button({ children, onPress, variant = 'primary', disabled, loading, size = 'md', style }: ButtonProps) {
+export function Button({ children, onPress, variant = 'primary', disabled, loading, size = 'md', style, testID }: ButtonProps) {
   const v = VARIANT_STYLES[variant];
   const s = SIZE_STYLES[size];
   const isDisabled = disabled || loading;
@@ -37,6 +38,7 @@ export function Button({ children, onPress, variant = 'primary', disabled, loadi
     <Pressable
       onPress={onPress}
       disabled={isDisabled}
+      testID={testID}
       style={({ pressed }) => {
         const base: ViewStyle = {
           backgroundColor: isDisabled ? colors.textMuted : pressed ? v.bgPressed : v.bg,

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -8,6 +8,7 @@ type CardProps = {
   style?: ViewStyle;
   variant?: 'default' | 'accent' | 'success' | 'warning' | 'error' | 'purple';
   padding?: keyof typeof spacing;
+  testID?: string;
 };
 
 const BORDER_COLORS: Record<string, string> = {
@@ -19,7 +20,7 @@ const BORDER_COLORS: Record<string, string> = {
   purple: '#D1C4E9',
 };
 
-export function Card({ children, onPress, style, variant = 'default', padding = 'lg' }: CardProps) {
+export function Card({ children, onPress, style, variant = 'default', padding = 'lg', testID }: CardProps) {
   const cardStyle: ViewStyle = {
     backgroundColor: colors.card,
     borderRadius: radius.lg,
@@ -32,11 +33,11 @@ export function Card({ children, onPress, style, variant = 'default', padding = 
 
   if (onPress) {
     return (
-      <Pressable onPress={onPress} style={({ pressed }) => [cardStyle, pressed && { opacity: 0.9, transform: [{ scale: 0.99 }] }]}>
+      <Pressable testID={testID} onPress={onPress} style={({ pressed }) => [cardStyle, pressed && { opacity: 0.9, transform: [{ scale: 0.99 }] }]}>
         {children}
       </Pressable>
     );
   }
 
-  return <View style={cardStyle}>{children}</View>;
+  return <View testID={testID} style={cardStyle}>{children}</View>;
 }

--- a/apps/mobile/src/components/ui/ChipSelector.tsx
+++ b/apps/mobile/src/components/ui/ChipSelector.tsx
@@ -13,6 +13,7 @@ type ChipSelectorProps<T extends string = string> = {
   multiple?: boolean;
   scrollable?: boolean;
   style?: ViewStyle;
+  testIDPrefix?: string;
 };
 
 export function ChipSelector<T extends string = string>({
@@ -21,6 +22,7 @@ export function ChipSelector<T extends string = string>({
   onSelect,
   scrollable,
   style,
+  testIDPrefix,
 }: ChipSelectorProps<T>) {
   const isSelected = (value: T) => (Array.isArray(selected) ? selected.includes(value) : selected === value);
 
@@ -30,6 +32,7 @@ export function ChipSelector<T extends string = string>({
       <Pressable
         key={opt.value}
         onPress={() => onSelect(opt.value)}
+        testID={testIDPrefix ? `${testIDPrefix}-${opt.value}` : undefined}
         style={{
           paddingVertical: 8,
           paddingHorizontal: 14,

--- a/apps/mobile/src/components/ui/EmptyState.tsx
+++ b/apps/mobile/src/components/ui/EmptyState.tsx
@@ -9,11 +9,12 @@ type EmptyStateProps = {
   actionLabel?: string;
   onAction?: () => void;
   style?: ViewStyle;
+  testID?: string;
 };
 
-export function EmptyState({ icon, message, actionLabel, onAction, style }: EmptyStateProps) {
+export function EmptyState({ icon, message, actionLabel, onAction, style, testID }: EmptyStateProps) {
   return (
-    <View style={[{ alignItems: 'center', paddingVertical: spacing['3xl'], gap: spacing.md }, style]}>
+    <View testID={testID} style={[{ alignItems: 'center', paddingVertical: spacing['3xl'], gap: spacing.md }, style]}>
       {icon ?? null}
       <Text style={{ fontSize: 15, color: colors.textMuted, textAlign: 'center' }}>{message}</Text>
       {actionLabel && onAction ? (


### PR DESCRIPTION
## 概要

E2E テスト用 testID を profile / settings / comparison / nutrition-targets の各画面に網羅追加。

## 変更ファイル

| ファイル | 追加 testID |
|---|---|
| `apps/mobile/app/profile/index.tsx` | `profile-screen`, `profile-tab-{id}` ×7, `profile-nickname/height/weight-input`, `profile-gender-{code}`, `profile-save-button`, `profile-logout-button` |
| `apps/mobile/app/profile/nutrition-targets.tsx` | `nutrition-targets-screen`, `nutrition-targets-recalculate-button` |
| `apps/mobile/app/(tabs)/settings.tsx` | `settings-screen`, `settings-notifications/auto-analyze-toggle`, `settings-week-start-sunday/monday`, `settings-profile/blood-test/nutrition-targets/export-json/export-csv/tos/privacy/account-row`, `settings-logout-button`, `settings-logout-confirm-modal`, `settings-logout-confirm/cancel-button` |
| `apps/mobile/app/settings/account.tsx` | `account-screen`, `account-delete-button` |
| `apps/mobile/app/comparison/index.tsx` | `comparison-screen`, `comparison-period-{value}` ×3, `comparison-recalculate-button`, `comparison-ranking-item-{code}`, `comparison-empty`, `comparison-error-text` |

## UIコンポーネント変更

- `Button.tsx`: `testID` prop 追加
- `Card.tsx`: `testID` prop 追加
- `ChipSelector.tsx`: `testIDPrefix` prop 追加（各 chip に `{prefix}-{value}` を自動付与）
- `EmptyState.tsx`: `testID` prop 追加

## スキップ項目（実装に存在しないため）

- `profile-birthdate-input`: birthdate フィールドが実装にない
- `profile-error-text`: エラーは Alert.alert のみ
- `nutrition-targets-{macro}-input`: TextInput なし（表示のみ）
- `nutrition-targets-save-button`: 保存ボタンが実装にない
- `nutrition-targets-error-text`: エラーは Alert.alert のみ
- `account-delete-confirm/cancel-button`: Alert.alert のボタンのため DOM に存在しない