### PR TITLE
feat(mobile): StatsModal を新設し栄養分析今日/今週タブを実装する

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -17,9 +17,11 @@ import { NUTRIENT_DEFINITIONS, type NutrientDefinition, PROGRESS_PHASES, ULTIMAT
 import { Button, Card, EmptyState, LoadingState, StatusBadge } from "../../../src/components/ui";
 import { AddMealSlotModal } from "../../../src/components/menu/AddMealSlotModal";
 import { ConfirmDeleteModal } from "../../../src/components/menu/ConfirmDeleteModal";
+import { ImproveMealModal } from "../../../src/components/menu/ImproveMealModal";
 import { RoleBadge } from "../../../src/components/menu/RoleBadge";
 import { RecipeModal, type RecipeModalMeal } from "../../../src/components/menu/RecipeModal";
 import { ServingsModal } from "../../../src/components/menu/ServingsModal";
+import { StatsModal, type NutrientValues, type WeekNutrientData } from "../../../src/components/menu/StatsModal";
 import { WeeklyHeader } from "../../../src/components/menu/WeeklyHeader";
 import { V4GenerateModal } from "../../../src/components/menu/V4GenerateModal";
 import { useV4MenuGeneration } from "../../../src/hooks/useV4MenuGeneration";
@@ -770,6 +772,7 @@ export default function WeeklyMenuPage() {
   const [activeModal, setActiveModal] = useState<'stats' | 'fridge' | 'shopping' | null>(null);
   const [showServingsModal, setShowServingsModal] = useState(false);
   const [deleteTargetMeal, setDeleteTargetMeal] = useState<{ id: string; name: string } | null>(null);
+  const [showImproveMealModal, setShowImproveMealModal] = useState(false);
 
   // AddMealSlotModal state
   const [addMealSlotVisible, setAddMealSlotVisible] = useState(false);
@@ -1234,6 +1237,71 @@ export default function WeeklyMenuPage() {
   }, [days]);
 
   const weekRangeLabel = `${weekStartStr.slice(5)} - ${weekEndStr.slice(5)}`;
+
+  // StatsModal 用: 選択日の今日栄養素
+  const todayNutrientsForStats = useMemo((): NutrientValues => {
+    const day = days.find((d) => d.day_date === selectedDate);
+    const meals = day?.planned_meals ?? [];
+    return {
+      caloriesKcal: meals.reduce((s, m) => s + (m.calories_kcal ?? 0), 0),
+      proteinG: meals.reduce((s, m) => s + (m.protein_g ?? 0), 0),
+      fatG: meals.reduce((s, m) => s + (m.fat_g ?? 0), 0),
+      carbsG: meals.reduce((s, m) => s + (m.carbs_g ?? 0), 0),
+      fiberG: meals.reduce((s, m) => s + (m.fiber_g ?? 0), 0),
+      sodiumG: meals.reduce((s, m) => s + (m.sodium_g ?? 0), 0),
+      sugarG: meals.reduce((s, m) => s + (m.sugar_g ?? 0), 0),
+      potassiumMg: meals.reduce((s, m) => s + (m.potassium_mg ?? 0), 0),
+      calciumMg: meals.reduce((s, m) => s + (m.calcium_mg ?? 0), 0),
+      magnesiumMg: meals.reduce((s, m) => s + (m.magnesium_mg ?? 0), 0),
+      phosphorusMg: meals.reduce((s, m) => s + (m.phosphorus_mg ?? 0), 0),
+      ironMg: meals.reduce((s, m) => s + (m.iron_mg ?? 0), 0),
+      zincMg: meals.reduce((s, m) => s + (m.zinc_mg ?? 0), 0),
+      iodineUg: meals.reduce((s, m) => s + (m.iodine_ug ?? 0), 0),
+      cholesterolMg: meals.reduce((s, m) => s + (m.cholesterol_mg ?? 0), 0),
+      vitaminAUg: meals.reduce((s, m) => s + (m.vitamin_a_ug ?? 0), 0),
+      vitaminB1Mg: meals.reduce((s, m) => s + (m.vitamin_b1_mg ?? 0), 0),
+      vitaminB2Mg: meals.reduce((s, m) => s + (m.vitamin_b2_mg ?? 0), 0),
+      vitaminB6Mg: meals.reduce((s, m) => s + (m.vitamin_b6_mg ?? 0), 0),
+      vitaminB12Ug: meals.reduce((s, m) => s + (m.vitamin_b12_ug ?? 0), 0),
+      vitaminCMg: meals.reduce((s, m) => s + (m.vitamin_c_mg ?? 0), 0),
+      vitaminDUg: meals.reduce((s, m) => s + (m.vitamin_d_ug ?? 0), 0),
+      vitaminEMg: meals.reduce((s, m) => s + (m.vitamin_e_mg ?? 0), 0),
+      vitaminKUg: meals.reduce((s, m) => s + (m.vitamin_k_ug ?? 0), 0),
+      folicAcidUg: meals.reduce((s, m) => s + (m.folic_acid_ug ?? 0), 0),
+      saturatedFatG: meals.reduce((s, m) => s + (m.saturated_fat_g ?? 0), 0),
+    };
+  }, [days, selectedDate]);
+
+  // StatsModal 用: 週間栄養集計
+  const weekNutrientsForStats = useMemo((): WeekNutrientData => {
+    const activeDays = days.filter((d) => d.planned_meals.length > 0);
+    const count = activeDays.length || 1;
+    const dailyKcal = days.map((d) =>
+      d.planned_meals.reduce((s, m) => s + (m.calories_kcal ?? 0), 0)
+    );
+    const totalProtein = days.flatMap((d) => d.planned_meals).reduce((s, m) => s + (m.protein_g ?? 0), 0);
+    const totalFat = days.flatMap((d) => d.planned_meals).reduce((s, m) => s + (m.fat_g ?? 0), 0);
+    const totalCarbs = days.flatMap((d) => d.planned_meals).reduce((s, m) => s + (m.carbs_g ?? 0), 0);
+    const totalFiber = days.flatMap((d) => d.planned_meals).reduce((s, m) => s + (m.fiber_g ?? 0), 0);
+    const totalKcal = dailyKcal.reduce((s, v) => s + v, 0);
+    return {
+      avgCalories: totalKcal / count,
+      dailyKcal,
+      avgProtein: totalProtein / count,
+      avgFat: totalFat / count,
+      avgCarbs: totalCarbs / count,
+      avgFiber: totalFiber / count,
+    };
+  }, [days]);
+
+  // StatsModal 用: 選択日の meals (AI feedback 取得用)
+  const todayMealsForStats = useMemo(() => {
+    const day = days.find((d) => d.day_date === selectedDate);
+    return (day?.planned_meals ?? []).map((m) => ({
+      dish_name: m.dish_name,
+      calories_kcal: m.calories_kcal,
+    }));
+  }, [days, selectedDate]);
 
   function handleCalendarDateClick(day: Date) {
     const newWeekStart = getWeekStart(day, weekStartDay);
@@ -1800,7 +1868,31 @@ export default function WeeklyMenuPage() {
         }}
       />
 
-      {/* 栄養分析ボトムシート */}
+      {/* 栄養分析モーダル (StatsModal) */}
+      <StatsModal
+        visible={activeModal === 'stats'}
+        onClose={() => setActiveModal(null)}
+        onOpenImprove={() => {
+          setActiveModal(null);
+          setShowImproveMealModal(true);
+        }}
+        selectedDate={selectedDate}
+        weekRange={{ start: weekStartStr, end: weekEndStr }}
+        todayNutrients={todayNutrientsForStats}
+        weekNutrients={weekNutrientsForStats}
+        userId={profile?.id ?? ''}
+        weekDayLabels={getDayLabels(weekStartDay)}
+        todayMeals={todayMealsForStats}
+      />
+
+      {/* 献立を改善モーダル */}
+      <ImproveMealModal
+        visible={showImproveMealModal}
+        onClose={() => setShowImproveMealModal(false)}
+        selectedDate={selectedDate}
+      />
+
+      {/* 旧: 栄養分析ボトムシート (非表示) */}
       <NutritionBottomSheet
         visible={nutritionSheetDay !== null}
         onClose={() => setNutritionSheetDay(null)}

--- a/apps/mobile/maestro/flows/menus-weekly/15-stats-modal.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/15-stats-modal.yaml
@@ -1,0 +1,30 @@
+appId: com.homegohan.app
+---
+- launchApp
+- tapOn:
+    text: "ほめゴハン"
+- tapOn:
+    id: "tab-menus"
+- waitForAnimationToEnd
+- tapOn:
+    id: "header-stats-btn"
+- assertVisible:
+    id: "stats-modal"
+- assertVisible:
+    id: "stats-tab-today"
+- tapOn:
+    id: "stats-tab-week"
+- assertVisible:
+    text: "平均"
+- tapOn:
+    id: "stats-tab-today"
+- tapOn:
+    id: "stats-radar-edit-btn"
+- assertVisible:
+    id: "stats-radar-key-proteinG"
+- tapOn:
+    id: "stats-radar-edit-btn"
+- tapOn:
+    id: "stats-improve-btn"
+- assertVisible:
+    id: "improve-meal-modal"

--- a/apps/mobile/src/components/menu/BarChart.tsx
+++ b/apps/mobile/src/components/menu/BarChart.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { colors } from '../../theme/colors';
+import { radius, spacing } from '../../theme/spacing';
+import { typography } from '../../theme/typography';
+
+interface Props {
+  values: number[];
+  labels: string[];
+  /** バーの最大高さ (px) */
+  maxBarHeight?: number;
+}
+
+export const BarChart: React.FC<Props> = ({ values, labels, maxBarHeight = 120 }) => {
+  const max = Math.max(...values, 1);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.barsRow}>
+        {values.map((v, i) => {
+          const heightRatio = v / max;
+          const barH = Math.max(heightRatio * maxBarHeight, 4);
+          return (
+            <View key={i} style={styles.barWrapper}>
+              <Text style={styles.barValue}>{v > 0 ? Math.round(v) : ''}</Text>
+              <View style={[styles.barTrack, { height: maxBarHeight }]}>
+                <View
+                  style={[
+                    styles.barFill,
+                    { height: barH },
+                  ]}
+                />
+              </View>
+              <Text style={styles.barLabel}>{labels[i] ?? ''}</Text>
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: spacing.md,
+  },
+  barsRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'space-around',
+    gap: spacing.xs,
+  },
+  barWrapper: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 4,
+  },
+  barValue: {
+    fontSize: 9,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+  barTrack: {
+    width: '100%',
+    justifyContent: 'flex-end',
+    backgroundColor: colors.border,
+    borderRadius: radius.sm,
+    overflow: 'hidden',
+  },
+  barFill: {
+    width: '100%',
+    backgroundColor: colors.accent,
+    borderRadius: radius.sm,
+    opacity: 0.85,
+  },
+  barLabel: {
+    ...typography.caption,
+    color: colors.textMuted,
+    fontSize: 11,
+    textAlign: 'center',
+  },
+});

--- a/apps/mobile/src/components/menu/DriBar.tsx
+++ b/apps/mobile/src/components/menu/DriBar.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { NUTRIENT_DEFINITIONS, calculateDriPercentage } from '@homegohan/shared';
+
+import { colors } from '../../theme/colors';
+import { radius, spacing } from '../../theme/spacing';
+import { typography } from '../../theme/typography';
+
+interface Props {
+  nutrientKey: string;
+  value: number | null | undefined;
+}
+
+function barColor(pct: number): string {
+  if (pct > 150) return colors.error;
+  if (pct >= 80 && pct <= 120) return colors.success;
+  if (pct < 50) return colors.warning;
+  return colors.accent;
+}
+
+export const DriBar: React.FC<Props> = ({ nutrientKey, value }) => {
+  const def = NUTRIENT_DEFINITIONS.find((d) => d.key === nutrientKey);
+  if (!def) return null;
+
+  const v = value ?? 0;
+  const pct = calculateDriPercentage(nutrientKey, v);
+  const fillColor = barColor(pct);
+  const displayVal = v.toFixed(def.decimals);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <Text style={styles.label}>{def.label}</Text>
+        <View style={styles.valueRow}>
+          <Text style={styles.value}>
+            {displayVal}{def.unit}
+          </Text>
+          <Text style={[styles.pct, { color: fillColor }]}>{pct}%</Text>
+        </View>
+      </View>
+      <View style={styles.track}>
+        <View
+          style={[
+            styles.fill,
+            { width: `${Math.min(pct, 100)}%`, backgroundColor: fillColor },
+          ]}
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.card,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    gap: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  label: {
+    ...typography.caption,
+    color: colors.textLight,
+  },
+  valueRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  value: {
+    fontSize: 11,
+    color: colors.textMuted,
+  },
+  pct: {
+    fontSize: 11,
+    fontWeight: '700',
+    minWidth: 36,
+    textAlign: 'right',
+  },
+  track: {
+    height: 6,
+    backgroundColor: colors.border,
+    borderRadius: 3,
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+    borderRadius: 3,
+  },
+});

