### PR TITLE
feat(mobile): App 既存究極モードを WEB 同様 disabled に揃える

### DIFF
--- a/apps/mobile/app/menus/weekly/request/index.tsx
+++ b/apps/mobile/app/menus/weekly/request/index.tsx
@@ -2,9 +2,10 @@ import { Ionicons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
 import { router } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
-import { Alert, Image, Pressable, ScrollView, Text, View } from "react-native";
+import { Alert, Image, ScrollView, Text, View } from "react-native";
 
 import { Button, Card, ChipSelector, Input, PageHeader, SectionHeader } from "../../../../src/components/ui";
+import { UltimateModeToggle } from "../../../../src/components/menu/UltimateModeToggle";
 import { getApi } from "../../../../src/lib/api";
 import { uploadFridgePhoto } from "../../../../src/lib/storage";
 import { colors, radius, spacing } from "../../../../src/theme";
@@ -12,20 +13,6 @@ import { useProfile } from "../../../../src/providers/ProfileProvider";
 import type { WeekStartDay } from "../../../../src/providers/ProfileProvider";
 import { THEME_LABELS_REQUEST } from "@homegohan/shared";
 
-const MEAL_TYPES = ["breakfast", "lunch", "dinner"] as const;
-
-function buildWeekTargetSlots(weekStartStr: string): { date: string; mealType: string }[] {
-  const slots: { date: string; mealType: string }[] = [];
-  for (let i = 0; i < 7; i++) {
-    const d = new Date(weekStartStr + "T00:00:00");
-    d.setDate(d.getDate() + i);
-    const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-    for (const mealType of MEAL_TYPES) {
-      slots.push({ date: dateStr, mealType });
-    }
-  }
-  return slots;
-}
 
 const formatLocalDate = (date: Date): string => {
   const y = date.getFullYear();
@@ -64,7 +51,6 @@ export default function WeeklyRequestPage() {
     setStartDate(formatLocalDate(getWeekStart(new Date(), weekStartDay)));
   }, [weekStartDay]);
 
-  const [isUltimateMode, setIsUltimateMode] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -146,54 +132,23 @@ export default function WeeklyRequestPage() {
 
       const api = getApi();
 
-      if (isUltimateMode) {
-        // 究極モード: /api/ai/menu/v4/generate に ultimateMode: true で送信
-        const useFridgeFirst = selectedThemes.includes("💰 Saving");
-        const quickMeals = selectedThemes.includes("⏱️ Speed");
-        const japaneseStyle = selectedThemes.includes("🍱 Bento");
-        const healthy = selectedThemes.includes("🥗 Diet");
-        const extraLines: string[] = [];
-        if (selectedThemes.length) extraLines.push(`テーマ: ${selectedThemes.join("、")}`);
-        if (ingredients.length) extraLines.push(`使いたい食材: ${ingredients.join("、")}`);
-        if (parsedCheatDay) extraLines.push(`チートデイ: ${parsedCheatDay}`);
-        const noteForV4 = [note.trim(), ...extraLines].filter(Boolean).join("\n");
-        const targetSlots = buildWeekTargetSlots(weekStartStr);
-        await api.post("/api/ai/menu/v4/generate", {
-          targetSlots,
-          resolveExistingMeals: true,
-          note: noteForV4,
-          ultimateMode: true,
+      // 通常モード: WEB 形式 constraints で送信 (ultimateMode は WEB に揃えて false 固定)
+      // 過渡期: cookingTime は固定値 (PR 3-2 でスライダー追加予定)
+      await api.post("/api/ai/menu/weekly/request", {
+        startDate: weekStartStr,
+        constraints: {
+          ingredients,
+          cookingTime: { weekday: 30, weekend: 60 },
+          themes: webThemes,
           familySize: parsedFamilySize,
-          constraints: {
-            useFridgeFirst,
-            quickMeals,
-            japaneseStyle,
-            healthy,
-            ingredients,
-          },
-        });
-        Alert.alert(
-          "究極モード生成開始",
-          "6ステップの栄養バランス分析で究極の献立を生成します。完了まで数分かかります。"
-        );
-      } else {
-        // 通常モード: WEB 形式 constraints で送信
-        // 過渡期: cookingTime は固定値 (PR 3-2 でスライダー追加予定)
-        await api.post("/api/ai/menu/weekly/request", {
-          startDate: weekStartStr,
-          constraints: {
-            ingredients,
-            cookingTime: { weekday: 30, weekend: 60 },
-            themes: webThemes,
-            familySize: parsedFamilySize,
-            cheatDay: parsedCheatDay,
-          },
-          inventoryImageUrl: inventoryImageUrl ?? null,
-          detectedIngredients: ingredients,
-          note: note.trim() || null,
-        });
-        Alert.alert("生成開始", "週間献立の生成を開始しました。生成中は「生成中...」と表示されます。");
-      }
+          cheatDay: parsedCheatDay,
+        },
+        inventoryImageUrl: inventoryImageUrl ?? null,
+        detectedIngredients: ingredients,
+        note: note.trim() || null,
+        ultimateMode: false,
+      });
+      Alert.alert("生成開始", "週間献立の生成を開始しました。生成中は「生成中...」と表示されます。");
 
       router.replace("/menus/weekly");
     } catch (e: any) {
@@ -326,62 +281,14 @@ export default function WeeklyRequestPage() {
         </View>
       </Card>
 
-      {/* 究極モードトグル */}
-      <Pressable
-        testID="weekly-request-ultimate-toggle"
-        onPress={() => setIsUltimateMode((prev) => !prev)}
-        style={{
-          flexDirection: "row",
-          alignItems: "center",
-          gap: spacing.md,
-          padding: spacing.lg,
-          backgroundColor: isUltimateMode ? "#FFF8E7" : colors.card,
-          borderRadius: radius.lg,
-          borderWidth: 2,
-          borderColor: isUltimateMode ? "#F59E0B" : colors.border,
-        }}
-      >
-        <View
-          style={{
-            width: 44,
-            height: 44,
-            borderRadius: radius.md,
-            backgroundColor: isUltimateMode ? "#F59E0B" : colors.bg,
-            alignItems: "center",
-            justifyContent: "center",
-            borderWidth: isUltimateMode ? 0 : 1,
-            borderColor: colors.border,
-          }}
-        >
-          <Ionicons name="flash" size={22} color={isUltimateMode ? "#fff" : colors.textMuted} />
-        </View>
-        <View style={{ flex: 1, gap: 3 }}>
-          <Text style={{ fontSize: 15, fontWeight: "700", color: isUltimateMode ? "#B45309" : colors.text }}>
-            究極モード (V4 Ultimate)
-          </Text>
-          <Text style={{ fontSize: 12, color: isUltimateMode ? "#92400E" : colors.textMuted }}>
-            6ステップ栄養バランス分析＋改善（生成に数分かかります）
-          </Text>
-        </View>
-        <View
-          style={{
-            width: 26,
-            height: 26,
-            borderRadius: 13,
-            backgroundColor: isUltimateMode ? "#F59E0B" : colors.border,
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          {isUltimateMode && <Ionicons name="checkmark" size={16} color="#fff" />}
-        </View>
-      </Pressable>
+      {/* 究極モードトグル (WEB に揃えて disabled) */}
+      <UltimateModeToggle enabled={false} />
 
       <Button testID="weekly-request-submit-button" onPress={submit} disabled={isSubmitting || isUploading} loading={isSubmitting} size="lg">
         <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
-          <Ionicons name={isUltimateMode ? "flash" : "sparkles"} size={18} color="#FFFFFF" />
+          <Ionicons name="sparkles" size={18} color="#FFFFFF" />
           <Text style={{ color: "#FFFFFF", fontWeight: "700", fontSize: 16 }}>
-            {isSubmitting ? "生成中..." : isUltimateMode ? "究極モードで生成" : "生成する"}
+            {isSubmitting ? "生成中..." : "生成する"}
           </Text>
         </View>
       </Button>


### PR DESCRIPTION
## Summary

- `isUltimateMode` state を削除し、究極モード分岐ロジック (ultimateMode: true で `/api/ai/menu/v4/generate` を叩く処理) を全削除
- 既存の Pressable ベーストグル UI を PR 4-3 で追加した `<UltimateModeToggle enabled={false} />` に置換
- submit body の `ultimateMode` を `false` 固定に統一し、WEB と同じ挙動に揃える
- 不要になった `Pressable` import・`buildWeekTargetSlots` 関数・`MEAL_TYPES` 定数を削除

## 変更ファイル

- `apps/mobile/app/menus/weekly/request/index.tsx`

## Test plan

- [ ] request 画面で究極モードトグルが disabled (グレーアウト) で表示される
- [ ] トグルをタップすると「究極モードは Premium プラン準備中です」Alert が出る
- [ ] 生成ボタンを押すと `ultimateMode: false` で POST される
- [ ] 生成ボタンのラベルが「生成する」固定になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)