### PR TITLE
test(mobile-e2e): meals/favorites/shopping 35 flow

### DIFF
--- a/apps/mobile/maestro/flows/_shared/login.yaml
+++ b/apps/mobile/maestro/flows/_shared/login.yaml
@@ -1,0 +1,20 @@
+appId: com.homegohan.app
+---
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/favorites/01-search-filter.yaml
+++ b/apps/mobile/maestro/flows/favorites/01-search-filter.yaml
@@ -1,0 +1,25 @@
+appId: com.homegohan.app
+---
+# 正常 01: 検索フィルタ
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-favorites-tab"
+- assertVisible:
+    id: "favorites-screen"
+
+- tapOn:
+    id: "favorites-search-input"
+- inputText: "鶏"
+
+- extendedWaitUntil:
+    visible:
+      id: "favorites-list"
+    timeout: 5000
+
+- assertVisible:
+    id: "favorites-list-item"
+- assertNotVisible:
+    id: "favorites-empty-state"

--- a/apps/mobile/maestro/flows/favorites/02-sort-name-old.yaml
+++ b/apps/mobile/maestro/flows/favorites/02-sort-name-old.yaml
@@ -1,0 +1,35 @@
+appId: com.homegohan.app
+---
+# 正常 02: ソート切替 (名前順/古い順)
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-favorites-tab"
+- assertVisible:
+    id: "favorites-screen"
+
+- tapOn:
+    id: "favorites-sort-button"
+- assertVisible:
+    id: "favorites-sort-menu"
+
+- tapOn:
+    id: "favorites-sort-name-asc"
+- extendedWaitUntil:
+    visible:
+      id: "favorites-list"
+    timeout: 5000
+
+- tapOn:
+    id: "favorites-sort-button"
+- tapOn:
+    id: "favorites-sort-date-asc"
+- extendedWaitUntil:
+    visible:
+      id: "favorites-list"
+    timeout: 5000
+
+- assertVisible:
+    id: "favorites-list-item"

--- a/apps/mobile/maestro/flows/favorites/03-unheart-confirm-cancel.yaml
+++ b/apps/mobile/maestro/flows/favorites/03-unheart-confirm-cancel.yaml
@@ -1,0 +1,26 @@
+appId: com.homegohan.app
+---
+# 正常 03: ハート解除 → 確認 cancel でキャンセル
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-favorites-tab"
+- assertVisible:
+    id: "favorites-screen"
+
+- tapOn:
+    id: "favorites-first-heart-button"
+- assertVisible:
+    id: "unfavorite-confirm-dialog"
+
+- tapOn:
+    id: "unfavorite-cancel-button"
+
+- assertNotVisible:
+    id: "unfavorite-confirm-dialog"
+- assertVisible:
+    id: "favorites-first-heart-button"
+- assertVisible:
+    id: "favorites-list-item"

--- a/apps/mobile/maestro/flows/favorites/04-validation-search-empty.yaml
+++ b/apps/mobile/maestro/flows/favorites/04-validation-search-empty.yaml
@@ -1,0 +1,31 @@
+appId: com.homegohan.app
+---
+# バリデーション 04: 検索空 → 全件表示
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-favorites-tab"
+- assertVisible:
+    id: "favorites-screen"
+
+- tapOn:
+    id: "favorites-search-input"
+- inputText: "検索テスト"
+
+- extendedWaitUntil:
+    visible:
+      id: "favorites-list"
+    timeout: 5000
+
+- clearText:
+    id: "favorites-search-input"
+
+- extendedWaitUntil:
+    visible:
+      id: "favorites-list"
+    timeout: 5000
+
+- assertVisible:
+    id: "favorites-list-item"

--- a/apps/mobile/maestro/flows/favorites/05-validation-sort-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/favorites/05-validation-sort-rapid-tap.yaml
@@ -1,0 +1,38 @@
+appId: com.homegohan.app
+---
+# バリデーション 05: ソート連打
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-favorites-tab"
+- assertVisible:
+    id: "favorites-screen"
+
+- tapOn:
+    id: "favorites-sort-button"
+- tapOn:
+    id: "favorites-sort-name-asc"
+- tapOn:
+    id: "favorites-sort-button"
+- tapOn:
+    id: "favorites-sort-date-desc"
+- tapOn:
+    id: "favorites-sort-button"
+- tapOn:
+    id: "favorites-sort-name-asc"
+- tapOn:
+    id: "favorites-sort-button"
+- tapOn:
+    id: "favorites-sort-date-asc"
+
+- extendedWaitUntil:
+    visible:
+      id: "favorites-list"
+    timeout: 10000
+
+- assertNotVisible:
+    id: "app-crash-screen"
+- assertVisible:
+    id: "favorites-screen"