--- a/apps/mobile/src/components/menu/RadarChart.tsx
+++ b/apps/mobile/src/components/menu/RadarChart.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import Svg, { Circle, Line, Polygon, Text as SvgText } from 'react-native-svg';
+
+import { NUTRIENT_DEFINITIONS, calculateDriPercentage } from '@homegohan/shared';
+
+import { colors } from '../../theme/colors';
+
+interface Props {
+  keys: string[];
+  /** 各キーの値を格納したオブジェクト (キーが存在しない場合は 0 扱い) */
+  values: Record<string, number | null | undefined>;
+  size?: number;
+}
+
+function avgPctColor(pct: number): string {
+  if (pct > 150) return colors.error;
+  if (pct >= 80 && pct <= 120) return colors.success;
+  if (pct < 50) return colors.warning;
+  return colors.accent;
+}
+
+export const RadarChart: React.FC<Props> = ({ keys, values, size = 220 }) => {
+  const n = keys.length;
+  if (n < 3) {
+    return (
+      <View style={{ width: size, height: size, alignItems: 'center', justifyContent: 'center' }}>
+        <Text style={{ color: colors.textMuted, fontSize: 12 }}>軸を 3 本以上選択してください</Text>
+      </View>
+    );
+  }
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const maxRadius = size * 0.37;
+  const labelRadius = size * 0.47;
+  const LEVELS = 3;
+  const MAX_PCT = 150;
+
+  const angleOf = (i: number) => ((2 * Math.PI) / n) * i - Math.PI / 2;
+  const ptOnCircle = (r: number, i: number) => ({
+    x: cx + r * Math.cos(angleOf(i)),
+    y: cy + r * Math.sin(angleOf(i)),
+  });
+
+  // グリッドポリゴン
+  const gridPolygons = Array.from({ length: LEVELS }, (_, l) => {
+    const r = (maxRadius * (l + 1)) / LEVELS;
+    return Array.from({ length: n }, (__, i) => ptOnCircle(r, i))
+      .map((p) => `${p.x},${p.y}`)
+      .join(' ');
+  });
+
+  // スポーク (軸線)
+  const spokes = Array.from({ length: n }, (_, i) => ptOnCircle(maxRadius, i));
+
+  // 100% 参照ライン
+  const refPolygon = Array.from({ length: n }, (_, i) =>
+    ptOnCircle((100 / MAX_PCT) * maxRadius, i)
+  )
+    .map((p) => `${p.x},${p.y}`)
+    .join(' ');
+
+  // データポイント
+  const dataPoints = keys.map((key, i) => {
+    const val = values[key] ?? 0;
+    const pct = Math.min(calculateDriPercentage(key, val), MAX_PCT);
+    return ptOnCircle((pct / MAX_PCT) * maxRadius, i);
+  });
+  const dataPolygon = dataPoints.map((p) => `${p.x},${p.y}`).join(' ');
+
+  // 平均達成率
+  const pcts = keys.map((key) => {
+    const val = values[key] ?? 0;
+    return Math.min(calculateDriPercentage(key, val), MAX_PCT);
+  });
+  const avg = Math.round(pcts.reduce((s, v) => s + v, 0) / pcts.length);
+
+  const labelFontSize = Math.max(7, Math.min(9, size / 26));
+
+  return (
+    <View style={{ width: size, height: size, alignItems: 'center' }}>
+      <Svg width={size} height={size}>
+        {/* グリッド */}
+        {gridPolygons.map((pts, l) => (
+          <Polygon key={`g${l}`} points={pts} fill="none" stroke="#E8E8E8" strokeWidth={1} />
+        ))}
+        {/* 100% 参照ライン */}
+        <Polygon points={refPolygon} fill="none" stroke="#B0B0B0" strokeWidth={1} strokeDasharray="3 3" />
+        {/* スポーク */}
+        {spokes.map((p, i) => (
+          <Line key={`s${i}`} x1={cx} y1={cy} x2={p.x} y2={p.y} stroke="#E8E8E8" strokeWidth={1} />
+        ))}
+        {/* データポリゴン */}
+        <Polygon
+          points={dataPolygon}
+          fill="rgba(224,122,95,0.25)"
+          stroke={colors.accent}
+          strokeWidth={2}
+        />
+        {/* データポイント */}
+        {dataPoints.map((p, i) => (
+          <Circle key={`d${i}`} cx={p.x} cy={p.y} r={3} fill={colors.accent} />
+        ))}
+        {/* ラベル */}
+        {keys.map((key, i) => {
+          const lp = ptOnCircle(labelRadius, i);
+          const def = NUTRIENT_DEFINITIONS.find((d) => d.key === key);
+          const label = def?.label ?? key;
+          const anchor = Math.abs(lp.x - cx) < 4 ? 'middle' : lp.x < cx ? 'end' : 'start';
+          return (
+            <SvgText
+              key={`l${i}`}
+              x={lp.x}
+              y={lp.y}
+              fontSize={labelFontSize}
+              fill="#9A9A9A"
+              textAnchor={anchor}
+              alignmentBaseline="middle"
+            >
+              {label}
+            </SvgText>
+          );
+        })}
+      </Svg>
+      {/* 中央の平均達成率 */}
+      <View
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Text style={{ fontSize: 20, fontWeight: '800', color: avgPctColor(avg) }}>{avg}%</Text>
+        <Text style={{ fontSize: 9, color: colors.textMuted }}>平均達成率</Text>
+      </View>
+    </View>
+  );
+};

