### PR TITLE
feat(mobile): V4 条件 pill を独立 ConditionPills component に切り出す

### DIFF
--- a/apps/mobile/src/components/menu/ConditionPills.tsx
+++ b/apps/mobile/src/components/menu/ConditionPills.tsx
@@ -1,0 +1,105 @@
+import { Ionicons } from "@expo/vector-icons";
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { colors, radius, spacing } from "../../theme";
+import type { MenuGenerationConstraints } from "../../../../../types/domain";
+
+// ============================================================
+// Pill definitions
+// ============================================================
+
+const FILTERS: {
+  key: keyof MenuGenerationConstraints;
+  label: string;
+  iconName: keyof typeof Ionicons.glyphMap;
+}[] = [
+  { key: "useFridgeFirst", label: "冷蔵庫優先", iconName: "snow" },
+  { key: "quickMeals", label: "時短中心", iconName: "flash" },
+  { key: "japaneseStyle", label: "和食多め", iconName: "restaurant" },
+  { key: "healthy", label: "ヘルシー", iconName: "heart" },
+] as const;
+
+// ============================================================
+// Props
+// ============================================================
+
+interface Props {
+  values: MenuGenerationConstraints;
+  onChange: (values: MenuGenerationConstraints) => void;
+}
+
+// ============================================================
+// Component
+// ============================================================
+
+export const ConditionPills: React.FC<Props> = ({ values, onChange }) => {
+  return (
+    <View style={styles.row}>
+      {FILTERS.map((f) => {
+        const active = values[f.key];
+        return (
+          <Pressable
+            key={f.key}
+            testID={`v4-condition-${f.key}`}
+            onPress={() => onChange({ ...values, [f.key]: !active })}
+            style={({ pressed }) => [
+              styles.pill,
+              active ? styles.pillActive : styles.pillInactive,
+              pressed && styles.pillPressed,
+            ]}
+          >
+            <Ionicons
+              name={f.iconName}
+              size={14}
+              color={active ? "#FFFFFF" : colors.text}
+            />
+            <Text style={[styles.label, active && styles.labelActive]}>
+              {f.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+};
+
+// ============================================================
+// Styles
+// ============================================================
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+  },
+  pill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.full,
+    borderWidth: 1,
+  },
+  pillInactive: {
+    backgroundColor: "#FFFFFF",
+    borderColor: colors.border,
+  },
+  pillActive: {
+    backgroundColor: colors.accent,
+    borderColor: colors.accent,
+  },
+  pillPressed: {
+    opacity: 0.8,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: colors.text,
+  },
+  labelActive: {
+    color: "#FFFFFF",
+  },
+});

--- a/apps/mobile/src/components/menu/V4GenerateModal.tsx
+++ b/apps/mobile/src/components/menu/V4GenerateModal.tsx
@@ -13,6 +13,8 @@ import {
   View,
 } from "react-native";
 
+import { ConditionPills } from "./ConditionPills";
+
 import type { MenuGenerationConstraints, TargetSlot } from "../../../../../types/domain";
 import {
   buildAiOnlySlots,
@@ -314,10 +316,6 @@ export function V4GenerateModal({
     }
   };
 
-  const toggleConstraint = (key: keyof MenuGenerationConstraints) => {
-    setConstraints((prev: MenuGenerationConstraints) => ({ ...prev, [key]: !prev[key] }));
-  };
-
   const handleClose = () => {
     setSelectedMode(null);
     setIsSubmitting(false);
@@ -378,18 +376,6 @@ export function V4GenerateModal({
       disabled: false,
       testID: "v4-mode-range",
     },
-  ];
-
-  // Constraint options
-  const constraintOptions: {
-    key: keyof MenuGenerationConstraints;
-    iconName: keyof typeof Ionicons.glyphMap;
-    label: string;
-  }[] = [
-    { key: "useFridgeFirst", iconName: "cube-outline", label: "冷蔵庫優先" },
-    { key: "quickMeals", iconName: "flash-outline", label: "時短中心" },
-    { key: "japaneseStyle", iconName: "restaurant-outline", label: "和食多め" },
-    { key: "healthy", iconName: "heart-outline", label: "ヘルシー" },
   ];
 
   return (
@@ -630,47 +616,12 @@ export function V4GenerateModal({
               </View>
             )}
 
-            {/* 条件を指定 (PR 4-2 で詳細実装、仮 UI) */}
+            {/* 条件を指定 */}
             <View style={{ gap: spacing.sm }}>
               <Text style={{ fontSize: 13, fontWeight: "700", color: C.textLight }}>
                 条件を指定
               </Text>
-              <View style={{ flexDirection: "row", flexWrap: "wrap", gap: spacing.sm }}>
-                {constraintOptions.map((opt) => {
-                  const active = !!constraints[opt.key];
-                  return (
-                    <Pressable
-                      key={String(opt.key)}
-                      onPress={() => toggleConstraint(opt.key)}
-                      style={({ pressed }) => ({
-                        flexDirection: "row",
-                        alignItems: "center",
-                        gap: 4,
-                        paddingHorizontal: spacing.md,
-                        paddingVertical: spacing.sm,
-                        borderRadius: radius.full,
-                        backgroundColor: active ? C.accent : C.bg,
-                        opacity: pressed ? 0.8 : 1,
-                      })}
-                    >
-                      <Ionicons
-                        name={opt.iconName}
-                        size={14}
-                        color={active ? "#fff" : C.textLight}
-                      />
-                      <Text
-                        style={{
-                          fontSize: 13,
-                          fontWeight: "700",
-                          color: active ? "#fff" : C.textLight,
-                        }}
-                      >
-                        {opt.label}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </View>
+              <ConditionPills values={constraints} onChange={setConstraints} />
             </View>
 
             {/* 究極モード (PR 4-3 で実装、仮 UI: disabled) */}


### PR DESCRIPTION
## Summary

- `apps/mobile/src/components/menu/ConditionPills.tsx` を新設
- 4 種の条件 pill（冷蔵庫優先 / 時短中心 / 和食多め / ヘルシー）をトグル可能な独立 component として実装
- 選択時: accent 背景 + 白文字 / 非選択時: 白背景 + border + 黒文字
- testID: `v4-condition-{key}` (4 個)
- `V4GenerateModal` 内のインライン仮 UI を `<ConditionPills values={constraints} onChange={setConstraints} />` に置換

## Test plan

- [ ] `v4-condition-useFridgeFirst` タップ → アクセントカラー pill に変化
- [ ] `v4-condition-quickMeals` タップ → アクセントカラー pill に変化
- [ ] `v4-condition-japaneseStyle` タップ → アクセントカラー pill に変化
- [ ] `v4-condition-healthy` タップ → アクセントカラー pill に変化
- [ ] 複数同時選択可能
- [ ] 再タップで非選択に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)