### PR TITLE
fix(e2e): tab-settings testID が存在せず settings フロー全体が失敗する問題を修正

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -96,6 +96,7 @@ export default function TabsLayout() {
         options={{
           title: "比較",
           tabBarIcon: ({ color, size }) => <Ionicons name="bar-chart" size={size} color={color} />,
+          tabBarButtonTestID: "tab-comparison",
         }}
       />
       <Tabs.Screen
@@ -103,6 +104,7 @@ export default function TabsLayout() {
         options={{
           title: "マイページ",
           tabBarIcon: ({ color, size }) => <Ionicons name="person" size={size} color={color} />,
+          tabBarButtonTestID: "tab-profile",
         }}
       />
       {/* タブバーに表示しないが(tabs)グループ内に必要なファイル */}

--- a/apps/mobile/app/profile/index.tsx
+++ b/apps/mobile/app/profile/index.tsx
@@ -713,6 +713,7 @@ export default function ProfilePage() {
             right={<Ionicons name="chevron-forward" size={20} color={colors.textMuted} />}
           />
           <ListItem
+            testID="profile-settings-button"
             title="設定"
             subtitle="通知・週の開始日・アカウント"
             onPress={() => router.push("/(tabs)/settings")}

--- a/apps/mobile/maestro/flows/01-login.yaml
+++ b/apps/mobile/maestro/flows/01-login.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 01-login: アプリ起動 → ウェルカム画面 → ログイン画面 → メール+パスワード入力 → ホーム画面確認
-- launchApp:
+- launchApp
 # ウェルカム画面で「ログイン」をタップして login.tsx に移動
 - tapOn:
     text: "ログイン"

--- a/apps/mobile/maestro/flows/_shared/login.yaml
+++ b/apps/mobile/maestro/flows/_shared/login.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # _shared/login.yaml: 既存ユーザーでログインしてホーム画面まで遷移する共通フロー
-- launchApp:
+- launchApp
 - assertVisible:
     text: "ほめゴハン"
 - tapOn:

--- a/apps/mobile/maestro/flows/_shared/logout.yaml
+++ b/apps/mobile/maestro/flows/_shared/logout.yaml
@@ -1,0 +1,22 @@
+appId: com.homegohan.app
+---
+# _shared/logout.yaml: タブバーのプロファイルタブ → 設定 → ログアウトの共通フロー
+# 前提: ホーム画面または任意の画面 (タブバーが見える状態)
+- tapOn:
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
+- assertVisible:
+    id: "settings-screen"
+- tapOn:
+    id: "settings-logout-button"
+- assertVisible:
+    id: "settings-logout-confirm-modal"
+- tapOn:
+    id: "settings-logout-confirm-button"
+- extendedWaitUntil:
+    visible:
+      id: "welcome-screen"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/ai/21-send-bg-fg.yaml
+++ b/apps/mobile/maestro/flows/ai/21-send-bg-fg.yaml
@@ -43,7 +43,7 @@ appId: com.homegohan.app
     timeout: 3000
 
 # アプリをフォアグラウンドへ復帰
-- launchApp:
+- launchApp
     clearState: false
 
 # チャット画面が表示されることを確認

--- a/apps/mobile/maestro/flows/ai/23-image-attach-bg-fg.yaml
+++ b/apps/mobile/maestro/flows/ai/23-image-attach-bg-fg.yaml
@@ -45,7 +45,7 @@ appId: com.homegohan.app
     timeout: 3000
 
 # アプリをフォアグラウンドへ復帰
-- launchApp:
+- launchApp
     clearState: false
 
 # チャット画面に戻っていることを確認

--- a/apps/mobile/maestro/flows/auth/01-login-existing-user-to-home.yaml
+++ b/apps/mobile/maestro/flows/auth/01-login-existing-user-to-home.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_01_PASSWORD}
 ---
 # 01: 既存ユーザーで login → home 到達
-- launchApp:
+- launchApp
 - assertVisible:
     text: "ほめゴハン"
 - tapOn:

--- a/apps/mobile/maestro/flows/auth/02-admin-login-redirect-to-admin.yaml
+++ b/apps/mobile/maestro/flows/auth/02-admin-login-redirect-to-admin.yaml
@@ -4,11 +4,18 @@ env:
   E2E_ADMIN_PASSWORD: ${E2E_ADMIN_PASSWORD}
 ---
 # 02: admin ロールで login → /admin に redirect
+# 前提: 前のフロー後にホーム画面にいる可能性があるため、まずログアウト
 - launchApp
+# ホーム画面にいる場合はログアウトして welcome に戻る
+- runFlow:
+    when:
+      visible:
+        id: "home-screen"
+    file: "../_shared/logout.yaml"
 - assertVisible:
-    text: "ほめゴハン"
+    id: "welcome-screen"
 - tapOn:
-    text: "ログイン"
+    id: "welcome-login-button"
 - assertVisible:
     id: "login-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/auth/02-admin-login-redirect-to-admin.yaml
+++ b/apps/mobile/maestro/flows/auth/02-admin-login-redirect-to-admin.yaml
@@ -4,7 +4,7 @@ env:
   E2E_ADMIN_PASSWORD: ${E2E_ADMIN_PASSWORD}
 ---
 # 02: admin ロールで login → /admin に redirect
-- launchApp:
+- launchApp
 - assertVisible:
     text: "ほめゴハン"
 - tapOn:

--- a/apps/mobile/maestro/flows/auth/03-onboarding-incomplete-user-redirect.yaml
+++ b/apps/mobile/maestro/flows/auth/03-onboarding-incomplete-user-redirect.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_03_PASSWORD}
 ---
 # 03: onboarding 未完了 user で login → /onboarding/resume へ
-- launchApp:
+- launchApp
 - assertVisible:
     text: "ほめゴハン"
 - tapOn:

--- a/apps/mobile/maestro/flows/auth/04-signup-new-user-confirmation-email.yaml
+++ b/apps/mobile/maestro/flows/auth/04-signup-new-user-confirmation-email.yaml
@@ -4,7 +4,7 @@ env:
   E2E_NEW_USER_PASSWORD: ${E2E_USER_04_PASSWORD}
 ---
 # 04: /signup で新規登録 → 確認メール送信 Alert
-- launchApp:
+- launchApp
 - assertVisible:
     text: "ほめゴハン"
 - tapOn:

--- a/apps/mobile/maestro/flows/auth/05-forgot-password-send-email.yaml
+++ b/apps/mobile/maestro/flows/auth/05-forgot-password-send-email.yaml
@@ -3,7 +3,7 @@ env:
   E2E_USER_EMAIL: ${E2E_USER_05_EMAIL}
 ---
 # 05: forgot-password で email 入力 → 送信完了 banner
-- launchApp:
+- launchApp
 - assertVisible:
     text: "ほめゴハン"
 - tapOn:

--- a/apps/mobile/maestro/flows/auth/06-welcome-signup-login-e2e.yaml
+++ b/apps/mobile/maestro/flows/auth/06-welcome-signup-login-e2e.yaml
@@ -7,7 +7,7 @@ env:
 ---
 # 06: welcome から signup 経由でログインまで一気通貫
 # Step 1: welcome 画面確認
-- launchApp:
+- launchApp
 - assertVisible:
     text: "ほめゴハン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/07-login-empty-email-validation.yaml
+++ b/apps/mobile/maestro/flows/auth/07-login-empty-email-validation.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 07: login: email 空で submit → バリデーションエラー
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/08-login-password-too-short.yaml
+++ b/apps/mobile/maestro/flows/auth/08-login-password-too-short.yaml
@@ -5,7 +5,7 @@ env:
 # 08: login: password 7 字で submit → クライアント側エラーまたは API エラー
 # Note: login 画面はパスワード長チェックをしないが signup 側でバリデーション済み
 # ここでは 7 文字パスワードで API エラー (Invalid login credentials) を確認
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/09-signup-password-no-digit.yaml
+++ b/apps/mobile/maestro/flows/auth/09-signup-password-no-digit.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 09: signup: password 数字無し → バリデーションエラー
-- launchApp:
+- launchApp
 - tapOn:
     text: "新規登録"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/10-signup-password-no-letter.yaml
+++ b/apps/mobile/maestro/flows/auth/10-signup-password-no-letter.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 10: signup: password 英字無し → バリデーションエラー
-- launchApp:
+- launchApp
 - tapOn:
     text: "新規登録"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/11-signup-duplicate-email-silent-success.yaml
+++ b/apps/mobile/maestro/flows/auth/11-signup-duplicate-email-silent-success.yaml
@@ -5,7 +5,7 @@ env:
 ---
 # 11: signup: 既存 email 重複 → silent-success 検出 (#533)
 # Supabase は重複メールで identities: [] を返し、アプリがそれを検出してエラー表示
-- launchApp:
+- launchApp
 - tapOn:
     text: "新規登録"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/12-login-rate-limit-ban-after-3-failures.yaml
+++ b/apps/mobile/maestro/flows/auth/12-login-rate-limit-ban-after-3-failures.yaml
@@ -4,7 +4,7 @@ env:
 ---
 # 12: login: 30 秒 rate limit ban (3 回失敗 → 待機 banner)
 # 1 回目失敗でクライアント side rate limit が発動する実装 (#532)
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/13-login-wrong-password-rate-limit-set.yaml
+++ b/apps/mobile/maestro/flows/auth/13-login-wrong-password-rate-limit-set.yaml
@@ -3,7 +3,7 @@ env:
   E2E_USER_EMAIL: ${E2E_USER_09_EMAIL}
 ---
 # 13: login: 誤パスワード → rate limit セット確認
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/14-login-offline-airplane-mode.yaml
+++ b/apps/mobile/maestro/flows/auth/14-login-offline-airplane-mode.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_10_PASSWORD}
 ---
 # 14: オフライン中 login submit (Airplane mode)
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/15-login-429-too-many-requests.yaml
+++ b/apps/mobile/maestro/flows/auth/15-login-429-too-many-requests.yaml
@@ -6,7 +6,7 @@ env:
 # Supabase が 429 を返した場合のエラーハンドリング確認
 # Note: テスト環境では rate limit を意図的に超過させるか、
 #       mock server で 429 を返すシナリオを想定
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/16-signup-api-500-error.yaml
+++ b/apps/mobile/maestro/flows/auth/16-signup-api-500-error.yaml
@@ -3,7 +3,7 @@ appId: com.homegohan.app
 # 16: signup: API 500 エラー
 # Note: Supabase が内部エラーを返した場合のエラーハンドリング確認
 # テスト環境では不正な URL 設定や、mock により 500 を再現
