### PR TITLE
fix(mobile): metro.config.js で React 二重インスタンス問題を解消

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -15,7 +15,28 @@ config.resolver.nodeModulesPaths = [
 // Keep Expo default behavior (doctor expects false). Monorepo resolution is handled via nodeModulesPaths/watchFolders.
 config.resolver.disableHierarchicalLookup = false;
 
+// Force single React 19 instance across the entire bundle.
+// apps/mobile/node_modules/react = 19.0.0 (correct for this app)
+// workspace root node_modules/react = 18.3.1 (hoisted for web packages)
+// Without this, expo-router (loaded from workspace root) imports react 18.3.1
+// while app code uses react 19.0.0, causing "Cannot read property 'S' of undefined".
+const mobileNodeModules = path.resolve(projectRoot, "node_modules");
+const REACT_PREFIXES = ["react", "react-dom", "react/", "react-dom/"];
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  const isReact = REACT_PREFIXES.some(
+    (p) => moduleName === p.replace(/\/$/, "") || moduleName.startsWith(p)
+  );
+  if (isReact) {
+    // Always resolve react/react-dom from apps/mobile (React 19) regardless of caller location
+    const resolveFrom = require("resolve-from");
+    try {
+      const resolved = resolveFrom(mobileNodeModules, moduleName);
+      return { type: "sourceFile", filePath: resolved };
+    } catch (_) {
+      // fall through to default resolution
+    }
+  }
+  return context.resolveRequest(context, moduleName, platform);
+};
+
 module.exports = config;
-
-
-

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-native": "^5.4.3",
+    "resolve-from": "^5.0.0",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^30.0.0",
     "@types/react": "~19.0.10",


### PR DESCRIPTION
## 背景

monorepo workspace root の React 18.3.1 と apps/mobile の 19.0.0 が共存しており、Metro が両方解決して Hermes で `TypeError: Cannot read property 'S' of undefined` が発生。アプリが真っ白になる問題が E2E テスト中に発覚。

## 修正内容

- `apps/mobile/metro.config.js` に `resolver.resolveRequest` フックを追加
- `react` / `react-dom` を必ず `apps/mobile/node_modules` (React 19.0.0) 側に解決
- `resolve-from@^5.0.0` を `apps/mobile/package.json` の devDependencies に追加 (実態は既に node_modules に存在済み)

## before / after

**before:** `resolver.resolveRequest` なし → Metro が workspace root の React 18.3.1 を混入させる可能性あり

**after:** `resolver.resolveRequest` フックで react/react-dom を `apps/mobile/node_modules` に強制解決 → 単一 React 19 インスタンスに統一

## 実証

10 並列 Maestro E2E で 10 sim 全てでアプリ起動・テスト実行を確認済。