### PR TITLE
test(mobile-e2e): settings/profile/comparison 28 flow

### DIFF
--- a/apps/mobile/maestro/flows/comparison/01-daily-view.yaml
+++ b/apps/mobile/maestro/flows/comparison/01-daily-view.yaml
@@ -1,0 +1,39 @@
+appId: com.homegohan.app
+---
+# 01-daily-view: 比較画面で日次ビューを表示する (正常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 比較画面へ移動
+- tapOn:
+    id: "tab-comparison"
+- assertVisible:
+    id: "comparison-screen"
+
+# 日次ピリオドを選択
+- tapOn:
+    id: "comparison-period-daily"
+- assertVisible:
+    id: "comparison-period-daily"
+
+# ランキングアイテムが表示される
+- extendedWaitUntil:
+    visible:
+      id: "comparison-ranking-item-0"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/comparison/02-weekly-switch.yaml
+++ b/apps/mobile/maestro/flows/comparison/02-weekly-switch.yaml
@@ -1,0 +1,41 @@
+appId: com.homegohan.app
+---
+# 02-weekly-switch: 比較画面で週次ビューに切り替える (正常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 比較画面へ移動
+- tapOn:
+    id: "tab-comparison"
+- assertVisible:
+    id: "comparison-screen"
+
+# 日次→週次に切り替え
+- tapOn:
+    id: "comparison-period-daily"
+- tapOn:
+    id: "comparison-period-weekly"
+- assertVisible:
+    id: "comparison-period-weekly"
+
+# ランキングアイテムが表示される
+- extendedWaitUntil:
+    visible:
+      id: "comparison-ranking-item-0"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/comparison/03-recalculate.yaml
+++ b/apps/mobile/maestro/flows/comparison/03-recalculate.yaml
@@ -1,0 +1,43 @@
+appId: com.homegohan.app
+---
+# 03-recalculate: 再計算ボタンをタップしてランキングを更新する (正常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 比較画面へ移動
+- tapOn:
+    id: "tab-comparison"
+- assertVisible:
+    id: "comparison-screen"
+
+# 初回ロードを待機
+- extendedWaitUntil:
+    visible:
+      id: "comparison-ranking-item-0"
+    timeout: 10000
+
+# 再計算ボタンをタップ
+- tapOn:
+    id: "comparison-recalculate-button"
+
+# ローダーが表示されてから結果が更新される
+- extendedWaitUntil:
+    visible:
+      id: "comparison-ranking-item-0"
+    timeout: 15000

--- a/apps/mobile/maestro/flows/comparison/04-rankings-get-fail.yaml
+++ b/apps/mobile/maestro/flows/comparison/04-rankings-get-fail.yaml
@@ -1,0 +1,46 @@
+appId: com.homegohan.app
+---
+# 04-rankings-get-fail: rankings GET API が失敗した場合のエラー表示 (API 異常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# ネットワークをオフライン状態にする
+- setAirplaneMode: true
+
+# 比較画面へ移動
+- tapOn:
+    id: "tab-comparison"
+- assertVisible:
+    id: "comparison-screen"
+
+# エラー状態が表示される
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          id: "comparison-error-message"
+      - visible:
+          id: "comparison-network-error-toast"
+    timeout: 15000
+
+# ネットワークを復旧
+- setAirplaneMode: false
+
+# リトライが可能な状態であることを確認
+- assertVisible:
+    id: "comparison-retry-button"

--- a/apps/mobile/maestro/flows/comparison/05-period-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/comparison/05-period-rapid-tap.yaml
@@ -1,0 +1,47 @@
+appId: com.homegohan.app
+---
+# 05-period-rapid-tap: 期間切替ボタンを連打しても重複リクエストが発生しない (Adversarial)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 比較画面へ移動
+- tapOn:
+    id: "tab-comparison"
+- assertVisible:
+    id: "comparison-screen"
+
+# 期間ボタンを素早く連打
+- tapOn:
+    id: "comparison-period-daily"
+- tapOn:
+    id: "comparison-period-weekly"
+- tapOn:
+    id: "comparison-period-monthly"
+- tapOn:
+    id: "comparison-period-daily"
+- tapOn:
+    id: "comparison-period-weekly"
+
+# 最終的に weekly が選択された状態でデータが正常に表示される
+- extendedWaitUntil:
+    visible:
+      id: "comparison-ranking-item-0"
+    timeout: 20000
+- assertVisible:
+    id: "comparison-period-weekly"

