### PR TITLE
feat(mobile): RegenerateMealModal — AI単一食事再生成モーダル新設 (#5-6)

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -25,6 +25,7 @@ import { ServingsModal } from "../../../src/components/menu/ServingsModal";
 import { WeeklyHeader } from "../../../src/components/menu/WeeklyHeader";
 import { V4GenerateModal } from "../../../src/components/menu/V4GenerateModal";
 import { NutritionDetailModal } from "../../../src/components/menu/NutritionDetailModal";
+import { RegenerateMealModal } from "../../../src/components/menu/RegenerateMealModal";
 import { useV4MenuGeneration } from "../../../src/hooks/useV4MenuGeneration";
 import { colors, spacing, radius, shadows } from "../../../src/theme";
 import { getApi, getApiBaseUrl } from "../../../src/lib/api";
@@ -636,6 +637,10 @@ export default function WeeklyMenuPage() {
 
   // RecipeModal state
   const [recipeModalMeal, setRecipeModalMeal] = useState<RecipeModalMeal | null>(null);
+
+  // RegenerateMealModal state
+  const [showRegenerateModal, setShowRegenerateModal] = useState(false);
+  const [selectedMealForRegen, setSelectedMealForRegen] = useState<PlannedMealRow | null>(null);
 
   useEffect(() => {
     const fetchRadarProfile = async () => {
@@ -1568,7 +1573,10 @@ export default function WeeklyMenuPage() {
                           <Text style={{ fontSize: 11, color: colors.textLight }}>レシピ</Text>
                         </Pressable>
                         <Pressable
-                          onPress={() => regenerateMeal(m.id, m.meal_type)}
+                          onPress={() => {
+                            setSelectedMealForRegen(m);
+                            setShowRegenerateModal(true);
+                          }}
                           disabled={!!regeneratingMealId}
                           style={{
                             flexDirection: "row",
@@ -1583,6 +1591,7 @@ export default function WeeklyMenuPage() {
                           }}
                         >
                           <Ionicons name="refresh" size={14} color={regeneratingMealId === m.id ? colors.accent : colors.textLight} />
+                          <Text style={{ fontSize: 11, color: regeneratingMealId === m.id ? colors.accent : colors.textLight }}>AIで変更</Text>
                         </Pressable>
                         <Pressable
                           testID={`weekly-meal-delete-btn-${m.id}`}
@@ -1800,6 +1809,14 @@ export default function WeeklyMenuPage() {
         visible={recipeModalMeal !== null}
         meal={recipeModalMeal}
         onClose={() => setRecipeModalMeal(null)}
+      />
+      <RegenerateMealModal
+        visible={showRegenerateModal}
+        meal={selectedMealForRegen}
+        onClose={() => {
+          setShowRegenerateModal(false);
+          setSelectedMealForRegen(null);
+        }}
       />
     </View>
   );

--- a/apps/mobile/src/components/menu/RegenerateMealModal.tsx
+++ b/apps/mobile/src/components/menu/RegenerateMealModal.tsx
@@ -1,0 +1,272 @@
+import { Ionicons } from "@expo/vector-icons";
+import React, { useState } from "react";
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import { setItemWithTTL } from "../../lib/persistence";
+import { colors, radius, spacing } from "../../theme";
+import type { MenuGenerationConstraints } from "../../../../../types/domain";
+import { ConditionPills } from "./ConditionPills";
+import { getApiBaseUrl } from "../../lib/api";
+import { supabase } from "../../lib/supabase";
+
+// ============================================================
+// Types
+// ============================================================
+
+interface PlannedMealLike {
+  id: string;
+  dish_name?: string | null;
+  dishes?: Array<{ name: string }> | null;
+  meal_type?: string;
+}
+
+interface Props {
+  visible: boolean;
+  meal: PlannedMealLike | null;
+  onClose: () => void;
+}
+
+// ============================================================
+// Component
+// ============================================================
+
+export const RegenerateMealModal: React.FC<Props> = ({ visible, meal, onClose }) => {
+  const [conditions, setConditions] = useState<MenuGenerationConstraints>({
+    useFridgeFirst: false,
+    quickMeals: false,
+    japaneseStyle: false,
+    healthy: false,
+  });
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const mealName =
+    meal?.dishes?.[0]?.name ?? meal?.dish_name ?? "食事";
+
+  const handleClose = () => {
+    if (submitting) return;
+    setConditions({ useFridgeFirst: false, quickMeals: false, japaneseStyle: false, healthy: false });
+    setNote("");
+    onClose();
+  };
+
+  const submit = async () => {
+    if (!meal || submitting) return;
+    setSubmitting(true);
+    try {
+      const base = getApiBaseUrl();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const r = await fetch(`${base}/api/ai/menu/meal/regenerate`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(session?.access_token
+            ? { Authorization: `Bearer ${session.access_token}` }
+            : {}),
+        },
+        body: JSON.stringify({ mealId: meal.id, conditions, note }),
+      });
+      if (!r.ok) throw new Error("regenerate failed");
+      await setItemWithTTL("singleMealGenerating", { mealId: meal.id }, 2 * 60 * 1000);
+      handleClose();
+    } catch (_e) {
+      // エラー時は submitting をリセットして UI を壊さない
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={handleClose}
+    >
+      <View style={styles.backdrop}>
+        <View testID="regenerate-meal-modal" style={styles.container}>
+          {/* Header */}
+          <View style={styles.header}>
+            <View style={styles.headerLeft}>
+              <Ionicons name="sparkles" size={18} color={colors.accent} />
+              <Text style={styles.title}>AIで変更</Text>
+            </View>
+            <Pressable
+              testID="regenerate-meal-close"
+              onPress={handleClose}
+              style={styles.closeBtn}
+            >
+              <Ionicons name="close" size={20} color={colors.textLight} />
+            </Pressable>
+          </View>
+
+          <ScrollView
+            style={styles.body}
+            contentContainerStyle={styles.bodyContent}
+            keyboardShouldPersistTaps="handled"
+          >
+            {/* 現在の献立 */}
+            <View style={styles.currentMealBox}>
+              <Text style={styles.currentMealLabel}>現在の献立</Text>
+              <Text style={styles.currentMealName}>{mealName}</Text>
+            </View>
+
+            {/* 条件 */}
+            <Text style={styles.sectionLabel}>新しい条件を指定（複数選択可）</Text>
+            <ConditionPills values={conditions} onChange={setConditions} />
+
+            {/* メモ */}
+            <Text style={[styles.sectionLabel, { marginTop: spacing.lg }]}>
+              リクエスト（任意）
+            </Text>
+            <TextInput
+              testID="regenerate-meal-note"
+              multiline
+              numberOfLines={4}
+              value={note}
+              onChangeText={setNote}
+              placeholder="例: もっとヘルシーに、魚料理がいい..."
+              placeholderTextColor={colors.textMuted}
+              style={styles.textarea}
+            />
+          </ScrollView>
+
+          {/* Submit */}
+          <View style={styles.footer}>
+            <Pressable
+              testID="regenerate-meal-submit"
+              onPress={submit}
+              disabled={submitting}
+              style={[styles.submitBtn, submitting && styles.submitBtnDisabled]}
+            >
+              {submitting ? (
+                <ActivityIndicator color="#FFF" />
+              ) : (
+                <>
+                  <Ionicons name="sparkles" size={16} color="#FFF" />
+                  <Text style={styles.submitText}>AIで別の献立に変更</Text>
+                </>
+              )}
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+// ============================================================
+// Styles
+// ============================================================
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    justifyContent: "flex-end",
+  },
+  container: {
+    backgroundColor: colors.card,
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    maxHeight: "80%",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: colors.text,
+  },
+  closeBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: colors.bg,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  body: {
+    flex: 1,
+  },
+  bodyContent: {
+    padding: spacing.lg,
+  },
+  currentMealBox: {
+    backgroundColor: colors.bg,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    marginBottom: spacing.lg,
+  },
+  currentMealLabel: {
+    fontSize: 12,
+    color: colors.textMuted,
+    marginBottom: 4,
+  },
+  currentMealName: {
+    fontSize: 14,
+    fontWeight: "500",
+    color: colors.text,
+  },
+  sectionLabel: {
+    fontSize: 13,
+    color: colors.textMuted,
+    marginBottom: spacing.sm,
+  },
+  textarea: {
+    backgroundColor: colors.bg,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    fontSize: 13,
+    color: colors.text,
+    minHeight: 80,
+    textAlignVertical: "top",
+  },
+  footer: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.lg,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    backgroundColor: colors.card,
+  },
+  submitBtn: {
+    backgroundColor: colors.accent,
+    borderRadius: radius.md,
+    paddingVertical: 14,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+  },
+  submitBtnDisabled: {
+    opacity: 0.7,
+  },
+  submitText: {
+    color: "#FFF",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+});


### PR DESCRIPTION
## Summary

- `apps/mobile/src/components/menu/RegenerateMealModal.tsx` 新設
- ConditionPills (PR 4-2) を再利用し条件4種（冷蔵庫優先 / 時短中心 / 和食多め / ヘルシー）を複数選択可能
- メモ textarea でリクエスト自由入力
- POST `/api/ai/menu/meal/regenerate` を Bearer トークン付きで呼び出し
- 成功時 `setItemWithTTL('singleMealGenerating', { mealId }, 2分TTL)` を記録 (PR 7-2連携)
- testID 4個: `regenerate-meal-modal` / `regenerate-meal-close` / `regenerate-meal-note` / `regenerate-meal-submit`
- `weekly/index.tsx` の既存「AIで変更」ボタン押下でモーダルオープンに変更 (旧: API直接呼び出し)

## Test plan

- [ ] 食事カード展開 → 「AIで変更」ボタンタップ → `regenerate-meal-modal` が表示されること
- [ ] 条件 pill を複数選択できること (v4-condition-* testID)
- [ ] メモ欄に入力できること
- [ ] 「AIで別の献立に変更」タップ → API 200 → モーダルが閉じること
- [ ] ネットワーク切断時もモーダルが壊れないこと (submitting リセット)
- [ ] Maestro 13-regenerate-meal.yaml PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)