### PR TITLE
feat(mobile): ShoppingListModal を新設し週間献立から買い物リストをモーダルで操作できるようにする

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -28,6 +28,7 @@ import { WeeklyHeader } from "../../../src/components/menu/WeeklyHeader";
 import { V4GenerateModal } from "../../../src/components/menu/V4GenerateModal";
 import { NutritionDetailModal } from "../../../src/components/menu/NutritionDetailModal";
 import { RegenerateMealModal } from "../../../src/components/menu/RegenerateMealModal";
+import { ShoppingListModal } from "../../../src/components/menu/ShoppingListModal";
 import { useV4MenuGeneration } from "../../../src/hooks/useV4MenuGeneration";
 import { colors, spacing, radius, shadows } from "../../../src/theme";
 import { getApi, getApiBaseUrl } from "../../../src/lib/api";
@@ -1192,10 +1193,7 @@ export default function WeeklyMenuPage() {
           console.log('fridge modal placeholder');
           setActiveModal('fridge');
         }}
-        onPressShopping={() => {
-          console.log('shopping modal placeholder');
-          setActiveModal('shopping');
-        }}
+        onPressShopping={() => setActiveModal('shopping')}
       />
 
       {/* V4 AI アシスタント モーダル */}
@@ -1809,6 +1807,14 @@ export default function WeeklyMenuPage() {
         userId={profile?.id ?? ''}
         weekDayLabels={getDayLabels(weekStartDay)}
         todayMeals={todayMealsForStats}
+      />
+
+      {/* 買い物リストモーダル */}
+      <ShoppingListModal
+        visible={activeModal === 'shopping'}
+        onClose={() => setActiveModal(null)}
+        onOpenAdd={() => {}}
+        onOpenRange={() => setActiveModal(null)}
       />
 
       {/* 献立を改善モーダル */}

--- a/apps/mobile/maestro/flows/menus-weekly/07-shopping-modal.yaml
+++ b/apps/mobile/maestro/flows/menus-weekly/07-shopping-modal.yaml
@@ -1,0 +1,22 @@
+appId: com.homegohan.app
+---
+- launchApp
+- tapOn:
+    text: "ほめゴハン"
+- tapOn:
+    id: "tab-menus"
+- tapOn:
+    id: "header-shopping-btn"
+- assertVisible:
+    id: "shopping-list-modal"
+- tapOn:
+    id: "shopping-list-add-btn"
+- assertVisible:
+    id: "add-shopping-modal"
+- tapOn:
+    id: "add-shopping-name-input"
+- inputText: "テストアイテム"
+- tapOn:
+    id: "add-shopping-submit-btn"
+- assertVisible:
+    text: "テストアイテム"

--- a/apps/mobile/src/components/menu/AddShoppingModal.tsx
+++ b/apps/mobile/src/components/menu/AddShoppingModal.tsx
@@ -1,0 +1,276 @@
+import { Ionicons } from '@expo/vector-icons';
+import React, { useState } from 'react';
+import {
+  Alert,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+import { getApi } from '../../lib/api';
+import { colors, radius, spacing, typography } from '../../theme';
+
+// カテゴリ選択肢 (WEB page.tsx addShopping モーダルに合わせる)
+const CATEGORIES = [
+  '野菜',
+  '肉',
+  '魚',
+  '乳製品',
+  '卵',
+  '豆腐・大豆',
+  '麺・米',
+  '調味料',
+  '乾物',
+  '飲料',
+  'その他',
+];
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  onAdded: () => void;
+}
+
+export const AddShoppingModal: React.FC<Props> = ({ visible, onClose, onAdded }) => {
+  const [name, setName] = useState('');
+  const [quantity, setQuantity] = useState('');
+  const [category, setCategory] = useState('その他');
+  const [submitting, setSubmitting] = useState(false);
+  const [showCategoryPicker, setShowCategoryPicker] = useState(false);
+
+  function resetForm() {
+    setName('');
+    setQuantity('');
+    setCategory('その他');
+    setShowCategoryPicker(false);
+  }
+
+  function handleClose() {
+    resetForm();
+    onClose();
+  }
+
+  async function handleSubmit() {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setSubmitting(true);
+    try {
+      const api = getApi();
+      await api.post('/api/shopping-list', {
+        itemName: trimmed,
+        category: category || 'その他',
+        quantity: quantity.trim() || null,
+      });
+      resetForm();
+      onAdded();
+    } catch (e: any) {
+      Alert.alert('追加失敗', e?.message ?? '追加に失敗しました。');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      testID="add-shopping-modal"
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={handleClose}
+    >
+      <Pressable style={styles.overlay} onPress={handleClose}>
+        <Pressable style={styles.sheet} onPress={() => {}}>
+          {/* ヘッダー */}
+          <View style={styles.header}>
+            <Text style={styles.title}>買い物アイテム追加</Text>
+            <Pressable onPress={handleClose} style={styles.closeBtn} hitSlop={8}>
+              <Ionicons name="close" size={18} color={colors.textLight} />
+            </Pressable>
+          </View>
+
+          {/* フォーム */}
+          <View style={styles.form}>
+            {/* 品名 */}
+            <TextInput
+              testID="add-shopping-name-input"
+              style={styles.input}
+              placeholder="品名（例: もやし）"
+              placeholderTextColor={colors.textMuted}
+              value={name}
+              onChangeText={setName}
+              returnKeyType="next"
+            />
+
+            {/* 量 */}
+            <TextInput
+              testID="add-shopping-quantity-input"
+              style={styles.input}
+              placeholder="量（例: 2袋）"
+              placeholderTextColor={colors.textMuted}
+              value={quantity}
+              onChangeText={setQuantity}
+              returnKeyType="done"
+            />
+
+            {/* カテゴリ選択 */}
+            <Pressable
+              testID="add-shopping-category-select"
+              style={styles.selectBtn}
+              onPress={() => setShowCategoryPicker((prev) => !prev)}
+            >
+              <Text style={styles.selectText}>{category}</Text>
+              <Ionicons
+                name={showCategoryPicker ? 'chevron-up' : 'chevron-down'}
+                size={16}
+                color={colors.textMuted}
+              />
+            </Pressable>
+
+            {/* カテゴリドロップダウン */}
+            {showCategoryPicker && (
+              <ScrollView style={styles.pickerList} nestedScrollEnabled>
+                {CATEGORIES.map((cat) => (
+                  <Pressable
+                    key={cat}
+                    style={[
+                      styles.pickerItem,
+                      cat === category && styles.pickerItemSelected,
+                    ]}
+                    onPress={() => {
+                      setCategory(cat);
+                      setShowCategoryPicker(false);
+                    }}
+                  >
+                    <Text
+                      style={[
+                        styles.pickerItemText,
+                        cat === category && styles.pickerItemTextSelected,
+                      ]}
+                    >
+                      {cat}
+                    </Text>
+                  </Pressable>
+                ))}
+              </ScrollView>
+            )}
+
+            {/* 送信ボタン */}
+            <Pressable
+              testID="add-shopping-submit-btn"
+              style={[styles.submitBtn, (!name.trim() || submitting) && styles.submitBtnDisabled]}
+              onPress={handleSubmit}
+              disabled={!name.trim() || submitting}
+            >
+              <Text style={styles.submitBtnText}>
+                {submitting ? '追加中...' : '追加する'}
+              </Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: colors.card,
+    borderTopLeftRadius: radius['2xl'],
+    borderTopRightRadius: radius['2xl'],
+    paddingBottom: spacing['2xl'],
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  title: {
+    ...typography.h3,
+    color: colors.text,
+  },
+  closeBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: radius.full,
+    backgroundColor: colors.bg,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  form: {
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  input: {
+    ...typography.body,
+    color: colors.text,
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm + 4,
+  },
+  selectBtn: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm + 4,
+  },
+  selectText: {
+    ...typography.body,
+    color: colors.text,
+  },
+  pickerList: {
+    maxHeight: 200,
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+  },
+  pickerItem: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm + 2,
+  },
+  pickerItemSelected: {
+    backgroundColor: colors.accentLight,
+  },
+  pickerItemText: {
+    ...typography.body,
+    color: colors.text,
+  },
+  pickerItemTextSelected: {
+    color: colors.accent,
+    fontWeight: '700',
+  },
+  submitBtn: {
+    backgroundColor: colors.accent,
+    borderRadius: radius.lg,
+    paddingVertical: spacing.md,
+    alignItems: 'center',
+  },
+  submitBtnDisabled: {
+    opacity: 0.5,
+  },
+  submitBtnText: {
+    ...typography.bodyBold,
+    color: '#fff',
+  },
+});

--- a/apps/mobile/src/components/menu/ShoppingItem.tsx
+++ b/apps/mobile/src/components/menu/ShoppingItem.tsx
@@ -1,0 +1,189 @@
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { colors, radius, spacing, typography } from '../../theme';
+
+export type QuantityVariant = {
+  display: string;
+  unit: string;
+  value: number | null;
+};
+
+export type ShoppingItemData = {
+  id: string;
+  item_name: string;
+  quantity: string | null;
+  category: string | null;
+  is_checked: boolean;
+  source?: 'manual' | 'generated';
+  quantity_variants?: QuantityVariant[];
+  selected_variant_index?: number;
+};
+
+interface Props {
+  item: ShoppingItemData;
+  onToggleCheck: (id: string, next: boolean) => void;
+  onToggleVariant: (item: ShoppingItemData) => void;
+  onDelete: (id: string) => void;
+}
+
+export const ShoppingItem: React.FC<Props> = ({
+  item,
+  onToggleCheck,
+  onToggleVariant,
+  onDelete,
+}) => {
+  const hasVariants = item.quantity_variants && item.quantity_variants.length > 1;
+
+  return (
+    <View
+      testID={`shopping-list-item-${item.id}`}
+      style={[styles.row, item.is_checked && styles.rowChecked]}
+    >
+      {/* チェックボックス */}
+      <Pressable
+        testID={`shopping-list-checkbox-${item.id}`}
+        onPress={() => onToggleCheck(item.id, !item.is_checked)}
+        style={[styles.checkbox, item.is_checked && styles.checkboxChecked]}
+        hitSlop={8}
+      >
+        {item.is_checked && (
+          <Ionicons name="checkmark" size={12} color="#fff" />
+        )}
+      </Pressable>
+
+      {/* 品名 */}
+      <Text
+        style={[styles.name, item.is_checked && styles.nameChecked]}
+        numberOfLines={1}
+      >
+        {item.item_name}
+      </Text>
+
+      {/* 数量 / バリアントボタン */}
+      <Pressable
+        testID={`shopping-list-variant-${item.id}`}
+        onPress={() => hasVariants && onToggleVariant(item)}
+        disabled={!hasVariants}
+        style={[styles.quantityBtn, hasVariants && styles.quantityBtnActive]}
+      >
+        <Text style={styles.quantityText}>
+          {item.quantity ?? '適量'}
+          {hasVariants ? ' ⟳' : ''}
+        </Text>
+      </Pressable>
+
+      {/* AI/手動バッジ */}
+      <View
+        style={[
+          styles.badge,
+          item.source === 'generated' ? styles.badgeAi : styles.badgeManual,
+        ]}
+      >
+        <Text
+          style={[
+            styles.badgeText,
+            item.source === 'generated' ? styles.badgeAiText : styles.badgeManualText,
+          ]}
+        >
+          {item.source === 'generated' ? 'AI' : '手動'}
+        </Text>
+      </View>
+
+      {/* 削除ボタン */}
+      <Pressable
+        testID={`shopping-list-delete-${item.id}`}
+        onPress={() => onDelete(item.id)}
+        style={styles.deleteBtn}
+        hitSlop={8}
+      >
+        <Ionicons name="trash-outline" size={14} color={colors.textMuted} />
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    marginBottom: 6,
+  },
+  rowChecked: {
+    backgroundColor: colors.bg,
+    borderWidth: 0,
+    opacity: 0.6,
+  },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    borderColor: colors.border,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexShrink: 0,
+  },
+  checkboxChecked: {
+    borderWidth: 0,
+    backgroundColor: colors.success,
+  },
+  name: {
+    flex: 1,
+    ...typography.body,
+    color: colors.text,
+  },
+  nameChecked: {
+    color: colors.textMuted,
+    textDecorationLine: 'line-through',
+  },
+  quantityBtn: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radius.sm,
+  },
+  quantityBtnActive: {
+    backgroundColor: colors.bg,
+  },
+  quantityText: {
+    ...typography.small,
+    color: colors.textMuted,
+  },
+  badge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: radius.sm,
+  },
+  badgeAi: {
+    backgroundColor: '#E8F5E9',
+  },
+  badgeManual: {
+    backgroundColor: '#FFF3E0',
+  },
+  badgeText: {
+    fontSize: 10,
+    fontWeight: '700',
+  },
+  badgeAiText: {
+    color: '#2E7D32',
+  },
+  badgeManualText: {
+    color: '#E65100',
+  },
+  deleteBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: radius.md,
+    backgroundColor: 'rgba(0,0,0,0.05)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/apps/mobile/src/components/menu/ShoppingListModal.tsx
+++ b/apps/mobile/src/components/menu/ShoppingListModal.tsx
@@ -1,0 +1,480 @@
+import { Ionicons } from '@expo/vector-icons';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Dimensions,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { getApi, getApiBaseUrl } from '../../lib/api';
+import { supabase } from '../../lib/supabase';
+import { colors, radius, shadows, spacing, typography } from '../../theme';
+import { AddShoppingModal } from './AddShoppingModal';
+import { type ShoppingItemData, ShoppingItem } from './ShoppingItem';
+
+const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+
+// スーパーの動線に合わせたカテゴリ順序
+const CATEGORY_ORDER = [
+  '青果（野菜・果物）',
+  '精肉',
+  '鮮魚',
+  '乳製品・卵',
+  '豆腐・練り物',
+  '米・パン・麺',
+  '調味料',
+  '油・香辛料',
+  '乾物・缶詰',
+  '冷凍食品',
+  '飲料',
+  // 旧カテゴリとの互換性
+  '野菜',
+  '肉',
+  '魚',
+  '乳製品',
+  '卵',
+  '豆腐・大豆',
+  '麺・米',
+  '乾物',
+  '食材',
+  'その他',
+];
+
+function groupByCategoryOrder(items: ShoppingItemData[]): Array<[string, ShoppingItemData[]]> {
+  const map = new Map<string, ShoppingItemData[]>();
+  for (const item of items) {
+    const key = item.category ?? 'その他';
+    const arr = map.get(key) ?? [];
+    arr.push(item);
+    map.set(key, arr);
+  }
+  return Array.from(map.entries()).sort((a, b) => {
+    const idxA = CATEGORY_ORDER.indexOf(a[0]);
+    const idxB = CATEGORY_ORDER.indexOf(b[0]);
+    return (idxA === -1 ? 999 : idxA) - (idxB === -1 ? 999 : idxB);
+  });
+}
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  onOpenAdd: () => void;   // ShoppingListModal 内で AddShoppingModal を開く場合の外部トリガー (未使用だが設計書 props 準拠)
+  onOpenRange: () => void; // 再生成モーダル (本 PR では placeholder)
+}
+
+export const ShoppingListModal: React.FC<Props> = ({
+  visible,
+  onClose,
+  onOpenRange,
+}) => {
+  const [items, setItems] = useState<ShoppingItemData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [clearingAll, setClearingAll] = useState(false);
+  const [addModalVisible, setAddModalVisible] = useState(false);
+
+  const grouped = useMemo(() => groupByCategoryOrder(items), [items]);
+  const totalCount = items.length;
+  const uncheckedCount = items.filter((i) => !i.is_checked).length;
+
+  // データ取得
+  const load = useCallback(async () => {
+    if (!visible) return;
+    setLoading(true);
+    try {
+      const api = getApi();
+      const data = await api.get<{ items: ShoppingItemData[] }>('/api/shopping-list');
+      setItems(data?.items ?? []);
+    } catch (e: any) {
+      Alert.alert('読み込み失敗', e?.message ?? 'データの取得に失敗しました。');
+    } finally {
+      setLoading(false);
+    }
+  }, [visible]);
+
+  useEffect(() => {
+    if (visible) {
+      load();
+    }
+  }, [visible, load]);
+
+  // チェック切替 (楽観的更新)
+  const handleToggleCheck = useCallback(async (id: string, next: boolean) => {
+    // 楽観的に更新
+    setItems((prev) =>
+      prev.map((x) => (x.id === id ? { ...x, is_checked: next } : x))
+    );
+    try {
+      const api = getApi();
+      await api.patch(`/api/shopping-list/${id}`, { isChecked: next });
+    } catch (e: any) {
+      // 失敗時は revert
+      setItems((prev) =>
+        prev.map((x) => (x.id === id ? { ...x, is_checked: !next } : x))
+      );
+      Alert.alert('更新失敗', e?.message ?? '更新に失敗しました。');
+    }
+  }, []);
+
+  // バリアント切替 (楽観的更新)
+  const handleToggleVariant = useCallback(async (item: ShoppingItemData) => {
+    if (!item.quantity_variants || item.quantity_variants.length <= 1) return;
+    const nextIndex =
+      ((item.selected_variant_index ?? 0) + 1) % item.quantity_variants.length;
+    const nextQuantity = item.quantity_variants[nextIndex]?.display ?? item.quantity;
+
+    // 楽観的に更新
+    setItems((prev) =>
+      prev.map((x) =>
+        x.id === item.id
+          ? { ...x, selected_variant_index: nextIndex, quantity: nextQuantity }
+          : x
+      )
+    );
+    try {
+      const api = getApi();
+      const res = await api.patch<{ item?: ShoppingItemData }>(`/api/shopping-list/${item.id}`, {
+        selectedVariantIndex: nextIndex,
+      });
+      if (res?.item) {
+        setItems((prev) =>
+          prev.map((x) =>
+            x.id === item.id
+              ? { ...x, quantity: res.item!.quantity, selected_variant_index: nextIndex }
+              : x
+          )
+        );
+      }
+    } catch {
+      // 失敗時は revert
+      setItems((prev) =>
+        prev.map((x) =>
+          x.id === item.id
+            ? { ...x, selected_variant_index: item.selected_variant_index, quantity: item.quantity }
+            : x
+        )
+      );
+    }
+  }, []);
+
+  // 削除 (楽観的)
+  const handleDelete = useCallback((id: string) => {
+    Alert.alert('削除', 'この項目を削除しますか？', [
+      { text: 'キャンセル', style: 'cancel' },
+      {
+        text: '削除',
+        style: 'destructive',
+        onPress: async () => {
+          const prev = items;
+          setItems((cur) => cur.filter((x) => x.id !== id));
+          try {
+            const api = getApi();
+            await api.del(`/api/shopping-list/${id}`);
+          } catch (e: any) {
+            setItems(prev);
+            Alert.alert('削除失敗', e?.message ?? '削除に失敗しました。');
+          }
+        },
+      },
+    ]);
+  }, [items]);
+
+  // 全削除
+  const handleClearAll = useCallback(() => {
+    if (items.length === 0) return;
+    Alert.alert('全削除', `${items.length} 件すべてを削除しますか？`, [
+      { text: 'キャンセル', style: 'cancel' },
+      {
+        text: '全削除',
+        style: 'destructive',
+        onPress: async () => {
+          setClearingAll(true);
+          const snapshot = items;
+          setItems([]);
+          try {
+            const { data } = await supabase.auth.getSession();
+            const token = data.session?.access_token ?? null;
+            const baseUrl = getApiBaseUrl();
+            const itemIds = snapshot.map((i) => i.id);
+            const res = await fetch(`${baseUrl}/api/shopping-list`, {
+              method: 'DELETE',
+              headers: {
+                'Content-Type': 'application/json',
+                ...(token ? { Authorization: `Bearer ${token}` } : {}),
+              },
+              body: JSON.stringify({ itemIds }),
+            });
+            if (!res.ok) throw new Error('全削除に失敗しました');
+          } catch (e: any) {
+            setItems(snapshot);
+            Alert.alert('削除失敗', e?.message ?? '全削除に失敗しました。');
+          } finally {
+            setClearingAll(false);
+          }
+        },
+      },
+    ]);
+  }, [items]);
+
+  return (
+    <>
+      <Modal
+        testID="shopping-list-modal"
+        visible={visible}
+        transparent
+        animationType="slide"
+        onRequestClose={onClose}
+      >
+        <Pressable style={styles.overlay} onPress={onClose}>
+          <Pressable style={styles.sheet} onPress={() => {}}>
+            {/* ヘッダー */}
+            <View style={styles.header}>
+              <View style={styles.headerLeft}>
+                <Ionicons name="cart" size={18} color={colors.accent} />
+                <Text style={styles.headerTitle}>買い物リスト</Text>
+              </View>
+              <Pressable onPress={onClose} style={styles.closeBtn} hitSlop={8}>
+                <Ionicons name="close" size={18} color={colors.textLight} />
+              </Pressable>
+            </View>
+
+            {/* サブタイトル */}
+            {!loading && (
+              <View style={styles.subtitle}>
+                <Text style={styles.subtitleText}>
+                  {totalCount} 件（未チェック {uncheckedCount} 件）
+                </Text>
+              </View>
+            )}
+
+            {/* リスト */}
+            {loading ? (
+              <View style={styles.loadingBox}>
+                <ActivityIndicator color={colors.accent} />
+              </View>
+            ) : items.length === 0 ? (
+              <View style={styles.emptyBox}>
+                <Ionicons name="cart-outline" size={40} color={colors.textMuted} />
+                <Text style={styles.emptyText}>買い物リストが空です</Text>
+              </View>
+            ) : (
+              <ScrollView
+                style={styles.list}
+                contentContainerStyle={styles.listContent}
+                showsVerticalScrollIndicator={false}
+              >
+                {grouped.map(([category, catItems]) => (
+                  <View key={category}>
+                    {/* カテゴリヘッダー */}
+                    <View style={styles.categoryHeader}>
+                      <Text style={styles.categoryHeaderText}>
+                        {category} ({catItems.length})
+                      </Text>
+                    </View>
+                    {/* アイテム */}
+                    {catItems.map((item) => (
+                      <ShoppingItem
+                        key={item.id}
+                        item={item}
+                        onToggleCheck={handleToggleCheck}
+                        onToggleVariant={handleToggleVariant}
+                        onDelete={handleDelete}
+                      />
+                    ))}
+                  </View>
+                ))}
+              </ScrollView>
+            )}
+
+            {/* フッターボタン */}
+            <View style={styles.footer}>
+              <Pressable
+                testID="shopping-list-add-btn"
+                style={styles.addBtn}
+                onPress={() => setAddModalVisible(true)}
+              >
+                <Ionicons name="add" size={14} color={colors.textMuted} />
+                <Text style={styles.addBtnText}>追加</Text>
+              </Pressable>
+
+              <Pressable
+                testID="shopping-list-regenerate-btn"
+                style={styles.regenBtn}
+                onPress={onOpenRange}
+              >
+                <Ionicons name="refresh" size={14} color="#fff" />
+                <Text style={styles.regenBtnText}>献立から再生成</Text>
+              </Pressable>
+
+              <Pressable
+                testID="shopping-list-clear-all-btn"
+                style={[styles.clearBtn, (clearingAll || items.length === 0) && styles.clearBtnDisabled]}
+                onPress={handleClearAll}
+                disabled={clearingAll || items.length === 0}
+              >
+                {clearingAll ? (
+                  <ActivityIndicator size="small" color={colors.textMuted} />
+                ) : (
+                  <Ionicons name="trash-outline" size={16} color={colors.textMuted} />
+                )}
+              </Pressable>
+            </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
+
+      {/* 追加モーダル (ShoppingListModal の上にスタック) */}
+      <AddShoppingModal
+        visible={addModalVisible}
+        onClose={() => setAddModalVisible(false)}
+        onAdded={() => {
+          setAddModalVisible(false);
+          load();
+        }}
+      />
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: colors.card,
+    borderTopLeftRadius: radius['2xl'],
+    borderTopRightRadius: radius['2xl'],
+    maxHeight: SCREEN_HEIGHT * 0.85,
+    ...shadows.md,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  headerTitle: {
+    ...typography.h3,
+    color: colors.text,
+  },
+  closeBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: radius.full,
+    backgroundColor: colors.bg,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  subtitle: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.xs,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  subtitleText: {
+    ...typography.small,
+    color: colors.textMuted,
+  },
+  loadingBox: {
+    padding: spacing['3xl'],
+    alignItems: 'center',
+  },
+  emptyBox: {
+    padding: spacing['3xl'],
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  emptyText: {
+    ...typography.body,
+    color: colors.textMuted,
+  },
+  list: {
+    flex: 1,
+  },
+  listContent: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
+  },
+  categoryHeader: {
+    backgroundColor: colors.accentLight,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    marginBottom: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  categoryHeaderText: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.accent,
+  },
+  footer: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    paddingBottom: spacing['2xl'],
+  },
+  addBtn: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingVertical: spacing.md,
+    borderRadius: radius.lg,
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderStyle: 'dashed',
+  },
+  addBtnText: {
+    ...typography.small,
+    color: colors.textMuted,
+  },
+  regenBtn: {
+    flex: 2,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingVertical: spacing.md,
+    borderRadius: radius.lg,
+    backgroundColor: colors.accent,
+  },
+  regenBtnText: {
+    ...typography.smallBold,
+    color: '#fff',
+  },
+  clearBtn: {
+    width: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+    borderRadius: radius.lg,
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  clearBtnDisabled: {
+    opacity: 0.5,
+  },
+});


