### PR TITLE
fix(e2e): Maestro flow から clearState: true を除去 (#625)

### DIFF
--- a/apps/mobile/maestro/flows/01-login.yaml
+++ b/apps/mobile/maestro/flows/01-login.yaml
@@ -2,8 +2,6 @@ appId: com.homegohan.app
 ---
 # 01-login: アプリ起動 → ウェルカム画面 → ログイン画面 → メール+パスワード入力 → ホーム画面確認
 - launchApp:
-    clearState: true
-
 # ウェルカム画面で「ログイン」をタップして login.tsx に移動
 - tapOn:
     text: "ログイン"

--- a/apps/mobile/maestro/flows/_shared/login.yaml
+++ b/apps/mobile/maestro/flows/_shared/login.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # _shared/login.yaml: 既存ユーザーでログインしてホーム画面まで遷移する共通フロー
 - launchApp:
-    clearState: true
 - assertVisible:
     text: "ほめゴハン"
 - tapOn:

--- a/apps/mobile/maestro/flows/auth/01-login-existing-user-to-home.yaml
+++ b/apps/mobile/maestro/flows/auth/01-login-existing-user-to-home.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 01: 既存ユーザーで login → home 到達
 - launchApp:
-    clearState: true
 - assertVisible:
     text: "ほめゴハン"
 - tapOn:

--- a/apps/mobile/maestro/flows/auth/02-admin-login-redirect-to-admin.yaml
+++ b/apps/mobile/maestro/flows/auth/02-admin-login-redirect-to-admin.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 02: admin ロールで login → /admin に redirect
 - launchApp:
-    clearState: true
 - assertVisible:
     text: "ほめゴハン"
 - tapOn:

--- a/apps/mobile/maestro/flows/auth/03-onboarding-incomplete-user-redirect.yaml
+++ b/apps/mobile/maestro/flows/auth/03-onboarding-incomplete-user-redirect.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 03: onboarding 未完了 user で login → /onboarding/resume へ
 - launchApp:
-    clearState: true
 - assertVisible:
     text: "ほめゴハン"
 - tapOn:

--- a/apps/mobile/maestro/flows/auth/04-signup-new-user-confirmation-email.yaml
+++ b/apps/mobile/maestro/flows/auth/04-signup-new-user-confirmation-email.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 04: /signup で新規登録 → 確認メール送信 Alert
 - launchApp:
-    clearState: true
 - assertVisible:
     text: "ほめゴハン"
 - tapOn:

--- a/apps/mobile/maestro/flows/auth/05-forgot-password-send-email.yaml
+++ b/apps/mobile/maestro/flows/auth/05-forgot-password-send-email.yaml
@@ -4,7 +4,6 @@ env:
 ---
 # 05: forgot-password で email 入力 → 送信完了 banner
 - launchApp:
-    clearState: true
 - assertVisible:
     text: "ほめゴハン"
 - tapOn:

--- a/apps/mobile/maestro/flows/auth/06-welcome-signup-login-e2e.yaml
+++ b/apps/mobile/maestro/flows/auth/06-welcome-signup-login-e2e.yaml
@@ -8,7 +8,6 @@ env:
 # 06: welcome から signup 経由でログインまで一気通貫
 # Step 1: welcome 画面確認
 - launchApp:
-    clearState: true
 - assertVisible:
     text: "ほめゴハン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/07-login-empty-email-validation.yaml
+++ b/apps/mobile/maestro/flows/auth/07-login-empty-email-validation.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 07: login: email 空で submit → バリデーションエラー
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/08-login-password-too-short.yaml
+++ b/apps/mobile/maestro/flows/auth/08-login-password-too-short.yaml
@@ -6,7 +6,6 @@ env:
 # Note: login 画面はパスワード長チェックをしないが signup 側でバリデーション済み
 # ここでは 7 文字パスワードで API エラー (Invalid login credentials) を確認
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/09-signup-password-no-digit.yaml
+++ b/apps/mobile/maestro/flows/auth/09-signup-password-no-digit.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 09: signup: password 数字無し → バリデーションエラー
 - launchApp:
-    clearState: true
 - tapOn:
     text: "新規登録"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/10-signup-password-no-letter.yaml
+++ b/apps/mobile/maestro/flows/auth/10-signup-password-no-letter.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 10: signup: password 英字無し → バリデーションエラー
 - launchApp:
-    clearState: true
 - tapOn:
     text: "新規登録"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/11-signup-duplicate-email-silent-success.yaml
+++ b/apps/mobile/maestro/flows/auth/11-signup-duplicate-email-silent-success.yaml
@@ -6,7 +6,6 @@ env:
 # 11: signup: 既存 email 重複 → silent-success 検出 (#533)
 # Supabase は重複メールで identities: [] を返し、アプリがそれを検出してエラー表示
 - launchApp:
-    clearState: true
 - tapOn:
     text: "新規登録"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/12-login-rate-limit-ban-after-3-failures.yaml
+++ b/apps/mobile/maestro/flows/auth/12-login-rate-limit-ban-after-3-failures.yaml
@@ -5,7 +5,6 @@ env:
 # 12: login: 30 秒 rate limit ban (3 回失敗 → 待機 banner)
 # 1 回目失敗でクライアント side rate limit が発動する実装 (#532)
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/13-login-wrong-password-rate-limit-set.yaml
+++ b/apps/mobile/maestro/flows/auth/13-login-wrong-password-rate-limit-set.yaml
@@ -4,7 +4,6 @@ env:
 ---
 # 13: login: 誤パスワード → rate limit セット確認
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/14-login-offline-airplane-mode.yaml
+++ b/apps/mobile/maestro/flows/auth/14-login-offline-airplane-mode.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 14: オフライン中 login submit (Airplane mode)
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/15-login-429-too-many-requests.yaml
+++ b/apps/mobile/maestro/flows/auth/15-login-429-too-many-requests.yaml
@@ -7,7 +7,6 @@ env:
 # Note: テスト環境では rate limit を意図的に超過させるか、
 #       mock server で 429 を返すシナリオを想定
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/16-signup-api-500-error.yaml
+++ b/apps/mobile/maestro/flows/auth/16-signup-api-500-error.yaml
@@ -4,7 +4,6 @@ appId: com.homegohan.app
 # Note: Supabase が内部エラーを返した場合のエラーハンドリング確認
 # テスト環境では不正な URL 設定や、mock により 500 を再現
 - launchApp:
-    clearState: true
 - tapOn:
     text: "新規登録"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/17-adversarial-email-5000-chars.yaml
+++ b/apps/mobile/maestro/flows/auth/17-adversarial-email-5000-chars.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 17: email に 5000 字 → クラッシュしないこと確認
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/18-adversarial-password-sql-injection.yaml
+++ b/apps/mobile/maestro/flows/auth/18-adversarial-password-sql-injection.yaml
@@ -4,7 +4,6 @@ env:
 ---
 # 18: password に SQL injection → クラッシュしないこと、DBエラーにならないこと
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/19-adversarial-email-xss-payload.yaml
+++ b/apps/mobile/maestro/flows/auth/19-adversarial-email-xss-payload.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 19: login email に XSS payload → クラッシュしないこと、スクリプト実行されないこと
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/20-adversarial-next-param-open-redirect.yaml
+++ b/apps/mobile/maestro/flows/auth/20-adversarial-next-param-open-redirect.yaml
@@ -7,7 +7,6 @@ env:
 # アプリは ?next= が '/' 始まりでない場合、無視してデフォルトルートへ遷移
 # deep link で ?next=https://evil.com を付与してログインを試みる
 - launchApp:
-    clearState: true
     arguments:
       MAESTRO_NEXT_PARAM: "https://evil.com"
 

--- a/apps/mobile/maestro/flows/auth/21-adversarial-forgot-password-nonexistent-email.yaml
+++ b/apps/mobile/maestro/flows/auth/21-adversarial-forgot-password-nonexistent-email.yaml
@@ -4,7 +4,6 @@ appId: com.homegohan.app
 # Supabase の resetPasswordForEmail は存在しない email でも成功を返す (ユーザー列挙防止)
 # アプリが送信完了メッセージを表示すること (エラーにしないこと)
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/22-login-bg-fg-input-preserved.yaml
+++ b/apps/mobile/maestro/flows/auth/22-login-bg-fg-input-preserved.yaml
@@ -4,7 +4,6 @@ env:
 ---
 # 22: login 中に BG → FG → 入力保持
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/23-expired-jwt-home-redirect-to-root.yaml
+++ b/apps/mobile/maestro/flows/auth/23-expired-jwt-home-redirect-to-root.yaml
@@ -1,11 +1,10 @@
 appId: com.homegohan.app
 ---
 # 23: expired JWT で home 直アクセス → / redirect
-# clearState: true によりセッションがクリアされた状態で、
+# 未ログイン状態で、
 # ディープリンクで /(tabs)/home に直接アクセスを試みる
 # → 認証されていないため welcome 画面 (/) にリダイレクトされること
 - launchApp:
-    clearState: true
     arguments:
       MAESTRO_DEEP_LINK: "homegohan://home"
 - extendedWaitUntil:

--- a/apps/mobile/maestro/flows/auth/24-google-oauth-cancel-returns-to-login.yaml
+++ b/apps/mobile/maestro/flows/auth/24-google-oauth-cancel-returns-to-login.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 24: Google OAuth キャンセル → login 画面戻り
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/25-rate-limit-countdown-bg-fg-restored.yaml
+++ b/apps/mobile/maestro/flows/auth/25-rate-limit-countdown-bg-fg-restored.yaml
@@ -5,7 +5,6 @@ env:
 # 25: rate limit countdown 中に BG → FG → 残り秒復元 (#532)
 # AsyncStorage から残り制限時間を復元する機能のテスト
 - launchApp:
-    clearState: true
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/comparison/01-daily-view.yaml
+++ b/apps/mobile/maestro/flows/comparison/01-daily-view.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 01-daily-view: 比較画面で日次ビューを表示する (正常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/comparison/02-weekly-switch.yaml
+++ b/apps/mobile/maestro/flows/comparison/02-weekly-switch.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 02-weekly-switch: 比較画面で週次ビューに切り替える (正常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/comparison/03-recalculate.yaml
+++ b/apps/mobile/maestro/flows/comparison/03-recalculate.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 03-recalculate: 再計算ボタンをタップしてランキングを更新する (正常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/comparison/04-rankings-get-fail.yaml
+++ b/apps/mobile/maestro/flows/comparison/04-rankings-get-fail.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 04-rankings-get-fail: rankings GET API が失敗した場合のエラー表示 (API 異常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/comparison/05-period-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/comparison/05-period-rapid-tap.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 05-period-rapid-tap: 期間切替ボタンを連打しても重複リクエストが発生しない (Adversarial)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/comparison/06-loader-state.yaml
+++ b/apps/mobile/maestro/flows/comparison/06-loader-state.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 06-loader-state: 比較画面でローダーが正しく表示・非表示される (状態遷移)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/home/11-api-error-use-home-data-fail.yaml
+++ b/apps/mobile/maestro/flows/home/11-api-error-use-home-data-fail.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 11: API エラー - useHomeData のデータ取得失敗時にエラー表示
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/home/14-api-error-ai-suggestion-fail.yaml
+++ b/apps/mobile/maestro/flows/home/14-api-error-ai-suggestion-fail.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 14: API エラー - AI サジェスト取得失敗時にエラー/空状態が表示されること
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/menus-weekly/14-api-error-meal-plans-fail.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/14-api-error-meal-plans-fail.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 14: API エラー - meal-plans 取得失敗時にエラー表示
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/01-welcome-start-complete.yaml
+++ b/apps/mobile/maestro/flows/onboarding/01-welcome-start-complete.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 01: welcome → start → オンボーディング全設問回答 → complete
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/02-welcome-skip-home.yaml
+++ b/apps/mobile/maestro/flows/onboarding/02-welcome-skip-home.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 02: welcome → skip → home 画面に到達する
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/05-nutrition-goal-athlete-sport-type.yaml
+++ b/apps/mobile/maestro/flows/onboarding/05-nutrition-goal-athlete-sport-type.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 05: nutrition_goal=athlete_performance 選択時に sport_type 動的設問が出ることを確認
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/06-servings-grid-input.yaml
+++ b/apps/mobile/maestro/flows/onboarding/06-servings-grid-input.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 06: servings_grid で各人数を選択できることを確認
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/07-validation-nickname-empty.yaml
+++ b/apps/mobile/maestro/flows/onboarding/07-validation-nickname-empty.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 07: バリデーション - nickname 空のまま次へ → エラーメッセージ表示
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/08-validation-body-stats-string.yaml
+++ b/apps/mobile/maestro/flows/onboarding/08-validation-body-stats-string.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 08: バリデーション - body_stats に文字列入力 → エラーメッセージ表示
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/09-validation-number-range.yaml
+++ b/apps/mobile/maestro/flows/onboarding/09-validation-number-range.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 09: バリデーション - number range 超え (身長 999, 体重 999) → エラー
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/10-validation-date-invalid.yaml
+++ b/apps/mobile/maestro/flows/onboarding/10-validation-date-invalid.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 10: バリデーション - date 不正入力 (例: birthdate=9999-99-99) → エラー
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/11-validation-all-skip.yaml
+++ b/apps/mobile/maestro/flows/onboarding/11-validation-all-skip.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 11: バリデーション - 全問 skip ボタンで飛ばした場合の動作確認
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/12-api-error-complete-fail.yaml
+++ b/apps/mobile/maestro/flows/onboarding/12-api-error-complete-fail.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 12: API エラー - complete 送信時にサーバーエラー → エラーメッセージ表示・画面保持
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/14-api-error-welcome-skip-fail.yaml
+++ b/apps/mobile/maestro/flows/onboarding/14-api-error-welcome-skip-fail.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 14: API エラー - welcome skip 時にサーバーエラー → エラーメッセージ表示
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 # ネットワーク接続を切断してから skip

--- a/apps/mobile/maestro/flows/onboarding/15-adversarial-nickname-xss.yaml
+++ b/apps/mobile/maestro/flows/onboarding/15-adversarial-nickname-xss.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 15: Adversarial - nickname に XSS ペイロード入力 → サニタイズされて表示
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/16-adversarial-nickname-1000chars.yaml
+++ b/apps/mobile/maestro/flows/onboarding/16-adversarial-nickname-1000chars.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 16: Adversarial - nickname 1000文字入力 → バリデーションエラーまたは切り捨て
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/17-adversarial-weight-negative.yaml
+++ b/apps/mobile/maestro/flows/onboarding/17-adversarial-weight-negative.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 17: Adversarial - 体重に -5 入力 → バリデーションエラー
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/18-adversarial-height-999cm.yaml
+++ b/apps/mobile/maestro/flows/onboarding/18-adversarial-height-999cm.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 18: Adversarial - 身長に 999cm 入力 → バリデーションエラー
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/20-state-bg-fg-step-preserved.yaml
+++ b/apps/mobile/maestro/flows/onboarding/20-state-bg-fg-step-preserved.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 20: 状態遷移 - BG→FG でオンボーディングのステップが保持されること
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/21-state-network-disconnect-submit.yaml
+++ b/apps/mobile/maestro/flows/onboarding/21-state-network-disconnect-submit.yaml
@@ -5,7 +5,6 @@ env:
 ---
 # 21: 状態遷移 - ネット切断中に submit → オフラインエラー表示・データ保持
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/01-basic-tab-save.yaml
+++ b/apps/mobile/maestro/flows/profile/01-basic-tab-save.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 01-basic-tab-save: プロフィール基本タブの情報を保存する (正常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/02-goals-tab-save.yaml
+++ b/apps/mobile/maestro/flows/profile/02-goals-tab-save.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 02-goals-tab-save: プロフィール目標タブの情報を保存する (正常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/03-sports-tab-save.yaml
+++ b/apps/mobile/maestro/flows/profile/03-sports-tab-save.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 03-sports-tab-save: プロフィール競技タブの情報を保存する (正常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/04-health-tab-save.yaml
+++ b/apps/mobile/maestro/flows/profile/04-health-tab-save.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 04-health-tab-save: プロフィール健康タブの情報を保存する (正常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/05-height-zero-validation.yaml
+++ b/apps/mobile/maestro/flows/profile/05-height-zero-validation.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 05-height-zero-validation: 身長に 0 を入力した場合のバリデーションエラー (バリデーション)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/06-birthday-future-validation.yaml
+++ b/apps/mobile/maestro/flows/profile/06-birthday-future-validation.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 06-birthday-future-validation: 生年月日に未来の日付を入力した場合のバリデーションエラー (バリデーション)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/07-nickname-empty-validation.yaml
+++ b/apps/mobile/maestro/flows/profile/07-nickname-empty-validation.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 07-nickname-empty-validation: ニックネームを空にした場合のバリデーションエラー (バリデーション)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/08-nickname-xss-adversarial.yaml
+++ b/apps/mobile/maestro/flows/profile/08-nickname-xss-adversarial.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 08-nickname-xss-adversarial: ニックネームに XSS ペイロードを入力してもサニタイズされる (Adversarial)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/09-nickname-1000-chars-adversarial.yaml
+++ b/apps/mobile/maestro/flows/profile/09-nickname-1000-chars-adversarial.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 09-nickname-1000-chars-adversarial: ニックネームに 1000 文字を入力した場合の処理 (Adversarial)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/10-weight-negative-adversarial.yaml
+++ b/apps/mobile/maestro/flows/profile/10-weight-negative-adversarial.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 10-weight-negative-adversarial: 体重に -5 を入力した場合のバリデーションエラー (Adversarial)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/01-notification-toggle-on.yaml
+++ b/apps/mobile/maestro/flows/settings/01-notification-toggle-on.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 01-notification-toggle-on: 通知 toggle を ON にする (正常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/02-week-start-switch.yaml
+++ b/apps/mobile/maestro/flows/settings/02-week-start-switch.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 02-week-start-switch: 週開始日を日曜→月曜に切り替える (正常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/03-export-json.yaml
+++ b/apps/mobile/maestro/flows/settings/03-export-json.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 03-export-json: JSON エクスポートを実行する (正常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/04-export-csv.yaml
+++ b/apps/mobile/maestro/flows/settings/04-export-csv.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 04-export-csv: CSV エクスポートを実行する (正常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/05-logout.yaml
+++ b/apps/mobile/maestro/flows/settings/05-logout.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 05-logout: ログアウトを実行する (正常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/06-logout-cancel.yaml
+++ b/apps/mobile/maestro/flows/settings/06-logout-cancel.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 06-logout-cancel: ログアウト確認モーダルで cancel する (バリデーション)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/07-notification-patch-fail.yaml
+++ b/apps/mobile/maestro/flows/settings/07-notification-patch-fail.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 07-notification-patch-fail: 通知 PATCH API が失敗した場合のエラー表示 (API 異常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/08-json-export-auth-expired.yaml
+++ b/apps/mobile/maestro/flows/settings/08-json-export-auth-expired.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 08-json-export-auth-expired: JSON export 時に認証切れが発生した場合 (API 異常系)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/09-notification-os-denied.yaml
+++ b/apps/mobile/maestro/flows/settings/09-notification-os-denied.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 09-notification-os-denied: OS レベルで通知権限が拒否されている場合 (Adversarial)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/10-account-delete-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/settings/10-account-delete-rapid-tap.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 10-account-delete-rapid-tap: アカウント削除ボタンを連打しても二重実行されない (Adversarial)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/11-logout-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/settings/11-logout-rapid-tap.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 11-logout-rapid-tap: ログアウトボタンを連打しても二重実行されない (Adversarial)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/12-notification-toggle-bg-fg.yaml
+++ b/apps/mobile/maestro/flows/settings/12-notification-toggle-bg-fg.yaml
@@ -2,7 +2,6 @@ appId: com.homegohan.app
 ---
 # 12-notification-toggle-bg-fg: 通知 toggle 中にバックグラウンド→フォアグラウンドしても状態が保持される (状態遷移)
 - launchApp:
-    clearState: true
 - assertVisible:
     id: "welcome-screen"
 - tapOn:


### PR DESCRIPTION
## Summary

- 全 Maestro flow YAML (75 ファイル) から `clearState: true` を削除
- `- launchApp:` のみ残す形に統一 (state は保持される)
- `clearState: false` が設定された flow (bg/fg 系) は対象外として維持
- auth/23 のコメント内の誤った記述も合わせて修正

## 背景

Expo dev build が Metro URL を AsyncStorage に保存しており、`clearState: true` でそれが消えるためアプリが起動不能 (`No script URL provided`) になっていた (Issue #625)。

## 影響

- 75 flow が Metro URL 消失による起動不能を解消
- state 持ち越しはあるが、login 経由の連続シナリオで問題なし

Closes #625