### PR TITLE
feat(mobile): completionToggle を API 経由に統一

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -16,7 +16,7 @@ import Svg, { Circle, Line, Polygon, Text as SvgText } from "react-native-svg";
 import { NUTRIENT_DEFINITIONS, type NutrientDefinition, PROGRESS_PHASES, ULTIMATE_PROGRESS_PHASES, MODE_CONFIG as MODE_CONFIG_SHARED, MEAL_ORDER as MEAL_ORDER_SHARED, type PhaseDefinition } from "@homegohan/shared";
 import { Button, Card, EmptyState, LoadingState, PageHeader, StatusBadge } from "../../../src/components/ui";
 import { colors, spacing, radius, shadows } from "../../../src/theme";
-import { getApi } from "../../../src/lib/api";
+import { getApi, getApiBaseUrl } from "../../../src/lib/api";
 import { supabase } from "../../../src/lib/supabase";
 import { useProfile } from "../../../src/providers/ProfileProvider";
 import type { WeekStartDay } from "../../../src/providers/ProfileProvider";
@@ -1062,11 +1062,17 @@ export default function WeeklyMenuPage() {
       }))
     );
     try {
-      const { error: supaErr } = await supabase
-        .from("planned_meals")
-        .update({ is_completed: newCompleted })
-        .eq("id", mealId);
-      if (supaErr) throw supaErr;
+      const base = getApiBaseUrl();
+      const { data: { session } } = await supabase.auth.getSession();
+      const r = await fetch(`${base}/api/meal-plans/meals/${mealId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
+        },
+        body: JSON.stringify({ isCompleted: newCompleted }),
+      });
+      if (!r.ok) throw new Error(`PATCH failed: ${r.status}`);
       await loadData();
     } catch (e: any) {
       // ロールバック


### PR DESCRIPTION
## Summary

- `supabase.from('planned_meals').update` による直接UPDATE を `fetch PATCH /api/meal-plans/meals/:id` に置換
- WEB側 (`handleUpdateMeal`) と同一のAPIエンドポイントを使用し実装を統一
- 楽観的UI更新・失敗時ロールバックロジックは維持

## 変更ファイル

- `apps/mobile/app/menus/weekly/index.tsx`

## Test plan

- [ ] モバイルアプリで週間献立画面を開き、食事の完了チェックをタップ
- [ ] チェックマーク表示が即座に変わること（楽観的更新）
- [ ] `/api/meal-plans/meals/:id` に PATCH リクエストが 200 で返ること
- [ ] ネットワークエラー時にチェック状態が元に戻ること（ロールバック）