--- a/apps/mobile/maestro/flows/comparison/06-loader-state.yaml
+++ b/apps/mobile/maestro/flows/comparison/06-loader-state.yaml
@@ -1,0 +1,51 @@
+appId: com.homegohan.app
+---
+# 06-loader-state: 比較画面でローダーが正しく表示・非表示される (状態遷移)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 比較画面へ移動 (ローダーが表示されることを確認)
+- tapOn:
+    id: "tab-comparison"
+- assertVisible:
+    id: "comparison-screen"
+
+# ローダーが表示される
+- assertVisible:
+    id: "comparison-loader"
+
+# データ取得後にローダーが消えてコンテンツが表示される
+- extendedWaitUntil:
+    visible:
+      id: "comparison-ranking-item-0"
+    timeout: 15000
+- assertNotVisible:
+    id: "comparison-loader"
+
+# 再計算で再度ローダーが表示される
+- tapOn:
+    id: "comparison-recalculate-button"
+- assertVisible:
+    id: "comparison-loader"
+- extendedWaitUntil:
+    visible:
+      id: "comparison-ranking-item-0"
+    timeout: 15000
+- assertNotVisible:
+    id: "comparison-loader"

--- a/apps/mobile/maestro/flows/profile/01-basic-tab-save.yaml
+++ b/apps/mobile/maestro/flows/profile/01-basic-tab-save.yaml
@@ -1,0 +1,47 @@
+appId: com.homegohan.app
+---
+# 01-basic-tab-save: プロフィール基本タブの情報を保存する (正常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# プロフィール画面へ移動
+- tapOn:
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+
+# 基本タブを選択
+- tapOn:
+    id: "profile-tab-basic"
+- assertVisible:
+    id: "profile-tab-basic"
+
+# ニックネームを入力
+- tapOn:
+    id: "profile-nickname-input"
+- clearText
+- inputText: "テストユーザー01"
+
+# 保存ボタンをタップ
+- tapOn:
+    id: "profile-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "profile-save-success-toast"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/profile/02-goals-tab-save.yaml
+++ b/apps/mobile/maestro/flows/profile/02-goals-tab-save.yaml
@@ -1,0 +1,47 @@
+appId: com.homegohan.app
+---
+# 02-goals-tab-save: プロフィール目標タブの情報を保存する (正常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# プロフィール画面へ移動
+- tapOn:
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+
+# 目標タブを選択
+- tapOn:
+    id: "profile-tab-goals"
+- assertVisible:
+    id: "profile-tab-goals"
+
+# 目標体重を入力 (65.0 kg)
+- tapOn:
+    id: "profile-goal-weight-input"
+- clearText
+- inputText: "65.0"
+
+# 保存ボタンをタップ
+- tapOn:
+    id: "profile-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "profile-save-success-toast"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/profile/03-sports-tab-save.yaml
+++ b/apps/mobile/maestro/flows/profile/03-sports-tab-save.yaml
@@ -1,0 +1,45 @@
+appId: com.homegohan.app
+---
+# 03-sports-tab-save: プロフィール競技タブの情報を保存する (正常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# プロフィール画面へ移動
+- tapOn:
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+
+# 競技タブを選択
+- tapOn:
+    id: "profile-tab-sports"
+- assertVisible:
+    id: "profile-tab-sports"
+
+# 競技種目を選択 (サッカー)
+- tapOn:
+    id: "profile-sports-category-soccer"
+
+# 保存ボタンをタップ
+- tapOn:
+    id: "profile-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "profile-save-success-toast"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/profile/04-health-tab-save.yaml
+++ b/apps/mobile/maestro/flows/profile/04-health-tab-save.yaml
@@ -1,0 +1,47 @@
+appId: com.homegohan.app
+---
+# 04-health-tab-save: プロフィール健康タブの情報を保存する (正常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# プロフィール画面へ移動
+- tapOn:
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+
+# 健康タブを選択
+- tapOn:
+    id: "profile-tab-health"
+- assertVisible:
+    id: "profile-tab-health"
+
+# アレルギー情報を入力
+- tapOn:
+    id: "profile-allergy-input"
+- clearText
+- inputText: "乳製品"
+
+# 保存ボタンをタップ
+- tapOn:
+    id: "profile-save-button"
+- extendedWaitUntil:
+    visible:
+      id: "profile-save-success-toast"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/profile/05-height-zero-validation.yaml
+++ b/apps/mobile/maestro/flows/profile/05-height-zero-validation.yaml
@@ -1,0 +1,49 @@
+appId: com.homegohan.app
+---
+# 05-height-zero-validation: 身長に 0 を入力した場合のバリデーションエラー (バリデーション)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# プロフィール画面へ移動
+- tapOn:
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+
+# 基本タブを選択
+- tapOn:
+    id: "profile-tab-basic"
+
+# 身長に 0 を入力
+- tapOn:
+    id: "profile-height-input"
+- clearText
+- inputText: "0"
+
+# 保存ボタンをタップ
+- tapOn:
+    id: "profile-save-button"
+
+# バリデーションエラーが表示される
+- assertVisible:
+    id: "profile-height-error-message"
+
+# 保存成功トーストは表示されない
+- assertNotVisible:
+    id: "profile-save-success-toast"