-- launchApp:
+- launchApp
 - tapOn:
     text: "新規登録"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/17-adversarial-email-5000-chars.yaml
+++ b/apps/mobile/maestro/flows/auth/17-adversarial-email-5000-chars.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 17: email に 5000 字 → クラッシュしないこと確認
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/18-adversarial-password-sql-injection.yaml
+++ b/apps/mobile/maestro/flows/auth/18-adversarial-password-sql-injection.yaml
@@ -3,7 +3,7 @@ env:
   E2E_USER_EMAIL: ${E2E_USER_05_EMAIL}
 ---
 # 18: password に SQL injection → クラッシュしないこと、DBエラーにならないこと
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/19-adversarial-email-xss-payload.yaml
+++ b/apps/mobile/maestro/flows/auth/19-adversarial-email-xss-payload.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 19: login email に XSS payload → クラッシュしないこと、スクリプト実行されないこと
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/20-adversarial-next-param-open-redirect.yaml
+++ b/apps/mobile/maestro/flows/auth/20-adversarial-next-param-open-redirect.yaml
@@ -6,7 +6,7 @@ env:
 # 20: ?next= 改竄: https://evil.com → home に強制 redirect (open redirect 防止確認)
 # アプリは ?next= が '/' 始まりでない場合、無視してデフォルトルートへ遷移
 # deep link で ?next=https://evil.com を付与してログインを試みる
