### PR TITLE
fix(menus): AddMealModal の API URL を既存エンドポイントに修正

### DIFF
--- a/apps/mobile/src/components/menu/AddMealModal.tsx
+++ b/apps/mobile/src/components/menu/AddMealModal.tsx
@@ -120,7 +120,7 @@ export function AddMealModal({ visible, onClose, dayId: _dayId, dayDate, mealTyp
     setIsSubmitting(true);
     try {
       const api = getApi();
-      await api.post("/api/meal-plans/meals/simple", {
+      await api.post("/api/meal-plans/meals", {
         dayDate,
         mealType,
         mode: selectedMode,


### PR DESCRIPTION
## Summary

- `AddMealModal` の送信先 URL が `/api/meal-plans/meals/simple` になっており、存在しないルートへの POST で 404 が発生していた
- 既存の `/api/meal-plans/meals` は body 形式互換のため、URL のみ変更で対応
- これにより食事追加機能が動作するようになる

## 変更ファイル

- `apps/mobile/src/components/menu/AddMealModal.tsx` L123: URL 1 行のみ変更

## Test plan

- [ ] AddMealModal から食事を追加して 200 が返ることを確認
- [ ] 既存の POST /api/meal-plans/meals エンドポイントに正しく届くことを確認