--- a/apps/mobile/maestro/flows/profile/06-birthday-future-validation.yaml
+++ b/apps/mobile/maestro/flows/profile/06-birthday-future-validation.yaml
@@ -1,0 +1,49 @@
+appId: com.homegohan.app
+---
+# 06-birthday-future-validation: 生年月日に未来の日付を入力した場合のバリデーションエラー (バリデーション)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# プロフィール画面へ移動
+- tapOn:
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+
+# 基本タブを選択
+- tapOn:
+    id: "profile-tab-basic"
+
+# 生年月日に未来の日付を入力 (2099-12-31)
+- tapOn:
+    id: "profile-birthday-input"
+- clearText
+- inputText: "2099-12-31"
+
+# 保存ボタンをタップ
+- tapOn:
+    id: "profile-save-button"
+
+# バリデーションエラーが表示される
+- assertVisible:
+    id: "profile-birthday-error-message"
+
+# 保存成功トーストは表示されない
+- assertNotVisible:
+    id: "profile-save-success-toast"

--- a/apps/mobile/maestro/flows/profile/07-nickname-empty-validation.yaml
+++ b/apps/mobile/maestro/flows/profile/07-nickname-empty-validation.yaml
@@ -1,0 +1,48 @@
+appId: com.homegohan.app
+---
+# 07-nickname-empty-validation: ニックネームを空にした場合のバリデーションエラー (バリデーション)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# プロフィール画面へ移動
+- tapOn:
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+
+# 基本タブを選択
+- tapOn:
+    id: "profile-tab-basic"
+
+# ニックネームを空にする
+- tapOn:
+    id: "profile-nickname-input"
+- clearText
+
+# 保存ボタンをタップ
+- tapOn:
+    id: "profile-save-button"
+
+# バリデーションエラーが表示される
+- assertVisible:
+    id: "profile-nickname-error-message"
+
+# 保存成功トーストは表示されない
+- assertNotVisible:
+    id: "profile-save-success-toast"

--- a/apps/mobile/maestro/flows/profile/08-nickname-xss-adversarial.yaml
+++ b/apps/mobile/maestro/flows/profile/08-nickname-xss-adversarial.yaml
@@ -1,0 +1,54 @@
+appId: com.homegohan.app
+---
+# 08-nickname-xss-adversarial: ニックネームに XSS ペイロードを入力してもサニタイズされる (Adversarial)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# プロフィール画面へ移動
+- tapOn:
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+
+# 基本タブを選択
+- tapOn:
+    id: "profile-tab-basic"
+
+# XSS ペイロードを入力
+- tapOn:
+    id: "profile-nickname-input"
+- clearText
+- inputText: "<script>alert('xss')</script>"
+
+# 保存ボタンをタップ
+- tapOn:
+    id: "profile-save-button"
+
+# エラーまたは保存成功 (サニタイズして保存) が発生する
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          id: "profile-save-success-toast"
+      - visible:
+          id: "profile-nickname-error-message"
+    timeout: 10000
+
+# スクリプトタグがそのまま表示されていないことを確認
+- assertNotVisible:
+    text: "<script>"

