### PR TITLE
feat(mobile): PhotoEditModal 新設 + ManualEditModal 写真解析ボタン有効化 (#5-7)

### DIFF
--- a/apps/mobile/src/components/menu/ManualEditModal.tsx
+++ b/apps/mobile/src/components/menu/ManualEditModal.tsx
@@ -14,6 +14,7 @@ import {
 import { getApi } from "../../lib/api";
 import { colors, radius, shadows, spacing } from "../../theme";
 import { DishEditor, type DishItem } from "./DishEditor";
+import { PhotoEditModal, type MealAnalysis } from "./PhotoEditModal";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -82,6 +83,7 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
   const [isCatalogSearching, setIsCatalogSearching] = useState(false);
   const [catalogError, setCatalogError] = useState("");
   const [isSaving, setIsSaving] = useState(false);
+  const [showPhotoEdit, setShowPhotoEdit] = useState(false);
 
   const cancelledRef = useRef(false);
 
@@ -94,6 +96,7 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
       setCatalogResults([]);
       setCatalogError("");
       setIsSaving(false);
+      setShowPhotoEdit(false);
     }
   }, [visible, meal]);
 
@@ -207,7 +210,17 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
 
   // ─── Render ───────────────────────────────────────────────────────────────
 
+  function handlePhotoResult(analysis: MealAnalysis) {
+    const newDishes: DishItem[] = analysis.dishes.map((d) => ({
+      name: d.name,
+      role: d.role ?? "main",
+      kcal: d.kcal ?? null,
+    }));
+    setDishes((prev) => [...prev, ...newDishes]);
+  }
+
   return (
+    <>
     <Modal
       testID="manual-edit-modal"
       visible={visible}
@@ -422,8 +435,8 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
                 <View style={{ flexDirection: "row", gap: spacing.sm }}>
                   <Pressable
                     testID="manual-edit-photo-btn"
-                    disabled
-                    style={{
+                    onPress={() => setShowPhotoEdit(true)}
+                    style={({ pressed }) => ({
                       flex: 1,
                       flexDirection: "row",
                       alignItems: "center",
@@ -434,8 +447,8 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
                       backgroundColor: colors.blueLight,
                       borderWidth: 1,
                       borderColor: colors.border,
-                      opacity: 0.6,
-                    }}
+                      opacity: pressed ? 0.7 : 1,
+                    })}
                   >
                     <Ionicons name="camera-outline" size={16} color={colors.blue} />
                     <Text style={{ fontSize: 12, fontWeight: "600", color: colors.blue }}>
@@ -498,5 +511,11 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
         </View>
       </View>
     </Modal>
+    <PhotoEditModal
+      visible={showPhotoEdit}
+      onClose={() => setShowPhotoEdit(false)}
+      onResult={handlePhotoResult}
+    />
+    </>
   );
 }

