### PR TITLE
feat(app): AddMealSlotModal — 食事タイプ選択モーダルを新設

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -13,8 +13,9 @@ import {
 } from "react-native";
 import Svg, { Circle, Line, Polygon, Text as SvgText } from "react-native-svg";
 
-import { NUTRIENT_DEFINITIONS, type NutrientDefinition, PROGRESS_PHASES, ULTIMATE_PROGRESS_PHASES, MODE_CONFIG as MODE_CONFIG_SHARED, MEAL_ORDER as MEAL_ORDER_SHARED, type PhaseDefinition } from "@homegohan/shared";
+import { NUTRIENT_DEFINITIONS, type NutrientDefinition, PROGRESS_PHASES, ULTIMATE_PROGRESS_PHASES, MODE_CONFIG as MODE_CONFIG_SHARED, MEAL_ORDER as MEAL_ORDER_SHARED, type PhaseDefinition, type MealType } from "@homegohan/shared";
 import { Button, Card, EmptyState, LoadingState, StatusBadge } from "../../../src/components/ui";
+import { AddMealSlotModal } from "../../../src/components/menu/AddMealSlotModal";
 import { RoleBadge } from "../../../src/components/menu/RoleBadge";
 import { WeeklyHeader } from "../../../src/components/menu/WeeklyHeader";
 import { colors, spacing, radius, shadows } from "../../../src/theme";
@@ -715,6 +716,10 @@ export default function WeeklyMenuPage() {
 
   // Modal state (将来用 — Phase 5/6 で各モーダルを open する)
   const [activeModal, setActiveModal] = useState<'stats' | 'fridge' | 'shopping' | null>(null);
+
+  // AddMealSlotModal state
+  const [addMealSlotVisible, setAddMealSlotVisible] = useState(false);
+  const [addMealSlotDayId, setAddMealSlotDayId] = useState<string>("");
 
   useEffect(() => {
     const fetchRadarProfile = async () => {
@@ -1600,6 +1605,29 @@ export default function WeeklyMenuPage() {
                       </View>
                     );
                   })}
+
+                  {/* +食事タイプ追加ボタン */}
+                  <Pressable
+                    testID="weekly-add-meal-type-btn"
+                    onPress={() => {
+                      setAddMealSlotDayId(selectedDay.id);
+                      setAddMealSlotVisible(true);
+                    }}
+                    style={({ pressed }) => ({
+                      flexDirection: "row",
+                      alignItems: "center",
+                      gap: 4,
+                      paddingVertical: 6,
+                      paddingHorizontal: 10,
+                      borderRadius: radius.sm,
+                      backgroundColor: pressed ? colors.accentLight : colors.card,
+                      borderWidth: 1,
+                      borderColor: colors.accent,
+                    })}
+                  >
+                    <Ionicons name="add" size={14} color={colors.accent} />
+                    <Text style={{ fontSize: 11, color: colors.accent, fontWeight: "600" }}>食事タイプ追加</Text>
+                  </Pressable>
                 </View>
               )}
             </View>
@@ -1612,6 +1640,16 @@ export default function WeeklyMenuPage() {
         </>
       )}
       </ScrollView>
+
+      {/* 食事タイプ選択モーダル */}
+      <AddMealSlotModal
+        visible={addMealSlotVisible}
+        onClose={() => setAddMealSlotVisible(false)}
+        dayId={addMealSlotDayId}
+        onSelect={(_mealType: MealType) => {
+          setAddMealSlotVisible(false);
+        }}
+      />
 
       {/* 栄養分析ボトムシート */}
       <NutritionBottomSheet