--- a/apps/mobile/src/components/menu/RadarKeyPicker.tsx
+++ b/apps/mobile/src/components/menu/RadarKeyPicker.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { NUTRIENT_DEFINITIONS } from '@homegohan/shared';
+
+import { colors } from '../../theme/colors';
+import { radius, spacing } from '../../theme/spacing';
+import { typography } from '../../theme/typography';
+
+interface Props {
+  selected: string[];
+  onChange: (keys: string[]) => void;
+}
+
+const MIN_KEYS = 3;
+const MAX_KEYS = 8;
+
+export const RadarKeyPicker: React.FC<Props> = ({ selected, onChange }) => {
+  const toggle = (key: string) => {
+    if (selected.includes(key)) {
+      if (selected.length > MIN_KEYS) {
+        onChange(selected.filter((k) => k !== key));
+      }
+    } else {
+      if (selected.length < MAX_KEYS) {
+        onChange([...selected, key]);
+      }
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.hint}>
+        {selected.length}/{MAX_KEYS} 選択中（最低 {MIN_KEYS}、最大 {MAX_KEYS}）
+      </Text>
+      <View style={styles.grid}>
+        {NUTRIENT_DEFINITIONS.map((def) => {
+          const isSelected = selected.includes(def.key);
+          const isDisabled = isSelected
+            ? selected.length <= MIN_KEYS
+            : selected.length >= MAX_KEYS;
+          return (
+            <Pressable
+              key={def.key}
+              testID={`stats-radar-key-${def.key}`}
+              onPress={() => toggle(def.key)}
+              disabled={isDisabled && !isSelected}
+              style={[
+                styles.chip,
+                isSelected && styles.chipActive,
+                isDisabled && !isSelected && styles.chipDisabled,
+              ]}
+            >
+              <Text
+                style={[
+                  styles.chipText,
+                  isSelected && styles.chipTextActive,
+                  isDisabled && !isSelected && styles.chipTextDisabled,
+                ]}
+              >
+                {def.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.sm,
+  },
+  hint: {
+    ...typography.caption,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  chip: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    borderWidth: 1.5,
+    borderColor: colors.border,
+    backgroundColor: colors.bg,
+  },
+  chipActive: {
+    borderColor: colors.accent,
+    backgroundColor: colors.accentLight,
+  },
+  chipDisabled: {
+    opacity: 0.4,
+  },
+  chipText: {
+    fontSize: 12,
+    color: colors.textLight,
+    fontWeight: '500',
+  },
+  chipTextActive: {
+    color: colors.accent,
+    fontWeight: '700',
+  },
+  chipTextDisabled: {
+    color: colors.textMuted,
+  },
+});

--- a/apps/mobile/src/components/menu/StatsModal.tsx
+++ b/apps/mobile/src/components/menu/StatsModal.tsx
@@ -1,0 +1,859 @@
+import { Ionicons } from '@expo/vector-icons';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import {
+  DEFAULT_RADAR_NUTRIENTS,
+  NUTRIENT_DEFINITIONS,
+  calculateDriPercentage,
+} from '@homegohan/shared';
+
+import { getApi } from '../../lib/api';
+import { subscribeNutritionFeedback } from '../../lib/realtime';
+import { colors } from '../../theme/colors';
+import { radius, spacing } from '../../theme/spacing';
+import { shadows } from '../../theme';
+import { typography } from '../../theme/typography';
+import { BarChart } from './BarChart';
+import { DriBar } from './DriBar';
+import { RadarChart } from './RadarChart';
+import { RadarKeyPicker } from './RadarKeyPicker';
+
+// ============================================================
+// 型定義
+// ============================================================
+
+export interface NutrientValues {
+  caloriesKcal: number;
+  proteinG: number;
+  fatG: number;
+  carbsG: number;
+  fiberG: number;
+  sodiumG?: number;
+  sugarG?: number;
+  potassiumMg?: number;
+  calciumMg?: number;
+  magnesiumMg?: number;
+  phosphorusMg?: number;
+  ironMg?: number;
+  zincMg?: number;
+  iodineUg?: number;
+  cholesterolMg?: number;
+  vitaminAUg?: number;
+  vitaminB1Mg?: number;
+  vitaminB2Mg?: number;
+  vitaminB6Mg?: number;
+  vitaminB12Ug?: number;
+  vitaminCMg?: number;
+  vitaminDUg?: number;
+  vitaminEMg?: number;
+  vitaminKUg?: number;
+  folicAcidUg?: number;
+  saturatedFatG?: number;
+  [key: string]: number | undefined;
+}
+
+export interface WeekNutrientData {
+  avgCalories: number;
+  dailyKcal: number[];
+  avgProtein: number;
+  avgFat: number;
+  avgCarbs: number;
+  avgFiber: number;
+}
+
+export interface StatsModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onOpenImprove: () => void;
+  selectedDate: string;
+  weekRange: { start: string; end: string };
+  todayNutrients: NutrientValues;
+  weekNutrients: WeekNutrientData;
+  userId: string;
+  /** 週の日付ラベル (曜日) */
+  weekDayLabels?: string[];
+  /** 既存の Today の meals (AI feedback 取得に使用) */
+  todayMeals?: Array<{ dish_name: string; calories_kcal: number | null }>;
+}
+
+type Tab = 'today' | 'week';
+
+// ============================================================
+// カロリーバー (big)
+// ============================================================
+
+function CalBar({ calories }: { calories: number }) {
+  const calDef = NUTRIENT_DEFINITIONS.find((d) => d.key === 'caloriesKcal');
+  const dri = calDef?.dri ?? 2000;
+  const pct = Math.min((calories / dri) * 100, 100);
+
+  let barCol = colors.accent;
+  if (pct >= 80 && pct <= 120) barCol = colors.success;
+  else if (pct > 120) barCol = colors.error;
+
+  return (
+    <View style={calStyles.card}>
+      <View style={calStyles.header}>
+        <Ionicons name="flame" size={16} color={colors.accent} />
+        <Text style={calStyles.title}>カロリー</Text>
+        <Text style={[calStyles.pct, { color: barCol }]}>{Math.round(pct)}%</Text>
+      </View>
+      <Text style={calStyles.value}>
+        {Math.round(calories)} / {dri} kcal
+      </Text>
+      <View style={calStyles.track}>
+        <View style={[calStyles.fill, { width: `${pct}%`, backgroundColor: barCol }]} />
+      </View>
+    </View>
+  );
+}
+
+const calStyles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.card,
+    borderRadius: radius.lg,
+    padding: spacing.lg,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  title: {
+    ...typography.label,
+    flex: 1,
+  },
+  pct: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  value: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: colors.text,
+  },
+  track: {
+    height: 8,
+    backgroundColor: colors.border,
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+    borderRadius: 4,
+  },
+});
+
+// ============================================================
+// P/F/C ミニカード
+// ============================================================
+
+function PfcRow({ nutrients }: { nutrients: NutrientValues }) {
+  const items = [
+    { key: 'proteinG', label: 'タンパク質', short: 'P', value: nutrients.proteinG },
+    { key: 'fatG', label: '脂質', short: 'F', value: nutrients.fatG },
+    { key: 'carbsG', label: '炭水化物', short: 'C', value: nutrients.carbsG },
+  ] as const;
+
+  return (
+    <View style={pfcStyles.row}>
+      {items.map(({ key, label, short, value }) => {
+        const pct = calculateDriPercentage(key, value);
+        const def = NUTRIENT_DEFINITIONS.find((d) => d.key === key);
+        const decimals = def?.decimals ?? 1;
+        return (
+          <View key={key} style={pfcStyles.card}>
+            <Text style={pfcStyles.short}>{short}</Text>
+            <Text style={pfcStyles.label}>{label}</Text>
+            <Text style={pfcStyles.val}>
+              {value.toFixed(decimals)}g
+            </Text>
+            <Text style={pfcStyles.pct}>{pct}%</Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const pfcStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  card: {
+    flex: 1,
+    backgroundColor: colors.card,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    alignItems: 'center',
+    gap: 2,
+    ...shadows.sm,
+  },
+  short: {
+    fontSize: 16,
+    fontWeight: '900',
+    color: colors.accent,
+  },
+  label: {
+    ...typography.caption,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+  val: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  pct: {
+    fontSize: 11,
+    color: colors.textLight,
+  },
+});
+
+// ============================================================
+// 今日タブ
+// ============================================================
+
+interface TodayTabProps {
+  nutrients: NutrientValues;
+  radarKeys: string[];
+  setRadarKeys: (keys: string[]) => void;
+  editingRadar: boolean;
+  setEditingRadar: (v: boolean) => void;
+  feedback: { praise: string | null; advice: string | null } | null;
+  isLoadingFeedback: boolean;
+  onOpenImprove: () => void;
+  selectedDate: string;
+  mealCount: number;
+}
+
+function TodayTab({
+  nutrients,
+  radarKeys,
+  setRadarKeys,
+  editingRadar,
+  setEditingRadar,
+  feedback,
+  isLoadingFeedback,
+  onOpenImprove,
+  selectedDate,
+  mealCount,
+}: TodayTabProps) {
+  const dateLabel = selectedDate.replace(/-/g, '/');
+
+  return (
+    <ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={todayStyles.scroll}
+      showsVerticalScrollIndicator={false}
+    >
+      <Text style={todayStyles.dateTitle}>{dateLabel} の栄養</Text>
+      <Text style={todayStyles.mealCount}>{mealCount} 食分</Text>
+
+      {/* カロリー大バー */}
+      <CalBar calories={nutrients.caloriesKcal} />
+
+      {/* P/F/C */}
+      <PfcRow nutrients={nutrients} />
+
+      {/* レーダーチャート */}
+      <View style={todayStyles.radarSection}>
+        <View style={todayStyles.radarHeader}>
+          <Text style={todayStyles.sectionTitle}>栄養バランス</Text>
+          <Pressable
+            testID="stats-radar-edit-btn"
+            onPress={() => setEditingRadar(!editingRadar)}
+            style={todayStyles.editBtn}
+          >
+            <Text style={todayStyles.editBtnText}>{editingRadar ? '完了' : '編集'}</Text>
+          </Pressable>
+        </View>
+        {editingRadar ? (
+          <RadarKeyPicker selected={radarKeys} onChange={setRadarKeys} />
+        ) : (
+          <View style={{ alignItems: 'center' }}>
+            <RadarChart keys={radarKeys} values={nutrients as Record<string, number>} size={220} />
+          </View>
+        )}
+      </View>
+
+      {/* AI フィードバック */}
+      <View testID="stats-ai-feedback" style={todayStyles.feedbackSection}>
+        {/* 褒めポイント */}
+        <View style={todayStyles.praiseCard}>
+          <View style={todayStyles.feedbackHeader}>
+            <Ionicons name="heart" size={14} color={colors.success} />
+            <Text style={todayStyles.praiseTitleText}>褒めポイント</Text>
+          </View>
+          {isLoadingFeedback ? (
+            <View style={todayStyles.loadingRow}>
+              <ActivityIndicator size="small" color={colors.success} />
+              <Text style={todayStyles.loadingText}>あなたの献立を分析中...</Text>
+            </View>
+          ) : feedback?.praise ? (
+            <Text style={todayStyles.feedbackText}>{feedback.praise}</Text>
+          ) : (
+            <Text style={todayStyles.feedbackEmpty}>分析データがありません</Text>
+          )}
+        </View>
+
+        {/* 改善アドバイス */}
+        {(isLoadingFeedback || feedback?.advice) && (
+          <View style={todayStyles.adviceCard}>
+            <View style={todayStyles.feedbackHeader}>
+              <Ionicons name="sparkles" size={14} color={colors.accent} />
+              <Text style={todayStyles.adviceTitleText}>改善アドバイス</Text>
+            </View>
+            {isLoadingFeedback ? (
+              <Text style={todayStyles.loadingText}>...</Text>
+            ) : (
+              <Text style={todayStyles.feedbackText}>{feedback?.advice}</Text>
+            )}
+          </View>
+        )}
+      </View>
+
+      {/* DRI バー (主要栄養素) */}
+      <View style={todayStyles.driSection}>
+        <Text style={todayStyles.sectionTitle}>栄養素の達成率</Text>
+        <View style={{ gap: spacing.sm }}>
+          {NUTRIENT_DEFINITIONS.slice(0, 14).map((def) => (
+            <DriBar
+              key={def.key}
+              nutrientKey={def.key}
+              value={(nutrients as Record<string, number | undefined>)[def.key] ?? 0}
+            />
+          ))}
+        </View>
+      </View>
+
+      {/* 献立を改善ボタン */}
+      <Pressable
+        testID="stats-improve-btn"
+        onPress={onOpenImprove}
+        style={({ pressed }) => [todayStyles.improveBtn, pressed && { opacity: 0.85 }]}
+      >
+        <Ionicons name="refresh" size={16} color="#FFF" />
+        <Text style={todayStyles.improveBtnText}>献立を改善</Text>
+      </Pressable>
+
+      <View style={{ height: spacing['2xl'] }} />
+    </ScrollView>
+  );
+}
+
+const todayStyles = StyleSheet.create({
+  scroll: {
+    padding: spacing.lg,
+    gap: spacing.lg,
+  },
+  dateTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  mealCount: {
+    ...typography.caption,
+    color: colors.textMuted,
+    marginTop: -spacing.sm,
+  },
+  radarSection: {
+    backgroundColor: colors.card,
+    borderRadius: radius.lg,
+    padding: spacing.lg,
+    gap: spacing.md,
+    ...shadows.sm,
+  },
+  radarHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  sectionTitle: {
+    ...typography.label,
+    color: colors.text,
+  },
+  editBtn: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    borderWidth: 1.5,
+    borderColor: colors.accent,
+    backgroundColor: colors.accentLight,
+  },
+  editBtnText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.accent,
+  },
+  feedbackSection: {
+    gap: spacing.sm,
+  },
+  praiseCard: {
+    backgroundColor: colors.successLight,
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  adviceCard: {
+    backgroundColor: colors.accentLight,
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  feedbackHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  praiseTitleText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.success,
+  },
+  adviceTitleText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.accent,
+  },
+  feedbackText: {
+    fontSize: 13,
+    color: colors.text,
+    lineHeight: 20,
+  },
+  feedbackEmpty: {
+    fontSize: 11,
+    color: colors.textMuted,
+  },
+  loadingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  loadingText: {
+    fontSize: 11,
+    color: colors.textLight,
+  },
+  driSection: {
+    gap: spacing.md,
+  },
+  improveBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    ...shadows.sm,
+  },
+  improveBtnText: {
+    ...typography.label,
+    color: '#FFF',
+  },
+});
+
+// ============================================================
+// 今週タブ
+// ============================================================
+
+interface WeekTabProps {
+  data: WeekNutrientData;
+  weekDayLabels: string[];
+  weekRange: { start: string; end: string };
+}
+
+function WeekTab({ data, weekDayLabels, weekRange }: WeekTabProps) {
+  const rangeLabel = `${weekRange.start.slice(5).replace('-', '/')} 〜 ${weekRange.end.slice(5).replace('-', '/')}`;
+
+  return (
+    <ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={weekStyles.scroll}
+      showsVerticalScrollIndicator={false}
+    >
+      <Text style={weekStyles.rangeLabel}>{rangeLabel} の平均栄養</Text>
+
+      {/* 平均カロリー */}
+      <View style={weekStyles.avgCard}>
+        <Ionicons name="flame" size={18} color={colors.accent} />
+        <View style={weekStyles.avgBody}>
+          <Text style={weekStyles.avgValue}>{Math.round(data.avgCalories)}</Text>
+          <Text style={weekStyles.avgUnit}>kcal / 日</Text>
+        </View>
+      </View>
+
+      {/* 曜日別バーチャート */}
+      <View style={weekStyles.chartCard}>
+        <Text style={weekStyles.chartTitle}>曜日別カロリー</Text>
+        <BarChart
+          values={data.dailyKcal}
+          labels={weekDayLabels}
+          maxBarHeight={100}
+        />
+      </View>
+
+      {/* 週間栄養バー */}
+      <View style={weekStyles.nutrientSection}>
+        <Text style={weekStyles.sectionTitle}>週間栄養 (1 日平均比)</Text>
+        <View style={{ gap: spacing.sm }}>
+          <DriBar nutrientKey="proteinG" value={data.avgProtein} />
+          <DriBar nutrientKey="fatG" value={data.avgFat} />
+          <DriBar nutrientKey="carbsG" value={data.avgCarbs} />
+          <DriBar nutrientKey="fiberG" value={data.avgFiber} />
+        </View>
+      </View>
+
+      <View style={{ height: spacing['2xl'] }} />
+    </ScrollView>
+  );
+}
+
+const weekStyles = StyleSheet.create({
+  scroll: {
+    padding: spacing.lg,
+    gap: spacing.lg,
+  },
+  rangeLabel: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  avgCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    backgroundColor: colors.card,
+    borderRadius: radius.lg,
+    padding: spacing.lg,
+    ...shadows.sm,
+  },
+  avgBody: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: spacing.xs,
+  },
+  avgValue: {
+    fontSize: 36,
+    fontWeight: '900',
+    color: colors.text,
+  },
+  avgUnit: {
+    fontSize: 14,
+    color: colors.textMuted,
+    fontWeight: '600',
+  },
+  chartCard: {
+    backgroundColor: colors.card,
+    borderRadius: radius.lg,
+    padding: spacing.lg,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  chartTitle: {
+    ...typography.label,
+    color: colors.text,
+  },
+  nutrientSection: {
+    gap: spacing.md,
+  },
+  sectionTitle: {
+    ...typography.label,
+    color: colors.text,
+  },
+});
+
+// ============================================================
+// StatsModal メイン
+// ============================================================
+
+export const StatsModal: React.FC<StatsModalProps> = ({
+  visible,
+  onClose,
+  onOpenImprove,
+  selectedDate,
+  weekRange,
+  todayNutrients,
+  weekNutrients,
+  userId,
+  weekDayLabels = ['月', '火', '水', '木', '金', '土', '日'],
+  todayMeals = [],
+}) => {
+  const [tab, setTab] = useState<Tab>('today');
+  const [editingRadar, setEditingRadar] = useState(false);
+  const [radarKeys, setRadarKeys] = useState<string[]>(DEFAULT_RADAR_NUTRIENTS);
+  const [feedback, setFeedback] = useState<{ praise: string | null; advice: string | null } | null>(null);
+  const [isLoadingFeedback, setIsLoadingFeedback] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const unsubRef = useRef<(() => void) | null>(null);
+
+  const mealCount = todayMeals.filter((m) => m.dish_name).length;
+
+  useEffect(() => {
+    if (!visible || tab !== 'today') return;
+
+    setFeedback(null);
+    setIsLoadingFeedback(true);
+
+    if (mealCount === 0) {
+      setIsLoadingFeedback(false);
+      return;
+    }
+
+    // Realtime subscription
+    unsubRef.current = subscribeNutritionFeedback(userId, (row) => {
+      if (row.praise_comment || row.advice) {
+        setFeedback({ praise: row.praise_comment ?? null, advice: row.advice ?? null });
+        setIsLoadingFeedback(false);
+        if (pollRef.current) {
+          clearInterval(pollRef.current);
+          pollRef.current = null;
+        }
+      }
+    });
+
+    // ポーリング fallback (2 秒間隔、最大 40 秒)
+    let elapsed = 0;
+    let resolved = false;
+
+    const fetchFeedback = async (forceRefresh = false) => {
+      try {
+        const api = getApi();
+        const nutrition = {
+          caloriesKcal: todayNutrients.caloriesKcal,
+          proteinG: todayNutrients.proteinG,
+          fatG: todayNutrients.fatG,
+          carbsG: todayNutrients.carbsG,
+          fiberG: todayNutrients.fiberG,
+        };
+        const res = await api.post<any>('/api/ai/nutrition/feedback', {
+          date: selectedDate,
+          nutrition,
+          mealCount,
+          forceRefresh,
+          weekData: [],
+        });
+
+        if (res.cached && (res.praiseComment || res.feedback)) {
+          setFeedback({
+            praise: res.praiseComment ?? null,
+            advice: res.advice ?? res.feedback ?? null,
+          });
+          setIsLoadingFeedback(false);
+          resolved = true;
+          return;
+        }
+
+        if (res.status === 'generating' && res.cacheId) {
+          // ポーリングで完了待ち
+          let count = 0;
+          pollRef.current = setInterval(async () => {
+            elapsed += 2000;
+            count++;
+            if (resolved || count >= 20) {
+              if (pollRef.current) clearInterval(pollRef.current);
+              setIsLoadingFeedback(false);
+              return;
+            }
+            try {
+              const pollRes = await api.get<any>(`/api/ai/nutrition/feedback?cacheId=${res.cacheId}`);
+              if (pollRes.status === 'completed' && (pollRes.feedback || pollRes.praiseComment)) {
+                resolved = true;
+                setFeedback({
+                  praise: pollRes.praiseComment ?? null,
+                  advice: pollRes.advice ?? pollRes.feedback ?? null,
+                });
+                setIsLoadingFeedback(false);
+                if (pollRef.current) clearInterval(pollRef.current);
+              }
+            } catch {
+              // ignore
+            }
+          }, 2000);
+        } else {
+          setIsLoadingFeedback(false);
+        }
+      } catch {
+        setIsLoadingFeedback(false);
+      }
+    };
+
+    fetchFeedback();
+
+    return () => {
+      if (unsubRef.current) {
+        unsubRef.current();
+        unsubRef.current = null;
+      }
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [visible, tab, userId, selectedDate]);
+
+  // モーダルを閉じたときにリセット
+  useEffect(() => {
+    if (!visible) {
+      setTab('today');
+      setEditingRadar(false);
+    }
+  }, [visible]);
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <View style={styles.backdrop}>
+        <View testID="stats-modal" style={styles.container}>
+          {/* ヘッダー */}
+          <View style={styles.header}>
+            <Ionicons name="bar-chart" size={18} color={colors.accent} />
+            <Text style={styles.headerTitle}>栄養分析</Text>
+            <Pressable testID="stats-modal-close" onPress={onClose} style={styles.closeBtn} hitSlop={8}>
+              <Ionicons name="close" size={22} color={colors.textMuted} />
+            </Pressable>
+          </View>
+
+          {/* タブ切替 */}
+          <View style={styles.tabRow}>
+            <Pressable
+              testID="stats-tab-today"
+              onPress={() => setTab('today')}
+              style={[styles.tab, tab === 'today' && styles.tabActive]}
+            >
+              <Ionicons
+                name="today"
+                size={14}
+                color={tab === 'today' ? colors.accent : colors.textMuted}
+              />
+              <Text style={[styles.tabText, tab === 'today' && styles.tabTextActive]}>今日</Text>
+            </Pressable>
+            <Pressable
+              testID="stats-tab-week"
+              onPress={() => setTab('week')}
+              style={[styles.tab, tab === 'week' && styles.tabActive]}
+            >
+              <Ionicons
+                name="calendar"
+                size={14}
+                color={tab === 'week' ? colors.accent : colors.textMuted}
+              />
+              <Text style={[styles.tabText, tab === 'week' && styles.tabTextActive]}>今週</Text>
+            </Pressable>
+          </View>
+
+          {/* コンテンツ */}
+          {tab === 'today' ? (
+            <TodayTab
+              nutrients={todayNutrients}
+              radarKeys={radarKeys}
+              setRadarKeys={setRadarKeys}
+              editingRadar={editingRadar}
+              setEditingRadar={setEditingRadar}
+              feedback={feedback}
+              isLoadingFeedback={isLoadingFeedback}
+              onOpenImprove={onOpenImprove}
+              selectedDate={selectedDate}
+              mealCount={mealCount}
+            />
+          ) : (
+            <WeekTab
+              data={weekNutrients}
+              weekDayLabels={weekDayLabels}
+              weekRange={weekRange}
+            />
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    justifyContent: 'flex-end',
+  },
+  container: {
+    backgroundColor: colors.bg,
+    borderTopLeftRadius: radius['2xl'],
+    borderTopRightRadius: radius['2xl'],
+    maxHeight: '92%',
+    flex: 1,
+    ...shadows.lg,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerTitle: {
+    ...typography.h3,
+    flex: 1,
+    fontSize: 16,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: radius.sm,
+    backgroundColor: colors.border,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  tabRow: {
+    flexDirection: 'row',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    gap: spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  tab: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+    borderWidth: 1.5,
+    borderColor: colors.border,
+    backgroundColor: colors.bg,
+  },
+  tabActive: {
+    borderColor: colors.accent,
+    backgroundColor: colors.accentLight,
+  },
+  tabText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.textMuted,
+  },
+  tabTextActive: {
+    color: colors.accent,
+  },
+});


### PR DESCRIPTION
## Summary

- StatsModal（今日タブ・今週タブ）を新設し、ヘッダーの BarChart3 ボタン（PR 2-2）から開けるようにした
- RadarChart・RadarKeyPicker・DriBar・BarChart の 4 コンポーネントを新設
- AI feedback は subscribeNutritionFeedback（Realtime）+ ポーリング fallback で実装
- 「献立を改善」ボタン → ImproveMealModal（PR 6-3）連携
- 設計書 testID 7 点すべて実装済み

## Changes

- `apps/mobile/src/components/menu/StatsModal.tsx` — 新設（今日/今週タブ・AI feedback・改善ボタン）
- `apps/mobile/src/components/menu/RadarChart.tsx` — 新設（react-native-svg、3-8 軸、平均達成率表示）
- `apps/mobile/src/components/menu/RadarKeyPicker.tsx` — 新設（3-8 制限チップ選択）
- `apps/mobile/src/components/menu/DriBar.tsx` — 新設（PR 6-2 共有用）
- `apps/mobile/src/components/menu/BarChart.tsx` — 新設（週間曜日別カロリーチャート）
- `apps/mobile/app/menus/weekly/index.tsx` — StatsModal 統合・ImproveMealModal 追加・データ計算 useMemo 追加
- `apps/mobile/maestro/flows/menus-weekly/15-stats-modal.yaml` — Maestro テスト追加

## Test plan

- [ ] ヘッダー BarChart3 → stats-modal 表示
- [ ] 今日/今週タブ切替動作確認
- [ ] radar 編集モード（3-8 制限）確認
- [ ] AI feedback ローディング → テキスト表示
- [ ] 「献立を改善」→ improve-meal-modal 表示
- [ ] Maestro 15-stats-modal.yaml PASS