### PR TITLE
feat: App の analyze-fridge を Supabase Storage URL 方式に統一

### DIFF
--- a/apps/mobile/app/menus/weekly/request/index.tsx
+++ b/apps/mobile/app/menus/weekly/request/index.tsx
@@ -6,6 +6,7 @@ import { Alert, Image, Pressable, ScrollView, Text, View } from "react-native";
 
 import { Button, Card, ChipSelector, Input, PageHeader, SectionHeader } from "../../../../src/components/ui";
 import { getApi } from "../../../../src/lib/api";
+import { uploadFridgePhoto } from "../../../../src/lib/storage";
 import { colors, radius, spacing } from "../../../../src/theme";
 import { useProfile } from "../../../../src/providers/ProfileProvider";
 import type { WeekStartDay } from "../../../../src/providers/ProfileProvider";
@@ -55,6 +56,7 @@ export default function WeeklyRequestPage() {
 
   const [ingredients, setIngredients] = useState<string[]>([]);
   const [fridgeImageUri, setFridgeImageUri] = useState<string | null>(null);
+  const [inventoryImageUrl, setInventoryImageUrl] = useState<string | null>(null);
   const [fridgeSummary, setFridgeSummary] = useState<string | null>(null);
   const [fridgeSuggestions, setFridgeSuggestions] = useState<string[]>([]);
 
@@ -83,13 +85,12 @@ export default function WeeklyRequestPage() {
 
     const picked = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ["images"] as any,
-      base64: true,
       quality: 0.8,
     });
     if (picked.canceled) return;
 
     const asset = picked.assets?.[0];
