### PR TITLE
chore: @homegohan/shared の workspace シンボリックリンクを package-lock.json に追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@homegohan/core": "*",
+        "@homegohan/shared": "*",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-native-community/slider": "4.5.5",
         "@supabase/supabase-js": "^2.78.0",
@@ -85,6 +86,7 @@
         "jest": "~29.7.0",
         "jest-expo": "~53.0.14",
         "react-test-renderer": "^19.0.0",
+        "resolve-from": "^5.0.0",
         "typescript": "~5.8.3"
       }
     },
@@ -131,6 +133,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "apps/mobile/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "apps/mobile/node_modules/typescript": {
@@ -3431,6 +3443,10 @@
     },
     "node_modules/@homegohan/core": {
       "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@homegohan/shared": {
+      "resolved": "packages/shared",
       "link": true
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -20891,6 +20907,10 @@
       "peerDependencies": {
         "zod": "^3.0.0 || ^4.0.0"
       }
+    },
+    "packages/shared": {
+      "name": "@homegohan/shared",
+      "version": "0.1.0"
     }
   }
 }


### PR DESCRIPTION
## 概要

- `npm install` 実行時に `node_modules/@homegohan/shared` シンボリックリンクが作成されなかった問題を修正
- `package-lock.json` に `@homegohan/shared` の workspace リンクエントリが欠落していたことが原因

## 変更内容

- `package-lock.json` に以下のエントリを追加（npm install により自動生成）:
  - `node_modules/@homegohan/shared` → `packages/shared` (workspace link)
  - `apps/mobile` の dependencies に `@homegohan/shared: "*"` エントリを追加

## 動作確認

- `npm install` 実行後に `node_modules/@homegohan/shared -> ../../packages/shared` シンボリックリンクが正常作成されることを確認
- `npx tsc --noEmit` で `@homegohan/shared` 関連の新規エラーが出ないことを確認

## Test plan

- [ ] `npm install` が ENOTEMPTY エラーなく完了すること
- [ ] `ls -la node_modules/@homegohan/shared` でシンボリックリンクが確認できること
- [ ] `apps/mobile` から `@homegohan/shared` のインポートが TypeScript で解決されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)