--- a/apps/mobile/maestro/flows/profile/09-nickname-1000-chars-adversarial.yaml
+++ b/apps/mobile/maestro/flows/profile/09-nickname-1000-chars-adversarial.yaml
@@ -1,0 +1,50 @@
+appId: com.homegohan.app
+---
+# 09-nickname-1000-chars-adversarial: ニックネームに 1000 文字を入力した場合の処理 (Adversarial)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# プロフィール画面へ移動
+- tapOn:
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+
+# 基本タブを選択
+- tapOn:
+    id: "profile-tab-basic"
+
+# 1000 文字のニックネームを入力
+- tapOn:
+    id: "profile-nickname-input"
+- clearText
+- inputText: "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん"
+
+# 保存ボタンをタップ
+- tapOn:
+    id: "profile-save-button"
+
+# バリデーションエラーまたは文字数制限により入力がトランケートされる
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          id: "profile-nickname-error-message"
+      - visible:
+          id: "profile-save-success-toast"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/profile/10-weight-negative-adversarial.yaml
+++ b/apps/mobile/maestro/flows/profile/10-weight-negative-adversarial.yaml
@@ -1,0 +1,49 @@
+appId: com.homegohan.app
+---
+# 10-weight-negative-adversarial: 体重に -5 を入力した場合のバリデーションエラー (Adversarial)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# プロフィール画面へ移動
+- tapOn:
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+
+# 基本タブを選択
+- tapOn:
+    id: "profile-tab-basic"
+
+# 体重に -5 を入力
+- tapOn:
+    id: "profile-weight-input"
+- clearText
+- inputText: "-5"
+
+# 保存ボタンをタップ
+- tapOn:
+    id: "profile-save-button"
+
+# バリデーションエラーが表示される
+- assertVisible:
+    id: "profile-weight-error-message"
+
+# 保存成功トーストは表示されない
+- assertNotVisible:
+    id: "profile-save-success-toast"

--- a/apps/mobile/maestro/flows/settings/01-notification-toggle-on.yaml
+++ b/apps/mobile/maestro/flows/settings/01-notification-toggle-on.yaml
@@ -1,0 +1,36 @@
+appId: com.homegohan.app
+---
+# 01-notification-toggle-on: 通知 toggle を ON にする (正常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 設定画面へ移動
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+
+# 通知 toggle を ON にする
+- tapOn:
+    id: "settings-notifications-toggle"
+- assertVisible:
+    id: "settings-notifications-toggle"
+- assertTrue:
+    id: "settings-notifications-toggle"
+    enabled: true

--- a/apps/mobile/maestro/flows/settings/02-week-start-switch.yaml
+++ b/apps/mobile/maestro/flows/settings/02-week-start-switch.yaml
@@ -1,0 +1,39 @@
+appId: com.homegohan.app
+---
+# 02-week-start-switch: 週開始日を日曜→月曜に切り替える (正常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 設定画面へ移動
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+
+# 週開始日を月曜日に切り替え
+- tapOn:
+    id: "settings-week-start-monday"
+- assertVisible:
+    id: "settings-week-start-monday"
+
+# 日曜日に戻す
+- tapOn:
+    id: "settings-week-start-sunday"
+- assertVisible:
+    id: "settings-week-start-sunday"

--- a/apps/mobile/maestro/flows/settings/03-export-json.yaml
+++ b/apps/mobile/maestro/flows/settings/03-export-json.yaml
@@ -1,0 +1,35 @@
+appId: com.homegohan.app
+---
+# 03-export-json: JSON エクスポートを実行する (正常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 設定画面へ移動
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+
+# JSON エクスポートをタップ
+- tapOn:
+    id: "settings-export-json-row"
+- extendedWaitUntil:
+    visible:
+      id: "export-success-toast"
+    timeout: 15000

--- a/apps/mobile/maestro/flows/settings/04-export-csv.yaml
+++ b/apps/mobile/maestro/flows/settings/04-export-csv.yaml
@@ -1,0 +1,35 @@
+appId: com.homegohan.app
+---
+# 04-export-csv: CSV エクスポートを実行する (正常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 設定画面へ移動
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+
+# CSV エクスポートをタップ
+- tapOn:
+    id: "settings-export-csv-row"
+- extendedWaitUntil:
+    visible:
+      id: "export-success-toast"
+    timeout: 15000