--- a/apps/mobile/maestro/flows/favorites/06-api-list-fetch-fail.yaml
+++ b/apps/mobile/maestro/flows/favorites/06-api-list-fetch-fail.yaml
@@ -1,0 +1,19 @@
+appId: com.homegohan.app
+---
+# API 06: 一覧取得 fail → エラー表示
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-favorites-tab"
+
+- extendedWaitUntil:
+    visible:
+      id: "favorites-fetch-error-message"
+    timeout: 10000
+
+- assertVisible:
+    id: "favorites-retry-button"
+- assertNotVisible:
+    id: "favorites-list"

--- a/apps/mobile/maestro/flows/favorites/07-api-unfavorite-patch-fail.yaml
+++ b/apps/mobile/maestro/flows/favorites/07-api-unfavorite-patch-fail.yaml
@@ -1,0 +1,29 @@
+appId: com.homegohan.app
+---
+# API 07: 解除 PATCH fail → rollback + エラー表示
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-favorites-tab"
+- assertVisible:
+    id: "favorites-screen"
+
+- tapOn:
+    id: "favorites-first-heart-button"
+- assertVisible:
+    id: "unfavorite-confirm-dialog"
+
+- tapOn:
+    id: "unfavorite-confirm-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "favorites-delete-error-message"
+    timeout: 10000
+
+- assertVisible:
+    id: "favorites-first-heart-button"
+- assertVisible:
+    id: "favorites-list-item"

--- a/apps/mobile/maestro/flows/favorites/08-adversarial-200-items-scroll.yaml
+++ b/apps/mobile/maestro/flows/favorites/08-adversarial-200-items-scroll.yaml
@@ -1,0 +1,33 @@
+appId: com.homegohan.app
+---
+# Adversarial 08: 200 件無限スクロール
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-favorites-tab"
+- assertVisible:
+    id: "favorites-screen"
+
+- extendedWaitUntil:
+    visible:
+      id: "favorites-list"
+    timeout: 10000
+
+- scroll:
+    direction: DOWN
+    duration: 3000
+
+- scroll:
+    direction: DOWN
+    duration: 3000
+
+- scroll:
+    direction: DOWN
+    duration: 3000
+
+- assertNotVisible:
+    id: "app-crash-screen"
+- assertVisible:
+    id: "favorites-screen"

--- a/apps/mobile/maestro/flows/favorites/09-adversarial-search-xss.yaml
+++ b/apps/mobile/maestro/flows/favorites/09-adversarial-search-xss.yaml
@@ -1,0 +1,25 @@
+appId: com.homegohan.app
+---
+# Adversarial 09: 検索 XSS インジェクション
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-favorites-tab"
+- assertVisible:
+    id: "favorites-screen"
+
+- tapOn:
+    id: "favorites-search-input"
+- inputText: "<img src=x onerror=alert(1)>"
+
+- extendedWaitUntil:
+    visible:
+      id: "favorites-list"
+    timeout: 5000
+
+- assertNotVisible:
+    id: "app-crash-screen"
+- assertNotVisible:
+    text: "<img"

--- a/apps/mobile/maestro/flows/favorites/10-adversarial-duplicate-add-race.yaml
+++ b/apps/mobile/maestro/flows/favorites/10-adversarial-duplicate-add-race.yaml
@@ -1,0 +1,41 @@
+appId: com.homegohan.app
+---
+# Adversarial 10: 同一お気に入り重複 add (race condition)
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- assertVisible:
+    id: "meals-screen"
+
+- tapOn:
+    id: "meal-first-item"
+- assertVisible:
+    id: "meal-detail-screen"
+
+- tapOn:
+    id: "meal-heart-button"
+- tapOn:
+    id: "meal-heart-button"
+- tapOn:
+    id: "meal-heart-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "meal-detail-screen"
+    timeout: 5000
+
+- assertNotVisible:
+    id: "app-crash-screen"
+
+- tapOn:
+    id: "back-button"
+- tapOn:
+    id: "meals-favorites-tab"
+- assertVisible:
+    id: "favorites-screen"
+
+- extendedWaitUntil:
+    visible:
+      id: "favorites-list"
+    timeout: 5000

--- a/apps/mobile/maestro/flows/meals/01-mode-meal-capture-analyze-save.yaml
+++ b/apps/mobile/maestro/flows/meals/01-mode-meal-capture-analyze-save.yaml
@@ -1,0 +1,43 @@
+appId: com.homegohan.app
+---
+# 正常 01: mode=meal → 撮影 → AI解析 → 保存
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- assertVisible:
+    id: "meals-screen"
+
+- tapOn:
+    id: "meals-add-button"
+- assertVisible:
+    id: "meal-mode-select-screen"
+
+- tapOn:
+    id: "meal-mode-meal"
+
+- tapOn:
+    id: "camera-capture-button"
+- extendedWaitUntil:
+    visible:
+      id: "ai-analyzing-indicator"
+    timeout: 10000
+
+- extendedWaitUntil:
+    visible:
+      id: "meal-form-screen"
+    timeout: 30000
+
+- assertVisible:
+    id: "meal-name-input"
+- assertVisible:
+    id: "meal-calories-input"
+
+- tapOn:
+    id: "meal-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "meals-screen"
+    timeout: 10000
+- assertVisible:
+    id: "meal-list"

