### PR TITLE
feat(mobile): お気に入りタブを非表示化しマイページからリンクで到達可能に

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -85,11 +85,7 @@ export default function TabsLayout() {
       />
       <Tabs.Screen
         name="favorites"
-        options={{
-          title: "お気に入り",
-          tabBarIcon: ({ color, size }) => <Ionicons name="heart" size={size} color={color} />,
-          tabBarButtonTestID: "tab-favorites",
-        }}
+        options={{ href: null }}
       />
       <Tabs.Screen
         name="comparison"

--- a/apps/mobile/app/profile/index.tsx
+++ b/apps/mobile/app/profile/index.tsx
@@ -671,6 +671,14 @@ export default function ProfilePage() {
         {/* ── リンクメニュー ── */}
         <View style={{ gap: spacing.sm }}>
           <ListItem
+            testID="profile-favorites-link"
+            title="お気に入りレシピ"
+            subtitle="保存したお気に入りを確認"
+            onPress={() => router.push("/favorites")}
+            left={<View style={[s.menuIcon, { backgroundColor: colors.accentLight }]}><Ionicons name="heart-outline" size={18} color={colors.accent} /></View>}
+            right={<Ionicons name="chevron-forward" size={20} color={colors.textMuted} />}
+          />
+          <ListItem
             title="栄養目標"
             subtitle="目標値の確認・再計算"
             onPress={() => router.push("/profile/nutrition-targets")}

--- a/apps/mobile/maestro/flows/favorites/01-search-filter.yaml
+++ b/apps/mobile/maestro/flows/favorites/01-search-filter.yaml
@@ -6,9 +6,15 @@ env:
 # 正常 01: 検索フィルタ
 - runFlow: ../_shared/login.yaml
 
-# お気に入りタブへ移動
+# マイページ経由でお気に入り画面へ移動
 - tapOn:
-    id: "tab-favorites"
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 10000
+- tapOn:
+    id: "profile-favorites-link"
 - extendedWaitUntil:
     visible:
       id: "favorites-screen"

--- a/apps/mobile/maestro/flows/favorites/02-sort-name-old.yaml
+++ b/apps/mobile/maestro/flows/favorites/02-sort-name-old.yaml
@@ -6,9 +6,15 @@ env:
 # 正常 02: ソート切替 (名前順/古い順)
 - runFlow: ../_shared/login.yaml
 
-# お気に入りタブへ移動
+# マイページ経由でお気に入り画面へ移動
 - tapOn:
-    id: "tab-favorites"
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 10000
+- tapOn:
+    id: "profile-favorites-link"
 - extendedWaitUntil:
     visible:
       id: "favorites-screen"

--- a/apps/mobile/maestro/flows/favorites/03-unheart-confirm-cancel.yaml
+++ b/apps/mobile/maestro/flows/favorites/03-unheart-confirm-cancel.yaml
@@ -7,9 +7,15 @@ env:
 # NOTE: confirm ダイアログ未実装 (直接削除+Alert)、favorites-remove-${id} は動的 testID のため省略
 - runFlow: ../_shared/login.yaml
 
-# お気に入りタブへ移動
+# マイページ経由でお気に入り画面へ移動
 - tapOn:
-    id: "tab-favorites"
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 10000
+- tapOn:
+    id: "profile-favorites-link"
 - extendedWaitUntil:
     visible:
       id: "favorites-screen"

--- a/apps/mobile/maestro/flows/favorites/04-validation-search-empty.yaml
+++ b/apps/mobile/maestro/flows/favorites/04-validation-search-empty.yaml
@@ -6,9 +6,15 @@ env:
 # バリデーション 04: 検索空 → 全件表示
 - runFlow: ../_shared/login.yaml
 
-# お気に入りタブへ移動
+# マイページ経由でお気に入り画面へ移動
 - tapOn:
-    id: "tab-favorites"
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 10000
+- tapOn:
+    id: "profile-favorites-link"
 - extendedWaitUntil:
     visible:
       id: "favorites-screen"

--- a/apps/mobile/maestro/flows/favorites/05-validation-sort-rapid-tap.yaml
+++ b/apps/mobile/maestro/flows/favorites/05-validation-sort-rapid-tap.yaml
@@ -6,9 +6,15 @@ env:
 # バリデーション 05: ソート連打
 - runFlow: ../_shared/login.yaml
 
-# お気に入りタブへ移動
+# マイページ経由でお気に入り画面へ移動
 - tapOn:
-    id: "tab-favorites"
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 10000
+- tapOn:
+    id: "profile-favorites-link"
 - extendedWaitUntil:
     visible:
       id: "favorites-screen"

--- a/apps/mobile/maestro/flows/favorites/06-api-list-fetch-fail.yaml
+++ b/apps/mobile/maestro/flows/favorites/06-api-list-fetch-fail.yaml
@@ -7,9 +7,15 @@ env:
 # NOTE: setAirplaneMode 非対応のため、お気に入り画面の基本表示のみ確認
 - runFlow: ../_shared/login.yaml
 
-# お気に入りタブへ移動
+# マイページ経由でお気に入り画面へ移動
 - tapOn:
-    id: "tab-favorites"
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 10000
+- tapOn:
+    id: "profile-favorites-link"
 - extendedWaitUntil:
     visible:
       id: "favorites-screen"

--- a/apps/mobile/maestro/flows/favorites/07-api-unfavorite-patch-fail.yaml
+++ b/apps/mobile/maestro/flows/favorites/07-api-unfavorite-patch-fail.yaml
@@ -7,9 +7,15 @@ env:
 # NOTE: favorites-remove-${id} は動的 testID のため省略。画面表示確認のみ
 - runFlow: ../_shared/login.yaml
 
-# お気に入りタブへ移動
+# マイページ経由でお気に入り画面へ移動
 - tapOn:
-    id: "tab-favorites"
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 10000
+- tapOn:
+    id: "profile-favorites-link"
 - extendedWaitUntil:
     visible:
       id: "favorites-screen"

--- a/apps/mobile/maestro/flows/favorites/08-adversarial-200-items-scroll.yaml
+++ b/apps/mobile/maestro/flows/favorites/08-adversarial-200-items-scroll.yaml
@@ -6,9 +6,15 @@ env:
 # Adversarial 08: 無限スクロールでクラッシュしない
 - runFlow: ../_shared/login.yaml
 
-# お気に入りタブへ移動
+# マイページ経由でお気に入り画面へ移動
 - tapOn:
-    id: "tab-favorites"
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 10000
+- tapOn:
+    id: "profile-favorites-link"
 - extendedWaitUntil:
     visible:
       id: "favorites-screen"

--- a/apps/mobile/maestro/flows/favorites/09-adversarial-search-xss.yaml
+++ b/apps/mobile/maestro/flows/favorites/09-adversarial-search-xss.yaml
@@ -6,9 +6,15 @@ env:
 # Adversarial 09: 検索 XSS インジェクション
 - runFlow: ../_shared/login.yaml
 
-# お気に入りタブへ移動
+# マイページ経由でお気に入り画面へ移動
 - tapOn:
-    id: "tab-favorites"
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 10000
+- tapOn:
+    id: "profile-favorites-link"
 - extendedWaitUntil:
     visible:
       id: "favorites-screen"

--- a/apps/mobile/maestro/flows/favorites/10-adversarial-duplicate-add-race.yaml
+++ b/apps/mobile/maestro/flows/favorites/10-adversarial-duplicate-add-race.yaml
@@ -7,9 +7,15 @@ env:
 # NOTE: meal-first-item / meal-heart-button 動的 testID のため省略。お気に入り画面表示のみ確認
 - runFlow: ../_shared/login.yaml
 
-# お気に入りタブへ移動
+# マイページ経由でお気に入り画面へ移動
 - tapOn:
-    id: "tab-favorites"
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 10000
+- tapOn:
+    id: "profile-favorites-link"
 - extendedWaitUntil:
     visible:
       id: "favorites-screen"

--- a/apps/mobile/maestro/flows/menus-weekly/04-favorites-via-profile.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/04-favorites-via-profile.yaml
@@ -1,0 +1,29 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_01_EMAIL}
+  E2E_USER_PASSWORD: ${E2E_USER_01_PASSWORD}
+---
+# PR 1-2: タブ削除後のお気に入り到達確認 (マイページ経由)
+- runFlow: ../_shared/login.yaml
+
+# お気に入りタブが非表示であることを確認
+- assertNotVisible:
+    id: "tab-favorites"
+
+# マイページへ移動
+- tapOn:
+    id: "tab-profile"
+- waitForAnimationToEnd
+
+# マイページにお気に入りリンクが表示されることを確認
+- assertVisible:
+    id: "profile-favorites-link"
+
+# お気に入りリンクをタップ
+- tapOn:
+    id: "profile-favorites-link"
+- waitForAnimationToEnd
+
+# お気に入り画面が表示されることを確認
+- assertVisible:
+    text: "お気に入りレシピ"


### PR DESCRIPTION
## Summary

- `(tabs)/_layout.tsx`: favorites タブを `href: null` で非表示化（URL `/favorites` は保持、削除なし）
- `profile/index.tsx`: リンクメニュー先頭に「お気に入りレシピ」リンクを追加（`testID: profile-favorites-link`）
- `maestro/flows/favorites/` (01〜10): ナビゲーションを `tab-favorites` 直接アクセスからマイページ経由（`tab-profile` → `profile-favorites-link`）に変更
- `maestro/flows/menus-weekly/04-favorites-via-profile.yaml`: タブ削除確認 + マイページ経由アクセス確認の新規 flow を追加

## Test plan

- [ ] App タブバーが 5 可視タブに（ホーム / 献立 / FAB / 比較 / マイページ）
- [ ] `/favorites` URL は `profile-favorites-link` 経由で到達可能
- [ ] `testID: profile-favorites-link` が profile 画面に表示される
- [ ] 新規 Maestro flow `04-favorites-via-profile.yaml` が PASS
- [ ] 既存 favorites Maestro flow (01〜10) がマイページ経由で PASS
- [ ] tsc: 変更ファイルにエラーなし