### PR TITLE
fix(e2e): ensure-welcome waitForAnimationToEnd 追加・expo-image-manipulator plugin 除去

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -45,7 +45,6 @@
     },
     "plugins": [
       "expo-router",
-      "expo-image-manipulator",
       "expo-image-picker",
       "expo-notifications"
     ],

--- a/apps/mobile/maestro/flows/_shared/ensure-welcome.yaml
+++ b/apps/mobile/maestro/flows/_shared/ensure-welcome.yaml
@@ -17,7 +17,9 @@ appId: com.homegohan.app
         text: "Admin Console"
     file: "./back-from-admin.yaml"
 
-# ホーム画面にいる場合はログアウト
+# ホーム画面にいる場合はログアウト (画面ロード完了を少し待つ)
+- waitForAnimationToEnd:
+    timeout: 3000
 - runFlow:
     when:
       visible:


### PR DESCRIPTION
## 変更内容

- `ensure-welcome.yaml`: `runFlow(logout)` 前に `waitForAnimationToEnd: 3000` を追加
  - ホーム画面ロード完了前に `home-screen` ID 検出が失敗し、logout がスキップされる問題を修正
  - `launchApp` 直後に既にログイン済み状態でホーム画面が表示されている場合、3秒待ってから条件判定することで確実に検出できるようになった
- `app.json`: `expo-image-manipulator` を `plugins` 配列から削除
  - v13.1.7 の `main` が `src/index.ts` (ESM TypeScript) で、Expo config plugin 解決時に `require()` が `SyntaxError: Unexpected token 'export'` を投げてMetro が起動不可能になっていた
  - `expo-image-manipulator` は config plugin (ネイティブ設定変更) が不要なため、plugins 指定自体を削除で解決

## テスト

- auth/01 が連続 2 回 PASS (exit code 0) で確認済み