--- a/apps/mobile/maestro/flows/meals/02-auto-mode-classification.yaml
+++ b/apps/mobile/maestro/flows/meals/02-auto-mode-classification.yaml
@@ -1,0 +1,41 @@
+appId: com.homegohan.app
+---
+# 正常 02: auto モード → 正しく分類される
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- assertVisible:
+    id: "meals-screen"
+
+- tapOn:
+    id: "meals-add-button"
+- assertVisible:
+    id: "meal-mode-select-screen"
+
+- tapOn:
+    id: "meal-mode-auto"
+
+- tapOn:
+    id: "camera-capture-button"
+- extendedWaitUntil:
+    visible:
+      id: "ai-analyzing-indicator"
+    timeout: 10000
+
+- extendedWaitUntil:
+    visible:
+      id: "meal-form-screen"
+    timeout: 30000
+
+- assertVisible:
+    id: "meal-type-badge"
+- assertNotVisible:
+    id: "meal-type-unknown"
+
+- tapOn:
+    id: "meal-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "meals-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/meals/03-fridge-pantry-register.yaml
+++ b/apps/mobile/maestro/flows/meals/03-fridge-pantry-register.yaml
@@ -1,0 +1,39 @@
+appId: com.homegohan.app
+---
+# 正常 03: fridge → pantry 登録
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- assertVisible:
+    id: "meals-screen"
+
+- tapOn:
+    id: "meals-add-button"
+- assertVisible:
+    id: "meal-mode-select-screen"
+
+- tapOn:
+    id: "meal-mode-fridge"
+
+- tapOn:
+    id: "camera-capture-button"
+- extendedWaitUntil:
+    visible:
+      id: "ai-analyzing-indicator"
+    timeout: 10000
+
+- extendedWaitUntil:
+    visible:
+      id: "pantry-item-form-screen"
+    timeout: 30000
+
+- assertVisible:
+    id: "pantry-item-name-input"
+
+- tapOn:
+    id: "pantry-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "meals-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/meals/04-health-checkup-ocr.yaml
+++ b/apps/mobile/maestro/flows/meals/04-health-checkup-ocr.yaml
@@ -1,0 +1,39 @@
+appId: com.homegohan.app
+---
+# 正常 04: health_checkup OCR
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- assertVisible:
+    id: "meals-screen"
+
+- tapOn:
+    id: "meals-add-button"
+- assertVisible:
+    id: "meal-mode-select-screen"
+
+- tapOn:
+    id: "meal-mode-health-checkup"
+
+- tapOn:
+    id: "camera-capture-button"
+- extendedWaitUntil:
+    visible:
+      id: "ocr-analyzing-indicator"
+    timeout: 10000
+
+- extendedWaitUntil:
+    visible:
+      id: "health-checkup-form-screen"
+    timeout: 30000
+
+- assertVisible:
+    id: "checkup-result-fields"
+
+- tapOn:
+    id: "checkup-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "meals-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/meals/05-weight-scale-save.yaml
+++ b/apps/mobile/maestro/flows/meals/05-weight-scale-save.yaml
@@ -1,0 +1,39 @@
+appId: com.homegohan.app
+---
+# 正常 05: weight_scale 体重保存
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- assertVisible:
+    id: "meals-screen"
+
+- tapOn:
+    id: "meals-add-button"
+- assertVisible:
+    id: "meal-mode-select-screen"
+
+- tapOn:
+    id: "meal-mode-weight-scale"
+
+- tapOn:
+    id: "camera-capture-button"
+- extendedWaitUntil:
+    visible:
+      id: "ocr-analyzing-indicator"
+    timeout: 10000
+
+- extendedWaitUntil:
+    visible:
+      id: "weight-form-screen"
+    timeout: 30000
+
+- assertVisible:
+    id: "weight-value-input"
+
+- tapOn:
+    id: "weight-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "meals-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/meals/06-gallery-existing-photo.yaml
+++ b/apps/mobile/maestro/flows/meals/06-gallery-existing-photo.yaml
@@ -1,0 +1,43 @@
+appId: com.homegohan.app
+---
+# 正常 06: gallery 既存写真から食事登録
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- assertVisible:
+    id: "meals-screen"
+
+- tapOn:
+    id: "meals-add-button"
+- assertVisible:
+    id: "meal-mode-select-screen"
+
+- tapOn:
+    id: "meal-mode-meal"
+
+- tapOn:
+    id: "camera-gallery-button"
+- extendedWaitUntil:
+    visible:
+      id: "gallery-picker-screen"
+    timeout: 10000
+
+- tapOn:
+    id: "gallery-first-photo"
+- extendedWaitUntil:
+    visible:
+      id: "ai-analyzing-indicator"
+    timeout: 10000
+
+- extendedWaitUntil:
+    visible:
+      id: "meal-form-screen"
+    timeout: 30000
+
+- tapOn:
+    id: "meal-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "meals-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/meals/07-manual-input.yaml
+++ b/apps/mobile/maestro/flows/meals/07-manual-input.yaml
@@ -1,0 +1,36 @@
+appId: com.homegohan.app
+---
+# 正常 07: manual 手動入力で食事保存
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- assertVisible:
+    id: "meals-screen"
+
+- tapOn:
+    id: "meals-add-button"
+- assertVisible:
+    id: "meal-mode-select-screen"
+
+- tapOn:
+    id: "meal-mode-manual"
+- assertVisible:
+    id: "meal-form-screen"
+
+- tapOn:
+    id: "meal-name-input"
+- inputText: "テスト定食"
+
+- tapOn:
+    id: "meal-calories-input"
+- inputText: "650"
+
+- tapOn:
+    id: "meal-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "meals-screen"
+    timeout: 10000
+- assertVisible:
+    id: "meal-list"