-    if (!asset?.base64) {
+    if (!asset?.uri) {
       Alert.alert("失敗", "画像の取得に失敗しました。");
       return;
     }
@@ -99,6 +100,10 @@ export default function WeeklyRequestPage() {
     setFridgeSuggestions([]);
     try {
       setFridgeImageUri(asset.uri ?? null);
+      const userId = profile?.id;
+      if (!userId) throw new Error("ログインが必要です");
+      const uploadedUrl = await uploadFridgePhoto(asset.uri, userId);
+      setInventoryImageUrl(uploadedUrl);
       const api = getApi();
       const analyzed = await api.post<{
         ingredients: string[];
@@ -106,8 +111,7 @@ export default function WeeklyRequestPage() {
         summary: string;
         suggestions: string[];
       }>("/api/ai/analyze-fridge", {
-        imageBase64: asset.base64,
-        mimeType: (asset as any).mimeType ?? "image/jpeg",
+        imageUrl: uploadedUrl,
       });
 
       const detected: string[] = Array.isArray((analyzed as any)?.ingredients) ? (analyzed as any).ingredients : [];
@@ -175,7 +179,6 @@ export default function WeeklyRequestPage() {
       } else {
         // 通常モード: WEB 形式 constraints で送信
         // 過渡期: cookingTime は固定値 (PR 3-2 でスライダー追加予定)
-        // 過渡期: inventoryImageUrl は null (PR 8-1 で Supabase Storage URL 化予定)
         await api.post("/api/ai/menu/weekly/request", {
           startDate: weekStartStr,
           constraints: {
@@ -185,7 +188,7 @@ export default function WeeklyRequestPage() {
             familySize: parsedFamilySize,
             cheatDay: parsedCheatDay,
           },
-          inventoryImageUrl: null,
+          inventoryImageUrl: inventoryImageUrl ?? null,
           detectedIngredients: ingredients,
           note: note.trim() || null,
         });

--- a/apps/mobile/app/pantry/index.tsx
+++ b/apps/mobile/app/pantry/index.tsx
@@ -13,6 +13,8 @@ import { PageHeader } from "../../src/components/ui/PageHeader";
 import { SectionHeader } from "../../src/components/ui/SectionHeader";
 
 import { getApi } from "../../src/lib/api";
+import { uploadFridgePhoto } from "../../src/lib/storage";
+import { supabase } from "../../src/lib/supabase";
 import { colors, radius, spacing } from "../../src/theme";
 
 type PantryItem = {
@@ -240,7 +242,6 @@ export default function PantryPage() {
       }
       picked = await ImagePicker.launchCameraAsync({
         mediaTypes: ["images"],
-        base64: true,
         quality: 0.8,
       });
     } else {
@@ -251,14 +252,13 @@ export default function PantryPage() {
       }
       picked = await ImagePicker.launchImageLibraryAsync({
         mediaTypes: ["images"],
-        base64: true,
         quality: 0.8,
       });
     }
 
     if (picked.canceled) return;
     const asset = picked.assets?.[0];
-    if (!asset?.base64) {
+    if (!asset?.uri) {
       Alert.alert("失敗", "画像の取得に失敗しました。");
       return;
     }
@@ -269,6 +269,9 @@ export default function PantryPage() {
     setDetected([]);
     setSuggestions([]);
     try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) throw new Error("ログインが必要です");
+      const imageUrl = await uploadFridgePhoto(asset.uri, user.id);
       const api = getApi();
       const res = await api.post<{
         ingredients: string[];
@@ -276,8 +279,7 @@ export default function PantryPage() {
         summary: string;
         suggestions: string[];
       }>("/api/ai/analyze-fridge", {
-        imageBase64: asset.base64,
-        mimeType: (asset as any).mimeType ?? "image/jpeg",
+        imageUrl,
       });
       setAnalysisSummary(res.summary || null);
       setDetected((res.detailedIngredients ?? []) as any);

--- a/apps/mobile/src/lib/storage.ts
+++ b/apps/mobile/src/lib/storage.ts
@@ -1,0 +1,30 @@
+import { supabase } from './supabase';
+
+/**
+ * 冷蔵庫写真をローカル URI から Supabase Storage にアップロードし、
+ * public URL を返す。
+ *
+ * @param localUri expo-image-picker が返す asset.uri
+ * @param userId   Supabase auth user ID（Storage パスの prefix に使用）
+ * @returns        Supabase Storage の public URL
+ */
+export async function uploadFridgePhoto(localUri: string, userId: string): Promise<string> {
+  const ext = localUri.split('.').pop()?.toLowerCase() || 'jpg';
+  const path = `${userId}/${Date.now()}.${ext}`;
+
+  // fetch で Blob に変換してアップロード
+  const response = await fetch(localUri);
+  const blob = await response.blob();
+
+  const { data, error } = await supabase.storage
+    .from('fridge-images')
+    .upload(path, blob, { contentType: `image/${ext}` });
+
+  if (error) throw error;
+
+  const {
+    data: { publicUrl },
+  } = supabase.storage.from('fridge-images').getPublicUrl(data.path);
+
+  return publicUrl;
+}

--- a/src/app/api/ai/analyze-fridge/route.ts
+++ b/src/app/api/ai/analyze-fridge/route.ts
@@ -27,7 +27,9 @@ export async function POST(request: Request) {
 
   try {
     const body = await request.json();
-    const { imageUrl, imageBase64, mimeType } = body;
+    // inventoryImageUrl は imageUrl の別名として受け付ける (App / WEB 統一)
+    const { imageBase64, mimeType } = body;
+    const imageUrl: string | undefined = body.imageUrl ?? body.inventoryImageUrl;
 
     const images: { base64: string; mimeType: string }[] =
       Array.isArray(body.images) && body.images.length > 0


### PR DESCRIPTION
## Summary

- `apps/mobile/src/lib/storage.ts` を新設。`uploadFridgePhoto(localUri, userId)` ヘルパーが `fridge-images` bucket に upload して public URL を返す
- `apps/mobile/app/pantry/index.tsx`: `imageBase64` 直接送信 → Storage upload + `imageUrl` 送信に変更
- `apps/mobile/app/menus/weekly/request/index.tsx`: 同様に Storage upload へ変更。`submit()` 内の `inventoryImageUrl: null` を実 URL に反映
- `src/app/api/ai/analyze-fridge/route.ts`: `inventoryImageUrl` も `imageUrl` の別名として受け付けるよう拡張（後方互換）

## Notes

- Supabase Storage bucket: `fridge-images`（WEB と同一 bucket を使用）
- base64 取得不要になったため `ImagePicker` の `base64: true` オプションを削除
- `pantry/index.tsx` では `supabase.auth.getUser()` で userId を取得
- `request/index.tsx` では `profile?.id` を userId として使用

## Test plan

- [ ] App 起動 → pantry 画面で写真選択 → Storage に upload → analyze-fridge 呼び出し → 食材チップ表示
- [ ] App 起動 → request 画面で写真選択 → Storage に upload → analyze-fridge 呼び出し → ingredients 反映 → submit 時 inventoryImageUrl が null でなく実 URL になっている
- [ ] tsc PASS（新規エラーなし）