--- a/apps/mobile/src/components/menu/AddMealSlotModal.tsx
+++ b/apps/mobile/src/components/menu/AddMealSlotModal.tsx
@@ -1,0 +1,116 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Modal, Pressable, Text, View } from "react-native";
+
+import { MEAL_LABELS, type MealType } from "@homegohan/shared";
+import { colors, radius, shadows, spacing } from "../../theme";
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  onSelect: (mealType: MealType) => void;
+  dayId: string;
+}
+
+const TYPES: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
+
+const MEAL_ICONS: Record<MealType, keyof typeof Ionicons.glyphMap> = {
+  breakfast: "sunny",
+  lunch: "partly-sunny",
+  dinner: "moon",
+  snack: "cafe",
+  midnight_snack: "cloudy-night",
+};
+
+const MEAL_COLORS: Record<MealType, string> = {
+  breakfast: "#FF9800",
+  lunch: "#4CAF50",
+  dinner: "#7C4DFF",
+  snack: "#E91E63",
+  midnight_snack: "#3F51B5",
+};
+
+export function AddMealSlotModal({ visible, onClose, onSelect, dayId: _dayId }: Props) {
+  return (
+    <Modal
+      testID="add-meal-slot-modal"
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+    >
+      <View
+        style={{
+          flex: 1,
+          justifyContent: "flex-end",
+          backgroundColor: "rgba(0,0,0,0.4)",
+        }}
+      >
+        <View
+          style={{
+            backgroundColor: colors.bg,
+            borderTopLeftRadius: radius.xl,
+            borderTopRightRadius: radius.xl,
+            paddingBottom: spacing.xl,
+            ...shadows.lg,
+          }}
+        >
+          {/* ヘッダー */}
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: spacing.lg,
+              borderBottomWidth: 1,
+              borderBottomColor: colors.border,
+            }}
+          >
+            <Text style={{ fontSize: 17, fontWeight: "700", color: colors.text }}>
+              食事タイプを選択
+            </Text>
+            <Pressable onPress={onClose} style={{ padding: 4 }}>
+              <Ionicons name="close" size={22} color={colors.textMuted} />
+            </Pressable>
+          </View>
+
+          {/* 4 ボタン */}
+          <View style={{ padding: spacing.lg, gap: spacing.sm }}>
+            {TYPES.map((t) => (
+              <Pressable
+                key={t}
+                testID={`add-meal-slot-${t}`}
+                onPress={() => onSelect(t)}
+                style={({ pressed }: { pressed: boolean }) => ({
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: spacing.md,
+                  padding: spacing.md,
+                  borderRadius: radius.lg,
+                  backgroundColor: pressed ? colors.card : colors.bg,
+                  borderWidth: 1,
+                  borderColor: colors.border,
+                })}
+              >
+                <View
+                  style={{
+                    width: 40,
+                    height: 40,
+                    borderRadius: radius.md,
+                    backgroundColor: MEAL_COLORS[t],
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Ionicons name={MEAL_ICONS[t]} size={20} color="#fff" />
+                </View>
+                <Text style={{ fontSize: 16, fontWeight: "600", color: colors.text }}>
+                  {MEAL_LABELS[t]}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary

- `apps/mobile/src/components/menu/AddMealSlotModal.tsx` を新設
  - breakfast / lunch / dinner / snack 4 択の食事タイプ選択 UI (WEB の addMealSlot モーダルを App に移植)
  - BottomSheet スタイルのモーダル (animationType=slide, transparent)
  - testID: `add-meal-slot-modal` / `add-meal-slot-breakfast` / `add-meal-slot-lunch` / `add-meal-slot-dinner` / `add-meal-slot-snack`
- `apps/mobile/app/menus/weekly/index.tsx` に「+食事タイプ追加」ボタンを追加
  - testID: `weekly-add-meal-type-btn`
  - 押下で AddMealSlotModal を open
  - `@homegohan/shared` から `MealType` 型をインポート (PR 0-2 merged 前提)

## Test plan

- [ ] `tapOn: { id: "weekly-add-meal-type-btn" }` でモーダルが開く
- [ ] `assertVisible: { id: "add-meal-slot-modal" }` が通る
- [ ] 4 ボタン (`add-meal-slot-breakfast`, `add-meal-slot-lunch`, `add-meal-slot-dinner`, `add-meal-slot-snack`) が表示される
- [ ] 各ボタンタップでモーダルが閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)