### PR TITLE
refactor: NUTRIENT_DEFS / nutrition-constants を packages/shared に一元化

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "react-native";
 import Svg, { Circle, Line, Polygon, Text as SvgText } from "react-native-svg";
 
+import { NUTRIENT_DEFINITIONS, type NutrientDefinition } from "@homegohan/shared";
 import { Button, Card, EmptyState, LoadingState, PageHeader, StatusBadge } from "../../../src/components/ui";
 import { colors, spacing, radius, shadows } from "../../../src/theme";
 import { getApi } from "../../../src/lib/api";
@@ -81,7 +82,7 @@ type PendingProgress = {
 };
 
 // ============================================================
-// Nutrition Constants (DRI — mirrors lib/nutrition-constants.ts)
+// DayNutritionTotals — 26 栄養素の集計型
 // ============================================================
 
 interface DayNutritionTotals {
@@ -113,34 +114,8 @@ interface DayNutritionTotals {
   saturatedFatG: number;
 }
 
-interface NutrientDef {
-  key: keyof DayNutritionTotals;
-  label: string;
-  unit: string;
-  dri: number;
-  decimals: number;
-}
-
-const NUTRIENT_DEFS: NutrientDef[] = [
-  { key: "caloriesKcal", label: "エネルギー",   unit: "kcal", dri: 2000, decimals: 0 },
-  { key: "proteinG",     label: "タンパク質",   unit: "g",    dri: 60,    decimals: 1 },
-  { key: "fatG",         label: "脂質",         unit: "g",    dri: 55,    decimals: 1 },
-  { key: "carbsG",       label: "炭水化物",     unit: "g",    dri: 300,   decimals: 1 },
-  { key: "fiberG",       label: "食物繊維",     unit: "g",    dri: 21,    decimals: 1 },
-  { key: "sugarG",       label: "糖質",         unit: "g",    dri: 250,   decimals: 1 },
-  { key: "sodiumG",      label: "塩分",         unit: "g",    dri: 7.5,   decimals: 1 },
-  { key: "potassiumMg",  label: "カリウム",     unit: "mg",   dri: 2500,  decimals: 0 },
-  { key: "calciumMg",    label: "カルシウム",   unit: "mg",   dri: 700,   decimals: 0 },
-  { key: "magnesiumMg",  label: "マグネシウム", unit: "mg",   dri: 340,   decimals: 0 },
-  { key: "ironMg",       label: "鉄分",         unit: "mg",   dri: 7.5,   decimals: 1 },
-  { key: "zincMg",       label: "亜鉛",         unit: "mg",   dri: 10,    decimals: 1 },
-  { key: "vitaminAUg",   label: "ビタミンA",   unit: "µg",   dri: 850,   decimals: 0 },
-  { key: "vitaminB1Mg",  label: "ビタミンB1",  unit: "mg",   dri: 1.3,   decimals: 2 },
-  { key: "vitaminB2Mg",  label: "ビタミンB2",  unit: "mg",   dri: 1.5,   decimals: 2 },
-  { key: "vitaminCMg",   label: "ビタミンC",   unit: "mg",   dri: 100,   decimals: 0 },
-  { key: "vitaminDUg",   label: "ビタミンD",   unit: "µg",   dri: 8.5,   decimals: 1 },
-  { key: "vitaminEMg",   label: "ビタミンE",   unit: "mg",   dri: 6.5,   decimals: 1 },
-];
+// @homegohan/shared の NUTRIENT_DEFINITIONS を使用 (26 栄養素)
+const NUTRIENT_DEFS: NutrientDefinition[] = NUTRIENT_DEFINITIONS;
 
 const DEFAULT_RADAR_KEYS: (keyof DayNutritionTotals)[] = [
   "caloriesKcal", "proteinG", "fatG", "carbsG", "fiberG", "calciumMg", "vitaminCMg",
@@ -429,8 +404,8 @@ function NutritionBottomSheet({ visible, onClose, day, dateLabel, radarKeys, wee
             </Text>
             <View style={{ gap: spacing.sm }}>
               {DRI_BAR_NUTRIENTS.map((def) => {
-                const value = totals[def.key] as number;
-                const pct = driPercent(def.key, value);
+                const value = totals[def.key as keyof DayNutritionTotals] as number;
+                const pct = driPercent(def.key as keyof DayNutritionTotals, value);
                 const barColor = driColor(pct);
                 return (
                   <View key={String(def.key)} style={{ backgroundColor: colors.card, borderRadius: radius.md, padding: spacing.md, gap: 4 }}>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@homegohan/core": "*",
+    "@homegohan/shared": "*",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-community/slider": "4.5.5",
     "@supabase/supabase-js": "^2.78.0",

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "paths": {
+      "@homegohan/shared": ["../../packages/shared/src/index.ts"],
+      "@homegohan/shared/*": ["../../packages/shared/src/*"]
+    }
   },
   "include": [
     "**/*.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@homegohan/shared",
+  "version": "0.1.0",
+  "private": true,
+  "sideEffects": false,
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from './nutrition-constants';

--- a/packages/shared/src/nutrition-constants.ts
+++ b/packages/shared/src/nutrition-constants.ts
@@ -1,0 +1,91 @@
+/**
+ * 栄養素の定義（レーダーチャート・推奨量計算用）
+ *
+ * DRI (Dietary Reference Intakes) は日本人の食事摂取基準2020年版を参考
+ * 成人（18-49歳）の推奨量/目安量を基準としています
+ */
+
+export interface NutrientDefinition {
+  key: string;           // DB/コードで使用するキー
+  label: string;         // 表示名
+  unit: string;          // 単位
+  dri: number;           // 1日の推奨量/目安量
+  decimals: number;      // 小数点以下桁数
+  category: 'basic' | 'mineral' | 'vitamin' | 'fat'; // カテゴリ
+  description?: string;  // 説明
+}
+
+// 栄養素定義マスター
+export const NUTRIENT_DEFINITIONS: NutrientDefinition[] = [
+  // === 基本栄養素 ===
+  { key: 'caloriesKcal', label: 'エネルギー', unit: 'kcal', dri: 2000, decimals: 0, category: 'basic', description: '1日の活動エネルギー源' },
+  { key: 'proteinG', label: 'タンパク質', unit: 'g', dri: 60, decimals: 1, category: 'basic', description: '筋肉・臓器の構成成分' },
+  { key: 'fatG', label: '脂質', unit: 'g', dri: 55, decimals: 1, category: 'basic', description: 'エネルギー源・細胞膜の構成成分' },
+  { key: 'carbsG', label: '炭水化物', unit: 'g', dri: 300, decimals: 1, category: 'basic', description: '主要なエネルギー源' },
+  { key: 'fiberG', label: '食物繊維', unit: 'g', dri: 21, decimals: 1, category: 'basic', description: '腸内環境を整える' },
+  { key: 'sugarG', label: '糖質', unit: 'g', dri: 250, decimals: 1, category: 'basic', description: '即効性のあるエネルギー' },
+
+  // === ミネラル ===
+  { key: 'sodiumG', label: '塩分', unit: 'g', dri: 7.5, decimals: 1, category: 'mineral', description: '目標量（控えめに）' },
+  { key: 'potassiumMg', label: 'カリウム', unit: 'mg', dri: 2500, decimals: 0, category: 'mineral', description: '血圧調整・むくみ防止' },
+  { key: 'calciumMg', label: 'カルシウム', unit: 'mg', dri: 700, decimals: 0, category: 'mineral', description: '骨・歯の形成' },
+  { key: 'magnesiumMg', label: 'マグネシウム', unit: 'mg', dri: 340, decimals: 0, category: 'mineral', description: '酵素反応の補助' },
+  { key: 'phosphorusMg', label: 'リン', unit: 'mg', dri: 1000, decimals: 0, category: 'mineral', description: '骨・歯の形成' },
+  { key: 'ironMg', label: '鉄分', unit: 'mg', dri: 7.5, decimals: 1, category: 'mineral', description: '酸素運搬（ヘモグロビン）' },
+  { key: 'zincMg', label: '亜鉛', unit: 'mg', dri: 10, decimals: 1, category: 'mineral', description: '免疫機能・味覚' },
+  { key: 'iodineUg', label: 'ヨウ素', unit: 'µg', dri: 130, decimals: 0, category: 'mineral', description: '甲状腺ホルモンの材料' },
+
+  // === ビタミン ===
+  { key: 'vitaminAUg', label: 'ビタミンA', unit: 'µg', dri: 850, decimals: 0, category: 'vitamin', description: '視力・皮膚の健康' },
+  { key: 'vitaminB1Mg', label: 'ビタミンB1', unit: 'mg', dri: 1.3, decimals: 2, category: 'vitamin', description: '糖質代謝' },
+  { key: 'vitaminB2Mg', label: 'ビタミンB2', unit: 'mg', dri: 1.5, decimals: 2, category: 'vitamin', description: '脂質代謝・皮膚' },
+  { key: 'vitaminB6Mg', label: 'ビタミンB6', unit: 'mg', dri: 1.4, decimals: 2, category: 'vitamin', description: 'タンパク質代謝' },
+  { key: 'vitaminB12Ug', label: 'ビタミンB12', unit: 'µg', dri: 2.4, decimals: 1, category: 'vitamin', description: '神経機能・赤血球' },
+  { key: 'vitaminCMg', label: 'ビタミンC', unit: 'mg', dri: 100, decimals: 0, category: 'vitamin', description: '抗酸化・コラーゲン合成' },
+  { key: 'vitaminDUg', label: 'ビタミンD', unit: 'µg', dri: 8.5, decimals: 1, category: 'vitamin', description: 'カルシウム吸収' },
+  { key: 'vitaminEMg', label: 'ビタミンE', unit: 'mg', dri: 6.5, decimals: 1, category: 'vitamin', description: '抗酸化作用' },
+  { key: 'vitaminKUg', label: 'ビタミンK', unit: 'µg', dri: 150, decimals: 0, category: 'vitamin', description: '血液凝固・骨形成' },
+  { key: 'folicAcidUg', label: '葉酸', unit: 'µg', dri: 240, decimals: 0, category: 'vitamin', description: '細胞分裂・胎児発育' },
+
+  // === 脂質詳細 ===
+  { key: 'saturatedFatG', label: '飽和脂肪酸', unit: 'g', dri: 16, decimals: 1, category: 'fat', description: '摂りすぎ注意' },
+  { key: 'cholesterolMg', label: 'コレステロール', unit: 'mg', dri: 300, decimals: 0, category: 'fat', description: '細胞膜・ホルモン材料' },
+];
+
+// キーからNutrientDefinitionを取得
+export const getNutrientDefinition = (key: string): NutrientDefinition | undefined => {
+  return NUTRIENT_DEFINITIONS.find(n => n.key === key);
+};
+
+// 推奨量に対する割合を計算（%）
+export const calculateDriPercentage = (key: string, value: number | null | undefined): number => {
+  if (value == null) return 0;
+  const def = getNutrientDefinition(key);
+  if (!def) return 0;
+  return Math.round((value / def.dri) * 100);
+};
+
+// デフォルトのレーダーチャート栄養素（5角形）
+export const DEFAULT_RADAR_NUTRIENTS = [
+  'caloriesKcal',
+  'proteinG',
+  'fatG',
+  'carbsG',
+  'fiberG',
+];
+
+// カテゴリごとにグループ化
+export const NUTRIENT_BY_CATEGORY = {
+  basic: NUTRIENT_DEFINITIONS.filter(n => n.category === 'basic'),
+  mineral: NUTRIENT_DEFINITIONS.filter(n => n.category === 'mineral'),
+  vitamin: NUTRIENT_DEFINITIONS.filter(n => n.category === 'vitamin'),
+  fat: NUTRIENT_DEFINITIONS.filter(n => n.category === 'fat'),
+};
+
+// カテゴリ表示名
+export const CATEGORY_LABELS: Record<string, string> = {
+  basic: '基本栄養素',
+  mineral: 'ミネラル',
+  vitamin: 'ビタミン',
+  fat: '脂質詳細',
+};

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -14,7 +14,7 @@ import ReactMarkdown from "react-markdown";
 import { useV4MenuGeneration } from "@/hooks/useV4MenuGeneration";
 import { notifyMenuGenerated } from "@/lib/local-notification";
 // ProfileReminderBanner は dynamic import で lazy load (#322)
-import { DEFAULT_RADAR_NUTRIENTS, getNutrientDefinition, calculateDriPercentage, NUTRIENT_DEFINITIONS, NUTRIENT_BY_CATEGORY, CATEGORY_LABELS } from "@/lib/nutrition-constants";
+import { DEFAULT_RADAR_NUTRIENTS, getNutrientDefinition, calculateDriPercentage, NUTRIENT_DEFINITIONS, NUTRIENT_BY_CATEGORY, CATEGORY_LABELS } from "@homegohan/shared";
 import remarkGfm from "remark-gfm";
 
 // #182/#322: dynamic import で初期バンドルを削減 (LCP 改善)

--- a/src/app/api/ai/nutrition/feedback/route.ts
+++ b/src/app/api/ai/nutrition/feedback/route.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
-import { getNutrientDefinition, calculateDriPercentage } from '@/lib/nutrition-constants';
+import { getNutrientDefinition, calculateDriPercentage } from '@homegohan/shared';
 import crypto from 'crypto';
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;

--- a/src/components/NutritionRadarChart.tsx
+++ b/src/components/NutritionRadarChart.tsx
@@ -10,11 +10,11 @@ import {
   ResponsiveContainer,
   Tooltip,
 } from "recharts";
-import { 
-  getNutrientDefinition, 
+import {
+  getNutrientDefinition,
   calculateDriPercentage,
   DEFAULT_RADAR_NUTRIENTS,
-} from "@/lib/nutrition-constants";
+} from "@homegohan/shared";
 
 // ============================================
 // Types

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,12 @@
       "@/*": [
         "./src/*",
         "./*"
+      ],
+      "@homegohan/shared": [
+        "./packages/shared/src/index.ts"
+      ],
+      "@homegohan/shared/*": [
+        "./packages/shared/src/*"
       ]
     }
   },


### PR DESCRIPTION
## 概要

WEB と App で重複していた栄養素定義を `@homegohan/shared` パッケージに集約する。

**Before:**
- WEB: `lib/nutrition-constants.ts`（26栄養素）
- App: `apps/mobile/app/menus/weekly/index.tsx` インライン定義（18栄養素、8栄養素欠落）

**After:**
- `packages/shared/src/nutrition-constants.ts` に26栄養素を一元管理
- WEB・App 両方が `@homegohan/shared` から import

## 変更ファイル

- `packages/shared/` 新設（package.json, tsconfig.json, src/index.ts, src/nutrition-constants.ts）
- `apps/mobile/app/menus/weekly/index.tsx` — インライン18栄養素定義削除 → import 置換
- `apps/mobile/package.json` — `@homegohan/shared: "*"` dependency 追加
- `apps/mobile/tsconfig.json` — `@homegohan/shared` paths 追加
- `tsconfig.json`（ルート） — `@homegohan/shared` paths 追加
- `src/app/(main)/menus/weekly/page.tsx` — import 変更
- `src/components/NutritionRadarChart.tsx` — import 変更
- `src/app/api/ai/nutrition/feedback/route.ts` — import 変更

## DoD

- [x] `packages/shared/src/nutrition-constants.ts` 存在（26栄養素）
- [x] App `apps/mobile/app/menus/weekly/index.tsx` から18栄養素インライン定義削除
- [x] tsc エラーなし（既存の Button.tsx エラーを除く）
- [x] UI 変更なし（testID 新規追加なし）