### PR TITLE
fix(e2e): menus-weekly 全25フロー scroll・戻るボタン座標修正

### DIFF
--- a/apps/mobile/maestro/flows/menus-weekly/06-ai-generate-theme-japanese.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/06-ai-generate-theme-japanese.yaml
@@ -22,10 +22,12 @@ env:
     id: "weekly-request-screen"
 - assertVisible:
     id: "weekly-request-note-input"
+- scroll
 - assertVisible:
     id: "weekly-request-submit-button"
 - tapOn:
     id: "weekly-request-note-input"
 - inputText: "和食メインでお願いします"
+- scroll
 - assertVisible:
     id: "weekly-request-submit-button"

--- a/apps/mobile/maestro/flows/menus-weekly/08-ultimate-mode.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/08-ultimate-mode.yaml
@@ -19,11 +19,13 @@ env:
     timeout: 10000
 - assertVisible:
     id: "weekly-request-screen"
+- scroll
 - assertVisible:
     id: "weekly-request-ultimate-toggle"
 # Ultimate モードトグルをオン
 - tapOn:
     id: "weekly-request-ultimate-toggle"
 # submit ボタンが表示されること
+- scroll
 - assertVisible:
     id: "weekly-request-submit-button"

--- a/apps/mobile/maestro/flows/menus-weekly/15-api-error-ai-500.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/15-api-error-ai-500.yaml
@@ -21,5 +21,6 @@ env:
     timeout: 10000
 - assertVisible:
     id: "weekly-request-screen"
+- scroll
 - assertVisible:
     id: "weekly-request-submit-button"

--- a/apps/mobile/maestro/flows/menus-weekly/19-adversarial-ingredient-sqli.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/19-adversarial-ingredient-sqli.yaml
@@ -22,6 +22,7 @@ env:
 - tapOn:
     id: "weekly-request-note-input"
 - inputText: "'; DROP TABLE meal_plans; --"
+- scroll
 - tapOn:
     id: "weekly-request-submit-button"
 # SQL インジェクションが実行されず、アプリがクラッシュしないこと

--- a/apps/mobile/maestro/flows/menus-weekly/22-adversarial-submit-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/22-adversarial-submit-rapid-tap.yaml
@@ -22,6 +22,7 @@ env:
 - tapOn:
     id: "weekly-request-note-input"
 - inputText: "連打テスト"
+- scroll
 # submit ボタンを連打
 - tapOn:
     id: "weekly-request-submit-button"

--- a/apps/mobile/maestro/flows/menus-weekly/23-state-ai-generating-bg-fg.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/23-state-ai-generating-bg-fg.yaml
@@ -22,5 +22,6 @@ env:
     timeout: 10000
 - assertVisible:
     id: "weekly-request-screen"
+- scroll
 - assertVisible:
     id: "weekly-request-submit-button"

--- a/apps/mobile/maestro/flows/menus-weekly/24-state-week-start-day-switch.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/24-state-week-start-day-switch.yaml
@@ -19,6 +19,13 @@ env:
     timeout: 10000
 - assertVisible:
     id: "weekly-screen"
+# 週間献立画面はStack Navigatorで開かれるためタブバーが非表示 → ナビゲーション戻るボタン
+- tapOn:
+    point: "5%,8%"
+- extendedWaitUntil:
+    visible:
+      id: "menus-screen"
+    timeout: 10000
 # 設定画面に移動して週の開始日を変更
 - tapOn:
     id: "tab-profile"
@@ -50,7 +57,13 @@ env:
     timeout: 10000
 - assertVisible:
     id: "weekly-screen"
-# 月曜に戻す (テスト後のクリーンアップ)
+# 月曜に戻す (テスト後のクリーンアップ) → ナビゲーション戻るボタン
+- tapOn:
+    point: "5%,8%"
+- extendedWaitUntil:
+    visible:
+      id: "menus-screen"
+    timeout: 10000
 - tapOn:
     id: "tab-profile"
 - extendedWaitUntil:

--- a/apps/mobile/maestro/flows/menus-weekly/25-state-network-disconnect-submit.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/25-state-network-disconnect-submit.yaml
@@ -24,5 +24,6 @@ env:
 - tapOn:
     id: "weekly-request-note-input"
 - inputText: "オフライン送信テスト"
+- scroll
 - assertVisible:
     id: "weekly-request-submit-button"


### PR DESCRIPTION
## 変更内容

- **06, 08, 15, 23, 25**: `weekly-request-submit-button` がスクロール下にあるため、`assertVisible`/`tapOn` 前に `scroll` を追加
- **19, 22**: `weekly-request-note-input` 入力後、submit ボタンへ `scroll` を追加
- **24**: 週間献立画面はタブバーが非表示 (Stack Navigator) なので、`tapOn point(5%,8%)` でナビゲーション戻るボタンをタップして `menus-screen` に戻るよう修正

## テスト結果

menus-weekly 全 25 フロー PASS:
- 01 PASS (tab-this-week-exists)
- 02 PASS (tab-no-menu)  
- 03 PASS (weekly-date-tap)
- 04 PASS (meal-toggle)
- 05 PASS (radar-chart)
- 06 PASS (ai-generate-theme-japanese) ← scroll 修正
- 07 PASS (fridge-image-ai-analysis)
- 08 PASS (ultimate-mode) ← scroll 修正
- 09-13 PASS (validation 系)
- 14 PASS (api-error-meal-plans-fail)
- 15 PASS (api-error-ai-500) ← scroll 修正
- 16 PASS (api-error-image-upload-fail)
- 17 PASS (api-error-toggle-patch-fail)
- 18 PASS (adversarial-21-meals-radar)
- 19 PASS (adversarial-ingredient-sqli) ← scroll 修正
- 20-21 PASS (adversarial-image 系)
- 22 PASS (adversarial-submit-rapid-tap) ← scroll 修正
- 23 PASS (state-ai-generating-bg-fg) ← scroll 修正
- 24 PASS (state-week-start-day-switch) ← 戻るボタン座標修正
- 25 PASS (state-network-disconnect-submit) ← scroll 修正