### PR TITLE
test(mobile-e2e): auth ドメイン 25 flow 追加

### DIFF
--- a/apps/mobile/maestro/flows/auth/01-login-existing-user-to-home.yaml
+++ b/apps/mobile/maestro/flows/auth/01-login-existing-user-to-home.yaml
@@ -1,0 +1,26 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_01_EMAIL}
+  E2E_USER_PASSWORD: ${E2E_USER_01_PASSWORD}
+---
+# 01: 既存ユーザーで login → home 到達
+- launchApp:
+    clearState: true
+- assertVisible:
+    text: "ほめゴハン"
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/auth/02-admin-login-redirect-to-admin.yaml
+++ b/apps/mobile/maestro/flows/auth/02-admin-login-redirect-to-admin.yaml
@@ -1,0 +1,28 @@
+appId: com.homegohan.app
+env:
+  E2E_ADMIN_EMAIL: ${E2E_ADMIN_EMAIL}
+  E2E_ADMIN_PASSWORD: ${E2E_ADMIN_PASSWORD}
+---
+# 02: admin ロールで login → /admin に redirect
+- launchApp:
+    clearState: true
+- assertVisible:
+    text: "ほめゴハン"
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_ADMIN_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_ADMIN_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      text: "Users"
+    timeout: 10000
+- assertNotVisible:
+    id: "home-screen"

--- a/apps/mobile/maestro/flows/auth/03-onboarding-incomplete-user-redirect.yaml
+++ b/apps/mobile/maestro/flows/auth/03-onboarding-incomplete-user-redirect.yaml
@@ -1,0 +1,28 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_03_EMAIL}
+  E2E_USER_PASSWORD: ${E2E_USER_03_PASSWORD}
+---
+# 03: onboarding 未完了 user で login → /onboarding/resume へ
+- launchApp:
+    clearState: true
+- assertVisible:
+    text: "ほめゴハン"
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      text: "続きから再開"
+    timeout: 10000
+- assertNotVisible:
+    id: "home-screen"

--- a/apps/mobile/maestro/flows/auth/04-signup-new-user-confirmation-email.yaml
+++ b/apps/mobile/maestro/flows/auth/04-signup-new-user-confirmation-email.yaml
@@ -1,0 +1,28 @@
+appId: com.homegohan.app
+env:
+  E2E_NEW_USER_EMAIL: ${E2E_USER_04_EMAIL}
+  E2E_NEW_USER_PASSWORD: ${E2E_USER_04_PASSWORD}
+---
+# 04: /signup で新規登録 → 確認メール送信 Alert
+- launchApp:
+    clearState: true
+- assertVisible:
+    text: "ほめゴハン"
+- tapOn:
+    text: "新規登録"
+- assertVisible:
+    text: "新規登録"
+- tapOn:
+    text: "email@example.com"
+- inputText: ${E2E_NEW_USER_EMAIL}
+- tapOn:
+    text: "8文字以上・英字と数字を含む"
+- inputText: ${E2E_NEW_USER_PASSWORD}
+- tapOn:
+    text: "アカウント作成"
+- extendedWaitUntil:
+    visible:
+      text: "確認してください"
+    timeout: 10000
+- assertVisible:
+    text: "確認メールを送信しました"

--- a/apps/mobile/maestro/flows/auth/05-forgot-password-send-email.yaml
+++ b/apps/mobile/maestro/flows/auth/05-forgot-password-send-email.yaml
@@ -1,0 +1,28 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_05_EMAIL}
+---
+# 05: forgot-password で email 入力 → 送信完了 banner
+- launchApp:
+    clearState: true
+- assertVisible:
+    text: "ほめゴハン"
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    text: "パスワードを忘れた？"
+- assertVisible:
+    text: "パスワードを忘れた"
+- tapOn:
+    text: "email@example.com"
+- inputText: ${E2E_USER_EMAIL}
+- tapOn:
+    text: "送信"
+- extendedWaitUntil:
+    visible:
+      text: "送信しました"
+    timeout: 10000
+- assertVisible:
+    text: "パスワード再設定用のメールを送信しました"

