### PR TITLE
feat(mobile): NutritionDetailModal — 26 栄養素詳細 + AI feedback + DriBar/RadarChart

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -22,6 +22,7 @@ import { RecipeModal, type RecipeModalMeal } from "../../../src/components/menu/
 import { ServingsModal } from "../../../src/components/menu/ServingsModal";
 import { WeeklyHeader } from "../../../src/components/menu/WeeklyHeader";
 import { V4GenerateModal } from "../../../src/components/menu/V4GenerateModal";
+import { NutritionDetailModal } from "../../../src/components/menu/NutritionDetailModal";
 import { useV4MenuGeneration } from "../../../src/hooks/useV4MenuGeneration";
 import { colors, spacing, radius, shadows } from "../../../src/theme";
 import { getApi, getApiBaseUrl } from "../../../src/lib/api";
@@ -1800,7 +1801,7 @@ export default function WeeklyMenuPage() {
         }}
       />
 
-      {/* 栄養分析ボトムシート */}
+      {/* 栄養分析ボトムシート (旧) */}
       <NutritionBottomSheet
         visible={nutritionSheetDay !== null}
         onClose={() => setNutritionSheetDay(null)}
@@ -1809,6 +1810,27 @@ export default function WeeklyMenuPage() {
         radarKeys={radarChartNutrients}
         weekDays={days}
       />
+
+      {/* 栄養分析詳細モーダル (PR 6-2: 26 栄養素 + AI フィードバック) */}
+      {nutritionSheetDay && (
+        <NutritionDetailModal
+          visible={nutritionSheetDay !== null}
+          onClose={() => setNutritionSheetDay(null)}
+          date={nutritionSheetDay.day_date}
+          dateLabel={nutritionSheetLabel}
+          totals={calcDayTotals(nutritionSheetDay.planned_meals)}
+          mealCount={nutritionSheetDay.planned_meals.filter((m) => m.dish_name).length}
+          radarKeys={radarChartNutrients as string[]}
+          onRadarKeysSaved={(keys) => setRadarChartNutrients(keys as (keyof DayNutritionTotals)[])}
+          weekDays={days.map((d) => ({
+            date: d.day_date,
+            meals: d.planned_meals.map((m) => ({
+              title: m.dish_name,
+              calories: m.calories_kcal,
+            })),
+          }))}
+        />
+      )}
 
       {/* フローティング AI アシスタントボタン */}
       <Pressable

--- a/apps/mobile/src/components/menu/DriBar.tsx
+++ b/apps/mobile/src/components/menu/DriBar.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import {
+  NUTRIENT_DEFINITIONS,
+  type NutrientDefinition,
+} from '@homegohan/shared';
+
+import { colors } from '../../theme/colors';
+import { radius, spacing } from '../../theme/spacing';
+
+// ============================================================
+// helpers
+// ============================================================
+
+function getDriPercent(key: string, value: number): number {
+  const def = NUTRIENT_DEFINITIONS.find((d) => d.key === key);
+  if (!def || def.dri === 0) return 0;
+  return Math.round((value / def.dri) * 100);
+}
+
+function getBarColor(pct: number): string {
+  if (pct > 150) return colors.error;
+  if (pct >= 80 && pct <= 120) return colors.success;
+  if (pct < 50) return colors.warning;
+  return colors.accent;
+}
+
+// ============================================================
+// DriBar
+// ============================================================
+
+interface DriBarProps {
+  def: NutrientDefinition;
+  value: number;
+}
+
+export const DriBar: React.FC<DriBarProps> = ({ def, value }) => {
+  const pct = getDriPercent(def.key, value);
+  const barColor = getBarColor(pct);
+
+  return (
+    <View
+      testID={`nutrition-detail-bar-${def.key}`}
+      style={styles.container}
+    >
+      <View style={styles.labelRow}>
+        <Text style={styles.label}>{def.label}</Text>
+        <View style={styles.valueRow}>
+          <Text style={styles.value}>
+            {value.toFixed(def.decimals)}
+            {def.unit}
+          </Text>
+          <Text style={[styles.pct, { color: barColor }]}>{pct}%</Text>
+        </View>
+      </View>
+      <View style={styles.track}>
+        <View
+          style={[
+            styles.fill,
+            { width: `${Math.min(pct, 100)}%`, backgroundColor: barColor },
+          ]}
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.card,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    gap: 4,
+  },
+  labelRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  label: {
+    fontSize: 12,
+    color: colors.textLight,
+  },
+  valueRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  value: {
+    fontSize: 11,
+    color: colors.textMuted,
+  },
+  pct: {
+    fontSize: 11,
+    fontWeight: '700',
+    minWidth: 36,
+    textAlign: 'right',
+  },
+  track: {
+    height: 6,
+    backgroundColor: colors.border,
+    borderRadius: 3,
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+    borderRadius: 3,
+  },
+});

