### PR TITLE
feat(mobile): ウィークリーヘッダーにアイコン3個+バッジ追加 (PR 2-2)

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -14,7 +14,8 @@ import {
 import Svg, { Circle, Line, Polygon, Text as SvgText } from "react-native-svg";
 
 import { NUTRIENT_DEFINITIONS, type NutrientDefinition, PROGRESS_PHASES, ULTIMATE_PROGRESS_PHASES, MODE_CONFIG as MODE_CONFIG_SHARED, MEAL_ORDER as MEAL_ORDER_SHARED, type PhaseDefinition } from "@homegohan/shared";
-import { Button, Card, EmptyState, LoadingState, PageHeader, StatusBadge } from "../../../src/components/ui";
+import { Button, Card, EmptyState, LoadingState, StatusBadge } from "../../../src/components/ui";
+import { WeeklyHeader } from "../../../src/components/menu/WeeklyHeader";
 import { colors, spacing, radius, shadows } from "../../../src/theme";
 import { getApi } from "../../../src/lib/api";
 import { supabase } from "../../../src/lib/supabase";
@@ -710,6 +711,9 @@ export default function WeeklyMenuPage() {
   const [calendarMealDates, setCalendarMealDates] = useState<Set<string>>(new Set());
   const fetchedRangesRef = useRef<Set<string>>(new Set());
 
+  // Modal state (将来用 — Phase 5/6 で各モーダルを open する)
+  const [activeModal, setActiveModal] = useState<'stats' | 'fridge' | 'shopping' | null>(null);
+
   useEffect(() => {
     const fetchRadarProfile = async () => {
       try {
@@ -1124,6 +1128,21 @@ export default function WeeklyMenuPage() {
     return map;
   }, [days, calendarMealDates]);
 
+  // WeeklyHeader 用の集計値
+  const weeklyStats = useMemo(() => {
+    const allMeals = days.flatMap(d => d.planned_meals);
+    const totalMeals = allMeals.length;
+    if (totalMeals === 0) return { cookRate: 0, avgKcal: 0 };
+    const cookMeals = allMeals.filter(m => m.mode === 'cook' || m.mode === null).length;
+    const cookRate = Math.round((cookMeals / totalMeals) * 100);
+    const totalKcal = allMeals.reduce((s, m) => s + (m.calories_kcal ?? 0), 0);
+    const daysWithMeals = days.filter(d => d.planned_meals.length > 0).length;
+    const avgKcal = daysWithMeals > 0 ? Math.round(totalKcal / daysWithMeals) : 0;
+    return { cookRate, avgKcal };
+  }, [days]);
+
+  const weekRangeLabel = `${weekStartStr.slice(5)} - ${weekEndStr.slice(5)}`;
+
   function handleCalendarDateClick(day: Date) {
     const newWeekStart = getWeekStart(day, weekStartDay);
     const newWeekStartStr = formatLocalDate(newWeekStart);
@@ -1136,7 +1155,24 @@ export default function WeeklyMenuPage() {
 
   return (
     <View testID="weekly-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
-      <PageHeader title="週間献立" />
+      <WeeklyHeader
+        weekRangeLabel={weekRangeLabel}
+        weeklyStats={weeklyStats}
+        expiringCount={0}
+        uncheckedShoppingCount={0}
+        onPressStats={() => {
+          console.log('stats modal placeholder');
+          setActiveModal('stats');
+        }}
+        onPressFridge={() => {
+          console.log('fridge modal placeholder');
+          setActiveModal('fridge');
+        }}
+        onPressShopping={() => {
+          console.log('shopping modal placeholder');
+          setActiveModal('shopping');
+        }}
+      />
       <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
       {/* ヘッダー: 週ナビゲーション */}
       <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>

--- a/apps/mobile/maestro/flows/menus-weekly/06-header-icons.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/06-header-icons.yaml
@@ -1,0 +1,13 @@
+appId: com.homegohan.app
+env:
+  E2E_USER_EMAIL: ${E2E_USER_01_EMAIL}
+  E2E_USER_PASSWORD: ${E2E_USER_01_PASSWORD}
+---
+- launchApp
+- tapOn: { text: "ほめゴハン" }
+- waitForAnimationToEnd
+- tapOn: { id: "tab-menus" }
+- waitForAnimationToEnd
+- assertVisible: { id: "header-stats-btn" }
+- assertVisible: { id: "header-fridge-btn" }
+- assertVisible: { id: "header-shopping-btn" }

--- a/apps/mobile/src/components/menu/WeeklyHeader.tsx
+++ b/apps/mobile/src/components/menu/WeeklyHeader.tsx
@@ -1,0 +1,141 @@
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { colors } from '../../theme/colors';
+import { spacing } from '../../theme/spacing';
+import { typography } from '../../theme/typography';
+
+interface Props {
+  weekRangeLabel: string;
+  weeklyStats: {
+    cookRate: number;
+    avgKcal: number;
+  };
+  expiringCount: number;
+  uncheckedShoppingCount: number;
+  onPressStats: () => void;
+  onPressFridge: () => void;
+  onPressShopping: () => void;
+}
+
+export const WeeklyHeader: React.FC<Props> = ({
+  weekRangeLabel,
+  weeklyStats,
+  expiringCount,
+  uncheckedShoppingCount,
+  onPressStats,
+  onPressFridge,
+  onPressShopping,
+}) => {
+  const fridgeDanger = expiringCount > 0;
+
+  return (
+    <View style={styles.header}>
+      <View style={styles.titleRow}>
+        <Text style={styles.title}>献立表</Text>
+        <Text style={styles.weekLabel}>{weekRangeLabel}</Text>
+      </View>
+      <View style={styles.statsRow}>
+        <Text style={styles.statItem}>自炊率 {weeklyStats.cookRate}%</Text>
+        <Text style={styles.statItem}>平均 {weeklyStats.avgKcal} kcal</Text>
+      </View>
+      <View style={styles.actions}>
+        <Pressable testID="header-stats-btn" onPress={onPressStats} style={styles.iconBtn}>
+          <Ionicons name="bar-chart" size={20} color={colors.text} />
+        </Pressable>
+        <Pressable
+          testID="header-fridge-btn"
+          onPress={onPressFridge}
+          style={[styles.iconBtn, fridgeDanger && styles.iconBtnDanger]}
+        >
+          <Ionicons name="snow" size={20} color={fridgeDanger ? colors.error : colors.text} />
+          {expiringCount > 0 && (
+            <View style={styles.badge}>
+              <Text style={styles.badgeText}>{expiringCount}</Text>
+            </View>
+          )}
+        </Pressable>
+        <Pressable testID="header-shopping-btn" onPress={onPressShopping} style={styles.iconBtn}>
+          <Ionicons name="cart" size={20} color={colors.text} />
+          {uncheckedShoppingCount > 0 && (
+            <View style={styles.badge}>
+              <Text style={styles.badgeText}>{uncheckedShoppingCount}</Text>
+            </View>
+          )}
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    backgroundColor: colors.bg,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: spacing.sm,
+  },
+  title: {
+    ...typography.h2,
+    color: colors.text,
+  },
+  weekLabel: {
+    ...typography.body,
+    color: colors.textMuted,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    gap: spacing.lg,
+    marginTop: spacing.xs,
+  },
+  statItem: {
+    ...typography.bodySmall,
+    color: colors.textLight,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  iconBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    backgroundColor: colors.card,
+    justifyContent: 'center',
+    alignItems: 'center',
+    position: 'relative',
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  iconBtnDanger: {
+    backgroundColor: colors.errorLight,
+    borderColor: colors.error,
+  },
+  badge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    minWidth: 18,
+    height: 18,
+    borderRadius: 9,
+    paddingHorizontal: 4,
+    backgroundColor: colors.accent,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  badgeText: {
+    ...typography.caption,
+    color: '#FFF',
+    fontSize: 10,
+    fontWeight: '700',
+  },
+});


### PR DESCRIPTION
## Summary

- `apps/mobile/src/components/menu/WeeklyHeader.tsx` を新設。WEB ヘッダーと同等の bar-chart / snow / cart アイコンボタン + バッジ表示を実装
- `apps/mobile/app/menus/weekly/index.tsx` の `PageHeader` を `WeeklyHeader` に置換し、`activeModal` state を追加 (将来の Phase 5/6 モーダル統合用)
- 各アイコン onPress は本 PR では `console.log` プレースホルダー (モーダル本体は別 PR)
- testID 3 個: `header-stats-btn` / `header-fridge-btn` / `header-shopping-btn`
- Maestro flow `06-header-icons.yaml` を追加

## Test plan

- [ ] `assertVisible: { id: "header-stats-btn" }` PASS
- [ ] `assertVisible: { id: "header-fridge-btn" }` PASS
- [ ] `assertVisible: { id: "header-shopping-btn" }` PASS
- [ ] fridge danger スタイル (expiringCount > 0 の時、赤背景・赤アイコン)
- [ ] badge 数字表示 (uncheckedShoppingCount > 0 の時に数字付きバッジ)