### PR TITLE
feat(mobile): PR 2-4 PantryModal を weekly 画面に統合する

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -28,6 +28,7 @@ import { WeeklyHeader } from "../../../src/components/menu/WeeklyHeader";
 import { V4GenerateModal } from "../../../src/components/menu/V4GenerateModal";
 import { NutritionDetailModal } from "../../../src/components/menu/NutritionDetailModal";
 import { RegenerateMealModal } from "../../../src/components/menu/RegenerateMealModal";
+import { PantryModal } from "../../../src/components/menu/PantryModal";
 import { useV4MenuGeneration } from "../../../src/hooks/useV4MenuGeneration";
 import { colors, spacing, radius, shadows } from "../../../src/theme";
 import { getApi, getApiBaseUrl } from "../../../src/lib/api";
@@ -1909,6 +1910,12 @@ export default function WeeklyMenuPage() {
           setShowRegenerateModal(false);
           setSelectedMealForRegen(null);
         }}
+      />
+
+      {/* 冷蔵庫モーダル (PR 2-4) */}
+      <PantryModal
+        visible={activeModal === 'fridge'}
+        onClose={() => setActiveModal(null)}
       />
     </View>
   );

--- a/apps/mobile/src/components/menu/AddFridgeModal.tsx
+++ b/apps/mobile/src/components/menu/AddFridgeModal.tsx
@@ -1,0 +1,241 @@
+import { Ionicons } from '@expo/vector-icons';
+import React, { useState } from 'react';
+import {
+  Alert,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+import { getApi } from '../../lib/api';
+import { colors } from '../../theme/colors';
+import { radius, spacing } from '../../theme/spacing';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export const AddFridgeModal: React.FC<Props> = ({ visible, onClose, onSuccess }) => {
+  const [name, setName] = useState('');
+  const [amount, setAmount] = useState('');
+  const [expiryDate, setExpiryDate] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const reset = () => {
+    setName('');
+    setAmount('');
+    setExpiryDate('');
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    const n = name.trim();
+    if (!n) {
+      Alert.alert('入力エラー', '食材名を入力してください。');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const api = getApi();
+      await api.post('/api/pantry', {
+        name: n,
+        amount: amount.trim() || null,
+        expirationDate: expiryDate.trim() || null,
+      });
+      reset();
+      onSuccess();
+    } catch (e: any) {
+      Alert.alert('追加失敗', e?.message ?? '追加に失敗しました。');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      testID="add-fridge-modal"
+      visible={visible}
+      animationType="fade"
+      transparent
+      onRequestClose={handleClose}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.dialog}>
+          {/* Header */}
+          <View style={styles.header}>
+            <Text style={styles.title}>食材を追加</Text>
+            <Pressable onPress={handleClose} hitSlop={8} style={styles.closeBtn}>
+              <Ionicons name="close" size={20} color={colors.textMuted} />
+            </Pressable>
+          </View>
+
+          {/* Divider */}
+          <View style={styles.divider} />
+
+          {/* Form */}
+          <View style={styles.form}>
+            <View style={styles.field}>
+              <Text style={styles.label}>名前</Text>
+              <TextInput
+                testID="add-fridge-name-input"
+                style={styles.input}
+                value={name}
+                onChangeText={setName}
+                placeholder="例: キャベツ"
+                placeholderTextColor={colors.textMuted}
+                autoFocus
+              />
+            </View>
+
+            <View style={styles.field}>
+              <Text style={styles.label}>量</Text>
+              <TextInput
+                testID="add-fridge-amount-input"
+                style={styles.input}
+                value={amount}
+                onChangeText={setAmount}
+                placeholder="例: 1/2 個"
+                placeholderTextColor={colors.textMuted}
+              />
+            </View>
+
+            <View style={styles.field}>
+              <Text style={styles.label}>賞味期限</Text>
+              <TextInput
+                testID="add-fridge-expiry-input"
+                style={styles.input}
+                value={expiryDate}
+                onChangeText={setExpiryDate}
+                placeholder="YYYY-MM-DD"
+                placeholderTextColor={colors.textMuted}
+                keyboardType="numbers-and-punctuation"
+              />
+            </View>
+          </View>
+
+          {/* Actions */}
+          <View style={styles.actions}>
+            <Pressable onPress={handleClose} style={[styles.btn, styles.cancelBtn]}>
+              <Text style={styles.cancelBtnText}>キャンセル</Text>
+            </Pressable>
+            <Pressable
+              testID="add-fridge-submit-btn"
+              onPress={handleSubmit}
+              disabled={submitting}
+              style={[styles.btn, styles.submitBtn, submitting && styles.btnDisabled]}
+            >
+              <Text style={styles.submitBtnText}>
+                {submitting ? '追加中...' : '追加'}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.lg,
+  },
+  dialog: {
+    backgroundColor: colors.card,
+    borderRadius: radius.xl,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.md,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: radius.md,
+    backgroundColor: colors.bg,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginHorizontal: spacing.lg,
+  },
+  form: {
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  field: {
+    gap: spacing.xs,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.textLight,
+  },
+  input: {
+    backgroundColor: colors.bg,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    fontSize: 15,
+    color: colors.text,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.lg,
+  },
+  btn: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cancelBtn: {
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  cancelBtnText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.textLight,
+  },
+  submitBtn: {
+    backgroundColor: colors.accent,
+  },
+  submitBtnText: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+  btnDisabled: {
+    opacity: 0.6,
+  },
+});

--- a/apps/mobile/src/components/menu/PantryItem.tsx
+++ b/apps/mobile/src/components/menu/PantryItem.tsx
@@ -1,0 +1,157 @@
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { colors } from '../../theme/colors';
+import { radius } from '../../theme/spacing';
+import { spacing } from '../../theme/spacing';
+
+export type PantryItemData = {
+  id: string;
+  name: string;
+  amount: string | null;
+  category: string | null;
+  expirationDate: string | null;
+  addedAt: string | null;
+};
+
+export type ExpiryStatus = 'expired' | 'expiringSoon' | 'normal';
+
+export function daysFromToday(expiryDate: string): number {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const exp = new Date(expiryDate);
+  exp.setHours(0, 0, 0, 0);
+  return Math.round((exp.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+export function getExpiryStatus(expiryDate: string | null): ExpiryStatus {
+  if (!expiryDate) return 'normal';
+  const days = daysFromToday(expiryDate);
+  if (days < 0) return 'expired';
+  if (days <= 1) return 'expiringSoon';
+  return 'normal';
+}
+
+interface Props {
+  item: PantryItemData;
+  onDelete: (id: string) => void;
+}
+
+export const PantryItem: React.FC<Props> = ({ item, onDelete }) => {
+  const status = getExpiryStatus(item.expirationDate);
+  const days = item.expirationDate ? daysFromToday(item.expirationDate) : null;
+
+  let badgeEl: React.ReactNode = null;
+  if (item.expirationDate) {
+    if (status === 'expired') {
+      badgeEl = (
+        <View style={styles.badgeExpired}>
+          <Text style={styles.badgeExpiredText}>期限切れ</Text>
+        </View>
+      );
+    } else if (status === 'expiringSoon') {
+      const label = days === 0 ? 'あと 0 日' : `あと ${days} 日`;
+      badgeEl = (
+        <View style={styles.badgeExpiringSoon}>
+          <Text style={styles.badgeExpiringSoonText}>{label}</Text>
+        </View>
+      );
+    } else {
+      const label = `あと ${days} 日`;
+      badgeEl = (
+        <View style={styles.badgeNormal}>
+          <Text style={styles.badgeNormalText}>{label}</Text>
+        </View>
+      );
+    }
+  }
+
+  return (
+    <View testID={`pantry-item-${item.id}`} style={styles.row}>
+      <View style={styles.info}>
+        <Text style={styles.name} numberOfLines={1}>
+          {item.name}
+          {item.amount ? (
+            <Text style={styles.amount}>{'  '}{item.amount}</Text>
+          ) : null}
+        </Text>
+      </View>
+      <View style={styles.right}>
+        {badgeEl}
+        <Pressable
+          testID={`pantry-delete-${item.id}`}
+          onPress={() => onDelete(item.id)}
+          hitSlop={8}
+          style={styles.deleteBtn}
+        >
+          <Ionicons name="trash-outline" size={16} color={colors.textMuted} />
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  info: {
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  name: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  amount: {
+    fontSize: 13,
+    fontWeight: '400',
+    color: colors.textLight,
+  },
+  right: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  badgeExpired: {
+    backgroundColor: '#EF9A9A',
+    borderRadius: radius.full,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  badgeExpiredText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#B71C1C',
+  },
+  badgeExpiringSoon: {
+    backgroundColor: colors.warningLight,
+    borderRadius: radius.full,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  badgeExpiringSoonText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.warning,
+  },
+  badgeNormal: {
+    borderRadius: radius.full,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  badgeNormalText: {
+    fontSize: 11,
+    color: colors.textMuted,
+  },
+  deleteBtn: {
+    padding: 4,
+  },
+});

--- a/apps/mobile/src/components/menu/PantryModal.tsx
+++ b/apps/mobile/src/components/menu/PantryModal.tsx
@@ -1,0 +1,241 @@
+import { Ionicons } from '@expo/vector-icons';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { getApi } from '../../lib/api';
+import { colors } from '../../theme/colors';
+import { radius, spacing } from '../../theme/spacing';
+import { AddFridgeModal } from './AddFridgeModal';
+import { PantryItem, type PantryItemData } from './PantryItem';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export const PantryModal: React.FC<Props> = ({ visible, onClose }) => {
+  const [items, setItems] = useState<PantryItemData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [addVisible, setAddVisible] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const api = getApi();
+      const res = await api.get<{ items: PantryItemData[] }>('/api/pantry');
+      setItems(res.items ?? []);
+    } catch (e: any) {
+      Alert.alert('取得失敗', e?.message ?? '冷蔵庫の食材を取得できませんでした。');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return;
+    load();
+  }, [visible, load]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    Alert.alert('削除', 'この食材を削除しますか？', [
+      { text: 'キャンセル', style: 'cancel' },
+      {
+        text: '削除',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            const api = getApi();
+            await api.del(`/api/pantry/${id}`);
+            setItems((prev) => prev.filter((x) => x.id !== id));
+          } catch (e: any) {
+            Alert.alert('削除失敗', e?.message ?? '削除に失敗しました。');
+          }
+        },
+      },
+    ]);
+  }, []);
+
+  const handleAddSuccess = useCallback(() => {
+    setAddVisible(false);
+    load();
+  }, [load]);
+
+  return (
+    <>
+      <Modal
+        testID="pantry-modal"
+        visible={visible}
+        animationType="slide"
+        transparent
+        onRequestClose={onClose}
+      >
+        <View style={styles.overlay}>
+          <View style={styles.sheet}>
+            {/* Header */}
+            <View style={styles.header}>
+              <View style={styles.headerLeft}>
+                <Ionicons name="snow-outline" size={18} color={colors.accent} />
+                <Text style={styles.title}>冷蔵庫</Text>
+                {!loading && (
+                  <Text style={styles.count}>{items.length}品</Text>
+                )}
+              </View>
+              <View style={styles.headerRight}>
+                <Pressable
+                  testID="pantry-add-btn"
+                  onPress={() => setAddVisible(true)}
+                  style={styles.addBtn}
+                >
+                  <Ionicons name="add" size={16} color={colors.accent} />
+                  <Text style={styles.addBtnText}>追加</Text>
+                </Pressable>
+                <Pressable onPress={onClose} style={styles.closeBtn} hitSlop={8}>
+                  <Ionicons name="close" size={20} color={colors.textMuted} />
+                </Pressable>
+              </View>
+            </View>
+
+            {/* Divider */}
+            <View style={styles.divider} />
+
+            {/* Content */}
+            {loading ? (
+              <View style={styles.loadingContainer}>
+                <ActivityIndicator size="small" color={colors.accent} />
+                <Text style={styles.loadingText}>読み込み中...</Text>
+              </View>
+            ) : items.length === 0 ? (
+              <View style={styles.emptyContainer}>
+                <Ionicons name="nutrition-outline" size={36} color={colors.textMuted} />
+                <Text style={styles.emptyText}>冷蔵庫は空です</Text>
+              </View>
+            ) : (
+              <ScrollView
+                style={styles.list}
+                contentContainerStyle={styles.listContent}
+                showsVerticalScrollIndicator={false}
+              >
+                {items.map((item) => (
+                  <PantryItem
+                    key={item.id}
+                    item={item}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </ScrollView>
+            )}
+          </View>
+        </View>
+      </Modal>
+
+      <AddFridgeModal
+        visible={addVisible}
+        onClose={() => setAddVisible(false)}
+        onSuccess={handleAddSuccess}
+      />
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: colors.card,
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    maxHeight: '80%',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing.md,
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  headerRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  count: {
+    fontSize: 13,
+    color: colors.textMuted,
+  },
+  addBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: colors.accentLight,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 6,
+  },
+  addBtnText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.accent,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: radius.md,
+    backgroundColor: colors.bg,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginHorizontal: spacing.lg,
+  },
+  loadingContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing['3xl'],
+  },
+  loadingText: {
+    fontSize: 14,
+    color: colors.textMuted,
+  },
+  emptyContainer: {
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingVertical: spacing['3xl'],
+  },
+  emptyText: {
+    fontSize: 14,
+    color: colors.textMuted,
+  },
+  list: {
+    flex: 1,
+  },
+  listContent: {
+    paddingBottom: spacing.lg,
+  },
+});


### PR DESCRIPTION
## Summary

- `PantryItem.tsx` を新設: 食材行コンポーネント。期限バッジを expired/expiringSoon/normal の 3 段階で色分け表示
- `PantryModal.tsx` を新設: 底面スライドモーダル。`GET /api/pantry` でロード、`DELETE /api/pantry/:id` で削除、追加ボタンから AddFridgeModal を呼び出し
- `AddFridgeModal.tsx` を新設: 食材追加ダイアログ。`POST /api/pantry` でサーバーへ送信
- `weekly/index.tsx` に PantryModal を組み込み: `activeModal === 'fridge'` で表示（WeeklyHeader の `onPressFridge` → `setActiveModal('fridge')` は既実装済み）
- testID 9 個追加: 設計書 Section 4.4 準拠

## Test plan

- [ ] `header-fridge-btn` をタップすると `pantry-modal` が表示される
- [ ] `pantry-add-btn` をタップすると `add-fridge-modal` が表示される
- [ ] `add-fridge-name-input` に食材名を入力し `add-fridge-submit-btn` をタップで追加される
- [ ] `pantry-delete-{id}` タップで確認ダイアログが出て削除できる
- [ ] 期限切れ食材には赤バッジ「期限切れ」が表示される
- [ ] 期限 1 日以内の食材にはオレンジバッジ「あと N 日」が表示される
- [ ] 期限に余裕がある食材にはグレー「あと N 日」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)