--- a/apps/mobile/maestro/flows/meals/08-favorites-search-unheart.yaml
+++ b/apps/mobile/maestro/flows/meals/08-favorites-search-unheart.yaml
@@ -1,0 +1,35 @@
+appId: com.homegohan.app
+---
+# 正常 08: favorites 検索 → ハート解除
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- assertVisible:
+    id: "meals-screen"
+
+- tapOn:
+    id: "meals-favorites-tab"
+- assertVisible:
+    id: "favorites-screen"
+
+- tapOn:
+    id: "favorites-search-input"
+- inputText: "ご飯"
+
+- extendedWaitUntil:
+    visible:
+      id: "favorites-list"
+    timeout: 5000
+
+- tapOn:
+    id: "favorites-first-heart-button"
+- assertVisible:
+    id: "unfavorite-confirm-dialog"
+
+- tapOn:
+    id: "unfavorite-confirm-button"
+- extendedWaitUntil:
+    visible:
+      id: "favorites-list"
+    timeout: 5000

--- a/apps/mobile/maestro/flows/meals/09-validation-manual-empty-name.yaml
+++ b/apps/mobile/maestro/flows/meals/09-validation-manual-empty-name.yaml
@@ -1,0 +1,28 @@
+appId: com.homegohan.app
+---
+# バリデーション 09: manual 料理名空で保存試行
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- assertVisible:
+    id: "meals-screen"
+
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-manual"
+- assertVisible:
+    id: "meal-form-screen"
+
+- tapOn:
+    id: "meal-calories-input"
+- inputText: "500"
+
+- tapOn:
+    id: "meal-save-button"
+
+- assertVisible:
+    id: "meal-name-error"
+- assertNotVisible:
+    id: "meals-screen"

--- a/apps/mobile/maestro/flows/meals/10-validation-calories-string.yaml
+++ b/apps/mobile/maestro/flows/meals/10-validation-calories-string.yaml
@@ -1,0 +1,29 @@
+appId: com.homegohan.app
+---
+# バリデーション 10: カロリーに文字列を入力
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-manual"
+- assertVisible:
+    id: "meal-form-screen"
+
+- tapOn:
+    id: "meal-name-input"
+- inputText: "テスト料理"
+
+- tapOn:
+    id: "meal-calories-input"
+- inputText: "abc"
+
+- tapOn:
+    id: "meal-save-button"
+
+- assertVisible:
+    id: "meal-calories-error"
+- assertNotVisible:
+    id: "meals-screen"

--- a/apps/mobile/maestro/flows/meals/11-validation-calories-negative.yaml
+++ b/apps/mobile/maestro/flows/meals/11-validation-calories-negative.yaml
@@ -1,0 +1,29 @@
+appId: com.homegohan.app
+---
+# バリデーション 11: カロリー負値を入力
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-manual"
+- assertVisible:
+    id: "meal-form-screen"
+
+- tapOn:
+    id: "meal-name-input"
+- inputText: "テスト料理"
+
+- tapOn:
+    id: "meal-calories-input"
+- inputText: "-100"
+
+- tapOn:
+    id: "meal-save-button"
+
+- assertVisible:
+    id: "meal-calories-error"
+- assertNotVisible:
+    id: "meals-screen"