-- launchApp:
+- launchApp
     arguments:
       MAESTRO_NEXT_PARAM: "https://evil.com"
 

--- a/apps/mobile/maestro/flows/auth/21-adversarial-forgot-password-nonexistent-email.yaml
+++ b/apps/mobile/maestro/flows/auth/21-adversarial-forgot-password-nonexistent-email.yaml
@@ -3,7 +3,7 @@ appId: com.homegohan.app
 # 21: forgot-password: 存在しない email
 # Supabase の resetPasswordForEmail は存在しない email でも成功を返す (ユーザー列挙防止)
 # アプリが送信完了メッセージを表示すること (エラーにしないこと)
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/22-login-bg-fg-input-preserved.yaml
+++ b/apps/mobile/maestro/flows/auth/22-login-bg-fg-input-preserved.yaml
@@ -3,7 +3,7 @@ env:
   E2E_USER_EMAIL: ${E2E_USER_06_EMAIL}
 ---
 # 22: login 中に BG → FG → 入力保持
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:
@@ -18,7 +18,7 @@ env:
 - pressKey: HOME
 
 # フォアグラウンドへ復帰
-- launchApp:
+- launchApp
     clearState: false
 
 # login-screen が表示されていること

--- a/apps/mobile/maestro/flows/auth/23-expired-jwt-home-redirect-to-root.yaml
+++ b/apps/mobile/maestro/flows/auth/23-expired-jwt-home-redirect-to-root.yaml
@@ -4,7 +4,7 @@ appId: com.homegohan.app
 # 未ログイン状態で、
 # ディープリンクで /(tabs)/home に直接アクセスを試みる
 # → 認証されていないため welcome 画面 (/) にリダイレクトされること