--- a/apps/mobile/maestro/flows/auth/06-welcome-signup-login-e2e.yaml
+++ b/apps/mobile/maestro/flows/auth/06-welcome-signup-login-e2e.yaml
@@ -1,0 +1,58 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_06_EMAIL}
+  E2E_USER_PASSWORD: ${E2E_USER_06_PASSWORD}
+  E2E_NEW_EMAIL: ${E2E_USER_07_EMAIL}
+  E2E_NEW_PASSWORD: ${E2E_USER_07_PASSWORD}
+---
+# 06: welcome から signup 経由でログインまで一気通貫
+# Step 1: welcome 画面確認
+- launchApp:
+    clearState: true
+- assertVisible:
+    text: "ほめゴハン"
+- assertVisible:
+    text: "ログイン"
+- assertVisible:
+    text: "新規登録"
+
+# Step 2: signup へ進む
+- tapOn:
+    text: "新規登録"
+- assertVisible:
+    text: "はじめまして！"
+
+# Step 3: 新規登録フォーム送信
+- tapOn:
+    text: "email@example.com"
+- inputText: ${E2E_NEW_EMAIL}
+- tapOn:
+    text: "8文字以上・英字と数字を含む"
+- inputText: ${E2E_NEW_PASSWORD}
+- tapOn:
+    text: "アカウント作成"
+- extendedWaitUntil:
+    visible:
+      text: "確認してください"
+    timeout: 10000
+
+# Step 4: ダイアログを閉じてログイン画面へ
+- tapOn:
+    text: "OK"
+- assertVisible:
+    id: "login-screen"
+
+# Step 5: 既存ユーザーでログインして home 到達
+- clearText
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/auth/07-login-empty-email-validation.yaml
+++ b/apps/mobile/maestro/flows/auth/07-login-empty-email-validation.yaml
@@ -1,0 +1,24 @@
+appId: com.homegohan.app
+---
+# 07: login: email 空で submit → バリデーションエラー
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+# email を空のまま password だけ入力
+- tapOn:
+    id: "password-input"
+- inputText: "Password1"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      text: "入力エラー"
+    timeout: 5000
+- assertVisible:
+    text: "メールアドレスとパスワードを入力してください"
+# ログイン画面に留まっていること
+- assertVisible:
+    id: "login-screen"

--- a/apps/mobile/maestro/flows/auth/08-login-password-too-short.yaml
+++ b/apps/mobile/maestro/flows/auth/08-login-password-too-short.yaml
@@ -1,0 +1,27 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_08_EMAIL}
+---
+# 08: login: password 7 字で submit → クライアント側エラーまたは API エラー
+# Note: login 画面はパスワード長チェックをしないが signup 側でバリデーション済み
+# ここでは 7 文字パスワードで API エラー (Invalid login credentials) を確認
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: "Pass123"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      text: "ログイン失敗"
+    timeout: 10000
+- assertVisible:
+    id: "login-screen"

--- a/apps/mobile/maestro/flows/auth/09-signup-password-no-digit.yaml
+++ b/apps/mobile/maestro/flows/auth/09-signup-password-no-digit.yaml
@@ -1,0 +1,26 @@
+appId: com.homegohan.app
+---
+# 09: signup: password 数字無し → バリデーションエラー
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "新規登録"
+- assertVisible:
+    text: "はじめまして！"
+- tapOn:
+    text: "email@example.com"
+- inputText: "test.nodigit@example.com"
+- tapOn:
+    text: "8文字以上・英字と数字を含む"
+- inputText: "PasswordOnly"
+- tapOn:
+    text: "アカウント作成"
+- extendedWaitUntil:
+    visible:
+      text: "入力エラー"
+    timeout: 5000
+- assertVisible:
+    text: "パスワードには数字を含めてください"
+# signup 画面に留まっていること
+- assertVisible:
+    text: "はじめまして！"