--- a/apps/mobile/maestro/flows/settings/05-logout.yaml
+++ b/apps/mobile/maestro/flows/settings/05-logout.yaml
@@ -1,0 +1,45 @@
+appId: com.homegohan.app
+---
+# 05-logout: ログアウトを実行する (正常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 設定画面へ移動
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+
+# ログアウトボタンをタップ
+- tapOn:
+    id: "settings-logout-button"
+
+# 確認モーダルが表示される
+- assertVisible:
+    id: "settings-logout-confirm-modal"
+
+# 確認ボタンをタップしてログアウト
+- tapOn:
+    id: "settings-logout-confirm-button"
+
+# ウェルカム画面に戻ることを確認
+- extendedWaitUntil:
+    visible:
+      id: "welcome-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/settings/06-logout-cancel.yaml
+++ b/apps/mobile/maestro/flows/settings/06-logout-cancel.yaml
@@ -1,0 +1,45 @@
+appId: com.homegohan.app
+---
+# 06-logout-cancel: ログアウト確認モーダルで cancel する (バリデーション)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 設定画面へ移動
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+
+# ログアウトボタンをタップ
+- tapOn:
+    id: "settings-logout-button"
+
+# 確認モーダルが表示される
+- assertVisible:
+    id: "settings-logout-confirm-modal"
+
+# キャンセルをタップ
+- tapOn:
+    id: "settings-logout-cancel-button"
+
+# モーダルが閉じてホーム画面は設定のまま
+- assertNotVisible:
+    id: "settings-logout-confirm-modal"
+- assertVisible:
+    id: "settings-screen"

--- a/apps/mobile/maestro/flows/settings/07-notification-patch-fail.yaml
+++ b/apps/mobile/maestro/flows/settings/07-notification-patch-fail.yaml
@@ -1,0 +1,41 @@
+appId: com.homegohan.app
+---
+# 07-notification-patch-fail: 通知 PATCH API が失敗した場合のエラー表示 (API 異常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 設定画面へ移動
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+
+# ネットワークをオフライン状態にしてから toggle をタップ
+- setAirplaneMode: true
+- tapOn:
+    id: "settings-notifications-toggle"
+
+# エラートーストが表示される
+- extendedWaitUntil:
+    visible:
+      id: "notification-update-error-toast"
+    timeout: 10000
+
+# ネットワークを復旧
+- setAirplaneMode: false

--- a/apps/mobile/maestro/flows/settings/08-json-export-auth-expired.yaml
+++ b/apps/mobile/maestro/flows/settings/08-json-export-auth-expired.yaml
@@ -1,0 +1,41 @@
+appId: com.homegohan.app
+---
+# 08-json-export-auth-expired: JSON export 時に認証切れが発生した場合 (API 異常系)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 設定画面へ移動
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+
+# 認証トークンを無効化するため clearKeychain を実行してから export をタップ
+- clearKeychain
+- tapOn:
+    id: "settings-export-json-row"
+
+# 認証エラーによりウェルカム画面にリダイレクトされるか、エラートーストが表示される
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          id: "welcome-screen"
+      - visible:
+          id: "auth-expired-error-toast"
+    timeout: 15000

--- a/apps/mobile/maestro/flows/settings/09-notification-os-denied.yaml
+++ b/apps/mobile/maestro/flows/settings/09-notification-os-denied.yaml
@@ -1,0 +1,40 @@
+appId: com.homegohan.app
+---
+# 09-notification-os-denied: OS レベルで通知権限が拒否されている場合 (Adversarial)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 設定画面へ移動
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+
+# 通知 toggle をタップ (OS 側で拒否されているため警告が出る想定)
+- tapOn:
+    id: "settings-notifications-toggle"
+
+# OS 設定へ誘導するダイアログまたはエラートーストが表示される
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          id: "notification-permission-denied-dialog"
+      - visible:
+          id: "notification-os-settings-toast"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/settings/10-account-delete-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/settings/10-account-delete-rapid-tap.yaml
@@ -1,0 +1,45 @@
+appId: com.homegohan.app
+---
+# 10-account-delete-rapid-tap: アカウント削除ボタンを連打しても二重実行されない (Adversarial)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 設定画面へ移動
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+
+# アカウント削除ボタンを連打
+- tapOn:
+    id: "settings-delete-account-button"
+- tapOn:
+    id: "settings-delete-account-button"
+- tapOn:
+    id: "settings-delete-account-button"
+
+# 確認モーダルが 1 つだけ表示される (重複しない)
+- assertVisible:
+    id: "settings-delete-account-confirm-modal"
+
+# キャンセルして画面を復元
+- tapOn:
+    id: "settings-delete-account-cancel-button"
+- assertNotVisible:
+    id: "settings-delete-account-confirm-modal"