-- launchApp:
+- launchApp
     arguments:
       MAESTRO_DEEP_LINK: "homegohan://home"
 - extendedWaitUntil:

--- a/apps/mobile/maestro/flows/auth/24-google-oauth-cancel-returns-to-login.yaml
+++ b/apps/mobile/maestro/flows/auth/24-google-oauth-cancel-returns-to-login.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 24: Google OAuth キャンセル → login 画面戻り
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:

--- a/apps/mobile/maestro/flows/auth/25-rate-limit-countdown-bg-fg-restored.yaml
+++ b/apps/mobile/maestro/flows/auth/25-rate-limit-countdown-bg-fg-restored.yaml
@@ -4,7 +4,7 @@ env:
 ---
 # 25: rate limit countdown 中に BG → FG → 残り秒復元 (#532)
 # AsyncStorage から残り制限時間を復元する機能のテスト
-- launchApp:
+- launchApp
 - tapOn:
     text: "ログイン"
 - assertVisible:
@@ -42,7 +42,7 @@ env:
     timeout: 1000
 
 # フォアグラウンドへ復帰
-- launchApp:
+- launchApp
     clearState: false
 
 # login-screen が表示されていること

--- a/apps/mobile/maestro/flows/comparison/01-daily-view.yaml
+++ b/apps/mobile/maestro/flows/comparison/01-daily-view.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 01-daily-view: 比較画面で日次ビューを表示する (正常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/comparison/02-weekly-switch.yaml
+++ b/apps/mobile/maestro/flows/comparison/02-weekly-switch.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 02-weekly-switch: 比較画面で週次ビューに切り替える (正常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/comparison/03-recalculate.yaml
+++ b/apps/mobile/maestro/flows/comparison/03-recalculate.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 03-recalculate: 再計算ボタンをタップしてランキングを更新する (正常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/comparison/04-rankings-get-fail.yaml
+++ b/apps/mobile/maestro/flows/comparison/04-rankings-get-fail.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 04-rankings-get-fail: rankings GET API が失敗した場合のエラー表示 (API 異常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/comparison/05-period-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/comparison/05-period-rapid-tap.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 05-period-rapid-tap: 期間切替ボタンを連打しても重複リクエストが発生しない (Adversarial)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/comparison/06-loader-state.yaml
+++ b/apps/mobile/maestro/flows/comparison/06-loader-state.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 06-loader-state: 比較画面でローダーが正しく表示・非表示される (状態遷移)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/home/11-api-error-use-home-data-fail.yaml
+++ b/apps/mobile/maestro/flows/home/11-api-error-use-home-data-fail.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_01_PASSWORD}
 ---
 # 11: API エラー - useHomeData のデータ取得失敗時にエラー表示
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/home/14-api-error-ai-suggestion-fail.yaml
+++ b/apps/mobile/maestro/flows/home/14-api-error-ai-suggestion-fail.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_04_PASSWORD}
 ---
 # 14: API エラー - AI サジェスト取得失敗時にエラー/空状態が表示されること
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/home/20-state-bg-fg-refetch.yaml
+++ b/apps/mobile/maestro/flows/home/20-state-bg-fg-refetch.yaml
@@ -11,7 +11,7 @@ env:
 - pressKey: Home
 - wait: 3000
 # フォアグラウンドに戻す
-- launchApp:
+- launchApp
     clearState: false
 # ホーム画面が表示されデータが再取得されること
 - extendedWaitUntil:

--- a/apps/mobile/maestro/flows/menus-weekly/14-api-error-meal-plans-fail.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/14-api-error-meal-plans-fail.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_04_PASSWORD}
 ---
 # 14: API エラー - meal-plans 取得失敗時にエラー表示
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/menus-weekly/23-state-ai-generating-bg-fg.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/23-state-ai-generating-bg-fg.yaml
@@ -30,7 +30,7 @@ env:
 - pressKey: Home
 - wait: 3000
 # フォアグラウンドに戻す
-- launchApp:
+- launchApp
     clearState: false
 # ローディングまたは完了状態が表示されること
 - extendedWaitUntil:

--- a/apps/mobile/maestro/flows/menus-weekly/24-state-week-start-day-switch.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/24-state-week-start-day-switch.yaml
@@ -15,7 +15,11 @@ env:
     id: "weekly-date-picker"
 # 設定画面に移動して週の開始日を変更
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - extendedWaitUntil:
     visible:
       id: "settings-screen"

--- a/apps/mobile/maestro/flows/onboarding/01-welcome-start-complete.yaml
+++ b/apps/mobile/maestro/flows/onboarding/01-welcome-start-complete.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_01_PASSWORD}
 ---
 # 01: welcome → start → オンボーディング全設問回答 → complete
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/02-welcome-skip-home.yaml
+++ b/apps/mobile/maestro/flows/onboarding/02-welcome-skip-home.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_02_PASSWORD}
 ---
 # 02: welcome → skip → home 画面に到達する
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/03-resume-continue.yaml
+++ b/apps/mobile/maestro/flows/onboarding/03-resume-continue.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_03_PASSWORD}
 ---
 # 03: 途中中断したオンボーディングを resume=true で再開 → continue