--- a/apps/mobile/maestro/flows/auth/10-signup-password-no-letter.yaml
+++ b/apps/mobile/maestro/flows/auth/10-signup-password-no-letter.yaml
@@ -1,0 +1,26 @@
+appId: com.homegohan.app
+---
+# 10: signup: password 英字無し → バリデーションエラー
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "新規登録"
+- assertVisible:
+    text: "はじめまして！"
+- tapOn:
+    text: "email@example.com"
+- inputText: "test.noletter@example.com"
+- tapOn:
+    text: "8文字以上・英字と数字を含む"
+- inputText: "12345678"
+- tapOn:
+    text: "アカウント作成"
+- extendedWaitUntil:
+    visible:
+      text: "入力エラー"
+    timeout: 5000
+- assertVisible:
+    text: "パスワードには英字を含めてください"
+# signup 画面に留まっていること
+- assertVisible:
+    text: "はじめまして！"

--- a/apps/mobile/maestro/flows/auth/11-signup-duplicate-email-silent-success.yaml
+++ b/apps/mobile/maestro/flows/auth/11-signup-duplicate-email-silent-success.yaml
@@ -1,0 +1,31 @@
+appId: com.homegohan.app
+env:
+  E2E_EXISTING_EMAIL: ${E2E_USER_01_EMAIL}
+  E2E_NEW_PASSWORD: ${E2E_USER_01_PASSWORD}
+---
+# 11: signup: 既存 email 重複 → silent-success 検出 (#533)
+# Supabase は重複メールで identities: [] を返し、アプリがそれを検出してエラー表示
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "新規登録"
+- assertVisible:
+    text: "はじめまして！"
+- tapOn:
+    text: "email@example.com"
+- inputText: ${E2E_EXISTING_EMAIL}
+- tapOn:
+    text: "8文字以上・英字と数字を含む"
+- inputText: ${E2E_NEW_PASSWORD}
+- tapOn:
+    text: "アカウント作成"
+- extendedWaitUntil:
+    visible:
+      text: "登録できませんでした"
+    timeout: 10000
+- assertVisible:
+    text: "このメールアドレスは既に登録されています"
+- tapOn:
+    text: "ログインへ"
+- assertVisible:
+    id: "login-screen"

--- a/apps/mobile/maestro/flows/auth/12-login-rate-limit-ban-after-3-failures.yaml
+++ b/apps/mobile/maestro/flows/auth/12-login-rate-limit-ban-after-3-failures.yaml
@@ -1,0 +1,42 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_02_EMAIL}
+---
+# 12: login: 30 秒 rate limit ban (3 回失敗 → 待機 banner)
+# 1 回目失敗でクライアント side rate limit が発動する実装 (#532)
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+
+# 1 回目: 失敗
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: "WrongPass1"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      text: "ログイン失敗"
+    timeout: 10000
+- tapOn:
+    text: "OK"
+
+# rate limit カウントダウンが表示されること
+- extendedWaitUntil:
+    visible:
+      text: "再試行まで"
+    timeout: 5000
+
+# login-button が disabled 状態 (ボタンテキストに秒数が表示される)
+- assertVisible:
+    text: "再試行まで"
+
+# ログイン画面に留まっていること
+- assertVisible:
+    id: "login-screen"

--- a/apps/mobile/maestro/flows/auth/13-login-wrong-password-rate-limit-set.yaml
+++ b/apps/mobile/maestro/flows/auth/13-login-wrong-password-rate-limit-set.yaml
@@ -1,0 +1,33 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_09_EMAIL}
+---
+# 13: login: 誤パスワード → rate limit セット確認
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: "WrongPassword99"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      text: "ログイン失敗"
+    timeout: 10000
+# エラーメッセージが表示されること
+- assertVisible:
+    text: "メールアドレスまたはパスワードが正しくありません"
+- tapOn:
+    text: "OK"
+# rate limit カウントダウンが開始されること
+- assertVisible:
+    text: "再試行まで"
+- assertVisible:
+    id: "login-screen"

--- a/apps/mobile/maestro/flows/auth/14-login-offline-airplane-mode.yaml
+++ b/apps/mobile/maestro/flows/auth/14-login-offline-airplane-mode.yaml
@@ -1,0 +1,40 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_10_EMAIL}
+  E2E_USER_PASSWORD: ${E2E_USER_10_PASSWORD}
+---
+# 14: オフライン中 login submit (Airplane mode)
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_PASSWORD}
+
+# Airplane モードを有効化
+- runScript:
+    file: "../scripts/enable-airplane-mode.js"
+
+# submit
+- tapOn:
+    id: "login-button"
+
+# ネットワークエラーが表示されること
+- extendedWaitUntil:
+    visible:
+      text: "ログイン失敗"
+    timeout: 15000
+
+# ログイン画面に留まっていること
+- assertVisible:
+    id: "login-screen"
+
+# Airplane モードを解除
+- runScript:
+    file: "../scripts/disable-airplane-mode.js"

