### PR TITLE
feat(mobile): 役割バッジ (RoleBadge) を MealCard に追加

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -15,6 +15,7 @@ import Svg, { Circle, Line, Polygon, Text as SvgText } from "react-native-svg";
 
 import { NUTRIENT_DEFINITIONS, type NutrientDefinition, PROGRESS_PHASES, ULTIMATE_PROGRESS_PHASES, MODE_CONFIG as MODE_CONFIG_SHARED, MEAL_ORDER as MEAL_ORDER_SHARED, type PhaseDefinition } from "@homegohan/shared";
 import { Button, Card, EmptyState, LoadingState, PageHeader, StatusBadge } from "../../../src/components/ui";
+import { RoleBadge } from "../../../src/components/menu/RoleBadge";
 import { colors, spacing, radius, shadows } from "../../../src/theme";
 import { getApi } from "../../../src/lib/api";
 import { supabase } from "../../../src/lib/supabase";
@@ -26,6 +27,7 @@ type PlannedMealRow = {
   meal_type: string;
   dish_name: string;
   mode: string | null;
+  role: string | null;
   calories_kcal: number | null;
   is_completed: boolean | null;
   is_generating: boolean | null;
@@ -1479,6 +1481,7 @@ export default function WeeklyMenuPage() {
                       <Text testID={`weekly-meal-dish-name-${m.id}`} style={{ fontSize: 15, fontWeight: "700", color: colors.text }} numberOfLines={1}>
                         {isGenerating ? "生成中..." : m.dish_name || "（未設定）"}
                       </Text>
+                      {m.role ? <RoleBadge role={m.role} /> : null}
                       <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
                         <Text style={{ fontSize: 12, color: colors.textMuted }}>{mealCfg.label}</Text>
                         <View

--- a/apps/mobile/maestro/flows/menus-weekly/05-role-badge-visible.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/05-role-badge-visible.yaml
@@ -1,0 +1,8 @@
+appId: com.homegohan.app
+---
+- launchApp
+- tapOn: { text: "ほめゴハン" }
+- waitForAnimationToEnd
+- tapOn: { id: "tab-menus" }
+- waitForAnimationToEnd
+- assertVisible: { id: "role-badge" }

--- a/apps/mobile/src/components/menu/RoleBadge.tsx
+++ b/apps/mobile/src/components/menu/RoleBadge.tsx
@@ -1,0 +1,43 @@
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { getDishConfig } from '@homegohan/shared';
+import { ICON_MAP_IONICONS } from '../../lib/icon-map';
+import { colors } from '../../theme/colors';
+import { typography } from '../../theme/typography';
+
+interface Props {
+  role: string;
+}
+
+export const RoleBadge: React.FC<Props> = ({ role }) => {
+  if (!role) return null;
+  const cfg = getDishConfig(role);
+  const color = colors[cfg.colorKey as keyof typeof colors] as string;
+  const iconName = ICON_MAP_IONICONS[cfg.iconKey] ?? 'help-circle-outline';
+
+  return (
+    <View testID="role-badge" style={[styles.container, { backgroundColor: color + '22' }]}>
+      <Ionicons name={iconName as any} size={10} color={color} />
+      <Text style={[styles.label, { color }]}>{cfg.label}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 9999,
+    alignSelf: 'flex-start',
+  },
+  label: {
+    ...(typography.caption as object),
+    fontSize: 10,
+    fontWeight: '700',
+  },
+});


### PR DESCRIPTION
## Summary

- `apps/mobile/src/components/menu/RoleBadge.tsx` を新設。`getDishConfig` (@homegohan/shared) で各 dish role の colorKey / iconKey を解決し、Ionicons アイコンと日本語ラベルをピル形状で表示する。testID `role-badge` 付き。
- `apps/mobile/app/menus/weekly/index.tsx` の `PlannedMealRow` 型に `role: string | null` を追加し、MealCard 内 dish 名の直下に `{m.role ? <RoleBadge role={m.role} /> : null}` を挿入。
- Maestro テスト `05-role-badge-visible.yaml` を新設。tab-menus 遷移後に `role-badge` の表示を assertVisible で検証。

## 色分け

| role | color |
|------|-------|
| 主菜 | accent #FF8A65 |
| 副菜 / サラダ | success #4CAF50 |
| 汁物 | blue #2196F3 |
| ご飯 | warning #FF9800 |
| デザート | purple #7C4DFF |

## Test plan

- [ ] Maestro `05-role-badge-visible.yaml` が PASS
- [ ] seed データの各 dish に role バッジが表示される
- [ ] role ごとに色が設計書と一致する