### PR TITLE
chore: THEME_LABELS / getDishConfig / MEAL_LABELS / MODE_CONFIG / PROGRESS_PHASES を packages/shared に移動 (PR 0-2)

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -13,7 +13,7 @@ import {
 } from "react-native";
 import Svg, { Circle, Line, Polygon, Text as SvgText } from "react-native-svg";
 
-import { NUTRIENT_DEFINITIONS, type NutrientDefinition } from "@homegohan/shared";
+import { NUTRIENT_DEFINITIONS, type NutrientDefinition, PROGRESS_PHASES, ULTIMATE_PROGRESS_PHASES, MODE_CONFIG as MODE_CONFIG_SHARED, MEAL_ORDER as MEAL_ORDER_SHARED, type PhaseDefinition } from "@homegohan/shared";
 import { Button, Card, EmptyState, LoadingState, PageHeader, StatusBadge } from "../../../src/components/ui";
 import { colors, spacing, radius, shadows } from "../../../src/theme";
 import { getApi } from "../../../src/lib/api";
@@ -497,41 +497,7 @@ function getWeekStart(date: Date, weekStartDay: WeekStartDay = 'monday'): Date {
   return d;
 }
 
-// AI生成進捗フェーズ定義（Webの PROGRESS_PHASES / ULTIMATE_PROGRESS_PHASES に準拠）
-const PROGRESS_PHASES = [
-  { phase: "user_context", label: "ユーザー情報を取得", threshold: 5 },
-  { phase: "search_references", label: "参考レシピを検索", threshold: 10 },
-  { phase: "generating", label: "献立をAIが作成", threshold: 15 },
-  { phase: "step1_complete", label: "献立生成完了", threshold: 40 },
-  { phase: "reviewing", label: "献立のバランスをチェック", threshold: 45 },
-  { phase: "review_done", label: "改善点を発見", threshold: 55 },
-  { phase: "fixing", label: "改善点を修正", threshold: 60 },
-  { phase: "no_issues", label: "問題なし", threshold: 70 },
-  { phase: "step2_complete", label: "レビュー完了", threshold: 75 },
-  { phase: "calculating", label: "栄養価を計算", threshold: 80 },
-  { phase: "saving", label: "献立を保存", threshold: 88 },
-  { phase: "completed", label: "完了！", threshold: 100 },
-];
-
-const ULTIMATE_PROGRESS_PHASES = [
-  { phase: "user_context", label: "ユーザー情報を取得", threshold: 3 },
-  { phase: "search_references", label: "参考レシピを検索", threshold: 6 },
-  { phase: "generating", label: "献立をAIが作成", threshold: 10 },
-  { phase: "step1_complete", label: "献立生成完了", threshold: 25 },
-  { phase: "reviewing", label: "献立のバランスをチェック", threshold: 28 },
-  { phase: "fixing", label: "改善点を修正", threshold: 32 },
-  { phase: "step2_complete", label: "レビュー完了", threshold: 38 },
-  { phase: "calculating", label: "栄養価を計算", threshold: 42 },
-  { phase: "step3_complete", label: "栄養計算完了", threshold: 48 },
-  { phase: "nutrition_analyzing", label: "栄養バランスを詳細分析", threshold: 55 },
-  { phase: "nutrition_feedback", label: "改善アドバイスを生成", threshold: 62 },
-  { phase: "improving", label: "献立を改善中", threshold: 70 },
-  { phase: "step5_complete", label: "改善完了", threshold: 82 },
-  { phase: "final_saving", label: "最終保存中", threshold: 90 },
-  { phase: "completed", label: "究極の献立が完成！", threshold: 100 },
-];
-
-type PhaseDefinition = { phase: string; label: string; threshold: number };
+// PROGRESS_PHASES / ULTIMATE_PROGRESS_PHASES / PhaseDefinition は @homegohan/shared からインポート
 
 type ProgressTodoCardProps = {
   progress: PendingProgress | null;
@@ -683,7 +649,9 @@ function ProgressTodoCard({ progress, phases = PROGRESS_PHASES, defaultMessage =
 
 const DOW = ["月", "火", "水", "木", "金", "土", "日"];
 
-const MEAL_ORDER = ["breakfast", "lunch", "snack", "dinner", "midnight_snack"] as const;
+// MEAL_ORDER は @homegohan/shared からインポート (MEAL_ORDER_SHARED)
+// 表示順: breakfast / lunch / dinner / snack / midnight_snack
+const MEAL_ORDER = MEAL_ORDER_SHARED;
 
 const MEAL_CONFIG: Record<string, { icon: keyof typeof Ionicons.glyphMap; label: string; color: string }> = {
   breakfast: { icon: "sunny", label: "朝食", color: "#FF9800" },
@@ -693,14 +661,18 @@ const MEAL_CONFIG: Record<string, { icon: keyof typeof Ionicons.glyphMap; label:
   midnight_snack: { icon: "cloudy-night", label: "夜食", color: "#3F51B5" },
 };
 
-const MODE_CONFIG: Record<string, { icon?: string; label: string; color: string; bg: string }> = {
-  cook: { label: "自炊", color: colors.success, bg: colors.successLight },
-  quick: { label: "時短", color: colors.blue, bg: colors.blueLight },
-  buy: { label: "買う", color: colors.purple, bg: colors.purpleLight },
-  out: { label: "外食", color: colors.warning, bg: colors.warningLight },
-  skip: { label: "なし", color: colors.textMuted, bg: colors.bg },
-  ai_creative: { icon: "sparkles", label: "AI献立", color: colors.accent, bg: colors.accentLight },
-};
+// MODE_CONFIG — @homegohan/shared の抽象キーを App 用の実色値に変換
+const MODE_CONFIG = Object.fromEntries(
+  Object.entries(MODE_CONFIG_SHARED).map(([key, cfg]) => [
+    key,
+    {
+      icon: cfg.iconKey === 'sparkles' ? 'sparkles' : undefined,
+      label: cfg.label,
+      color: colors[cfg.colorKey as keyof typeof colors],
+      bg: colors[cfg.bgColorKey as keyof typeof colors],
+    },
+  ])
+) as Record<string, { icon?: string; label: string; color: string; bg: string }>;
 
 export default function WeeklyMenuPage() {
   const { profile } = useProfile();

--- a/apps/mobile/app/menus/weekly/request/index.tsx
+++ b/apps/mobile/app/menus/weekly/request/index.tsx
@@ -9,6 +9,7 @@ import { getApi } from "../../../../src/lib/api";
 import { colors, radius, spacing } from "../../../../src/theme";
 import { useProfile } from "../../../../src/providers/ProfileProvider";
 import type { WeekStartDay } from "../../../../src/providers/ProfileProvider";
+import { THEME_LABELS_REQUEST } from "@homegohan/shared";
 
 const MEAL_TYPES = ["breakfast", "lunch", "dinner"] as const;
 
@@ -43,16 +44,6 @@ function getWeekStart(date: Date, weekStartDay: WeekStartDay = 'monday'): Date {
   return d;
 }
 
-// 過渡期マッピング: 日本語テーマ選択 → WEB 形式英語テーマキー
-// PR 3-3 で明示テーマ選択 UI に切り替えたとき削除予定
-function japaneseThemesToWebThemes(selectedJaThemes: string[]): string[] {
-  const themes: string[] = [];
-  if (selectedJaThemes.includes("冷蔵庫の食材を優先")) themes.push("💰 Saving");
-  if (selectedJaThemes.includes("時短メニュー中心")) themes.push("⏱️ Speed");
-  if (selectedJaThemes.includes("和食多め")) themes.push("🍱 Bento");
-  if (selectedJaThemes.includes("ヘルシーに")) themes.push("🥗 Diet");
-  return themes;
-}
 
 export default function WeeklyRequestPage() {
   const { profile } = useProfile();
@@ -75,15 +66,8 @@ export default function WeeklyRequestPage() {
   const [isUploading, setIsUploading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const themes = useMemo(
-    () => [
-      "冷蔵庫の食材を優先",
-      "時短メニュー中心",
-      "和食多め",
-      "ヘルシーに",
-    ],
-    []
-  );
+  // テーマ選択肢: @homegohan/shared の THEME_LABELS_REQUEST (英語 6 種)
+  const themes = useMemo(() => THEME_LABELS_REQUEST, []);
   const [selectedThemes, setSelectedThemes] = useState<string[]>([]);
 
   function toggleTheme(t: string) {
@@ -153,18 +137,17 @@ export default function WeeklyRequestPage() {
 
       const parsedFamilySize = Math.max(1, Math.min(10, parseInt(familySize || "1") || 1));
       const parsedCheatDay = cheatDay.trim() || null;
-      // 過渡期マッピング: 日本語テーマ → WEB 形式英語テーマ (PR 3-3 で UI 切替後に削除)
-      const webThemes = japaneseThemesToWebThemes(selectedThemes);
+      // selectedThemes は英語 6 種 (THEME_LABELS_REQUEST) から選択されるため変換不要
+      const webThemes = selectedThemes;
 
       const api = getApi();
 
       if (isUltimateMode) {
         // 究極モード: /api/ai/menu/v4/generate に ultimateMode: true で送信
-        // TODO: PR 4-1 で constraints を WEB 形式に統一
-        const useFridgeFirst = selectedThemes.includes("冷蔵庫の食材を優先");
-        const quickMeals = selectedThemes.includes("時短メニュー中心");
-        const japaneseStyle = selectedThemes.includes("和食多め");
-        const healthy = selectedThemes.includes("ヘルシーに");
+        const useFridgeFirst = selectedThemes.includes("💰 Saving");
+        const quickMeals = selectedThemes.includes("⏱️ Speed");
+        const japaneseStyle = selectedThemes.includes("🍱 Bento");
+        const healthy = selectedThemes.includes("🥗 Diet");
         const extraLines: string[] = [];
         if (selectedThemes.length) extraLines.push(`テーマ: ${selectedThemes.join("、")}`);
         if (ingredients.length) extraLines.push(`使いたい食材: ${ingredients.join("、")}`);

--- a/apps/mobile/src/lib/icon-map.ts
+++ b/apps/mobile/src/lib/icon-map.ts
@@ -1,0 +1,17 @@
+/**
+ * アイコンマップ (Ionicons)
+ *
+ * @homegohan/shared の iconKey → Ionicons アイコン名への解決マップ
+ */
+
+export const ICON_MAP_IONICONS: Record<string, string> = {
+  utensils: 'restaurant',
+  leaf: 'leaf',
+  soup: 'cafe',
+  wheat: 'nutrition',
+  salad: 'leaf-outline',
+  cake: 'ice-cream',
+  help: 'help-circle-outline',
+};
+
+export type DishIconKey = keyof typeof ICON_MAP_IONICONS;

--- a/packages/shared/src/dish-roles.ts
+++ b/packages/shared/src/dish-roles.ts
@@ -1,0 +1,49 @@
+/**
+ * 料理役割 (DishRole) 定数と getDishConfig 関数
+ *
+ * colorKey は各 platform の colors オブジェクトのキーに対応する抽象キー
+ * iconKey は各 platform のアイコンマップ (icon-map.ts) で解決する抽象キー
+ */
+
+export type DishRole = 'main' | 'side' | 'soup' | 'rice' | 'salad' | 'dessert';
+
+export interface DishConfig {
+  label: string;
+  colorKey: 'accent' | 'success' | 'blue' | 'warning' | 'purple' | 'textMuted';
+  iconKey: 'utensils' | 'leaf' | 'soup' | 'wheat' | 'salad' | 'cake' | 'help';
+}
+
+/**
+ * 役割に応じた設定を返す（英語・日本語両方対応）
+ */
+export function getDishConfig(role?: string): DishConfig {
+  switch (role) {
+    case 'main':
+    case '主菜':
+    case '主食':
+      return { label: '主菜', colorKey: 'accent', iconKey: 'utensils' };
+    case 'side':
+    case 'side1':
+    case 'side2':
+    case '副菜':
+    case '副食':
+      return { label: '副菜', colorKey: 'success', iconKey: 'leaf' };
+    case 'soup':
+    case '汁物':
+    case '味噌汁':
+      return { label: '汁物', colorKey: 'blue', iconKey: 'soup' };
+    case 'rice':
+    case 'ご飯':
+    case '白飯':
+      return { label: 'ご飯', colorKey: 'warning', iconKey: 'wheat' };
+    case 'salad':
+    case 'サラダ':
+      return { label: 'サラダ', colorKey: 'success', iconKey: 'salad' };
+    case 'dessert':
+    case 'デザート':
+    case 'フルーツ':
+      return { label: 'デザート', colorKey: 'purple', iconKey: 'cake' };
+    default:
+      return { label: role || 'おかず', colorKey: 'textMuted', iconKey: 'help' };
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,6 @@
 export * from './nutrition-constants';
+export * from './theme-labels';
+export * from './dish-roles';
+export * from './meal-types';
+export * from './mode-config';
+export * from './progress-phases';

--- a/packages/shared/src/meal-types.ts
+++ b/packages/shared/src/meal-types.ts
@@ -1,0 +1,21 @@
+/**
+ * 食事タイプ定数
+ */
+
+export type MealType = 'breakfast' | 'lunch' | 'dinner' | 'snack' | 'midnight_snack';
+
+export const MEAL_LABELS: Record<MealType, string> = {
+  breakfast: '朝食',
+  lunch: '昼食',
+  dinner: '夕食',
+  snack: 'おやつ',
+  midnight_snack: '夜食',
+};
+
+export const MEAL_ORDER: MealType[] = [
+  'breakfast',
+  'lunch',
+  'dinner',
+  'snack',
+  'midnight_snack',
+];

--- a/packages/shared/src/mode-config.ts
+++ b/packages/shared/src/mode-config.ts
@@ -1,0 +1,54 @@
+/**
+ * 食事モード設定定数
+ *
+ * colorKey は各 platform の colors オブジェクトのキーに対応する抽象キー
+ * iconKey は各 platform のアイコンマップ (icon-map.ts) で解決する抽象キー
+ */
+
+export type ModeKey = 'cook' | 'quick' | 'buy' | 'out' | 'skip' | 'ai_creative';
+
+export interface ModeConfig {
+  label: string;
+  colorKey: 'success' | 'blue' | 'purple' | 'warning' | 'textMuted' | 'accent';
+  bgColorKey: 'successLight' | 'blueLight' | 'purpleLight' | 'warningLight' | 'bg' | 'accentLight';
+  iconKey: 'chef-hat' | 'zap' | 'store' | 'utensils-crossed' | 'fast-forward' | 'sparkles';
+}
+
+export const MODE_CONFIG: Record<ModeKey, ModeConfig> = {
+  cook: {
+    label: '自炊',
+    colorKey: 'success',
+    bgColorKey: 'successLight',
+    iconKey: 'chef-hat',
+  },
+  quick: {
+    label: '時短',
+    colorKey: 'blue',
+    bgColorKey: 'blueLight',
+    iconKey: 'zap',
+  },
+  buy: {
+    label: '買う',
+    colorKey: 'purple',
+    bgColorKey: 'purpleLight',
+    iconKey: 'store',
+  },
+  out: {
+    label: '外食',
+    colorKey: 'warning',
+    bgColorKey: 'warningLight',
+    iconKey: 'utensils-crossed',
+  },
+  skip: {
+    label: 'なし',
+    colorKey: 'textMuted',
+    bgColorKey: 'bg',
+    iconKey: 'fast-forward',
+  },
+  ai_creative: {
+    label: 'AI献立',
+    colorKey: 'accent',
+    bgColorKey: 'accentLight',
+    iconKey: 'sparkles',
+  },
+};

--- a/packages/shared/src/progress-phases.ts
+++ b/packages/shared/src/progress-phases.ts
@@ -1,0 +1,57 @@
+/**
+ * 献立生成進捗フェーズ定数
+ *
+ * PROGRESS_PHASES: 通常モード 12 フェーズ
+ * ULTIMATE_PROGRESS_PHASES: 究極モード 15 フェーズ
+ * SHOPPING_LIST_PHASES: 買い物リスト再生成 8 フェーズ
+ */
+
+export interface PhaseDefinition {
+  phase: string;
+  label: string;
+  threshold: number;
+}
+
+export const PROGRESS_PHASES: PhaseDefinition[] = [
+  { phase: 'user_context', label: 'ユーザー情報を取得', threshold: 5 },
+  { phase: 'search_references', label: '参考レシピを検索', threshold: 10 },
+  { phase: 'generating', label: '献立をAIが作成', threshold: 15 },
+  { phase: 'step1_complete', label: '献立生成完了', threshold: 40 },
+  { phase: 'reviewing', label: '献立のバランスをチェック', threshold: 45 },
+  { phase: 'review_done', label: '改善点を発見', threshold: 55 },
+  { phase: 'fixing', label: '改善点を修正', threshold: 60 },
+  { phase: 'no_issues', label: '問題なし', threshold: 70 },
+  { phase: 'step2_complete', label: 'レビュー完了', threshold: 75 },
+  { phase: 'calculating', label: '栄養価を計算', threshold: 80 },
+  { phase: 'saving', label: '献立を保存', threshold: 88 },
+  { phase: 'completed', label: '完了！', threshold: 100 },
+];
+
+export const ULTIMATE_PROGRESS_PHASES: PhaseDefinition[] = [
+  { phase: 'user_context', label: 'ユーザー情報を取得', threshold: 3 },
+  { phase: 'search_references', label: '参考レシピを検索', threshold: 6 },
+  { phase: 'generating', label: '献立をAIが作成', threshold: 10 },
+  { phase: 'step1_complete', label: '献立生成完了', threshold: 25 },
+  { phase: 'reviewing', label: '献立のバランスをチェック', threshold: 28 },
+  { phase: 'fixing', label: '改善点を修正', threshold: 32 },
+  { phase: 'step2_complete', label: 'レビュー完了', threshold: 38 },
+  { phase: 'calculating', label: '栄養価を計算', threshold: 42 },
+  { phase: 'step3_complete', label: '栄養計算完了', threshold: 48 },
+  { phase: 'nutrition_analyzing', label: '栄養バランスを詳細分析', threshold: 55 },
+  { phase: 'nutrition_feedback', label: '改善アドバイスを生成', threshold: 62 },
+  { phase: 'improving', label: '献立を改善中', threshold: 70 },
+  { phase: 'step5_complete', label: '改善完了', threshold: 82 },
+  { phase: 'final_saving', label: '最終保存中', threshold: 90 },
+  { phase: 'completed', label: '究極の献立が完成！', threshold: 100 },
+];
+
+export const SHOPPING_LIST_PHASES: PhaseDefinition[] = [
+  { phase: 'starting', label: '開始中...', threshold: 0 },
+  { phase: 'extracting', label: '献立から材料を抽出', threshold: 10 },
+  { phase: 'normalizing', label: 'AIが材料を整理中', threshold: 30 },
+  { phase: 'validating', label: '整合性チェック', threshold: 60 },
+  { phase: 'categorizing', label: 'カテゴリ分類', threshold: 70 },
+  { phase: 'saving', label: '保存中', threshold: 85 },
+  { phase: 'completed', label: '完了！', threshold: 100 },
+  { phase: 'failed', label: 'エラーが発生しました', threshold: 0 },
+];

--- a/packages/shared/src/theme-labels.ts
+++ b/packages/shared/src/theme-labels.ts
@@ -1,0 +1,22 @@
+/**
+ * テーマラベル定数
+ *
+ * THEME_LABELS_REQUEST: 英語 6 種（WEB/App 共通）
+ * AI_CONDITIONS: 日本語 4 種（WEB weekly page の AI 条件チップ用）
+ */
+
+export const THEME_LABELS_REQUEST: string[] = [
+  '💰 Saving',
+  '💪 Muscle',
+  '⚡️ Recovery',
+  '🥗 Diet',
+  '🍱 Bento',
+  '⏱️ Speed',
+];
+
+export const AI_CONDITIONS: string[] = [
+  '冷蔵庫の食材を優先',
+  '時短メニュー中心',
+  '和食多め',
+  'ヘルシーに',
+];

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -14,7 +14,7 @@ import ReactMarkdown from "react-markdown";
 import { useV4MenuGeneration } from "@/hooks/useV4MenuGeneration";
 import { notifyMenuGenerated } from "@/lib/local-notification";
 // ProfileReminderBanner は dynamic import で lazy load (#322)
-import { DEFAULT_RADAR_NUTRIENTS, getNutrientDefinition, calculateDriPercentage, NUTRIENT_DEFINITIONS, NUTRIENT_BY_CATEGORY, CATEGORY_LABELS } from "@homegohan/shared";
+import { DEFAULT_RADAR_NUTRIENTS, getNutrientDefinition, calculateDriPercentage, NUTRIENT_DEFINITIONS, NUTRIENT_BY_CATEGORY, CATEGORY_LABELS, THEME_LABELS_REQUEST, AI_CONDITIONS, getDishConfig as getDishConfigShared, type DishConfig, MEAL_LABELS, MEAL_ORDER as MEAL_ORDER_SHARED, PROGRESS_PHASES, ULTIMATE_PROGRESS_PHASES, SHOPPING_LIST_PHASES, type PhaseDefinition, MODE_CONFIG as MODE_CONFIG_SHARED } from "@homegohan/shared";
 import remarkGfm from "remark-gfm";
 
 // #182/#322: dynamic import で初期バンドルを削減 (LCP 改善)
@@ -129,58 +129,45 @@ const colors = {
   dangerLight: '#FDECEC',
 };
 
-const MODE_CONFIG: Record<string, { icon: typeof ChefHat; label: string; color: string; bg: string }> = {
-  cook: { icon: ChefHat, label: '自炊', color: colors.success, bg: colors.successLight },
-  quick: { icon: Zap, label: '時短', color: colors.blue, bg: colors.blueLight },
-  buy: { icon: Store, label: '買う', color: colors.purple, bg: colors.purpleLight },
-  out: { icon: UtensilsCrossed, label: '外食', color: colors.warning, bg: colors.warningLight },
-  skip: { icon: FastForward, label: 'なし', color: colors.textMuted, bg: colors.bg },
-  ai_creative: { icon: Sparkles, label: 'AI献立', color: colors.accent, bg: colors.accentLight },
+// アイコンマッピング (Lucide) — MODE_CONFIG の iconKey を解決するため WEB 専用で保持
+const MODE_ICON_MAP: Record<string, typeof ChefHat> = {
+  'chef-hat': ChefHat,
+  'zap': Zap,
+  'store': Store,
+  'utensils-crossed': UtensilsCrossed,
+  'fast-forward': FastForward,
+  'sparkles': Sparkles,
 };
+
+// @homegohan/shared の MODE_CONFIG_SHARED を WEB 用に変換（アイコン・実色値付き）
+const MODE_CONFIG = Object.fromEntries(
+  Object.entries(MODE_CONFIG_SHARED).map(([key, cfg]) => [
+    key,
+    {
+      icon: MODE_ICON_MAP[cfg.iconKey] ?? ChefHat,
+      label: cfg.label,
+      color: colors[cfg.colorKey],
+      bg: colors[cfg.bgColorKey],
+    },
+  ])
+) as Record<string, { icon: typeof ChefHat; label: string; color: string; bg: string }>;
 
 // モード設定を安全に取得するヘルパー（未知のモードでもエラーにならない）
 const getModeConfig = (mode?: string) => MODE_CONFIG[mode || 'cook'] || MODE_CONFIG.cook;
 
-// 役割に応じた色設定（英語・日本語両方対応）
+// getDishConfig — @homegohan/shared の定義を WEB colors で解決するラッパー
 const getDishConfig = (role?: string): { label: string; color: string; bg: string } => {
-  switch (role) {
-    case 'main':
-    case '主菜':
-    case '主食':
-      return { label: '主菜', color: colors.accent, bg: colors.accentLight };
-    case 'side':
-    case 'side1':
-    case 'side2':
-    case '副菜':
-    case '副食':
-      return { label: '副菜', color: colors.success, bg: colors.successLight };
-    case 'soup':
-    case '汁物':
-    case '味噌汁':
-      return { label: '汁物', color: colors.blue, bg: colors.blueLight };
-    case 'rice':
-    case 'ご飯':
-    case '白飯':
-      return { label: 'ご飯', color: colors.warning, bg: colors.warningLight };
-    case 'salad':
-    case 'サラダ':
-      return { label: 'サラダ', color: colors.success, bg: colors.successLight };
-    case 'dessert':
-    case 'デザート':
-    case 'フルーツ':
-      return { label: 'デザート', color: colors.purple, bg: colors.purpleLight };
-    default:
-      return { label: role || 'おかず', color: colors.textLight, bg: colors.bg };
-  }
+  const cfg = getDishConfigShared(role);
+  const colorKey = cfg.colorKey as keyof typeof colors;
+  const bgKey = (cfg.colorKey + 'Light') as keyof typeof colors;
+  return {
+    label: cfg.label,
+    color: colors[colorKey] ?? colors.textMuted,
+    bg: colorKey === 'textMuted' ? colors.bg : (colors[bgKey] ?? colors.bg),
+  };
 };
 
-const MEAL_LABELS: Record<MealType, string> = { 
-  breakfast: '朝食', 
-  lunch: '昼食', 
-  dinner: '夕食',
-  snack: 'おやつ',
-  midnight_snack: '夜食'
-};
+// MEAL_LABELS は @homegohan/shared からインポート (MealType の型付き Record)
 
 // AIが自動生成する基本の3食
 const BASE_MEAL_TYPES: MealType[] = ['breakfast', 'lunch', 'dinner'];
@@ -248,57 +235,9 @@ const NutritionItem = ({ label, value, unit, decimals = 1, textColor }: {
   );
 };
 
+// PROGRESS_PHASES / ULTIMATE_PROGRESS_PHASES / SHOPPING_LIST_PHASES / PhaseDefinition は @homegohan/shared からインポート
+
 // 進捗ToDoカード（タップで展開）
-// 通常モード用（3ステップ）
-const PROGRESS_PHASES = [
-  { phase: 'user_context', label: 'ユーザー情報を取得', threshold: 5 },
-  { phase: 'search_references', label: '参考レシピを検索', threshold: 10 },
-  { phase: 'generating', label: '献立をAIが作成', threshold: 15 },
-  { phase: 'step1_complete', label: '献立生成完了', threshold: 40 },
-  { phase: 'reviewing', label: '献立のバランスをチェック', threshold: 45 },
-  { phase: 'review_done', label: '改善点を発見', threshold: 55 },
-  { phase: 'fixing', label: '改善点を修正', threshold: 60 },
-  { phase: 'no_issues', label: '問題なし', threshold: 70 },
-  { phase: 'step2_complete', label: 'レビュー完了', threshold: 75 },
-  { phase: 'calculating', label: '栄養価を計算', threshold: 80 },
-  { phase: 'saving', label: '献立を保存', threshold: 88 },
-  { phase: 'completed', label: '完了！', threshold: 100 },
-];
-
-// 究極モード用（6ステップ）
-const ULTIMATE_PROGRESS_PHASES = [
-  { phase: 'user_context', label: 'ユーザー情報を取得', threshold: 3 },
-  { phase: 'search_references', label: '参考レシピを検索', threshold: 6 },
-  { phase: 'generating', label: '献立をAIが作成', threshold: 10 },
-  { phase: 'step1_complete', label: '献立生成完了', threshold: 25 },
-  { phase: 'reviewing', label: '献立のバランスをチェック', threshold: 28 },
-  { phase: 'fixing', label: '改善点を修正', threshold: 32 },
-  { phase: 'step2_complete', label: 'レビュー完了', threshold: 38 },
-  { phase: 'calculating', label: '栄養価を計算', threshold: 42 },
-  { phase: 'step3_complete', label: '栄養計算完了', threshold: 48 },
-  // 究極モード専用フェーズ
-  { phase: 'nutrition_analyzing', label: '栄養バランスを詳細分析', threshold: 55 },
-  { phase: 'nutrition_feedback', label: '改善アドバイスを生成', threshold: 62 },
-  { phase: 'improving', label: '献立を改善中', threshold: 70 },
-  { phase: 'step5_complete', label: '改善完了', threshold: 82 },
-  { phase: 'final_saving', label: '最終保存中', threshold: 90 },
-  { phase: 'completed', label: '究極の献立が完成！', threshold: 100 },
-];
-
-// 買い物リスト再生成の進捗フェーズ
-const SHOPPING_LIST_PHASES = [
-  { phase: 'starting', label: '開始中...', threshold: 0 },
-  { phase: 'extracting', label: '献立から材料を抽出', threshold: 10 },
-  { phase: 'normalizing', label: 'AIが材料を整理中', threshold: 30 },
-  { phase: 'validating', label: '整合性チェック', threshold: 60 },
-  { phase: 'categorizing', label: 'カテゴリ分類', threshold: 70 },
-  { phase: 'saving', label: '保存中', threshold: 85 },
-  { phase: 'completed', label: '完了！', threshold: 100 },
-  { phase: 'failed', label: 'エラーが発生しました', threshold: 0 },
-];
-
-type PhaseDefinition = { phase: string; label: string; threshold: number };
-
 const ProgressTodoCard = ({ 
   progress, 
   colors: cardColors,
@@ -521,7 +460,7 @@ const formatRecipeStepsToMarkdown = (recipeStepsText: string | null | undefined,
   }
   return '';
 };
-const AI_CONDITIONS = ['冷蔵庫の食材を優先', '時短メニュー中心', '和食多め', 'ヘルシーに'];
+// AI_CONDITIONS は @homegohan/shared からインポート
 
 // Helper functions
 const formatLocalDate = (date: Date): string => {

--- a/src/app/(main)/menus/weekly/request/page.tsx
+++ b/src/app/(main)/menus/weekly/request/page.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { createClient } from "@/lib/supabase/client";
 import { BackButton } from "@/components/ui/shared/BackButton";
+import { THEME_LABELS_REQUEST } from "@homegohan/shared";
 
 // ステップ定義
 const STEPS = [
@@ -357,7 +358,7 @@ export default function MenuRequestWizard() {
                 <div>
                   <Label>Theme</Label>
                   <div className="grid grid-cols-2 gap-3 mt-2">
-                    {["💰 Saving", "💪 Muscle", "⚡️ Recovery", "🥗 Diet", "🍱 Bento", "⏱️ Speed"].map(theme => (
+                    {THEME_LABELS_REQUEST.map(theme => (
                       <button
                         key={theme}
                         onClick={() => toggleTheme(theme)}

--- a/src/lib/icon-map.ts
+++ b/src/lib/icon-map.ts
@@ -1,0 +1,19 @@
+/**
+ * アイコンマップ (Lucide React)
+ *
+ * @homegohan/shared の iconKey → Lucide コンポーネントへの解決マップ
+ */
+
+import { Utensils, Leaf, Soup, Wheat, Salad, Cake, HelpCircle } from 'lucide-react';
+
+export const ICON_MAP_LUCIDE = {
+  utensils: Utensils,
+  leaf: Leaf,
+  soup: Soup,
+  wheat: Wheat,
+  salad: Salad,
+  cake: Cake,
+  help: HelpCircle,
+} as const;
+
+export type DishIconKey = keyof typeof ICON_MAP_LUCIDE;


### PR DESCRIPTION
## 概要

WEB と App でそれぞれ別定義だった以下定数群を `@homegohan/shared` に集約 (PR 0-1 に続く第 2 弾)。

- THEME_LABELS_REQUEST / AI_CONDITIONS
- getDishConfig + DishConfig 型 (colorKey/iconKey 抽象キー)
- MEAL_LABELS / MEAL_ORDER / MealType
- MODE_CONFIG (iconKey/colorKey 抽象キー)
- PROGRESS_PHASES (12) / ULTIMATE_PROGRESS_PHASES (15) / SHOPPING_LIST_PHASES (8)

## 変更ファイル

新設:
- `packages/shared/src/theme-labels.ts`
- `packages/shared/src/dish-roles.ts`
- `packages/shared/src/meal-types.ts`
- `packages/shared/src/mode-config.ts`
- `packages/shared/src/progress-phases.ts`
- `src/lib/icon-map.ts` (Lucide マッピング)
- `apps/mobile/src/lib/icon-map.ts` (Ionicons マッピング)

変更:
- `packages/shared/src/index.ts` (re-export 追加)
- `src/app/(main)/menus/weekly/page.tsx` (インライン定数削除 + shared インポート)
- `src/app/(main)/menus/weekly/request/page.tsx` (THEME_LABELS_REQUEST インポート化)
- `apps/mobile/app/menus/weekly/index.tsx` (インライン定数削除 + shared インポート)
- `apps/mobile/app/menus/weekly/request/index.tsx` (テーマ ChipSelector を英語 6 種に切替)

## DoD

- [x] 5 ファイル shared 化完了
- [x] WEB / App 両方からインライン定義が消えている
- [x] tsc エラーなし (WEB: 0 件、App: 既存 Button.tsx 1 件のみで今回と無関係)
- [x] テーマ ChipSelector が App でも 6 ボタン (英語+絵文字) に切り替わっている