--- a/apps/mobile/maestro/flows/auth/15-login-429-too-many-requests.yaml
+++ b/apps/mobile/maestro/flows/auth/15-login-429-too-many-requests.yaml
@@ -1,0 +1,32 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_02_EMAIL}
+---
+# 15: login: 429 too many requests
+# Supabase が 429 を返した場合のエラーハンドリング確認
+# Note: テスト環境では rate limit を意図的に超過させるか、
+#       mock server で 429 を返すシナリオを想定
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: "WrongPass1"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      text: "ログイン失敗"
+    timeout: 15000
+
+# 429 または通常エラーで rate limit が発動すること
+- assertVisible:
+    id: "login-screen"
+- assertVisible:
+    text: "再試行まで"

--- a/apps/mobile/maestro/flows/auth/16-signup-api-500-error.yaml
+++ b/apps/mobile/maestro/flows/auth/16-signup-api-500-error.yaml
@@ -1,0 +1,25 @@
+appId: com.homegohan.app
+---
+# 16: signup: API 500 エラー
+# Note: Supabase が内部エラーを返した場合のエラーハンドリング確認
+# テスト環境では不正な URL 設定や、mock により 500 を再現
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "新規登録"
+- assertVisible:
+    text: "はじめまして！"
+- tapOn:
+    text: "email@example.com"
+- inputText: "api500test@example.com"
+- tapOn:
+    text: "8文字以上・英字と数字を含む"
+- inputText: "Valid1234"
+- tapOn:
+    text: "アカウント作成"
+- extendedWaitUntil:
+    visible:
+      text: "登録失敗"
+    timeout: 15000
+- assertVisible:
+    text: "はじめまして！"

--- a/apps/mobile/maestro/flows/auth/17-adversarial-email-5000-chars.yaml
+++ b/apps/mobile/maestro/flows/auth/17-adversarial-email-5000-chars.yaml
@@ -1,0 +1,25 @@
+appId: com.homegohan.app
+---
+# 17: email に 5000 字 → クラッシュしないこと確認
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    id: "email-input"
+# 5000 字の文字列 (実際の実行時はランタイムで生成される文字列を模倣)
+- inputText: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@evil.com"
+- tapOn:
+    id: "password-input"
+- inputText: "Password1"
+- tapOn:
+    id: "login-button"
+# アプリがクラッシュせず、エラーまたは login 画面に留まること
+- extendedWaitUntil:
+    visible:
+      id: "login-screen"
+    timeout: 10000
+- assertNotVisible:
+    id: "home-screen"

--- a/apps/mobile/maestro/flows/auth/18-adversarial-password-sql-injection.yaml
+++ b/apps/mobile/maestro/flows/auth/18-adversarial-password-sql-injection.yaml
@@ -1,0 +1,28 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_05_EMAIL}
+---
+# 18: password に SQL injection → クラッシュしないこと、DBエラーにならないこと
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: "' OR '1'='1'; DROP TABLE users; --"
+- tapOn:
+    id: "login-button"
+# 認証エラーになること (ログインできないこと)
+- extendedWaitUntil:
+    visible:
+      text: "ログイン失敗"
+    timeout: 10000
+- assertNotVisible:
+    id: "home-screen"
+- assertVisible:
+    id: "login-screen"

--- a/apps/mobile/maestro/flows/auth/19-adversarial-email-xss-payload.yaml
+++ b/apps/mobile/maestro/flows/auth/19-adversarial-email-xss-payload.yaml
@@ -1,0 +1,28 @@
+appId: com.homegohan.app
+---
+# 19: login email に XSS payload → クラッシュしないこと、スクリプト実行されないこと
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    id: "email-input"
+- inputText: "<script>alert('xss')</script>@evil.com"
+- tapOn:
+    id: "password-input"
+- inputText: "Password1"
+- tapOn:
+    id: "login-button"
+# 認証エラーになること (スクリプトが実行されないこと)
+- extendedWaitUntil:
+    visible:
+      text: "ログイン失敗"
+    timeout: 10000
+- assertNotVisible:
+    text: "xss"
+- assertNotVisible:
+    id: "home-screen"
+- assertVisible:
+    id: "login-screen"