--- a/apps/mobile/maestro/flows/meals/12-validation-future-date.yaml
+++ b/apps/mobile/maestro/flows/meals/12-validation-future-date.yaml
@@ -1,0 +1,37 @@
+appId: com.homegohan.app
+---
+# バリデーション 12: 未来日付で保存試行
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-manual"
+- assertVisible:
+    id: "meal-form-screen"
+
+- tapOn:
+    id: "meal-name-input"
+- inputText: "未来の食事"
+
+- tapOn:
+    id: "meal-calories-input"
+- inputText: "500"
+
+- tapOn:
+    id: "meal-date-input"
+- assertVisible:
+    id: "date-picker"
+
+- tapOn:
+    id: "date-picker-future-date"
+
+- tapOn:
+    id: "meal-save-button"
+
+- assertVisible:
+    id: "meal-date-error"
+- assertNotVisible:
+    id: "meals-screen"

--- a/apps/mobile/maestro/flows/meals/13-validation-gallery-permission-denied.yaml
+++ b/apps/mobile/maestro/flows/meals/13-validation-gallery-permission-denied.yaml
@@ -1,0 +1,24 @@
+appId: com.homegohan.app
+---
+# バリデーション 13: ギャラリー権限拒否
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-meal"
+
+- tapOn:
+    id: "camera-gallery-button"
+
+- assertVisible:
+    id: "permission-request-dialog"
+- tapOn:
+    id: "permission-deny-button"
+
+- assertVisible:
+    id: "gallery-permission-denied-message"
+- assertNotVisible:
+    id: "gallery-picker-screen"

--- a/apps/mobile/maestro/flows/meals/14-api-error-ai-analyze-500.yaml
+++ b/apps/mobile/maestro/flows/meals/14-api-error-ai-analyze-500.yaml
@@ -1,0 +1,32 @@
+appId: com.homegohan.app
+---
+# API エラー 14: AI 解析 500 エラー
+- runFlow: ../_shared/login.yaml
+
+- setLocation:
+    latitude: 0
+    longitude: 0
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-meal"
+
+- tapOn:
+    id: "camera-capture-button"
+- extendedWaitUntil:
+    visible:
+      id: "ai-analyzing-indicator"
+    timeout: 10000
+
+- extendedWaitUntil:
+    visible:
+      id: "ai-analyze-error-message"
+    timeout: 30000
+
+- assertVisible:
+    id: "ai-analyze-retry-button"
+- assertNotVisible:
+    id: "meal-form-screen"

--- a/apps/mobile/maestro/flows/meals/15-api-error-image-upload-fail.yaml
+++ b/apps/mobile/maestro/flows/meals/15-api-error-image-upload-fail.yaml
@@ -1,0 +1,28 @@
+appId: com.homegohan.app
+---
+# API エラー 15: image upload 失敗
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-meal"
+
+- tapOn:
+    id: "camera-capture-button"
+- extendedWaitUntil:
+    visible:
+      id: "image-upload-indicator"
+    timeout: 10000
+
+- extendedWaitUntil:
+    visible:
+      id: "image-upload-error-message"
+    timeout: 30000
+
+- assertVisible:
+    id: "image-upload-retry-button"
+- assertNotVisible:
+    id: "meal-form-screen"

--- a/apps/mobile/maestro/flows/meals/16-api-error-save-fail.yaml
+++ b/apps/mobile/maestro/flows/meals/16-api-error-save-fail.yaml
@@ -1,0 +1,34 @@
+appId: com.homegohan.app
+---
+# API エラー 16: 保存 fail
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-manual"
+- assertVisible:
+    id: "meal-form-screen"
+
+- tapOn:
+    id: "meal-name-input"
+- inputText: "エラーテスト"
+
+- tapOn:
+    id: "meal-calories-input"
+- inputText: "500"
+
+- tapOn:
+    id: "meal-save-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "meal-save-error-message"
+    timeout: 10000
+
+- assertVisible:
+    id: "meal-save-retry-button"
+- assertNotVisible:
+    id: "meals-screen"

--- a/apps/mobile/maestro/flows/meals/17-api-error-favorites-delete-fail.yaml
+++ b/apps/mobile/maestro/flows/meals/17-api-error-favorites-delete-fail.yaml
@@ -1,0 +1,27 @@
+appId: com.homegohan.app
+---
+# API エラー 17: favorites DELETE fail
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-favorites-tab"
+- assertVisible:
+    id: "favorites-screen"
+
+- tapOn:
+    id: "favorites-first-heart-button"
+- assertVisible:
+    id: "unfavorite-confirm-dialog"
+
+- tapOn:
+    id: "unfavorite-confirm-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "favorites-delete-error-message"
+    timeout: 10000
+
+- assertVisible:
+    id: "favorites-list"

