### PR TITLE
feat(mobile): AsyncStorage 永続化ヘルパーと 5 キー定数を新設

### DIFF
--- a/apps/mobile/src/lib/persistence.ts
+++ b/apps/mobile/src/lib/persistence.ts
@@ -1,0 +1,63 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+interface StoredItem<T> {
+  data: T;
+  expiresAt: number;
+}
+
+/**
+ * TTL 付きで AsyncStorage にデータを保存する。
+ *
+ * @param key   ストレージキー
+ * @param data  保存するデータ
+ * @param ttlMs 有効期限（ミリ秒）。Infinity を渡すと永続保存。
+ */
+export async function setItemWithTTL<T>(key: string, data: T, ttlMs: number): Promise<void> {
+  const item: StoredItem<T> = { data, expiresAt: Date.now() + ttlMs };
+  await AsyncStorage.setItem(key, JSON.stringify(item));
+}
+
+/**
+ * TTL 付きで AsyncStorage からデータを取得する。
+ * TTL が切れている場合は自動削除して null を返す。
+ *
+ * @param key ストレージキー
+ * @returns   データ、または null（未存在・TTL 切れ）
+ */
+export async function getItemWithTTL<T>(key: string): Promise<T | null> {
+  const raw = await AsyncStorage.getItem(key);
+  if (!raw) return null;
+  const item: StoredItem<T> = JSON.parse(raw);
+  if (Date.now() > item.expiresAt) {
+    await AsyncStorage.removeItem(key);
+    return null;
+  }
+  return item.data;
+}
+
+/**
+ * AsyncStorage からアイテムを削除する。
+ *
+ * @param key ストレージキー
+ */
+export async function clearItem(key: string): Promise<void> {
+  await AsyncStorage.removeItem(key);
+}
+
+/**
+ * App の永続化キー定義。
+ * WEB の localStorage キーと対応している。
+ *
+ * - weeklyMenuGenerating: 週間献立 AI 生成中フラグ（2 分 TTL）
+ * - singleMealGenerating: 単品 AI 生成中フラグ（2 分 TTL）
+ * - shoppingListRegenerating: 買い物リスト再生成中フラグ（5 分 TTL）
+ * - v4MenuGenerating: V4 献立生成中状態 { requestId, totalSlots, startedAt }（30 分 TTL）
+ * - v4_range_days: V4Modal の期間モード設定（永続）
+ */
+export const PERSISTENCE_KEYS = {
+  weeklyMenuGenerating: { key: 'weeklyMenuGenerating', ttl: 2 * 60 * 1000 },
+  singleMealGenerating: { key: 'singleMealGenerating', ttl: 2 * 60 * 1000 },
+  shoppingListRegenerating: { key: 'shoppingListRegenerating', ttl: 5 * 60 * 1000 },
+  v4MenuGenerating: { key: 'v4MenuGenerating', ttl: 30 * 60 * 1000 },
+  v4_range_days: { key: 'v4_range_days', ttl: Infinity },
+} as const;


### PR DESCRIPTION
## Summary

- `apps/mobile/src/lib/persistence.ts` を新設
- `setItemWithTTL<T>` / `getItemWithTTL<T>` / `clearItem` の TTL 付き AsyncStorage ユーティリティを実装
- `PERSISTENCE_KEYS` 定数で 5 キー（weeklyMenuGenerating / singleMealGenerating / shoppingListRegenerating / v4MenuGenerating / v4_range_days）を定義

## Background

WEB では `useV4MenuGeneration.ts` と `weekly/page.tsx` で localStorage を使って AI 生成状態を永続化している。App ではアプリ再起動時に生成状態が消えるため、AsyncStorage による同等機能を実装。

本 PR ではヘルパー新設のみ。実際の利用（V4 hook の restore / weekly 画面のマウント復元）は後続 PR で実装する。

## Test plan

- [ ] `tsc --noEmit` で persistence.ts に型エラーがないことを確認
- [ ] 後続 PR での統合テスト（AI 生成キックオフ → アプリ kill → 再起動 → ProgressTodoCard 表示継続）

🤖 Generated with [Claude Code](https://claude.com/claude-code)