--- a/apps/mobile/src/components/menu/PhotoEditModal.tsx
+++ b/apps/mobile/src/components/menu/PhotoEditModal.tsx
@@ -1,0 +1,248 @@
+import { Ionicons } from "@expo/vector-icons";
+import * as ImagePicker from "expo-image-picker";
+import React, { useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  Image,
+  Modal,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+
+import { getApi } from "../../lib/api";
+import { colors, radius, shadows, spacing } from "../../theme";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface MealAnalysis {
+  dishes: { name: string; kcal: number; role: string; ingredients: string[] }[];
+}
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  onResult: (analysis: MealAnalysis) => void;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function PhotoEditModal({ visible, onClose, onResult }: Props) {
+  const [photos, setPhotos] = useState<string[]>([]); // base64
+  const [analyzing, setAnalyzing] = useState(false);
+
+  // モーダルが閉じたときに state をリセット
+  function handleClose() {
+    setPhotos([]);
+    setAnalyzing(false);
+    onClose();
+  }
+
+  const pickPhoto = async () => {
+    const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!perm.granted) {
+      Alert.alert("権限エラー", "写真ライブラリへのアクセスを許可してください");
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ["images"] as any,
+      base64: true,
+      quality: 0.7,
+    });
+    if (!result.canceled) {
+      const b64 = result.assets[0].base64;
+      if (b64) setPhotos((prev) => [...prev, b64]);
+    }
+  };
+
+  const removePhoto = (index: number) => {
+    setPhotos((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const analyze = async () => {
+    if (photos.length === 0) return;
+    setAnalyzing(true);
+    try {
+      const api = getApi();
+      const data = await api.post<MealAnalysis>("/api/ai/analyze-meal-photo", {
+        images: photos.map((b64) => ({ base64: b64, mimeType: "image/jpeg" })),
+      });
+      onResult(data);
+      handleClose();
+    } catch (e: any) {
+      Alert.alert("解析エラー", "写真の解析に失敗しました");
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={handleClose}
+    >
+      <View
+        style={{
+          flex: 1,
+          justifyContent: "flex-end",
+          backgroundColor: "rgba(0,0,0,0.4)",
+        }}
+      >
+        <View
+          testID="photo-edit-modal"
+          style={{
+            backgroundColor: colors.bg,
+            borderTopLeftRadius: radius["2xl"],
+            borderTopRightRadius: radius["2xl"],
+            maxHeight: "85%",
+            paddingBottom: spacing["2xl"],
+            ...shadows.lg,
+          }}
+        >
+          {/* ヘッダー */}
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: spacing.lg,
+              borderBottomWidth: 1,
+              borderBottomColor: colors.border,
+            }}
+          >
+            <Text style={{ fontSize: 17, fontWeight: "700", color: colors.text }}>
+              写真から解析
+            </Text>
+            <Pressable
+              testID="photo-edit-close"
+              onPress={handleClose}
+              hitSlop={8}
+              style={{ padding: 4 }}
+            >
+              <Ionicons name="close" size={22} color={colors.textMuted} />
+            </Pressable>
+          </View>
+
+          {/* 説明文 */}
+          <View style={{ paddingHorizontal: spacing.lg, paddingTop: spacing.md }}>
+            <Text style={{ fontSize: 13, color: colors.textMuted, lineHeight: 18 }}>
+              食事の写真をアップロードすると、AIが料理名・カロリーを自動で認識します。複数枚まとめて解析できます。
+            </Text>
+          </View>
+
+          {/* プレビュー横スクロール */}
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={{ marginTop: spacing.lg }}
+            contentContainerStyle={{
+              paddingHorizontal: spacing.lg,
+              gap: spacing.sm,
+              alignItems: "flex-start",
+            }}
+          >
+            {photos.map((p, i) => (
+              <View
+                key={i}
+                style={{
+                  width: 90,
+                  height: 90,
+                  borderRadius: radius.lg,
+                  overflow: "visible",
+                  position: "relative",
+                }}
+              >
+                <Image
+                  source={{ uri: `data:image/jpeg;base64,${p}` }}
+                  style={{
+                    width: 90,
+                    height: 90,
+                    borderRadius: radius.lg,
+                    backgroundColor: colors.card,
+                  }}
+                />
+                <Pressable
+                  testID={`photo-edit-remove-${i}`}
+                  onPress={() => removePhoto(i)}
+                  style={{
+                    position: "absolute",
+                    top: -6,
+                    right: -6,
+                    backgroundColor: colors.bg,
+                    borderRadius: 10,
+                    padding: 0,
+                  }}
+                >
+                  <Ionicons name="close-circle" size={22} color={colors.error} />
+                </Pressable>
+              </View>
+            ))}
+
+            {/* + 写真追加ボタン */}
+            <Pressable
+              testID="photo-edit-add-photo"
+              onPress={pickPhoto}
+              style={{
+                width: 90,
+                height: 90,
+                borderRadius: radius.lg,
+                borderWidth: 1.5,
+                borderColor: colors.accent,
+                borderStyle: "dashed",
+                backgroundColor: colors.accentLight,
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 4,
+              }}
+            >
+              <Ionicons name="add" size={28} color={colors.accent} />
+              <Text style={{ fontSize: 11, fontWeight: "600", color: colors.accent }}>
+                写真追加
+              </Text>
+            </Pressable>
+          </ScrollView>
+
+          {/* 解析ボタン */}
+          <View
+            style={{
+              paddingHorizontal: spacing.lg,
+              paddingTop: spacing.lg,
+              paddingBottom: spacing.sm,
+            }}
+          >
+            <Pressable
+              testID="photo-edit-analyze-btn"
+              onPress={analyze}
+              disabled={photos.length === 0 || analyzing}
+              style={({ pressed }: { pressed: boolean }) => ({
+                alignItems: "center" as const,
+                justifyContent: "center" as const,
+                paddingVertical: spacing.md,
+                borderRadius: radius.lg,
+                backgroundColor: colors.accent,
+                opacity: photos.length === 0 || analyzing || pressed ? 0.5 : 1,
+                flexDirection: "row" as const,
+                gap: spacing.sm,
+              })}
+            >
+              {analyzing ? (
+                <ActivityIndicator size="small" color="#FFF" />
+              ) : (
+                <>
+                  <Ionicons name="sparkles-outline" size={18} color="#FFF" />
+                  <Text style={{ fontSize: 15, fontWeight: "700", color: "#FFF" }}>
+                    AIで解析する
+                  </Text>
+                </>
+              )}
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## 概要

PR 5-7: WEB の photoEdit モーダルを App に移植。ManualEditModal (PR 5-5) から呼び出されるサブモーダル。

## 変更内容

- `apps/mobile/src/components/menu/PhotoEditModal.tsx` 新設
  - expo-image-picker で写真を複数枚選択し base64 取得
  - 横スクロールプレビュー + 個別削除ボタン
  - POST `/api/ai/analyze-meal-photo` で AI 解析
  - 解析結果 (MealAnalysis 型) を `onResult` コールバックで返す
  - `testID`: `photo-edit-modal`, `photo-edit-close`, `photo-edit-add-photo`, `photo-edit-remove-{i}`, `photo-edit-analyze-btn`

- `apps/mobile/src/components/menu/ManualEditModal.tsx` 変更
  - 「写真解析」ボタンの `disabled` を解除し `onPress={() => setShowPhotoEdit(true)}` を設定
  - PhotoEditModal をサブモーダルとして組み込み
  - `handlePhotoResult` で `analysis.dishes` を既存 `dishes` state に追記マージ

## テスト計画

- [ ] ManualEditModal 内「写真解析」ボタンをタップ → PhotoEditModal が開く
- [ ] 「写真追加」ボタンをタップ → ImagePicker が起動する
- [ ] 写真選択後プレビューが表示される
- [ ] ✕ボタンで個別削除できる
- [ ] 「AIで解析する」ボタンをタップ → spinner 表示 → dishes に結果が追記される
- [ ] Maestro: `14-photo-edit-modal-open.yaml`