--- a/apps/mobile/maestro/flows/meals/18-adversarial-meal-name-xss.yaml
+++ b/apps/mobile/maestro/flows/meals/18-adversarial-meal-name-xss.yaml
@@ -1,0 +1,32 @@
+appId: com.homegohan.app
+---
+# Adversarial 18: 料理名 XSS インジェクション
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-manual"
+- assertVisible:
+    id: "meal-form-screen"
+
+- tapOn:
+    id: "meal-name-input"
+- inputText: "<script>alert('xss')</script>"
+
+- tapOn:
+    id: "meal-calories-input"
+- inputText: "500"
+
+- tapOn:
+    id: "meal-save-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "meals-screen"
+    timeout: 10000
+
+- assertNotVisible:
+    text: "<script>"

--- a/apps/mobile/maestro/flows/meals/19-adversarial-meal-name-500chars.yaml
+++ b/apps/mobile/maestro/flows/meals/19-adversarial-meal-name-500chars.yaml
@@ -1,0 +1,27 @@
+appId: com.homegohan.app
+---
+# Adversarial 19: 料理名 500 字境界値
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-manual"
+- assertVisible:
+    id: "meal-form-screen"
+
+- tapOn:
+    id: "meal-name-input"
+- inputText: "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかき"
+
+- tapOn:
+    id: "meal-calories-input"
+- inputText: "500"
+
+- tapOn:
+    id: "meal-save-button"
+
+- assertVisible:
+    id: "meal-name-length-error"

--- a/apps/mobile/maestro/flows/meals/20-adversarial-calories-99999.yaml
+++ b/apps/mobile/maestro/flows/meals/20-adversarial-calories-99999.yaml
@@ -1,0 +1,27 @@
+appId: com.homegohan.app
+---
+# Adversarial 20: カロリー 99999 極端な値
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-manual"
+- assertVisible:
+    id: "meal-form-screen"
+
+- tapOn:
+    id: "meal-name-input"
+- inputText: "極端カロリー料理"
+
+- tapOn:
+    id: "meal-calories-input"
+- inputText: "99999"
+
+- tapOn:
+    id: "meal-save-button"
+
+- assertVisible:
+    id: "meal-calories-error"

--- a/apps/mobile/maestro/flows/meals/21-adversarial-duplicate-photos.yaml
+++ b/apps/mobile/maestro/flows/meals/21-adversarial-duplicate-photos.yaml
@@ -1,0 +1,36 @@
+appId: com.homegohan.app
+---
+# Adversarial 21: 同一写真 5 連発
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+
+- repeat:
+    times: 5
+    commands:
+      - tapOn:
+          id: "meals-add-button"
+      - tapOn:
+          id: "meal-mode-meal"
+      - tapOn:
+          id: "camera-gallery-button"
+      - extendedWaitUntil:
+          visible:
+            id: "gallery-picker-screen"
+          timeout: 10000
+      - tapOn:
+          id: "gallery-first-photo"
+      - extendedWaitUntil:
+          visible:
+            id: "meal-form-screen"
+          timeout: 30000
+      - tapOn:
+          id: "meal-save-button"
+      - extendedWaitUntil:
+          visible:
+            id: "meals-screen"
+          timeout: 10000
+
+- assertVisible:
+    id: "meal-list"

--- a/apps/mobile/maestro/flows/meals/22-adversarial-4k-image.yaml
+++ b/apps/mobile/maestro/flows/meals/22-adversarial-4k-image.yaml
@@ -1,0 +1,38 @@
+appId: com.homegohan.app
+---
+# Adversarial 22: 4K 画像アップロード
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-meal"
+
+- tapOn:
+    id: "camera-gallery-button"
+- extendedWaitUntil:
+    visible:
+      id: "gallery-picker-screen"
+    timeout: 10000
+
+- tapOn:
+    id: "gallery-4k-photo"
+
+- extendedWaitUntil:
+    visible:
+      id: "image-upload-indicator"
+    timeout: 10000
+
+- extendedWaitUntil:
+    visible:
+      id: "meal-form-screen"
+    timeout: 60000
+
+- tapOn:
+    id: "meal-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "meals-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/meals/23-adversarial-favorites-search-sqli.yaml
+++ b/apps/mobile/maestro/flows/meals/23-adversarial-favorites-search-sqli.yaml
@@ -1,0 +1,25 @@
+appId: com.homegohan.app
+---
+# Adversarial 23: favorites 検索 SQL injection
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-favorites-tab"
+- assertVisible:
+    id: "favorites-screen"
+
+- tapOn:
+    id: "favorites-search-input"
+- inputText: "' OR '1'='1"
+
+- extendedWaitUntil:
+    visible:
+      id: "favorites-list"
+    timeout: 5000
+
+- assertNotVisible:
+    id: "favorites-sql-error"
+- assertNotVisible:
+    id: "app-crash-screen"