--- a/apps/mobile/src/components/menu/NutritionDetailModal.tsx
+++ b/apps/mobile/src/components/menu/NutritionDetailModal.tsx
@@ -1,0 +1,578 @@
+/**
+ * NutritionDetailModal — 26 栄養素詳細モーダル (PR 6-2)
+ *
+ * 機能:
+ * - 26 栄養素を category 別 (basic/mineral/vitamin/fat) に section 表示
+ * - 各栄養素 DRI バー (DriBar コンポーネント)
+ * - Radar chart 上部 + 編集ボタン (RadarChart / RadarKeyPicker)
+ * - AI feedback Realtime + 2 秒ポーリング (最大 40 秒)
+ * - 「献立を改善」ボタン → ImproveMealModal
+ */
+
+import { Ionicons } from '@expo/vector-icons';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import {
+  CATEGORY_LABELS,
+  NUTRIENT_BY_CATEGORY,
+} from '@homegohan/shared';
+
+import { getApi } from '../../lib/api';
+import { supabase } from '../../lib/supabase';
+import { useAuth } from '../../providers/AuthProvider';
+import { colors } from '../../theme/colors';
+import { radius, spacing } from '../../theme/spacing';
+import { typography } from '../../theme/typography';
+import { DriBar } from './DriBar';
+import { ImproveMealModal } from './ImproveMealModal';
+import { RadarChart } from './RadarChart';
+import { RadarKeyPicker } from './RadarKeyPicker';
+
+// ============================================================
+// Types
+// ============================================================
+
+/** 26 栄養素の集計値マップ (nutrientKey → 数値) */
+export type NutritionTotals = Record<string, number>;
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  /** 表示日 (YYYY-MM-DD) */
+  date: string;
+  /** 画面上部に表示する日付ラベル (例: "5/4") */
+  dateLabel: string;
+  /** 集計済み 26 栄養素の値 */
+  totals: NutritionTotals;
+  /** 食事数 (フィードバック API に渡す) */
+  mealCount: number;
+  /** レーダーチャートに表示する栄養素キー */
+  radarKeys: string[];
+  /** radarKeys が変更されたときに呼ばれる */
+  onRadarKeysSaved: (keys: string[]) => void;
+  /** weekDays (フィードバック API に渡す) */
+  weekDays?: Array<{ date: string; meals: Array<{ title: string; calories: number | null }> }>;
+}
+
+// ============================================================
+// Category section order
+// ============================================================
+
+const CATEGORY_ORDER = ['basic', 'mineral', 'vitamin', 'fat'] as const;
+
+// ============================================================
+// NutritionDetailModal
+// ============================================================
+
+export const NutritionDetailModal: React.FC<Props> = ({
+  visible,
+  onClose,
+  date,
+  dateLabel,
+  totals,
+  mealCount,
+  radarKeys,
+  onRadarKeysSaved,
+  weekDays = [],
+}) => {
+  const { user } = useAuth();
+
+  // --- AI feedback state ---
+  const [praiseComment, setPraiseComment] = useState<string | null>(null);
+  const [adviceText, setAdviceText] = useState<string | null>(null);
+  const [nutritionTip, setNutritionTip] = useState<string | null>(null);
+  const [isLoadingFeedback, setIsLoadingFeedback] = useState(false);
+
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const realtimeCleanupRef = useRef<(() => void) | null>(null);
+
+  // --- ImproveMealModal state ---
+  const [showImprove, setShowImprove] = useState(false);
+
+  // ----------------------------------------------------------------
+  // fetch / polling helpers
+  // ----------------------------------------------------------------
+
+  const clearPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const clearRealtime = useCallback(() => {
+    if (realtimeCleanupRef.current) {
+      realtimeCleanupRef.current();
+      realtimeCleanupRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback(
+    (cacheId: string) => {
+      let resolved = false;
+      let count = 0;
+      pollRef.current = setInterval(async () => {
+        if (resolved || count >= 20) {
+          clearPolling();
+          setIsLoadingFeedback(false);
+          return;
+        }
+        count++;
+        try {
+          const api = getApi();
+          const res = await api.get<any>(
+            `/api/ai/nutrition/feedback?cacheId=${cacheId}`
+          );
+          if (res.status === 'completed' && (res.feedback || res.praiseComment)) {
+            resolved = true;
+            setPraiseComment(res.praiseComment ?? null);
+            setAdviceText(res.advice ?? res.feedback ?? null);
+            setNutritionTip(res.nutritionTip ?? null);
+            setIsLoadingFeedback(false);
+            clearPolling();
+          }
+        } catch {
+          // ignore
+        }
+      }, 2000);
+    },
+    [clearPolling]
+  );
+
+  const fetchFeedback = useCallback(
+    async (forceRefresh = false) => {
+      if (mealCount === 0) return;
+      setIsLoadingFeedback(true);
+      try {
+        const api = getApi();
+        const res = await api.post<any>('/api/ai/nutrition/feedback', {
+          date,
+          nutrition: totals,
+          mealCount,
+          forceRefresh,
+          weekData: weekDays,
+        });
+        if (res.cached && (res.feedback || res.praiseComment)) {
+          setPraiseComment(res.praiseComment ?? null);
+          setAdviceText(res.advice ?? res.feedback ?? null);
+          setNutritionTip(res.nutritionTip ?? null);
+          setIsLoadingFeedback(false);
+          return;
+        }
+        if (res.status === 'generating' && res.cacheId) {
+          startPolling(res.cacheId);
+        } else {
+          setIsLoadingFeedback(false);
+        }
+      } catch {
+        setIsLoadingFeedback(false);
+      }
+    },
+    [date, totals, mealCount, weekDays, startPolling]
+  );
+
+  // ----------------------------------------------------------------
+  // effect: open / close
+  // ----------------------------------------------------------------
+
+  useEffect(() => {
+    if (!visible) {
+      clearPolling();
+      clearRealtime();
+      return;
+    }
+
+    // reset
+    setPraiseComment(null);
+    setAdviceText(null);
+    setNutritionTip(null);
+    clearPolling();
+    clearRealtime();
+
+    // Realtime subscription for ai_nutrition_feedback INSERT
+    if (user?.id) {
+      const channel = supabase
+        .channel(`nutrition-detail-${user.id}-${date}`)
+        .on(
+          'postgres_changes',
+          {
+            event: 'INSERT',
+            schema: 'public',
+            table: 'ai_nutrition_feedback',
+            filter: `user_id=eq.${user.id}`,
+          },
+          (payload: any) => {
+            if (payload.new?.summary) {
+              setPraiseComment(payload.new.summary);
+              setIsLoadingFeedback(false);
+              clearPolling();
+            }
+          }
+        )
+        .subscribe();
+
+      realtimeCleanupRef.current = () => {
+        supabase.removeChannel(channel);
+      };
+    }
+
+    fetchFeedback();
+
+    return () => {
+      clearPolling();
+      clearRealtime();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, date]);
+
+  // ----------------------------------------------------------------
+  // render
+  // ----------------------------------------------------------------
+
+  return (
+    <>
+      <Modal
+        testID="nutrition-detail-modal"
+        visible={visible}
+        animationType="slide"
+        transparent
+        statusBarTranslucent
+        onRequestClose={onClose}
+      >
+        <View style={styles.backdrop}>
+          <View style={styles.sheet}>
+            {/* Header */}
+            <View style={styles.header}>
+              <View style={styles.headerLeft}>
+                <Ionicons name="bar-chart" size={18} color={colors.accent} />
+                <Text style={styles.headerTitle}>
+                  {dateLabel} の栄養分析
+                </Text>
+              </View>
+              <Pressable
+                testID="nutrition-detail-close"
+                onPress={onClose}
+                hitSlop={8}
+                style={styles.closeBtn}
+              >
+                <Ionicons name="close" size={22} color={colors.textMuted} />
+              </Pressable>
+            </View>
+
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              showsVerticalScrollIndicator={false}
+            >
+              {/* Radar Chart */}
+              <View style={styles.radarSection}>
+                <View style={styles.radarChart}>
+                  <RadarChart totals={totals} nutrientKeys={radarKeys} size={220} />
+                </View>
+                <View style={styles.radarPickerWrapper}>
+                  <RadarKeyPicker
+                    selectedKeys={radarKeys}
+                    onSaved={onRadarKeysSaved}
+                  />
+                </View>
+              </View>
+
+              {/* AI Feedback */}
+              <View testID="nutrition-detail-ai-feedback" style={styles.feedbackSection}>
+                {/* 褒めポイント */}
+                <View style={styles.praiseCard}>
+                  <View style={styles.cardHeader}>
+                    <Ionicons name="heart" size={14} color={colors.success} />
+                    <Text style={styles.praiseTitle}>褒めポイント</Text>
+                    {(praiseComment || adviceText) && !isLoadingFeedback && (
+                      <Pressable
+                        onPress={() => fetchFeedback(true)}
+                        style={styles.reanalyzeBtn}
+                      >
+                        <Text style={styles.reanalyzeBtnText}>再分析</Text>
+                      </Pressable>
+                    )}
+                  </View>
+                  {isLoadingFeedback ? (
+                    <View style={styles.loadingRow}>
+                      <ActivityIndicator size="small" color={colors.success} />
+                      <Text style={styles.loadingText}>
+                        あなたの献立を分析中...
+                      </Text>
+                    </View>
+                  ) : praiseComment ? (
+                    <Text style={styles.praiseText}>{praiseComment}</Text>
+                  ) : (
+                    <Text style={styles.emptyText}>分析データがありません</Text>
+                  )}
+                </View>
+
+                {/* 改善アドバイス */}
+                {(adviceText || isLoadingFeedback) && (
+                  <View style={styles.adviceCard}>
+                    <View style={styles.cardHeader}>
+                      <Ionicons name="sparkles" size={14} color={colors.accent} />
+                      <Text style={styles.adviceTitle}>改善アドバイス</Text>
+                    </View>
+                    {isLoadingFeedback ? (
+                      <Text style={styles.emptyText}>...</Text>
+                    ) : (
+                      <Text style={styles.adviceText}>{adviceText}</Text>
+                    )}
+                  </View>
+                )}
+
+                {/* 栄養豆知識 */}
+                {nutritionTip && (
+                  <View style={styles.tipCard}>
+                    <Text style={styles.tipIcon}>💡</Text>
+                    <Text style={styles.tipText}>{nutritionTip}</Text>
+                  </View>
+                )}
+              </View>
+
+              {/* 献立を改善ボタン */}
+              {mealCount > 0 && (
+                <Pressable
+                  testID="nutrition-detail-improve-btn"
+                  onPress={() => setShowImprove(true)}
+                  style={({ pressed }) => [
+                    styles.improveBtn,
+                    pressed && styles.improveBtnPressed,
+                  ]}
+                >
+                  <Ionicons name="refresh" size={16} color="#FFF" />
+                  <Text style={styles.improveBtnText}>献立を改善</Text>
+                </Pressable>
+              )}
+
+              {/* 全 26 栄養素 DRI バー */}
+              {CATEGORY_ORDER.map((cat) => {
+                const defs = NUTRIENT_BY_CATEGORY[cat];
+                return (
+                  <View
+                    key={cat}
+                    testID={`nutrition-detail-section-${cat}`}
+                    style={styles.categorySection}
+                  >
+                    <Text style={styles.categoryLabel}>
+                      {CATEGORY_LABELS[cat]}（{defs.length}）
+                    </Text>
+                    <View style={styles.barList}>
+                      {defs.map((def) => (
+                        <DriBar
+                          key={def.key}
+                          def={def}
+                          value={totals[def.key] ?? 0}
+                        />
+                      ))}
+                    </View>
+                  </View>
+                );
+              })}
+
+              <View style={styles.bottomPad} />
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+
+      {/* 献立改善モーダル */}
+      <ImproveMealModal
+        visible={showImprove}
+        onClose={() => setShowImprove(false)}
+        selectedDate={date}
+      />
+    </>
+  );
+};
+
+// ============================================================
+// Styles
+// ============================================================
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: colors.bg,
+    borderTopLeftRadius: radius['2xl'],
+    borderTopRightRadius: radius['2xl'],
+    maxHeight: '92%',
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowRadius: 16,
+    shadowOffset: { width: 0, height: -4 },
+    elevation: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: spacing.lg,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  headerTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: radius.sm,
+    backgroundColor: colors.border,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  scrollContent: {
+    padding: spacing.lg,
+    gap: spacing.lg,
+  },
+  // --- Radar ---
+  radarSection: {
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  radarChart: {
+    alignItems: 'center',
+  },
+  radarPickerWrapper: {
+    width: '100%',
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    paddingTop: spacing.sm,
+  },
+  // --- AI Feedback ---
+  feedbackSection: {
+    gap: spacing.md,
+  },
+  praiseCard: {
+    backgroundColor: colors.successLight,
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  praiseTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.success,
+    flex: 1,
+  },
+  reanalyzeBtn: {
+    backgroundColor: colors.bg,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.sm,
+  },
+  reanalyzeBtnText: {
+    fontSize: 10,
+    color: colors.textMuted,
+  },
+  loadingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  loadingText: {
+    fontSize: 11,
+    color: colors.textLight,
+  },
+  praiseText: {
+    fontSize: 13,
+    color: colors.text,
+    lineHeight: 20,
+  },
+  emptyText: {
+    fontSize: 11,
+    color: colors.textMuted,
+  },
+  adviceCard: {
+    backgroundColor: colors.accentLight,
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  adviceTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.accent,
+  },
+  adviceText: {
+    fontSize: 12,
+    color: colors.text,
+    lineHeight: 18,
+  },
+  tipCard: {
+    backgroundColor: colors.blueLight,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+  },
+  tipIcon: {
+    fontSize: 12,
+  },
+  tipText: {
+    flex: 1,
+    fontSize: 11,
+    color: colors.blue,
+    lineHeight: 17,
+  },
+  // --- Improve button ---
+  improveBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: spacing.md,
+  },
+  improveBtnPressed: {
+    opacity: 0.85,
+  },
+  improveBtnText: {
+    ...typography.label,
+    color: '#FFF',
+  },
+  // --- Category sections ---
+  categorySection: {
+    gap: spacing.sm,
+  },
+  categoryLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  barList: {
+    gap: spacing.sm,
+  },
+  // --- Bottom padding ---
+  bottomPad: {
+    height: spacing.xl,
+  },
+});

--- a/apps/mobile/src/components/menu/RadarChart.tsx
+++ b/apps/mobile/src/components/menu/RadarChart.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import Svg, {
+  Circle,
+  Line,
+  Polygon,
+  Text as SvgText,
+} from 'react-native-svg';
+
+import { NUTRIENT_DEFINITIONS } from '@homegohan/shared';
+
+import { colors } from '../../theme/colors';
+
+// ============================================================
+// helpers
+// ============================================================
+
+function getDriPercent(key: string, value: number): number {
+  const def = NUTRIENT_DEFINITIONS.find((d) => d.key === key);
+  if (!def || def.dri === 0) return 0;
+  return Math.round((value / def.dri) * 100);
+}
+
+function getBarColor(pct: number): string {
+  if (pct > 150) return colors.error;
+  if (pct >= 80 && pct <= 120) return colors.success;
+  if (pct < 50) return colors.warning;
+  return colors.accent;
+}
+
+// ============================================================
+// RadarChart
+// ============================================================
+
+export interface RadarChartProps {
+  /** nutrientKey → value のマップ */
+  totals: Record<string, number>;
+  /** 表示する栄養素キー (3〜8 個) */
+  nutrientKeys: string[];
+  size?: number;
+}
+
+export const RadarChart: React.FC<RadarChartProps> = ({
+  totals,
+  nutrientKeys,
+  size = 220,
+}) => {
+  const n = nutrientKeys.length;
+  if (n < 3) return null;
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const maxRadius = size * 0.37;
+  const labelRadius = size * 0.47;
+  const LEVELS = 3;
+  const MAX_PCT = 150;
+
+  const angleOf = (i: number) =>
+    ((2 * Math.PI) / n) * i - Math.PI / 2;
+
+  const ptOnCircle = (r: number, i: number) => ({
+    x: cx + r * Math.cos(angleOf(i)),
+    y: cy + r * Math.sin(angleOf(i)),
+  });
+
+  const gridPolygons = Array.from({ length: LEVELS }, (_, l) => {
+    const r = (maxRadius * (l + 1)) / LEVELS;
+    return Array.from({ length: n }, (__, i) => ptOnCircle(r, i))
+      .map((p) => `${p.x},${p.y}`)
+      .join(' ');
+  });
+
+  const spokes = Array.from({ length: n }, (_, i) =>
+    ptOnCircle(maxRadius, i)
+  );
+
+  const dataPoints = nutrientKeys.map((key, i) => {
+    const val = totals[key] ?? 0;
+    const pct = Math.min(getDriPercent(key, val), MAX_PCT);
+    return ptOnCircle((pct / MAX_PCT) * maxRadius, i);
+  });
+
+  const dataPolygon = dataPoints.map((p) => `${p.x},${p.y}`).join(' ');
+  const refPolygon = Array.from({ length: n }, (_, i) =>
+    ptOnCircle((100 / MAX_PCT) * maxRadius, i)
+  )
+    .map((p) => `${p.x},${p.y}`)
+    .join(' ');
+
+  const pcts = nutrientKeys.map((key) =>
+    Math.min(getDriPercent(key, totals[key] ?? 0), MAX_PCT)
+  );
+  const avgPct = Math.round(
+    pcts.reduce((s, v) => s + v, 0) / pcts.length
+  );
+
+  const labelFontSize = Math.max(7, Math.min(9, size / 26));
+
+  return (
+    <View style={{ alignItems: 'center', width: size, height: size }}>
+      <Svg width={size} height={size}>
+        {gridPolygons.map((pts, l) => (
+          <Polygon
+            key={`g${l}`}
+            points={pts}
+            fill="none"
+            stroke="#E8E8E8"
+            strokeWidth={1}
+          />
+        ))}
+        <Polygon
+          points={refPolygon}
+          fill="none"
+          stroke="#B0B0B0"
+          strokeWidth={1}
+          strokeDasharray="3 3"
+        />
+        {spokes.map((p, i) => (
+          <Line
+            key={`s${i}`}
+            x1={cx}
+            y1={cy}
+            x2={p.x}
+            y2={p.y}
+            stroke="#E8E8E8"
+            strokeWidth={1}
+          />
+        ))}
+        <Polygon
+          points={dataPolygon}
+          fill="rgba(224,122,95,0.25)"
+          stroke={colors.accent}
+          strokeWidth={2}
+        />
+        {dataPoints.map((p, i) => (
+          <Circle key={`d${i}`} cx={p.x} cy={p.y} r={3} fill={colors.accent} />
+        ))}
+        {nutrientKeys.map((key, i) => {
+          const lp = ptOnCircle(labelRadius, i);
+          const def = NUTRIENT_DEFINITIONS.find((d) => d.key === key);
+          const label = def?.label ?? key;
+          const anchor =
+            Math.abs(lp.x - cx) < 4
+              ? 'middle'
+              : lp.x < cx
+              ? 'end'
+              : 'start';
+          return (
+            <SvgText
+              key={`l${i}`}
+              x={lp.x}
+              y={lp.y}
+              fontSize={labelFontSize}
+              fill="#9A9A9A"
+              textAnchor={anchor}
+              alignmentBaseline="middle"
+            >
+              {label}
+            </SvgText>
+          );
+        })}
+      </Svg>
+      <View
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Text
+          style={{
+            fontSize: 20,
+            fontWeight: '800',
+            color: getBarColor(avgPct),
+          }}
+        >
+          {avgPct}%
+        </Text>
+        <Text style={{ fontSize: 9, color: colors.textMuted }}>
+          平均達成率
+        </Text>
+      </View>
+    </View>
+  );
+};

--- a/apps/mobile/src/components/menu/RadarKeyPicker.tsx
+++ b/apps/mobile/src/components/menu/RadarKeyPicker.tsx
@@ -1,0 +1,263 @@
+import React, { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import {
+  CATEGORY_LABELS,
+  NUTRIENT_BY_CATEGORY,
+  NUTRIENT_DEFINITIONS,
+} from '@homegohan/shared';
+
+import { getApi } from '../../lib/api';
+import { colors } from '../../theme/colors';
+import { radius, spacing } from '../../theme/spacing';
+import { typography } from '../../theme/typography';
+
+// ============================================================
+// RadarKeyPicker
+// ============================================================
+
+interface RadarKeyPickerProps {
+  /** 現在選択中の栄養素キー一覧 */
+  selectedKeys: string[];
+  /** 変更が保存されたときに呼ばれる */
+  onSaved: (keys: string[]) => void;
+}
+
+export const RadarKeyPicker: React.FC<RadarKeyPickerProps> = ({
+  selectedKeys,
+  onSaved,
+}) => {
+  const [editing, setEditing] = useState(false);
+  const [tempKeys, setTempKeys] = useState<string[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const startEdit = () => {
+    setTempKeys([...selectedKeys]);
+    setEditing(true);
+  };
+
+  const toggleKey = (key: string) => {
+    setTempKeys((prev) => {
+      if (prev.includes(key)) return prev.filter((k) => k !== key);
+      if (prev.length >= 8) return prev;
+      return [...prev, key];
+    });
+  };
+
+  const save = async () => {
+    if (tempKeys.length < 3) {
+      Alert.alert('エラー', '3 個以上選択してください');
+      return;
+    }
+    setSaving(true);
+    try {
+      const api = getApi();
+      await api.post('/api/profile', { radarChartNutrients: tempKeys });
+      onSaved(tempKeys);
+      setEditing(false);
+    } catch {
+      Alert.alert('エラー', '保存に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!editing) {
+    return (
+      <View style={styles.viewRow}>
+        <Text style={styles.viewHint}>
+          レーダーチャート（{selectedKeys.length}角形）
+        </Text>
+        <Pressable
+          testID="nutrition-detail-radar-edit"
+          onPress={startEdit}
+          style={styles.editBtn}
+          hitSlop={8}
+        >
+          <Text style={styles.editBtnText}>編集</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.editContainer}>
+      <Text style={styles.editHint}>3〜8 個を選択（選択順で表示）</Text>
+      {Object.entries(NUTRIENT_BY_CATEGORY).map(([cat, defs]) => (
+        <View key={cat} style={styles.catBlock}>
+          <Text style={styles.catLabel}>{CATEGORY_LABELS[cat]}</Text>
+          <View style={styles.chipRow}>
+            {defs.map((def) => {
+              const selected = tempKeys.includes(def.key);
+              const idx = tempKeys.indexOf(def.key);
+              const disabled = !selected && tempKeys.length >= 8;
+              return (
+                <Pressable
+                  key={def.key}
+                  onPress={() => toggleKey(def.key)}
+                  disabled={disabled}
+                  style={[
+                    styles.chip,
+                    selected && styles.chipSelected,
+                    disabled && styles.chipDisabled,
+                  ]}
+                >
+                  {selected && (
+                    <Text style={styles.chipIdx}>{idx + 1}</Text>
+                  )}
+                  <Text
+                    style={[
+                      styles.chipText,
+                      selected && styles.chipTextSelected,
+                    ]}
+                  >
+                    {def.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+      ))}
+      <View style={styles.actionRow}>
+        <Pressable
+          onPress={() => setEditing(false)}
+          style={[styles.actionBtn, styles.cancelBtn]}
+        >
+          <Text style={styles.cancelText}>キャンセル</Text>
+        </Pressable>
+        <Pressable
+          onPress={save}
+          disabled={tempKeys.length < 3 || saving}
+          style={[
+            styles.actionBtn,
+            styles.saveBtn,
+            (tempKeys.length < 3 || saving) && styles.saveBtnDisabled,
+          ]}
+        >
+          {saving ? (
+            <ActivityIndicator color="#FFF" size="small" />
+          ) : (
+            <Text style={styles.saveText}>
+              保存（{tempKeys.length}角形）
+            </Text>
+          )}
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  viewRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.sm,
+  },
+  viewHint: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  editBtn: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.sm,
+    backgroundColor: colors.bg,
+  },
+  editBtnText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.accent,
+  },
+  editContainer: {
+    gap: spacing.sm,
+    paddingTop: spacing.sm,
+  },
+  editHint: {
+    ...typography.caption,
+    color: colors.textMuted,
+    marginBottom: spacing.xs,
+  },
+  catBlock: {
+    marginBottom: spacing.xs,
+  },
+  catLabel: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: colors.textMuted,
+    marginBottom: spacing.xs,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    backgroundColor: colors.bg,
+  },
+  chipSelected: {
+    backgroundColor: colors.accent,
+  },
+  chipDisabled: {
+    opacity: 0.4,
+  },
+  chipIdx: {
+    fontSize: 9,
+    color: '#FFF',
+    fontWeight: '700',
+  },
+  chipText: {
+    fontSize: 10,
+    color: colors.textLight,
+  },
+  chipTextSelected: {
+    color: '#FFF',
+    fontWeight: '600',
+  },
+  actionRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  actionBtn: {
+    flex: 1,
+    paddingVertical: spacing.md,
+    borderRadius: radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cancelBtn: {
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  cancelText: {
+    ...typography.caption,
+    color: colors.textMuted,
+  },
+  saveBtn: {
+    backgroundColor: colors.accent,
+  },
+  saveBtnDisabled: {
+    opacity: 0.5,
+  },
+  saveText: {
+    ...typography.caption,
+    color: '#FFF',
+    fontWeight: '700',
+  },
+});


### PR DESCRIPTION
## Summary

- `DriBar` / `RadarChart` / `RadarKeyPicker` 共有コンポーネントを新設 (PR 6-1 と共通設計)
- `NutritionDetailModal` を新設: 26 栄養素を basic/mineral/vitamin/fat カテゴリ別 section に DRI バー表示
- Radar chart 上部 + RadarKeyPicker で 3〜8 軸の栄養素をプロフィール保存
- AI feedback: Realtime (postgres_changes INSERT) + 2 秒ポーリング (最大 40 秒) フォールバック
- 「献立を改善」ボタン → ImproveMealModal (PR 6-3) を呼び出し
- `apps/mobile/app/menus/weekly/index.tsx` に `NutritionDetailModal` を組み込み

## testID

- `nutrition-detail-modal`
- `nutrition-detail-section-{basic|mineral|vitamin|fat}`
- `nutrition-detail-bar-{nutrientKey}`
- `nutrition-detail-radar-edit`
- `nutrition-detail-ai-feedback`
- `nutrition-detail-improve-btn`

## Test plan

- [ ] 週間献立画面で日付の栄養分析を開くと NutritionDetailModal が表示される
- [ ] 26 栄養素が 4 カテゴリに分かれて DRI バーとして表示される
- [ ] レーダーチャートが正しく描画される
- [ ] 「編集」ボタンで RadarKeyPicker が開き、栄養素を選択して保存できる
- [ ] AI フィードバックがローディング → 表示される
- [ ] 「献立を改善」ボタンで ImproveMealModal が開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)