--- a/apps/mobile/maestro/flows/settings/11-logout-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/settings/11-logout-rapid-tap.yaml
@@ -1,0 +1,47 @@
+appId: com.homegohan.app
+---
+# 11-logout-rapid-tap: ログアウトボタンを連打しても二重実行されない (Adversarial)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 設定画面へ移動
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+
+# ログアウトボタンを連打
+- tapOn:
+    id: "settings-logout-button"
+- tapOn:
+    id: "settings-logout-button"
+- tapOn:
+    id: "settings-logout-button"
+
+# 確認モーダルが 1 つだけ表示される
+- assertVisible:
+    id: "settings-logout-confirm-modal"
+
+# 確認してログアウト
+- tapOn:
+    id: "settings-logout-confirm-button"
+- extendedWaitUntil:
+    visible:
+      id: "welcome-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/settings/12-notification-toggle-bg-fg.yaml
+++ b/apps/mobile/maestro/flows/settings/12-notification-toggle-bg-fg.yaml
@@ -1,0 +1,51 @@
+appId: com.homegohan.app
+---
+# 12-notification-toggle-bg-fg: 通知 toggle 中にバックグラウンド→フォアグラウンドしても状態が保持される (状態遷移)
+- launchApp:
+    clearState: true
+- assertVisible:
+    id: "welcome-screen"
+- tapOn:
+    id: "welcome-login-button"
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_01_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_01_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# 設定画面へ移動
+- tapOn:
+    id: "tab-settings"
+- assertVisible:
+    id: "settings-screen"
+
+# 通知 toggle をタップ
+- tapOn:
+    id: "settings-notifications-toggle"
+
+# アプリをバックグラウンドに移動
+- runFlow:
+    commands:
+      - pressKey: HOME
+
+# 少し待機してフォアグラウンドに戻す
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 5000
+- openLink: "homegohan://"
+- extendedWaitUntil:
+    visible:
+      id: "settings-screen"
+    timeout: 10000
+
+# toggle の状態が維持されていることを確認
+- assertVisible:
+    id: "settings-notifications-toggle"


### PR DESCRIPTION
## 概要

settings / profile / comparison の Maestro E2E flow を 28 本追加します。

| カテゴリ | 正常 | バリデーション | API 異常 | Adversarial | 状態遷移 | 計 |
|---------|------|-------------|---------|------------|--------|---|
| settings | 5 | 1 | 2 | 3 | 1 | 12 |
| profile | 4 | 3 | 0 | 3 | 0 | 10 |
| comparison | 3 | 0 | 1 | 1 | 1 | 6 |
| **合計** | **12** | **4** | **3** | **7** | **2** | **28** |

## ファイル構成

- `apps/mobile/maestro/flows/settings/` — 12 本
- `apps/mobile/maestro/flows/profile/` — 10 本
- `apps/mobile/maestro/flows/comparison/` — 6 本

## 認証

全 flow は `E2E_USER_01_EMAIL` / `E2E_USER_01_PASSWORD` を使った inline login を冒頭に含みます。

## YAML lint

全 28 ファイルを `yaml.safe_load_all` で検証し、全 PASS を確認済みです。

## Test plan

- [ ] CI の Maestro job でデバイスに対して実行し、settings 各シナリオが PASS
- [ ] profile タブ別保存・バリデーション・Adversarial が PASS
- [ ] comparison 期間切替・再計算・エラーハンドリングが PASS
- [ ] merge は別 agent が後で行う