--- a/apps/mobile/maestro/flows/meals/24-state-capture-bg-fg.yaml
+++ b/apps/mobile/maestro/flows/meals/24-state-capture-bg-fg.yaml
@@ -1,0 +1,31 @@
+appId: com.homegohan.app
+---
+# 状態遷移 24: 撮影中 BG→FG 復帰
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-meal"
+
+- assertVisible:
+    id: "camera-screen"
+
+- pressKey: Home
+- pause:
+    milliseconds: 2000
+
+- openLink: "homegohan://"
+- extendedWaitUntil:
+    visible:
+      id: "camera-screen"
+    timeout: 10000
+
+- tapOn:
+    id: "camera-capture-button"
+- extendedWaitUntil:
+    visible:
+      id: "meal-form-screen"
+    timeout: 30000

--- a/apps/mobile/maestro/flows/meals/25-state-analyzing-bg-fg.yaml
+++ b/apps/mobile/maestro/flows/meals/25-state-analyzing-bg-fg.yaml
@@ -1,0 +1,31 @@
+appId: com.homegohan.app
+---
+# 状態遷移 25: analyzing 中 BG→FG 復帰
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-meal"
+
+- tapOn:
+    id: "camera-capture-button"
+- extendedWaitUntil:
+    visible:
+      id: "ai-analyzing-indicator"
+    timeout: 10000
+
+- pressKey: Home
+- pause:
+    milliseconds: 2000
+
+- openLink: "homegohan://"
+- extendedWaitUntil:
+    visible:
+      id: "meal-form-screen"
+    timeout: 30000
+
+- assertVisible:
+    id: "meal-name-input"

--- a/apps/mobile/maestro/flows/meals/26-state-save-modal-close.yaml
+++ b/apps/mobile/maestro/flows/meals/26-state-save-modal-close.yaml
@@ -1,0 +1,37 @@
+appId: com.homegohan.app
+---
+# 状態遷移 26: 保存後 modal 閉じ確認
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-manual"
+- assertVisible:
+    id: "meal-form-screen"
+
+- tapOn:
+    id: "meal-name-input"
+- inputText: "モーダルテスト"
+
+- tapOn:
+    id: "meal-calories-input"
+- inputText: "400"
+
+- tapOn:
+    id: "meal-save-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "meal-save-success-message"
+    timeout: 10000
+
+- extendedWaitUntil:
+    visible:
+      id: "meals-screen"
+    timeout: 5000
+
+- assertNotVisible:
+    id: "meal-form-screen"

--- a/apps/mobile/maestro/flows/meals/27-state-week-crossing-date.yaml
+++ b/apps/mobile/maestro/flows/meals/27-state-week-crossing-date.yaml
@@ -1,0 +1,42 @@
+appId: com.homegohan.app
+---
+# 状態遷移 27: 週またぎ日付選択
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-meals"
+- tapOn:
+    id: "meals-add-button"
+- tapOn:
+    id: "meal-mode-manual"
+- assertVisible:
+    id: "meal-form-screen"
+
+- tapOn:
+    id: "meal-name-input"
+- inputText: "週またぎテスト"
+
+- tapOn:
+    id: "meal-calories-input"
+- inputText: "500"
+
+- tapOn:
+    id: "meal-date-input"
+- assertVisible:
+    id: "date-picker"
+
+- tapOn:
+    id: "date-picker-prev-week-button"
+
+- assertVisible:
+    id: "date-picker-previous-week-dates"
+
+- tapOn:
+    id: "date-picker-last-sunday"
+
+- tapOn:
+    id: "meal-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "meals-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/shopping/01-list-display-check-item.yaml
+++ b/apps/mobile/maestro/flows/shopping/01-list-display-check-item.yaml
@@ -1,0 +1,30 @@
+appId: com.homegohan.app
+---
+# 正常 01: 買い物リスト表示 → アイテムチェック
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-menus"
+- assertVisible:
+    id: "menus-weekly-screen"
+
+- tapOn:
+    id: "shopping-list-tab"
+- assertVisible:
+    id: "shopping-list-screen"
+
+- extendedWaitUntil:
+    visible:
+      id: "shopping-list-item"
+    timeout: 10000
+
+- tapOn:
+    id: "shopping-first-item-checkbox"
+
+- extendedWaitUntil:
+    visible:
+      id: "shopping-first-item-checked"
+    timeout: 5000
+
+- assertVisible:
+    id: "shopping-checked-count"