-- launchApp:
+- launchApp
     clearState: false
 - extendedWaitUntil:
     visible:

--- a/apps/mobile/maestro/flows/onboarding/04-resume-reset.yaml
+++ b/apps/mobile/maestro/flows/onboarding/04-resume-reset.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_04_PASSWORD}
 ---
 # 04: 途中中断したオンボーディングを resume=true で再開 → reset (最初から)
-- launchApp:
+- launchApp
     clearState: false
 - extendedWaitUntil:
     visible:

--- a/apps/mobile/maestro/flows/onboarding/05-nutrition-goal-athlete-sport-type.yaml
+++ b/apps/mobile/maestro/flows/onboarding/05-nutrition-goal-athlete-sport-type.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_05_PASSWORD}
 ---
 # 05: nutrition_goal=athlete_performance 選択時に sport_type 動的設問が出ることを確認
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/06-servings-grid-input.yaml
+++ b/apps/mobile/maestro/flows/onboarding/06-servings-grid-input.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_06_PASSWORD}
 ---
 # 06: servings_grid で各人数を選択できることを確認
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/07-validation-nickname-empty.yaml
+++ b/apps/mobile/maestro/flows/onboarding/07-validation-nickname-empty.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_07_PASSWORD}
 ---
 # 07: バリデーション - nickname 空のまま次へ → エラーメッセージ表示
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/08-validation-body-stats-string.yaml
+++ b/apps/mobile/maestro/flows/onboarding/08-validation-body-stats-string.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_08_PASSWORD}
 ---
 # 08: バリデーション - body_stats に文字列入力 → エラーメッセージ表示
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/09-validation-number-range.yaml
+++ b/apps/mobile/maestro/flows/onboarding/09-validation-number-range.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_09_PASSWORD}
 ---
 # 09: バリデーション - number range 超え (身長 999, 体重 999) → エラー
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/10-validation-date-invalid.yaml
+++ b/apps/mobile/maestro/flows/onboarding/10-validation-date-invalid.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_10_PASSWORD}
 ---
 # 10: バリデーション - date 不正入力 (例: birthdate=9999-99-99) → エラー
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/11-validation-all-skip.yaml
+++ b/apps/mobile/maestro/flows/onboarding/11-validation-all-skip.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_01_PASSWORD}
 ---
 # 11: バリデーション - 全問 skip ボタンで飛ばした場合の動作確認
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/12-api-error-complete-fail.yaml
+++ b/apps/mobile/maestro/flows/onboarding/12-api-error-complete-fail.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_02_PASSWORD}
 ---
 # 12: API エラー - complete 送信時にサーバーエラー → エラーメッセージ表示・画面保持
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/13-api-error-resume-reset-fail.yaml
+++ b/apps/mobile/maestro/flows/onboarding/13-api-error-resume-reset-fail.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_03_PASSWORD}
 ---
 # 13: API エラー - resume reset 時にサーバーエラー → エラーメッセージ表示
-- launchApp:
+- launchApp
     clearState: false
 - extendedWaitUntil:
     visible:

--- a/apps/mobile/maestro/flows/onboarding/14-api-error-welcome-skip-fail.yaml
+++ b/apps/mobile/maestro/flows/onboarding/14-api-error-welcome-skip-fail.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_04_PASSWORD}
 ---
 # 14: API エラー - welcome skip 時にサーバーエラー → エラーメッセージ表示
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 # ネットワーク接続を切断してから skip

