### PR TITLE
feat(mobile): Realtime sub ヘルパー新設 (weekly_menu_requests + ai_nutrition_feedback)

### DIFF
--- a/apps/mobile/src/lib/realtime.ts
+++ b/apps/mobile/src/lib/realtime.ts
@@ -1,0 +1,122 @@
+import { supabase } from './supabase';
+
+/**
+ * weekly_menu_requests の UPDATE を購読する。
+ * Realtime 接続が切れた場合に備え、5 秒ポーリング fallback も併用する。
+ *
+ * @param requestId  購読対象の weekly_menu_requests.id
+ * @param onUpdate   行が UPDATE されるたびに呼ばれるコールバック (payload.new を渡す)
+ * @returns          クリーンアップ関数 (unsubscribe + ポーリング停止)
+ */
+export function subscribeWeeklyMenuRequest(
+  requestId: string,
+  onUpdate: (row: any) => void,
+): () => void {
+  // --- Realtime subscription ---
+  const channel = supabase
+    .channel(`v4-${requestId}`)
+    .on(
+      'postgres_changes',
+      {
+        event: 'UPDATE',
+        schema: 'public',
+        table: 'weekly_menu_requests',
+        filter: `id=eq.${requestId}`,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (payload: any) => onUpdate(payload.new),
+    )
+    .subscribe();
+
+  // --- 5 秒ポーリング fallback ---
+  const pollInterval = setInterval(() => {
+    supabase
+      .from('weekly_menu_requests')
+      .select('*')
+      .eq('id', requestId)
+      .single()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .then(({ data, error }: { data: any; error: any }) => {
+        if (!error && data) {
+          onUpdate(data);
+        }
+      })
+      .catch(() => {
+        // ポーリングエラーは無視 (Realtime 側が主系)
+      });
+  }, 5000);
+
+  return () => {
+    supabase.removeChannel(channel);
+    clearInterval(pollInterval);
+  };
+}
+
+/**
+ * ai_nutrition_feedback の INSERT を購読する。
+ * 5 秒ポーリング fallback も併用する。
+ *
+ * @param userId    購読対象の user_id
+ * @param onInsert  行が INSERT されるたびに呼ばれるコールバック (payload.new を渡す)
+ * @returns         クリーンアップ関数 (unsubscribe + ポーリング停止)
+ */
+export function subscribeNutritionFeedback(
+  userId: string,
+  onInsert: (row: any) => void,
+): () => void {
+  // --- Realtime subscription ---
+  const channel = supabase
+    .channel(`nutrition-${userId}`)
+    .on(
+      'postgres_changes',
+      {
+        event: 'INSERT',
+        schema: 'public',
+        table: 'ai_nutrition_feedback',
+        filter: `user_id=eq.${userId}`,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (payload: any) => onInsert(payload.new),
+    )
+    .subscribe();
+
+  // 最後に確認した行数を記録してポーリング差分を検出
+  let lastKnownCount = 0;
+  let initialized = false;
+
+  // --- 5 秒ポーリング fallback ---
+  const pollInterval = setInterval(() => {
+    supabase
+      .from('ai_nutrition_feedback')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .then(({ data, error }: { data: any[] | null; error: any }) => {
+        if (!error && data && data.length > 0) {
+          if (!initialized) {
+            // 初回ポーリングはベースラインを記録するだけでコールバックを呼ばない
+            lastKnownCount = data.length;
+            initialized = true;
+            return;
+          }
+          // 新規行が検出された場合のみコールバックを呼ぶ
+          if (data.length > lastKnownCount) {
+            lastKnownCount = data.length;
+            onInsert(data[0]);
+          }
+        } else if (!initialized) {
+          initialized = true;
+        }
+      })
+      .catch(() => {
+        // ポーリングエラーは無視 (Realtime 側が主系)
+      });
+  }, 5000);
+
+  return () => {
+    supabase.removeChannel(channel);
+    clearInterval(pollInterval);
+  };
+}


### PR DESCRIPTION
## Summary

- `apps/mobile/src/lib/realtime.ts` を新設し、Supabase Realtime 購読ヘルパーを実装
- `subscribeWeeklyMenuRequest(requestId, onUpdate)`: `weekly_menu_requests` テーブルの UPDATE を購読。5 秒ポーリング fallback を併用
- `subscribeNutritionFeedback(userId, onInsert)`: `ai_nutrition_feedback` テーブルの INSERT を購読。5 秒ポーリング fallback を併用
- 両関数ともクリーンアップ関数を返却し、`useEffect` の return で安全にアンサブスクライブ可能
- 本 PR はヘルパー新設のみ。PR 4-1 (V4 hook 移植) と PR 6-2 (NutritionDetailModal) で利用

## Test plan

- [ ] PR 4-1 の V4 hook で `subscribeWeeklyMenuRequest` を利用し、メニュー生成の進捗がリアルタイムで反映されることを確認
- [ ] PR 6-2 の NutritionDetailModal で `subscribeNutritionFeedback` を利用し、フィードバックが即時表示されることを確認
- [ ] Realtime が切れた状態でも 5 秒ポーリング fallback により状態が更新されることをスポット確認