--- a/apps/mobile/maestro/flows/shopping/02-check-all-zero-items.yaml
+++ b/apps/mobile/maestro/flows/shopping/02-check-all-zero-items.yaml
@@ -1,0 +1,32 @@
+appId: com.homegohan.app
+---
+# 正常 02: 全件チェック → 0 件表示
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-menus"
+- assertVisible:
+    id: "menus-weekly-screen"
+
+- tapOn:
+    id: "shopping-list-tab"
+- assertVisible:
+    id: "shopping-list-screen"
+
+- extendedWaitUntil:
+    visible:
+      id: "shopping-list-item"
+    timeout: 10000
+
+- tapOn:
+    id: "shopping-check-all-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "shopping-empty-state"
+    timeout: 10000
+
+- assertVisible:
+    id: "shopping-all-done-message"
+- assertNotVisible:
+    id: "shopping-list-item"

--- a/apps/mobile/maestro/flows/shopping/03-api-check-patch-fail-rollback.yaml
+++ b/apps/mobile/maestro/flows/shopping/03-api-check-patch-fail-rollback.yaml
@@ -1,0 +1,32 @@
+appId: com.homegohan.app
+---
+# API 03: チェック PATCH fail → rollback
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-menus"
+- assertVisible:
+    id: "menus-weekly-screen"
+
+- tapOn:
+    id: "shopping-list-tab"
+- assertVisible:
+    id: "shopping-list-screen"
+
+- extendedWaitUntil:
+    visible:
+      id: "shopping-list-item"
+    timeout: 10000
+
+- tapOn:
+    id: "shopping-first-item-checkbox"
+
+- extendedWaitUntil:
+    visible:
+      id: "shopping-check-error-message"
+    timeout: 10000
+
+- assertNotVisible:
+    id: "shopping-first-item-checked"
+- assertVisible:
+    id: "shopping-first-item-checkbox"

--- a/apps/mobile/maestro/flows/shopping/04-adversarial-200-items-list.yaml
+++ b/apps/mobile/maestro/flows/shopping/04-adversarial-200-items-list.yaml
@@ -1,0 +1,40 @@
+appId: com.homegohan.app
+---
+# Adversarial 04: 200 件リスト表示・スクロール
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-menus"
+- assertVisible:
+    id: "menus-weekly-screen"
+
+- tapOn:
+    id: "shopping-list-tab"
+- assertVisible:
+    id: "shopping-list-screen"
+
+- extendedWaitUntil:
+    visible:
+      id: "shopping-list-item"
+    timeout: 10000
+
+- scroll:
+    direction: DOWN
+    duration: 3000
+
+- scroll:
+    direction: DOWN
+    duration: 3000
+
+- scroll:
+    direction: DOWN
+    duration: 3000
+
+- scroll:
+    direction: UP
+    duration: 2000
+
+- assertNotVisible:
+    id: "app-crash-screen"
+- assertVisible:
+    id: "shopping-list-screen"

--- a/apps/mobile/maestro/flows/shopping/05-adversarial-rapid-check-race.yaml
+++ b/apps/mobile/maestro/flows/shopping/05-adversarial-rapid-check-race.yaml
@@ -1,0 +1,40 @@
+appId: com.homegohan.app
+---
+# Adversarial 05: 高速連打 race condition
+- runFlow: ../_shared/login.yaml
+
+- tapOn:
+    id: "tab-menus"
+- assertVisible:
+    id: "menus-weekly-screen"
+
+- tapOn:
+    id: "shopping-list-tab"
+- assertVisible:
+    id: "shopping-list-screen"
+
+- extendedWaitUntil:
+    visible:
+      id: "shopping-list-item"
+    timeout: 10000
+
+- tapOn:
+    id: "shopping-first-item-checkbox"
+- tapOn:
+    id: "shopping-first-item-checkbox"
+- tapOn:
+    id: "shopping-first-item-checkbox"
+- tapOn:
+    id: "shopping-second-item-checkbox"
+- tapOn:
+    id: "shopping-second-item-checkbox"
+- tapOn:
+    id: "shopping-third-item-checkbox"
+
+- extendedWaitUntil:
+    visible:
+      id: "shopping-list-screen"
+    timeout: 10000
+
+- assertNotVisible:
+    id: "app-crash-screen"


### PR DESCRIPTION
## Summary

- meals: 正常 8, バリデーション 5, API エラー 4, Adversarial 6, 状態遷移 4 = 27 flow
- favorites: 正常 3, バリデーション 2, API 2, Adversarial 3 = 10 flow
- shopping: 正常 2, API 1, Adversarial 2 = 5 flow
- `_shared/login.yaml` を共通ログイン flow として追加し、全 flow で `runFlow` 再利用
- 全 43 ファイル YAML lint OK (python3 yaml.safe_load_all)

## Test plan

- [ ] Maestro CLI で meals/01-mode-meal-capture-analyze-save.yaml を手動実行
- [ ] favorites/01-search-filter.yaml を手動実行
- [ ] shopping/01-list-display-check-item.yaml を手動実行
- [ ] CI の Maestro E2E ジョブが全 flow を認識することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)