--- a/apps/mobile/maestro/flows/onboarding/15-adversarial-nickname-xss.yaml
+++ b/apps/mobile/maestro/flows/onboarding/15-adversarial-nickname-xss.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_05_PASSWORD}
 ---
 # 15: Adversarial - nickname に XSS ペイロード入力 → サニタイズされて表示
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/16-adversarial-nickname-1000chars.yaml
+++ b/apps/mobile/maestro/flows/onboarding/16-adversarial-nickname-1000chars.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_06_PASSWORD}
 ---
 # 16: Adversarial - nickname 1000文字入力 → バリデーションエラーまたは切り捨て
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/17-adversarial-weight-negative.yaml
+++ b/apps/mobile/maestro/flows/onboarding/17-adversarial-weight-negative.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_07_PASSWORD}
 ---
 # 17: Adversarial - 体重に -5 入力 → バリデーションエラー
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/18-adversarial-height-999cm.yaml
+++ b/apps/mobile/maestro/flows/onboarding/18-adversarial-height-999cm.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_08_PASSWORD}
 ---
 # 18: Adversarial - 身長に 999cm 入力 → バリデーションエラー
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/19-adversarial-resume-param-tamper.yaml
+++ b/apps/mobile/maestro/flows/onboarding/19-adversarial-resume-param-tamper.yaml
@@ -5,7 +5,7 @@ env:
 ---
 # 19: Adversarial - ?resume=true パラメータ改竄でオンボーディング再開を試みる
 # 既にオンボーディング完了済みユーザーが resume=true でアクセス → home へリダイレクト
-- launchApp:
+- launchApp
     clearState: false
     arguments:
       resume: "true"

--- a/apps/mobile/maestro/flows/onboarding/20-state-bg-fg-step-preserved.yaml
+++ b/apps/mobile/maestro/flows/onboarding/20-state-bg-fg-step-preserved.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_10_PASSWORD}
 ---
 # 20: 状態遷移 - BG→FG でオンボーディングのステップが保持されること
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:
@@ -24,7 +24,7 @@ env:
 - pressKey: Home
 - wait: 2000
 # フォアグラウンドに戻す
-- launchApp:
+- launchApp
     clearState: false
 # body stats 画面が引き続き表示されていることを確認 (ステップ保持)
 - extendedWaitUntil:

--- a/apps/mobile/maestro/flows/onboarding/21-state-network-disconnect-submit.yaml
+++ b/apps/mobile/maestro/flows/onboarding/21-state-network-disconnect-submit.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_01_PASSWORD}
 ---
 # 21: 状態遷移 - ネット切断中に submit → オフラインエラー表示・データ保持
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/onboarding/22-state-completed-welcome-redirect.yaml
+++ b/apps/mobile/maestro/flows/onboarding/22-state-completed-welcome-redirect.yaml
@@ -4,7 +4,7 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_02_PASSWORD}
 ---
 # 22: 状態遷移 - オンボーディング完了後に welcome 画面に直接アクセス → home へリダイレクト
-- launchApp:
+- launchApp
     clearState: false
 # オンボーディング完了済みユーザーは welcome 画面ではなく home 画面に遷移する
 - extendedWaitUntil:

--- a/apps/mobile/maestro/flows/pantry/20-state-edit-bg-fg-input-preserved.yaml
+++ b/apps/mobile/maestro/flows/pantry/20-state-edit-bg-fg-input-preserved.yaml
@@ -37,7 +37,7 @@ appId: com.homegohan.app
     timeout: 2000
 
 # アプリをフォアグラウンドに戻す
-- launchApp:
+- launchApp
     clearState: false
 
 # 入力内容が保持されていることを確認

--- a/apps/mobile/maestro/flows/pantry/21-state-analysis-bg-fg.yaml
+++ b/apps/mobile/maestro/flows/pantry/21-state-analysis-bg-fg.yaml
@@ -39,7 +39,7 @@ appId: com.homegohan.app
     timeout: 2000
 
 # フォアグラウンドに戻す
-- launchApp:
+- launchApp
     clearState: false
 
 # 解析結果または継続中のローディングが表示されること

