### PR TITLE
test(mobile-e2e): health ドメインに testID 追加

### DIFF
--- a/apps/mobile/app/(tabs)/health.tsx
+++ b/apps/mobile/app/(tabs)/health.tsx
@@ -215,7 +215,7 @@ export default function HealthDashboardTab() {
   }
 
   return (
-    <View style={[styles.screen, { paddingTop: insets.top }]}>
+    <View testID="health-screen" style={[styles.screen, { paddingTop: insets.top }]}>
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
 
         {/* ─── Header ─── */}
@@ -233,7 +233,7 @@ export default function HealthDashboardTab() {
 
         {/* ─── Success Message ─── */}
         {message && (
-          <View style={styles.successBanner}>
+          <View testID="health-message-toast" style={styles.successBanner}>
             <Ionicons name="checkmark-circle" size={22} color={colors.success} />
             <Text style={styles.successText}>{message}</Text>
           </View>
@@ -248,7 +248,7 @@ export default function HealthDashboardTab() {
                 <Text style={styles.streakLabel}>連続記録</Text>
               </View>
               <View style={styles.streakValueRow}>
-                <Text style={styles.streakValue}>{streak?.current_streak ?? 0}</Text>
+                <Text testID="health-streak-value" style={styles.streakValue}>{streak?.current_streak ?? 0}</Text>
                 <Text style={styles.streakUnit}>日</Text>
               </View>
               <Text style={styles.streakLongest}>最長: {streak?.longest_streak ?? 0}日</Text>
@@ -257,13 +257,14 @@ export default function HealthDashboardTab() {
           </View>
 
           {/* Weekly calendar */}
-          <View style={styles.weekRow}>
+          <View testID="health-day-calendar" style={styles.weekRow}>
             {weekDays.map((d) => {
               const has = weeklyRecords.includes(d.date);
               const isSelected = selectedDate === d.date;
               return (
                 <Pressable
                   key={d.date}
+                  testID={`health-day-tab-${d.date}`}
                   onPress={() => void handleDaySelect(d.date)}
                   style={[
                     styles.weekDay,
@@ -335,7 +336,7 @@ export default function HealthDashboardTab() {
 
         {/* ─── Today's Record or Quick Record Button ─── */}
         {!todayRecord ? (
-          <Pressable style={styles.quickRecordBtn} onPress={() => setShowQuickRecord(true)}>
+          <Pressable testID="health-quick-record-button" style={styles.quickRecordBtn} onPress={() => setShowQuickRecord(true)}>
             <View style={[styles.iconBox, { backgroundColor: colors.accentLight }]}>
               <Ionicons name="add" size={24} color={colors.accent} />
             </View>
@@ -350,7 +351,7 @@ export default function HealthDashboardTab() {
             <View style={styles.todayHeader}>
               <Text style={styles.todaySectionTitle}>今日の記録</Text>
               <Link href="/health/record" asChild>
-                <Pressable style={styles.todayEditRow}>
+                <Pressable testID="health-record-detail-button" style={styles.todayEditRow}>
                   <Text style={styles.todayEditText}>詳細を編集</Text>
                   <Ionicons name="chevron-forward" size={16} color={colors.accent} />
                 </Pressable>
@@ -360,7 +361,7 @@ export default function HealthDashboardTab() {
               {/* Weight */}
               <View style={styles.todayCell}>
                 <Ionicons name="scale-outline" size={20} color={colors.accent} />
-                <Text style={styles.todayCellValue}>{todayRecord.weight ?? "-"}</Text>
+                <Text testID="health-today-weight" style={styles.todayCellValue}>{todayRecord.weight ?? "-"}</Text>
                 <Text style={styles.todayCellUnit}>kg</Text>
                 {weightChange !== null && (
                   <View style={styles.trendRow}>
@@ -429,17 +430,27 @@ export default function HealthDashboardTab() {
         <View>
           <Text style={styles.sectionTitle}>クイックアクション</Text>
           <View style={styles.actionsGrid}>
-            {QUICK_ACTIONS.map((a) => (
-              <Link key={a.href} href={a.href} asChild>
-                <Pressable style={styles.actionCard}>
-                  <View style={[styles.actionIcon, { backgroundColor: a.bg }]}>
-                    <Ionicons name={a.icon} size={20} color={a.fg} />
-                  </View>
-                  <Text style={styles.actionLabel}>{a.label}</Text>
-                  <Text style={styles.actionSub}>{a.sub}</Text>
-                </Pressable>
-              </Link>
-            ))}
+            {QUICK_ACTIONS.map((a) => {
+              const testID =
+                a.href === "/health/record"
+                  ? "health-record-detail-button"
+                  : a.href === "/health/graphs"
+                  ? "health-graphs-button"
+                  : a.href === "/health/goals"
+                  ? "health-goals-button"
+                  : undefined;
+              return (
+                <Link key={a.href} href={a.href} asChild>
+                  <Pressable testID={testID} style={styles.actionCard}>
+                    <View style={[styles.actionIcon, { backgroundColor: a.bg }]}>
+                      <Ionicons name={a.icon} size={20} color={a.fg} />
+                    </View>
+                    <Text style={styles.actionLabel}>{a.label}</Text>
+                    <Text style={styles.actionSub}>{a.sub}</Text>
+                  </Pressable>
+                </Link>
+              );
+            })}
           </View>
         </View>
 
@@ -455,7 +466,7 @@ export default function HealthDashboardTab() {
             </Link>
           </View>
           <Link href="/health/checkups" asChild>
-            <Pressable style={styles.checkupCard}>
+            <Pressable testID="health-checkups-button" style={styles.checkupCard}>
               <View style={[styles.iconBox, { backgroundColor: "#FFEBEE" }]}>
                 <Ionicons name="pulse" size={24} color={colors.error} />
               </View>
@@ -471,7 +482,7 @@ export default function HealthDashboardTab() {
         {/* ─── More Links ─── */}
         <View style={{ gap: spacing.sm }}>
           <Link href="/health/streaks" asChild>
-            <Pressable style={styles.moreLink}>
+            <Pressable testID="health-streaks-button" style={styles.moreLink}>
               <Ionicons name="flame-outline" size={20} color={colors.accent} />
               <Text style={styles.moreLinkText}>連続記録・バッジ</Text>
               <Ionicons name="chevron-forward" size={16} color={colors.textMuted} />
@@ -485,7 +496,7 @@ export default function HealthDashboardTab() {
             </Pressable>
           </Link>
           <Link href="/health/insights" asChild>
-            <Pressable style={styles.moreLink}>
+            <Pressable testID="health-insights-button" style={styles.moreLink}>
               <Ionicons name="sparkles-outline" size={20} color={colors.accent} />
               <Text style={styles.moreLinkText}>AIインサイト</Text>
               <Ionicons name="chevron-forward" size={16} color={colors.textMuted} />
@@ -505,7 +516,7 @@ export default function HealthDashboardTab() {
       <Modal visible={showQuickRecord} animationType="slide" transparent>
         <View style={styles.modalOverlay}>
           <Pressable style={styles.modalBackdrop} onPress={() => setShowQuickRecord(false)} />
-          <View style={[styles.modalSheet, { paddingBottom: insets.bottom + spacing.lg }]}>
+          <View testID="health-quick-modal" style={[styles.modalSheet, { paddingBottom: insets.bottom + spacing.lg }]}>
             <View style={styles.modalHandle} />
             <Text style={styles.modalTitle}>今日の記録</Text>
 
@@ -513,6 +524,7 @@ export default function HealthDashboardTab() {
             <View style={styles.modalField}>
               <Text style={styles.modalLabel}>体重 (kg)</Text>
               <TextInput
+                testID="health-quick-weight-input"
                 style={styles.modalInput}
                 value={quickWeight}
                 onChangeText={setQuickWeight}
@@ -538,6 +550,7 @@ export default function HealthDashboardTab() {
                 ].map((m) => (
                   <Pressable
                     key={m.score}
+                    testID={`health-quick-mood-${m.score}`}
                     style={[styles.moodBtn, quickMood === m.score && styles.moodBtnActive]}
                     onPress={() => setQuickMood(quickMood === m.score ? null : m.score)}
                   >
@@ -561,6 +574,7 @@ export default function HealthDashboardTab() {
                 {[1, 2, 3, 4, 5].map((s) => (
                   <Pressable
                     key={s}
+                    testID={`health-quick-sleep-${s}`}
                     style={[styles.sleepBtn, quickSleep === s && styles.sleepBtnActive]}
                     onPress={() => setQuickSleep(quickSleep === s ? null : s)}
                   >
@@ -575,7 +589,7 @@ export default function HealthDashboardTab() {
               </View>
             </View>
 
-            <Button onPress={handleQuickSave} loading={saving} disabled={saving}>
+            <Button testID="health-quick-save-button" onPress={handleQuickSave} loading={saving} disabled={saving}>
               {saving ? "保存中..." : "記録する"}
             </Button>
           </View>

--- a/apps/mobile/app/health/checkups/index.tsx
+++ b/apps/mobile/app/health/checkups/index.tsx
@@ -137,7 +137,7 @@ export default function CheckupsPage() {
   }
 
   return (
-    <View style={[styles.screen, { paddingTop: insets.top }]}>
+    <View testID="health-checkups-screen" style={[styles.screen, { paddingTop: insets.top }]}>
       {/* ─── Header ─── */}
       <View style={styles.header}>
         <Pressable onPress={() => router.back()} hitSlop={12}>
@@ -145,6 +145,7 @@ export default function CheckupsPage() {
         </Pressable>
         <Text style={styles.headerTitle}>健康診断記録</Text>
         <Pressable
+          testID="health-checkups-add-button"
           onPress={() => router.push("/health/checkups/new")}
           style={styles.addBtn}
           hitSlop={12}
@@ -157,7 +158,7 @@ export default function CheckupsPage() {
 
         {/* ─── 経年分析カード ─── */}
         {longitudinalReview?.trend_analysis && (
-          <View style={styles.longitudinalCard}>
+          <View testID="health-checkups-trend-card" style={styles.longitudinalCard}>
             <View style={styles.longitudinalHeader}>
               <Ionicons name="analytics-outline" size={20} color="#fff" />
               <Text style={styles.longitudinalTitle}>経年分析</Text>
@@ -205,6 +206,7 @@ export default function CheckupsPage() {
         {/* ─── 健康診断一覧 ─── */}
         {checkups.length === 0 ? (
           <EmptyState
+            testID="health-checkups-empty"
             icon={<Ionicons name="document-text-outline" size={48} color={colors.textMuted} />}
             message="健康診断の記録がありません。最初の記録を追加しましょう"
             actionLabel="記録を追加"
@@ -219,6 +221,7 @@ export default function CheckupsPage() {
               return (
                 <Pressable
                   key={checkup.id}
+                  testID={`health-checkups-item-${checkup.id}`}
                   style={styles.checkupCard}
                   onPress={() => router.push(`/health/checkups/${checkup.id}` as any)}
                 >

--- a/apps/mobile/app/health/checkups/new.tsx
+++ b/apps/mobile/app/health/checkups/new.tsx
@@ -381,10 +381,11 @@ export default function NewCheckupPage() {
         </View>
       </View>
 
-      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+      <ScrollView testID="health-checkup-new-screen" contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
 
         {/* OCR ボタン */}
         <Pressable
+          testID="health-checkup-ocr-button"
           style={styles.ocrButton}
           onPress={showOcrOptions}
           disabled={isOcrProcessing}
@@ -412,6 +413,7 @@ export default function NewCheckupPage() {
             <View style={styles.fieldRow}>
               <Text style={styles.fieldLabel}>検査日</Text>
               <TextInput
+                testID="health-checkup-field-checkup-date"
                 style={[styles.fieldInput, { flex: 1 }]}
                 value={form.checkup_date}
                 onChangeText={(v) => update("checkup_date", v)}
@@ -423,6 +425,7 @@ export default function NewCheckupPage() {
             <View style={styles.fieldRow}>
               <Text style={styles.fieldLabel}>医療機関</Text>
               <TextInput
+                testID="health-checkup-field-facility-name"
                 style={[styles.fieldInput, { flex: 1 }]}
                 value={form.facility_name}
                 onChangeText={(v) => update("facility_name", v)}
@@ -500,7 +503,7 @@ export default function NewCheckupPage() {
           </>
         ))}
 
-        <Button onPress={handleSave} loading={saving} disabled={saving}>
+        <Button testID="health-checkup-save-button" onPress={handleSave} loading={saving} disabled={saving}>
           {saving ? "保存中..." : "保存してAI分析を実行"}
         </Button>
       </ScrollView>

--- a/apps/mobile/app/health/graphs.tsx
+++ b/apps/mobile/app/health/graphs.tsx
@@ -374,7 +374,7 @@ export default function HealthGraphsPage() {
   const hasData = graphData.some((d) => d.value !== null);
 
   return (
-    <View style={styles.screen}>
+    <View testID="health-graphs-screen" style={styles.screen}>
       <PageHeader
         title="推移グラフ"
         right={
@@ -389,6 +389,7 @@ export default function HealthGraphsPage() {
           {(Object.keys(metricConfig) as Metric[]).map((m) => (
             <TouchableOpacity
               key={m}
+              testID={`health-graphs-metric-${m}`}
               onPress={() => setMetric(m)}
               style={[
                 styles.chip,
@@ -412,6 +413,7 @@ export default function HealthGraphsPage() {
           {(["week", "month", "3months", "year"] as Period[]).map((p) => (
             <TouchableOpacity
               key={p}
+              testID={`health-graphs-period-${p}`}
               onPress={() => setPeriod(p)}
               style={[
                 styles.periodBtn,
@@ -442,6 +444,7 @@ export default function HealthGraphsPage() {
           </Card>
         ) : !hasData ? (
           <EmptyState
+            testID="health-graphs-empty"
             icon={<Ionicons name="analytics-outline" size={48} color={colors.textMuted} />}
             message="データがありません。健康記録を開始しましょう。"
             actionLabel="記録する"
@@ -450,7 +453,7 @@ export default function HealthGraphsPage() {
         ) : (
           <>
             {/* メトリクスカード */}
-            <View style={styles.chartCard}>
+            <View testID="health-graphs-chart" style={styles.chartCard}>
               {/* サマリーヘッダー */}
               <View style={styles.chartHeader}>
                 <View>

--- a/apps/mobile/app/health/insights.tsx
+++ b/apps/mobile/app/health/insights.tsx
@@ -104,7 +104,7 @@ export default function HealthInsightsPage() {
   }
 
   return (
-    <View style={styles.screen}>
+    <View testID="health-insights-screen" style={styles.screen}>
       <PageHeader
         title="インサイト"
         right={
@@ -163,14 +163,15 @@ export default function HealthInsightsPage() {
           </Card>
         ) : items.length === 0 ? (
           <EmptyState
+            testID="health-insights-empty"
             icon={<Ionicons name="bulb-outline" size={40} color={colors.textMuted} />}
             message="インサイトがありません。AIインサイトを生成してみましょう。"
           />
         ) : (
           <View style={styles.list}>
             {items.map((i) => (
-              <Pressable key={i.id} onPress={() => handleSelectInsight(i)}>
-                <Card variant={i.is_alert ? "warning" : "default"}>
+              <Pressable key={i.id} testID={`health-insights-item-${i.id}`} onPress={() => handleSelectInsight(i)}>
+                <Card testID={`health-insights-mark-read-${i.id}`} variant={i.is_alert ? "warning" : "default"}>
                   <View style={styles.insightHeader}>
                     <View style={styles.insightTitleRow}>
                       {i.is_alert && <Ionicons name="alert-circle" size={18} color={colors.warning} />}

--- a/apps/mobile/app/health/record/index.tsx
+++ b/apps/mobile/app/health/record/index.tsx
@@ -44,10 +44,10 @@ export default function HealthRecordListPage() {
   }, []);
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="health-record-list-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader title="健康記録" />
       <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
-      <Button onPress={() => router.push("/health/record/quick")}>
+      <Button testID="health-record-quick-button" onPress={() => router.push("/health/record/quick")}>
         <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
           <Ionicons name="add-circle" size={20} color="#fff" />
           <Text style={{ color: "#fff", fontWeight: "700", fontSize: 14 }}>クイック入力</Text>
@@ -62,6 +62,7 @@ export default function HealthRecordListPage() {
         </Card>
       ) : records.length === 0 ? (
         <EmptyState
+          testID="health-record-empty"
           icon={<Ionicons name="heart-outline" size={48} color={colors.textMuted} />}
           message="まだ記録がありません"
           actionLabel="記録する"
@@ -72,6 +73,7 @@ export default function HealthRecordListPage() {
           {records.map((r) => (
             <Pressable
               key={r.id}
+              testID={`health-record-item-${r.id}`}
               onPress={() => router.push(`/health/record/${encodeURIComponent(r.record_date)}`)}
               style={({ pressed }) => ({
                 flexDirection: "row",

--- a/apps/mobile/app/health/record/quick.tsx
+++ b/apps/mobile/app/health/record/quick.tsx
@@ -54,11 +54,12 @@ export default function HealthQuickRecordPage() {
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+    <View testID="health-quick-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
       <PageHeader title="クイック記録" />
       <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
       {/* 日付 */}
       <Input
+        testID="health-quick-date-input"
         label="日付"
         value={recordDate}
         onChangeText={setRecordDate}
@@ -75,6 +76,7 @@ export default function HealthQuickRecordPage() {
             <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>体重</Text>
           </View>
           <Input
+            testID="health-quick-weight-field"
             value={weight}
             onChangeText={setWeight}
             keyboardType="decimal-pad"
@@ -99,6 +101,7 @@ export default function HealthQuickRecordPage() {
               return (
                 <Pressable
                   key={opt.value}
+                  testID={`health-quick-mood-btn-${opt.value}`}
                   onPress={() => setMoodScore(opt.value)}
                   style={{
                     alignItems: "center",
@@ -135,6 +138,7 @@ export default function HealthQuickRecordPage() {
               return (
                 <Pressable
                   key={opt.value}
+                  testID={`health-quick-sleep-btn-${opt.value}`}
                   onPress={() => setSleepQuality(opt.value)}
                   style={{
                     alignItems: "center",
@@ -156,7 +160,7 @@ export default function HealthQuickRecordPage() {
         </View>
       </Card>
 
-      <Button onPress={submit} loading={isSubmitting}>
+      <Button testID="health-quick-submit-button" onPress={submit} loading={isSubmitting}>
         {isSubmitting ? "保存中..." : "記録を保存"}
       </Button>
     </ScrollView>

--- a/apps/mobile/app/health/streaks.tsx
+++ b/apps/mobile/app/health/streaks.tsx
@@ -100,7 +100,7 @@ export default function HealthStreaksPage() {
   }
 
   return (
-    <View style={styles.screen}>
+    <View testID="health-streaks-screen" style={styles.screen}>
       <PageHeader
         title="連続記録"
         right={
@@ -129,6 +129,7 @@ export default function HealthStreaksPage() {
         <>
           <View style={styles.statsRow}>
             <StatCard
+              testID="health-streaks-current-value"
               icon={<Ionicons name="flame" size={22} color={colors.streak} />}
               label="現在の連続"
               value={data.streak.current_streak}
@@ -136,6 +137,7 @@ export default function HealthStreaksPage() {
               accentColor={colors.warningLight}
             />
             <StatCard
+              testID="health-streaks-longest-value"
               icon={<Ionicons name="trophy" size={22} color={colors.warning} />}
               label="最長記録"
               value={data.streak.longest_streak}
@@ -186,7 +188,7 @@ export default function HealthStreaksPage() {
               color={colors.streak}
               style={styles.weeklyProgress}
             />
-            <View style={styles.weekGrid}>
+            <View testID="health-streaks-week-calendar" style={styles.weekGrid}>
               {weekly.map((d) => (
                 <View key={d.date} style={styles.dayItem}>
                   <View

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -12,6 +12,7 @@ type ButtonProps = {
   loading?: boolean;
   size?: 'sm' | 'md' | 'lg';
   style?: ViewStyle;
+  testID?: string;
 };
 
 const VARIANT_STYLES: Record<ButtonVariant, { bg: string; bgPressed: string; text: string; border?: string }> = {
@@ -28,13 +29,14 @@ const SIZE_STYLES: Record<string, { paddingV: number; paddingH: number; fontSize
   lg: { paddingV: 16, paddingH: 20, fontSize: 16 },
 };
 
-export function Button({ children, onPress, variant = 'primary', disabled, loading, size = 'md', style }: ButtonProps) {
+export function Button({ children, onPress, variant = 'primary', disabled, loading, size = 'md', style, testID }: ButtonProps) {
   const v = VARIANT_STYLES[variant];
   const s = SIZE_STYLES[size];
   const isDisabled = disabled || loading;
 
   return (
     <Pressable
+      testID={testID}
       onPress={onPress}
       disabled={isDisabled}
       style={({ pressed }) => {

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -8,6 +8,7 @@ type CardProps = {
   style?: ViewStyle;
   variant?: 'default' | 'accent' | 'success' | 'warning' | 'error' | 'purple';
   padding?: keyof typeof spacing;
+  testID?: string;
 };
 
 const BORDER_COLORS: Record<string, string> = {
@@ -19,7 +20,7 @@ const BORDER_COLORS: Record<string, string> = {
   purple: '#D1C4E9',
 };
 
-export function Card({ children, onPress, style, variant = 'default', padding = 'lg' }: CardProps) {
+export function Card({ children, onPress, style, variant = 'default', padding = 'lg', testID }: CardProps) {
   const cardStyle: ViewStyle = {
     backgroundColor: colors.card,
     borderRadius: radius.lg,
@@ -32,11 +33,11 @@ export function Card({ children, onPress, style, variant = 'default', padding = 
 
   if (onPress) {
     return (
-      <Pressable onPress={onPress} style={({ pressed }) => [cardStyle, pressed && { opacity: 0.9, transform: [{ scale: 0.99 }] }]}>
+      <Pressable testID={testID} onPress={onPress} style={({ pressed }) => [cardStyle, pressed && { opacity: 0.9, transform: [{ scale: 0.99 }] }]}>
         {children}
       </Pressable>
     );
   }
 
-  return <View style={cardStyle}>{children}</View>;
+  return <View testID={testID} style={cardStyle}>{children}</View>;
 }

--- a/apps/mobile/src/components/ui/EmptyState.tsx
+++ b/apps/mobile/src/components/ui/EmptyState.tsx
@@ -9,11 +9,12 @@ type EmptyStateProps = {
   actionLabel?: string;
   onAction?: () => void;
   style?: ViewStyle;
+  testID?: string;
 };
 
-export function EmptyState({ icon, message, actionLabel, onAction, style }: EmptyStateProps) {
+export function EmptyState({ icon, message, actionLabel, onAction, style, testID }: EmptyStateProps) {
   return (
-    <View style={[{ alignItems: 'center', paddingVertical: spacing['3xl'], gap: spacing.md }, style]}>
+    <View testID={testID} style={[{ alignItems: 'center', paddingVertical: spacing['3xl'], gap: spacing.md }, style]}>
       {icon ?? null}
       <Text style={{ fontSize: 15, color: colors.textMuted, textAlign: 'center' }}>{message}</Text>
       {actionLabel && onAction ? (

--- a/apps/mobile/src/components/ui/StatCard.tsx
+++ b/apps/mobile/src/components/ui/StatCard.tsx
@@ -11,11 +11,13 @@ type StatCardProps = {
   borderColor?: string;
   accentColor?: string;
   style?: ViewStyle;
+  testID?: string;
 };
 
-export function StatCard({ icon, label, value, unit, trend, borderColor, accentColor, style }: StatCardProps) {
+export function StatCard({ icon, label, value, unit, trend, borderColor, accentColor, style, testID }: StatCardProps) {
   return (
     <View
+      testID={testID}
       style={{
         flex: 1,
         backgroundColor: colors.card,


### PR DESCRIPTION
## 概要

health ドメイン全体の画面・コンポーネントに `testID` を網羅追加し、E2E テストが要素を確実に特定できるようにする。

## 変更ファイル

### 画面 (8 ファイル)
- `apps/mobile/app/(tabs)/health.tsx` — ダッシュボード全体
- `apps/mobile/app/health/record/index.tsx` — 記録一覧
- `apps/mobile/app/health/record/quick.tsx` — クイック記録
- `apps/mobile/app/health/graphs.tsx` — グラフ
- `apps/mobile/app/health/streaks.tsx` — 連続記録
- `apps/mobile/app/health/checkups/index.tsx` — 健康診断一覧
- `apps/mobile/app/health/checkups/new.tsx` — 健康診断新規登録
- `apps/mobile/app/health/insights.tsx` — AIインサイト

### UI コンポーネント (4 ファイル) — `testID` prop を追加
- `Button`, `Card`, `EmptyState`, `StatCard`

## 主な testID 一覧

- `health-screen`, `health-streak-value`, `health-today-weight`
- `health-quick-record-button`, `health-quick-modal`, `health-quick-weight-input`
- `health-quick-mood-{1-5}`, `health-quick-sleep-{1-5}`, `health-quick-save-button`
- `health-message-toast`, `health-record-detail-button`, `health-graphs-button`
- `health-goals-button`, `health-streaks-button`, `health-checkups-button`, `health-insights-button`
- `health-day-tab-{date}` (週カレンダー)
- `health-record-list-screen`, `health-record-quick-button`, `health-record-item-{id}`, `health-record-empty`
- `health-quick-screen`, `health-quick-date-input`, `health-quick-weight-field`, `health-quick-submit-button`
- `health-graphs-screen`, `health-graphs-period-{period}`, `health-graphs-metric-{metric}`, `health-graphs-chart`, `health-graphs-empty`
- `health-streaks-screen`, `health-streaks-current-value`, `health-streaks-longest-value`, `health-streaks-week-calendar`
- `health-checkups-screen`, `health-checkups-add-button`, `health-checkups-item-{id}`, `health-checkups-trend-card`, `health-checkups-empty`
- `health-checkup-new-screen`, `health-checkup-ocr-button`, `health-checkup-field-checkup-date`, `health-checkup-field-facility-name`, `health-checkup-save-button`
- `health-insights-screen`, `health-insights-item-{id}`, `health-insights-mark-read-{id}`, `health-insights-empty`

## スキップした要素

- `health/goals/` — ディレクトリ不存在 (`goals.tsx` は存在するがサブディレクトリ構成なし)
- `checkups/[id].tsx` — ファイル不存在 (実際のファイルは存在しない)
- `health-streaks-badge-{code}` — バッジは UI に個別レンダリングなし
- `health-error-text` — `health.tsx` にエラー表示 UI なし (エラーはサイレント無視)