### PR DESCRIPTION
## Summary

- `ShoppingItem.tsx` 新設 — 1行UI (チェック / 量バリアント切替 / AI手動バッジ / 削除) + testID 5個
- `ShoppingListModal.tsx` 新設 — カテゴリ別グルーピング + CRUD全操作 + 楽観的更新 + testID 4個
- `AddShoppingModal.tsx` 新設 — 品名/量/カテゴリ入力フォーム + testID 4個
- `weekly/index.tsx` — `activeModal === 'shopping'` で ShoppingListModal を表示、`onPressShopping` を `setActiveModal('shopping')` に変更
- Maestro `07-shopping-modal.yaml` 追加

## API

| エンドポイント | 用途 |
|---|---|
| GET /api/shopping-list | 一覧取得 |
| PATCH /api/shopping-list/:id | チェック更新 / バリアント切替 (楽観的) |
| DELETE /api/shopping-list/:id | 削除 |
| POST /api/shopping-list | 手動追加 |
| DELETE /api/shopping-list (body: itemIds) | 全削除 |

## Test plan

- [ ] header-shopping-btn タップ → shopping-list-modal が表示される
- [ ] shopping-list-add-btn タップ → add-shopping-modal が表示される
- [ ] 品名入力 → add-shopping-submit-btn → リストに追加される
- [ ] チェックボックスタップ → 楽観的更新 + 取り消し線
- [ ] 削除ボタン → アイテムが消える
- [ ] 全削除ボタン → リストが空になる
- [ ] testID 13個すべて設計書 4.4 に一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)