--- a/apps/mobile/maestro/flows/profile/01-basic-tab-save.yaml
+++ b/apps/mobile/maestro/flows/profile/01-basic-tab-save.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 01-basic-tab-save: プロフィール基本タブの情報を保存する (正常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/02-goals-tab-save.yaml
+++ b/apps/mobile/maestro/flows/profile/02-goals-tab-save.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 02-goals-tab-save: プロフィール目標タブの情報を保存する (正常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/03-sports-tab-save.yaml
+++ b/apps/mobile/maestro/flows/profile/03-sports-tab-save.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 03-sports-tab-save: プロフィール競技タブの情報を保存する (正常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/04-health-tab-save.yaml
+++ b/apps/mobile/maestro/flows/profile/04-health-tab-save.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 04-health-tab-save: プロフィール健康タブの情報を保存する (正常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/05-height-zero-validation.yaml
+++ b/apps/mobile/maestro/flows/profile/05-height-zero-validation.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 05-height-zero-validation: 身長に 0 を入力した場合のバリデーションエラー (バリデーション)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/06-birthday-future-validation.yaml
+++ b/apps/mobile/maestro/flows/profile/06-birthday-future-validation.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 06-birthday-future-validation: 生年月日に未来の日付を入力した場合のバリデーションエラー (バリデーション)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/07-nickname-empty-validation.yaml
+++ b/apps/mobile/maestro/flows/profile/07-nickname-empty-validation.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 07-nickname-empty-validation: ニックネームを空にした場合のバリデーションエラー (バリデーション)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/08-nickname-xss-adversarial.yaml
+++ b/apps/mobile/maestro/flows/profile/08-nickname-xss-adversarial.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 08-nickname-xss-adversarial: ニックネームに XSS ペイロードを入力してもサニタイズされる (Adversarial)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/09-nickname-1000-chars-adversarial.yaml
+++ b/apps/mobile/maestro/flows/profile/09-nickname-1000-chars-adversarial.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 09-nickname-1000-chars-adversarial: ニックネームに 1000 文字を入力した場合の処理 (Adversarial)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/profile/10-weight-negative-adversarial.yaml
+++ b/apps/mobile/maestro/flows/profile/10-weight-negative-adversarial.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 10-weight-negative-adversarial: 体重に -5 を入力した場合のバリデーションエラー (Adversarial)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/01-notification-toggle-on.yaml
+++ b/apps/mobile/maestro/flows/settings/01-notification-toggle-on.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 01-notification-toggle-on: 通知 toggle を ON にする (正常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/01-notification-toggle-on.yaml
+++ b/apps/mobile/maestro/flows/settings/01-notification-toggle-on.yaml
@@ -21,7 +21,11 @@ appId: com.homegohan.app
 
 # 設定画面へ移動
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - assertVisible:
     id: "settings-screen"
 

--- a/apps/mobile/maestro/flows/settings/02-week-start-switch.yaml
+++ b/apps/mobile/maestro/flows/settings/02-week-start-switch.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 02-week-start-switch: 週開始日を日曜→月曜に切り替える (正常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/02-week-start-switch.yaml
+++ b/apps/mobile/maestro/flows/settings/02-week-start-switch.yaml
@@ -21,7 +21,11 @@ appId: com.homegohan.app
 
 # 設定画面へ移動
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - assertVisible:
     id: "settings-screen"
 

--- a/apps/mobile/maestro/flows/settings/03-export-json.yaml
+++ b/apps/mobile/maestro/flows/settings/03-export-json.yaml
@@ -21,7 +21,11 @@ appId: com.homegohan.app
 
 # 設定画面へ移動
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - assertVisible:
     id: "settings-screen"
 

--- a/apps/mobile/maestro/flows/settings/03-export-json.yaml
+++ b/apps/mobile/maestro/flows/settings/03-export-json.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 03-export-json: JSON エクスポートを実行する (正常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/04-export-csv.yaml
+++ b/apps/mobile/maestro/flows/settings/04-export-csv.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 04-export-csv: CSV エクスポートを実行する (正常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/04-export-csv.yaml
+++ b/apps/mobile/maestro/flows/settings/04-export-csv.yaml
@@ -21,7 +21,11 @@ appId: com.homegohan.app
 
 # 設定画面へ移動
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - assertVisible:
     id: "settings-screen"
 

--- a/apps/mobile/maestro/flows/settings/05-logout.yaml
+++ b/apps/mobile/maestro/flows/settings/05-logout.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 05-logout: ログアウトを実行する (正常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/05-logout.yaml
+++ b/apps/mobile/maestro/flows/settings/05-logout.yaml
@@ -21,7 +21,11 @@ appId: com.homegohan.app
 
 # 設定画面へ移動
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - assertVisible:
     id: "settings-screen"
 

--- a/apps/mobile/maestro/flows/settings/06-logout-cancel.yaml
+++ b/apps/mobile/maestro/flows/settings/06-logout-cancel.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 06-logout-cancel: ログアウト確認モーダルで cancel する (バリデーション)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/06-logout-cancel.yaml
+++ b/apps/mobile/maestro/flows/settings/06-logout-cancel.yaml
@@ -21,7 +21,11 @@ appId: com.homegohan.app
 
 # 設定画面へ移動
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - assertVisible:
     id: "settings-screen"
 

--- a/apps/mobile/maestro/flows/settings/07-notification-patch-fail.yaml
+++ b/apps/mobile/maestro/flows/settings/07-notification-patch-fail.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 07-notification-patch-fail: 通知 PATCH API が失敗した場合のエラー表示 (API 異常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/07-notification-patch-fail.yaml
+++ b/apps/mobile/maestro/flows/settings/07-notification-patch-fail.yaml
@@ -21,7 +21,11 @@ appId: com.homegohan.app
 
 # 設定画面へ移動
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - assertVisible:
     id: "settings-screen"
 

--- a/apps/mobile/maestro/flows/settings/08-json-export-auth-expired.yaml
+++ b/apps/mobile/maestro/flows/settings/08-json-export-auth-expired.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 08-json-export-auth-expired: JSON export 時に認証切れが発生した場合 (API 異常系)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/08-json-export-auth-expired.yaml
+++ b/apps/mobile/maestro/flows/settings/08-json-export-auth-expired.yaml
@@ -21,7 +21,11 @@ appId: com.homegohan.app
 
 # 設定画面へ移動
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - assertVisible:
     id: "settings-screen"
 

--- a/apps/mobile/maestro/flows/settings/09-notification-os-denied.yaml
+++ b/apps/mobile/maestro/flows/settings/09-notification-os-denied.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 09-notification-os-denied: OS レベルで通知権限が拒否されている場合 (Adversarial)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/09-notification-os-denied.yaml
+++ b/apps/mobile/maestro/flows/settings/09-notification-os-denied.yaml
@@ -21,7 +21,11 @@ appId: com.homegohan.app
 
 # 設定画面へ移動
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - assertVisible:
     id: "settings-screen"
 

--- a/apps/mobile/maestro/flows/settings/10-account-delete-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/settings/10-account-delete-rapid-tap.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 10-account-delete-rapid-tap: アカウント削除ボタンを連打しても二重実行されない (Adversarial)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/10-account-delete-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/settings/10-account-delete-rapid-tap.yaml
@@ -21,7 +21,11 @@ appId: com.homegohan.app
 
 # 設定画面へ移動
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - assertVisible:
     id: "settings-screen"
 

--- a/apps/mobile/maestro/flows/settings/11-logout-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/settings/11-logout-rapid-tap.yaml
@@ -21,7 +21,11 @@ appId: com.homegohan.app
 
 # 設定画面へ移動
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - assertVisible:
     id: "settings-screen"
 

--- a/apps/mobile/maestro/flows/settings/11-logout-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/settings/11-logout-rapid-tap.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 11-logout-rapid-tap: ログアウトボタンを連打しても二重実行されない (Adversarial)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/12-notification-toggle-bg-fg.yaml
+++ b/apps/mobile/maestro/flows/settings/12-notification-toggle-bg-fg.yaml
@@ -1,7 +1,7 @@
 appId: com.homegohan.app
 ---
 # 12-notification-toggle-bg-fg: 通知 toggle 中にバックグラウンド→フォアグラウンドしても状態が保持される (状態遷移)
-- launchApp:
+- launchApp
 - assertVisible:
     id: "welcome-screen"
 - tapOn:

--- a/apps/mobile/maestro/flows/settings/12-notification-toggle-bg-fg.yaml
+++ b/apps/mobile/maestro/flows/settings/12-notification-toggle-bg-fg.yaml
@@ -21,7 +21,11 @@ appId: com.homegohan.app
 
 # 設定画面へ移動
 - tapOn:
-    id: "tab-settings"
+    id: "tab-profile"
+- assertVisible:
+    id: "profile-screen"
+- tapOn:
+    id: "profile-settings-button"
 - assertVisible:
     id: "settings-screen"
 


### PR DESCRIPTION
## Summary
- `(tabs)/_layout.tsx` に `tab-comparison` / `tab-profile` の `tabBarButtonTestID` を追加
- `profile/index.tsx` の設定ボタンに `profile-settings-button` testID を追加
- settings フロー全12件と menus-weekly/24 で使われていた存在しない `tab-settings` を `tab-profile` → `profile-settings-button` の2ステップに変換
- `_shared/logout.yaml` を新設 (プロファイルタブ → 設定 → ログアウトの共通フロー)
- `auth/02` に `runFlow when visible home-screen` のログアウト前処理を追加

## Test plan
- [ ] auth/02 が成功すること (ホーム画面からのログアウト → admin ログイン)
- [ ] settings/01〜12 が profile → 設定ボタン → settings 画面に遷移できること
- [ ] menus-weekly/24 が settings 画面に遷移できること