### PR TITLE
feat(mobile): AddMealModal を新設し空スロットから食事追加を開けるようにする

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -15,6 +15,7 @@ import Svg, { Circle, Line, Polygon, Text as SvgText } from "react-native-svg";
 
 import { NUTRIENT_DEFINITIONS, type NutrientDefinition, PROGRESS_PHASES, ULTIMATE_PROGRESS_PHASES, MODE_CONFIG as MODE_CONFIG_SHARED, MEAL_ORDER as MEAL_ORDER_SHARED, type PhaseDefinition, type MealType } from "@homegohan/shared";
 import { Button, Card, EmptyState, LoadingState, StatusBadge } from "../../../src/components/ui";
+import { AddMealModal } from "../../../src/components/menu/AddMealModal";
 import { AddMealSlotModal } from "../../../src/components/menu/AddMealSlotModal";
 import { ConfirmDeleteModal } from "../../../src/components/menu/ConfirmDeleteModal";
 import { RoleBadge } from "../../../src/components/menu/RoleBadge";
@@ -774,6 +775,12 @@ export default function WeeklyMenuPage() {
   // AddMealSlotModal state
   const [addMealSlotVisible, setAddMealSlotVisible] = useState(false);
   const [addMealSlotDayId, setAddMealSlotDayId] = useState<string>("");
+
+  // AddMealModal state
+  const [addMealModalVisible, setAddMealModalVisible] = useState(false);
+  const [addMealModalDayId, setAddMealModalDayId] = useState<string>("");
+  const [addMealModalDayDate, setAddMealModalDayDate] = useState<string>("");
+  const [addMealModalMealType, setAddMealModalMealType] = useState<MealType>("dinner");
 
   // RecipeModal state
   const [recipeModalMeal, setRecipeModalMeal] = useState<RecipeModalMeal | null>(null);
@@ -1768,10 +1775,50 @@ export default function WeeklyMenuPage() {
               )}
             </View>
           ) : (
-            <EmptyState
-              icon={<Ionicons name="restaurant-outline" size={40} color={colors.textMuted} />}
-              message="この日の食事がありません"
-            />
+            <View style={{ gap: spacing.sm }}>
+              {MEAL_ORDER.slice(0, 3).map((mealType) => (
+                <Pressable
+                  key={mealType}
+                  testID={`weekly-empty-slot-${selectedDay?.id ?? ""}-${mealType}`}
+                  onPress={() => {
+                    if (!selectedDay) return;
+                    setAddMealModalDayId(selectedDay.id);
+                    setAddMealModalDayDate(selectedDay.day_date);
+                    setAddMealModalMealType(mealType);
+                    setAddMealModalVisible(true);
+                  }}
+                  style={({ pressed }) => ({
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: spacing.md,
+                    padding: spacing.lg,
+                    backgroundColor: pressed ? colors.card : colors.bg,
+                    borderRadius: radius.lg,
+                    borderWidth: 1,
+                    borderColor: colors.border,
+                    borderStyle: "dashed",
+                  })}
+                >
+                  <View
+                    style={{
+                      width: 44,
+                      height: 44,
+                      borderRadius: radius.md,
+                      backgroundColor: MEAL_CONFIG[mealType]?.color ?? colors.textMuted,
+                      alignItems: "center",
+                      justifyContent: "center",
+                      opacity: 0.3,
+                    }}
+                  >
+                    <Ionicons name={MEAL_CONFIG[mealType]?.icon ?? "ellipse"} size={22} color="#fff" />
+                  </View>
+                  <Text style={{ flex: 1, fontSize: 14, color: colors.textMuted }}>
+                    {MEAL_CONFIG[mealType]?.label ?? mealType} を追加
+                  </Text>
+                  <Ionicons name="add-circle-outline" size={20} color={colors.textMuted} />
+                </Pressable>
+              ))}
+            </View>
           )}
         </>
       )}
