### PR TITLE
style(mobile): typography/spacing/radius/shadows を WEB に揃える

### DIFF
--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -45,7 +45,7 @@ export function Button({ children, onPress, variant = 'primary', disabled, loadi
           backgroundColor: isDisabled ? colors.textMuted : pressed ? v.bgPressed : v.bg,
           paddingVertical: s.paddingV,
           paddingHorizontal: s.paddingH,
-          borderRadius: radius.md,
+          borderRadius: radius.full,
           alignItems: 'center',
           justifyContent: 'center',
           flexDirection: 'row',

--- a/apps/mobile/src/theme/index.ts
+++ b/apps/mobile/src/theme/index.ts
@@ -3,6 +3,7 @@ export type { ColorKey } from './colors';
 export { spacing, radius } from './spacing';
 export { typography } from './typography';
 
+// shadows: COMMON.md Section 4 準拠
 export const shadows = {
   sm: {
     shadowColor: '#000',
@@ -14,10 +15,11 @@ export const shadows = {
   md: {
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.08,
+    shadowOpacity: 0.10,
     shadowRadius: 8,
-    elevation: 2,
+    elevation: 3,
   },
+  // lg は既存スクリーンからの参照を維持するために残す
   lg: {
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 4 },

--- a/apps/mobile/src/theme/spacing.ts
+++ b/apps/mobile/src/theme/spacing.ts
@@ -1,3 +1,4 @@
+// spacing: COMMON.md Section 3 準拠 (Tailwind 互換)
 export const spacing = {
   xs: 4,
   sm: 8,
@@ -7,13 +8,15 @@ export const spacing = {
   '2xl': 24,
   '3xl': 32,
   '4xl': 40,
+  '5xl': 48,
 } as const;
 
+// radius: COMMON.md Section 4 準拠
 export const radius = {
-  sm: 8,
-  md: 12,
-  lg: 16,
-  xl: 20,
-  '2xl': 24,
-  full: 999,
+  sm: 4,
+  md: 8,
+  lg: 12,
+  xl: 16,
+  '2xl': 20,
+  full: 9999,
 } as const;

--- a/apps/mobile/src/theme/typography.ts
+++ b/apps/mobile/src/theme/typography.ts
@@ -2,26 +2,17 @@ import { TextStyle } from 'react-native';
 import { colors } from './colors';
 
 export const typography = {
-  h1: {
-    fontSize: 28,
-    fontWeight: '800',
-    color: colors.text,
-  } as TextStyle,
-  h2: {
-    fontSize: 22,
-    fontWeight: '800',
-    color: colors.text,
-  } as TextStyle,
-  h3: {
-    fontSize: 18,
-    fontWeight: '700',
-    color: colors.text,
-  } as TextStyle,
-  body: {
-    fontSize: 15,
-    fontWeight: '400',
-    color: colors.textLight,
-  } as TextStyle,
+  // --- 設計書 COMMON.md Section 2 準拠 ---
+  h1:       { fontSize: 24, fontWeight: '800' as const, lineHeight: 32 },
+  h2:       { fontSize: 20, fontWeight: '700' as const, lineHeight: 28 },
+  h3:       { fontSize: 16, fontWeight: '700' as const, lineHeight: 22 },
+  body:     { fontSize: 14, fontWeight: '400' as const, lineHeight: 20 },
+  bodyBold: { fontSize: 14, fontWeight: '700' as const, lineHeight: 20 },
+  small:    { fontSize: 12, fontWeight: '400' as const, lineHeight: 16 },
+  smallBold:{ fontSize: 12, fontWeight: '700' as const, lineHeight: 16 },
+  tiny:     { fontSize: 10, fontWeight: '700' as const, lineHeight: 14 },
+
+  // --- 後方互換 (既存スクリーンで参照中のキー) ---
   bodySmall: {
     fontSize: 13,
     fontWeight: '400',


### PR DESCRIPTION
## 目的

App の typography, spacing, radius, shadow を WEB の Tailwind 値に揃える (PR 9-2)。

## 変更内容

- `typography.ts`: COMMON.md Section 2 準拠。h1(24/800/32)〜tiny(10/700/14) の8種を定義。既存キー (bodySmall/caption/label/number) は後方互換で維持
- `spacing.ts`: `'5xl': 48` を追加 (xs〜5xl の9段階に)
- `spacing.ts` (radius): COMMON.md Section 4 準拠。sm:4/md:8/lg:12/xl:16/'2xl':20/full:9999 に変更
- `theme/index.ts` (shadows): md の shadowOpacity 0.08→0.10、elevation 2→3 に変更
- `Button.tsx`: `borderRadius: radius.full` (9999) に変更してボタン角丸を rounded-full に統一

## 影響範囲

App 全画面のフォント / 間隔 / 角丸が変わる。目視確認必須 (別途実施)。

## DoD

- [x] typography/spacing/radius/shadows 統一
- [x] ボタン rounded-full 統一
- [ ] 全画面目視 PASS (実機確認は別途)
- [ ] PR merged