--- a/apps/mobile/maestro/flows/auth/20-adversarial-next-param-open-redirect.yaml
+++ b/apps/mobile/maestro/flows/auth/20-adversarial-next-param-open-redirect.yaml
@@ -1,0 +1,33 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_01_EMAIL}
+  E2E_USER_PASSWORD: ${E2E_USER_01_PASSWORD}
+---
+# 20: ?next= 改竄: https://evil.com → home に強制 redirect (open redirect 防止確認)
+# アプリは ?next= が '/' 始まりでない場合、無視してデフォルトルートへ遷移
+# deep link で ?next=https://evil.com を付与してログインを試みる
+- launchApp:
+    clearState: true
+    arguments:
+      MAESTRO_NEXT_PARAM: "https://evil.com"
+
+# 通常のログインフロー (next= パラメータは URL から来るが、ここではログイン実行)
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_PASSWORD}
+- tapOn:
+    id: "login-button"
+# evil.com ではなく home-screen に遷移すること
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+- assertNotVisible:
+    text: "evil.com"

--- a/apps/mobile/maestro/flows/auth/21-adversarial-forgot-password-nonexistent-email.yaml
+++ b/apps/mobile/maestro/flows/auth/21-adversarial-forgot-password-nonexistent-email.yaml
@@ -1,0 +1,27 @@
+appId: com.homegohan.app
+---
+# 21: forgot-password: 存在しない email
+# Supabase の resetPasswordForEmail は存在しない email でも成功を返す (ユーザー列挙防止)
+# アプリが送信完了メッセージを表示すること (エラーにしないこと)
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+- tapOn:
+    text: "パスワードを忘れた？"
+- assertVisible:
+    text: "パスワードを忘れた"
+- tapOn:
+    text: "email@example.com"
+- inputText: "nonexistent.user.12345@example.com"
+- tapOn:
+    text: "送信"
+- extendedWaitUntil:
+    visible:
+      text: "送信しました"
+    timeout: 10000
+# 送信完了メッセージが表示されること (存在確認ができないこと)
+- assertVisible:
+    text: "パスワード再設定用のメールを送信しました"

--- a/apps/mobile/maestro/flows/auth/22-login-bg-fg-input-preserved.yaml
+++ b/apps/mobile/maestro/flows/auth/22-login-bg-fg-input-preserved.yaml
@@ -1,0 +1,31 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_06_EMAIL}
+---
+# 22: login 中に BG → FG → 入力保持
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+
+# email を入力
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+
+# バックグラウンドへ
+- pressKey: HOME
+
+# フォアグラウンドへ復帰
+- launchApp:
+    clearState: false
+
+# login-screen が表示されていること
+- assertVisible:
+    id: "login-screen"
+
+# email 入力が保持されていること
+- assertVisible:
+    text: ${E2E_USER_EMAIL}

--- a/apps/mobile/maestro/flows/auth/23-expired-jwt-home-redirect-to-root.yaml
+++ b/apps/mobile/maestro/flows/auth/23-expired-jwt-home-redirect-to-root.yaml
@@ -1,0 +1,20 @@
+appId: com.homegohan.app
+---
+# 23: expired JWT で home 直アクセス → / redirect
+# clearState: true によりセッションがクリアされた状態で、
+# ディープリンクで /(tabs)/home に直接アクセスを試みる
+# → 認証されていないため welcome 画面 (/) にリダイレクトされること
+- launchApp:
+    clearState: true
+    arguments:
+      MAESTRO_DEEP_LINK: "homegohan://home"
+- extendedWaitUntil:
+    visible:
+      text: "ほめゴハン"
+    timeout: 10000
+# home-screen には到達しないこと
+- assertNotVisible:
+    id: "home-screen"
+# ログインボタンが表示されること (welcome 画面)
+- assertVisible:
+    text: "ログイン"