@@ -1782,9 +1829,23 @@ export default function WeeklyMenuPage() {
         visible={addMealSlotVisible}
         onClose={() => setAddMealSlotVisible(false)}
         dayId={addMealSlotDayId}
-        onSelect={(_mealType: MealType) => {
+        onSelect={(mealType: MealType) => {
           setAddMealSlotVisible(false);
+          setAddMealModalDayId(addMealSlotDayId);
+          setAddMealModalDayDate(selectedDate);
+          setAddMealModalMealType(mealType);
+          setAddMealModalVisible(true);
         }}
+      />
+
+      {/* 食事追加モーダル */}
+      <AddMealModal
+        visible={addMealModalVisible}
+        onClose={() => setAddMealModalVisible(false)}
+        dayId={addMealModalDayId}
+        dayDate={addMealModalDayDate}
+        mealType={addMealModalMealType}
+        onSuccess={() => loadData()}
       />
 
       {/* 削除確認モーダル */}

--- a/apps/mobile/src/components/menu/AddMealModal.tsx
+++ b/apps/mobile/src/components/menu/AddMealModal.tsx
@@ -1,0 +1,396 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  Modal,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import type { MealType } from "@homegohan/shared";
+import { getApi } from "../../lib/api";
+import { colors, radius, shadows, spacing } from "../../theme";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface CatalogProduct {
+  id: string;
+  name: string;
+  brandName: string;
+  categoryCode: string | null;
+  caloriesKcal: number | null;
+  proteinG: number | null;
+  fatG: number | null;
+  carbsG: number | null;
+  priceYen: number | null;
+}
+
+type Mode = "cook" | "buy" | "out" | "quick";
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  /** user_daily_meals.id */
+  dayId: string;
+  /** 対応する日付文字列 YYYY-MM-DD (POST に必要) */
+  dayDate: string;
+  mealType: MealType;
+  onSuccess?: () => void;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const MODE_CONFIG: Record<Mode, { label: string; icon: keyof typeof Ionicons.glyphMap; bg: string; color: string }> = {
+  cook:  { label: "自炊",   icon: "restaurant-outline",  bg: colors.successLight, color: colors.success },
+  quick: { label: "時短",   icon: "flash-outline",       bg: colors.blueLight,    color: colors.blue },
+  buy:   { label: "買う",   icon: "bag-handle-outline",  bg: colors.purpleLight,  color: colors.purple },
+  out:   { label: "外食",   icon: "fork-outline" as any, bg: colors.warningLight, color: colors.warning },
+};
+
+const MODES: Mode[] = ["cook", "quick", "buy", "out"];
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function AddMealModal({ visible, onClose, dayId: _dayId, dayDate, mealType, onSuccess }: Props) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<CatalogProduct[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchError, setSearchError] = useState("");
+  const [selectedProduct, setSelectedProduct] = useState<CatalogProduct | null>(null);
+  const [selectedMode, setSelectedMode] = useState<Mode>("cook");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const cancelledRef = useRef(false);
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (visible) {
+      setQuery("");
+      setResults([]);
+      setIsSearching(false);
+      setSearchError("");
+      setSelectedProduct(null);
+      setSelectedMode("cook");
+      setIsSubmitting(false);
+    }
+  }, [visible]);
+
+  // 250ms debounce catalog search
+  useEffect(() => {
+    const q = query.trim();
+    if (q.length < 2) {
+      setResults([]);
+      setSearchError("");
+      setIsSearching(false);
+      return;
+    }
+    cancelledRef.current = false;
+    const timer = setTimeout(async () => {
+      setIsSearching(true);
+      setSearchError("");
+      try {
+        const api = getApi();
+        const data = await api.get<{ products: CatalogProduct[] }>(
+          `/api/catalog/products?q=${encodeURIComponent(q)}&limit=8`
+        );
+        if (!cancelledRef.current) {
+          setResults(Array.isArray(data.products) ? data.products : []);
+        }
+      } catch (e: any) {
+        if (!cancelledRef.current) {
+          setResults([]);
+          setSearchError(e?.message ?? "商品検索に失敗しました");
+        }
+      } finally {
+        if (!cancelledRef.current) setIsSearching(false);
+      }
+    }, 250);
+    return () => {
+      cancelledRef.current = true;
+      clearTimeout(timer);
+    };
+  }, [query]);
+
+  async function handleSubmit() {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      const api = getApi();
+      await api.post("/api/meal-plans/meals/simple", {
+        dayDate,
+        mealType,
+        mode: selectedMode,
+        dishName: (selectedProduct?.name ?? query.trim()) || "未設定",
+        isSimple: true,
+        catalogProductId: selectedProduct?.id ?? undefined,
+        caloriesKcal: selectedProduct?.caloriesKcal ?? undefined,
+      });
+      onSuccess?.();
+      onClose();
+    } catch (e: any) {
+      Alert.alert("追加失敗", e?.message ?? "食事の追加に失敗しました");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      testID="add-meal-modal"
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+    >
+      <View
+        style={{
+          flex: 1,
+          justifyContent: "flex-end",
+          backgroundColor: "rgba(0,0,0,0.4)",
+        }}
+      >
+        <View
+          style={{
+            backgroundColor: colors.bg,
+            borderTopLeftRadius: radius["2xl"],
+            borderTopRightRadius: radius["2xl"],
+            maxHeight: "85%",
+            paddingBottom: spacing["2xl"],
+            ...shadows.lg,
+          }}
+        >
+          {/* ヘッダー */}
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: spacing.lg,
+              borderBottomWidth: 1,
+              borderBottomColor: colors.border,
+            }}
+          >
+            <Text style={{ fontSize: 17, fontWeight: "700", color: colors.text }}>
+              食事を追加
+            </Text>
+            <Pressable onPress={onClose} hitSlop={8} style={{ padding: 4 }}>
+              <Ionicons name="close" size={22} color={colors.textMuted} />
+            </Pressable>
+          </View>
+
+          <ScrollView
+            style={{ flex: 1 }}
+            contentContainerStyle={{ padding: spacing.lg, gap: spacing.md }}
+            keyboardShouldPersistTaps="handled"
+          >
+            {/* 検索 */}
+            <Text style={{ fontSize: 12, color: colors.textMuted, marginBottom: 4 }}>
+              市販品・外食メニューから選ぶ
+            </Text>
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                backgroundColor: colors.card,
+                borderRadius: radius.lg,
+                borderWidth: 1,
+                borderColor: colors.border,
+                paddingHorizontal: spacing.md,
+                gap: spacing.sm,
+              }}
+            >
+              <Ionicons name="search" size={16} color={colors.textMuted} />
+              <TextInput
+                testID="add-meal-search-input"
+                value={query}
+                onChangeText={(text) => {
+                  setQuery(text);
+                  if (selectedProduct) setSelectedProduct(null);
+                }}
+                placeholder="商品名で検索"
+                placeholderTextColor={colors.textMuted}
+                style={{
+                  flex: 1,
+                  paddingVertical: spacing.md,
+                  fontSize: 14,
+                  color: colors.text,
+                }}
+                autoCorrect={false}
+                autoCapitalize="none"
+              />
+              {isSearching && <ActivityIndicator size="small" color={colors.accent} />}
+            </View>
+
+            {/* 検索状態メッセージ */}
+            {isSearching && (
+              <Text style={{ fontSize: 12, color: colors.textMuted }}>検索中...</Text>
+            )}
+            {searchError ? (
+              <Text style={{ fontSize: 12, color: colors.error }}>{searchError}</Text>
+            ) : null}
+
+            {/* 検索結果リスト */}
+            {results.length > 0 && (
+              <View style={{ gap: spacing.sm }}>
+                {results.map((product, index) => {
+                  const isSelected = selectedProduct?.id === product.id;
+                  return (
+                    <Pressable
+                      key={product.id}
+                      testID={`add-meal-result-${index}`}
+                      onPress={() => setSelectedProduct(isSelected ? null : product)}
+                      style={{
+                        padding: spacing.md,
+                        borderRadius: radius.lg,
+                        backgroundColor: isSelected ? colors.accentLight : colors.card,
+                        borderWidth: 1,
+                        borderColor: isSelected ? colors.accent : colors.border,
+                        flexDirection: "row",
+                        alignItems: "flex-start",
+                        justifyContent: "space-between",
+                        gap: spacing.md,
+                      }}
+                    >
+                      <View style={{ flex: 1 }}>
+                        {product.brandName ? (
+                          <Text style={{ fontSize: 11, color: colors.textMuted, marginBottom: 2 }}>
+                            {product.brandName}
+                          </Text>
+                        ) : null}
+                        <Text style={{ fontSize: 13, fontWeight: "600", color: colors.text }}>
+                          {product.name}
+                        </Text>
+                        {product.categoryCode ? (
+                          <Text style={{ fontSize: 11, color: colors.textLight, marginTop: 2 }}>
+                            {product.categoryCode}
+                            {product.priceYen ? ` / ${product.priceYen}円` : ""}
+                          </Text>
+                        ) : null}
+                      </View>
+                      <View style={{ alignItems: "flex-end" }}>
+                        <Text style={{ fontSize: 11, color: colors.textMuted }}>
+                          {product.caloriesKcal ?? "-"} kcal
+                        </Text>
+                        <Text style={{ fontSize: 10, color: colors.textLight }}>
+                          P {product.proteinG != null ? product.proteinG.toFixed(1) : "-"}g
+                        </Text>
+                        <Text style={{ fontSize: 10, color: colors.textLight }}>
+                          F {product.fatG != null ? product.fatG.toFixed(1) : "-"}g
+                        </Text>
+                        <Text style={{ fontSize: 10, color: colors.textLight }}>
+                          C {product.carbsG != null ? product.carbsG.toFixed(1) : "-"}g
+                        </Text>
+                      </View>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            )}
+
+            {/* 選択済み商品 */}
+            {selectedProduct && (
+              <View
+                style={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: spacing.sm,
+                  paddingVertical: spacing.sm,
+                  paddingHorizontal: spacing.md,
+                  backgroundColor: colors.accentLight,
+                  borderRadius: radius.md,
+                  borderWidth: 1,
+                  borderColor: colors.accent,
+                }}
+              >
+                <Ionicons name="checkmark-circle" size={16} color={colors.accent} />
+                <Text style={{ flex: 1, fontSize: 13, color: colors.text, fontWeight: "600" }}>
+                  {selectedProduct.name}
+                </Text>
+                <Pressable onPress={() => setSelectedProduct(null)} hitSlop={8}>
+                  <Ionicons name="close-circle" size={16} color={colors.textMuted} />
+                </Pressable>
+              </View>
+            )}
+
+            {/* モード選択 */}
+            <Text style={{ fontSize: 13, fontWeight: "600", color: colors.text, marginTop: spacing.sm }}>
+              追加方法
+            </Text>
+            <View style={{ gap: spacing.sm }}>
+              {MODES.map((mode) => {
+                const cfg = MODE_CONFIG[mode];
+                const isActive = selectedMode === mode;
+                return (
+                  <Pressable
+                    key={mode}
+                    testID={`add-meal-mode-${mode}`}
+                    onPress={() => setSelectedMode(mode)}
+                    style={{
+                      flexDirection: "row",
+                      alignItems: "center",
+                      gap: spacing.md,
+                      padding: spacing.md,
+                      borderRadius: radius.lg,
+                      backgroundColor: isActive ? cfg.bg : colors.card,
+                      borderWidth: 1,
+                      borderColor: isActive ? cfg.color : colors.border,
+                    }}
+                  >
+                    <Ionicons name={cfg.icon} size={20} color={cfg.color} />
+                    <Text style={{ fontSize: 14, fontWeight: isActive ? "700" : "500", color: colors.text }}>
+                      {cfg.label}で追加
+                    </Text>
+                    {isActive && (
+                      <View style={{ marginLeft: "auto" }}>
+                        <Ionicons name="checkmark-circle" size={18} color={cfg.color} />
+                      </View>
+                    )}
+                  </Pressable>
+                );
+              })}
+            </View>
+          </ScrollView>
+
+          {/* 追加ボタン */}
+          <View
+            style={{
+              paddingHorizontal: spacing.lg,
+              paddingTop: spacing.md,
+              borderTopWidth: 1,
+              borderTopColor: colors.border,
+            }}
+          >
+            <Pressable
+              testID="add-meal-submit-btn"
+              onPress={handleSubmit}
+              disabled={isSubmitting}
+              style={({ pressed }) => ({
+                alignItems: "center",
+                justifyContent: "center",
+                paddingVertical: spacing.md,
+                borderRadius: radius.lg,
+                backgroundColor: isSubmitting ? colors.textMuted : colors.accent,
+                opacity: pressed || isSubmitting ? 0.8 : 1,
+                flexDirection: "row",
+                gap: spacing.sm,
+              })}
+            >
+              {isSubmitting ? (
+                <ActivityIndicator size="small" color="#fff" />
+              ) : (
+                <Ionicons name="add-circle-outline" size={18} color="#fff" />
+              )}
+              <Text style={{ fontSize: 15, fontWeight: "700", color: "#fff" }}>
+                {isSubmitting ? "追加中..." : "追加"}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary

- `apps/mobile/src/components/menu/AddMealModal.tsx` を新設
  - カタログ検索 (250ms debounce) — `GET /api/catalog/products?q=...&limit=8`
  - モードボタン: 自炊 / 時短 / 買う / 外食
  - `POST /api/meal-plans/meals/simple` で食事登録・成功後に一覧リロード
  - testID: `add-meal-modal` / `add-meal-search-input` / `add-meal-result-{index}` / `add-meal-mode-{cook|buy|out|quick}` / `add-meal-submit-btn`
- `apps/mobile/app/menus/weekly/index.tsx` を更新
  - `AddMealSlotModal` の `onSelect` から `AddMealModal` を連鎖表示
  - 食事 0 件の日に空スロット行 (朝食/昼食/夕食) を表示、クリックで直接モーダル起動
  - testID: `weekly-empty-slot-{dayId}-{mealType}`

## Test plan

- [ ] 空スロット `weekly-empty-slot-{dayId}-breakfast` をタップ → `add-meal-modal` が表示される
- [ ] 検索欄に 2 文字以上入力 → 250ms 後にカタログ結果が表示される
- [ ] 結果行 `add-meal-result-0` をタップ → 選択ハイライト表示
- [ ] `add-meal-mode-cook` / `buy` / `out` / `quick` を切り替え可能
- [ ] `add-meal-submit-btn` タップ → 追加されてモーダルが閉じ一覧が更新される
- [ ] `AddMealSlotModal` で食事タイプ選択後も `AddMealModal` が連鎖表示される
- [ ] tsc エラーなし（実装ファイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)