--- a/apps/mobile/maestro/flows/auth/24-google-oauth-cancel-returns-to-login.yaml
+++ b/apps/mobile/maestro/flows/auth/24-google-oauth-cancel-returns-to-login.yaml
@@ -1,0 +1,28 @@
+appId: com.homegohan.app
+---
+# 24: Google OAuth キャンセル → login 画面戻り
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+
+# Google ログインボタンをタップ
+- tapOn:
+    text: "Googleでログイン"
+
+# WebBrowser が開かれるので、すぐにキャンセル (Back ボタンまたは dismiss)
+# iOS: ブラウザが閉じられると type=cancel が返る
+# Android: Back キーでキャンセル
+- pressKey: BACK
+
+# login 画面に戻ること
+- extendedWaitUntil:
+    visible:
+      id: "login-screen"
+    timeout: 8000
+
+# home-screen には遷移しないこと
+- assertNotVisible:
+    id: "home-screen"

--- a/apps/mobile/maestro/flows/auth/25-rate-limit-countdown-bg-fg-restored.yaml
+++ b/apps/mobile/maestro/flows/auth/25-rate-limit-countdown-bg-fg-restored.yaml
@@ -1,0 +1,55 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_10_EMAIL}
+---
+# 25: rate limit countdown 中に BG → FG → 残り秒復元 (#532)
+# AsyncStorage から残り制限時間を復元する機能のテスト
+- launchApp:
+    clearState: true
+- tapOn:
+    text: "ログイン"
+- assertVisible:
+    id: "login-screen"
+
+# 失敗してrate limit を発動
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: "WrongPass1"
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      text: "ログイン失敗"
+    timeout: 10000
+- tapOn:
+    text: "OK"
+
+# rate limit カウントダウン確認
+- extendedWaitUntil:
+    visible:
+      text: "再試行まで"
+    timeout: 5000
+
+# バックグラウンドへ
+- pressKey: HOME
+
+# 少し待機 (3秒)
+- extendedWaitUntil:
+    visible:
+      text: "HOME"
+    timeout: 1000
+
+# フォアグラウンドへ復帰
+- launchApp:
+    clearState: false
+
+# login-screen が表示されていること
+- assertVisible:
+    id: "login-screen"
+
+# rate limit カウントダウンが復元されていること (AsyncStorage から読み込み)
+- assertVisible:
+    text: "再試行まで"


### PR DESCRIPTION
正常 6 / バリデーション 7 / ネットワーク 3 / Adversarial 5 / 状態遷移 4

## シナリオ一覧

### 正常系 (6)
- 01: 既存ユーザーで login → home 到達
- 02: admin ロールで login → /admin に redirect
- 03: onboarding 未完了 user で login → /onboarding/resume へ
- 04: /signup で新規登録 → 確認メール送信 Alert
- 05: forgot-password で email 入力 → 送信完了 banner
- 06: welcome から signup 経由でログインまで一気通貫

### バリデーション系 (7)
- 07: login: email 空で submit
- 08: login: password 7 字で submit (エラー期待)
- 09: signup: password 数字無し
- 10: signup: password 英字無し
- 11: signup: 既存 email 重複 (silent-success 検出 #533)
- 12: login: 30 秒 rate limit ban (失敗 → 待機 banner #532)
- 13: login: 誤パスワード (rate limit セット確認 #532)

### ネットワーク/API エラー系 (3)
- 14: オフライン中 login submit (Airplane mode)
- 15: login: 429 too many requests
- 16: signup: API 500

### Adversarial (5)
- 17: email に 5000 字
- 18: password に SQL injection
- 19: login email に XSS payload
- 20: ?next= 改竄: https://evil.com → home に強制 redirect
- 21: forgot-password: 存在しない email

### 状態遷移 (4)
- 22: login 中に BG → FG → 入力保持
- 23: expired JWT で home 直アクセス → / redirect
- 24: Google OAuth キャンセル → login 画面戻り
- 25: rate limit countdown 中に BG → FG → 残り秒復元 (#532)

## YAML lint
全 25 ファイル `yaml.safe_load_all` パス済み