### PR TITLE
fix(nav): 献立画面でタブバーが消える問題を修正

### DIFF
--- a/apps/mobile/app/(tabs)/menus.tsx
+++ b/apps/mobile/app/(tabs)/menus.tsx
@@ -1,4 +1,1 @@
-import { Redirect } from 'expo-router';
-export default function MenusTabRedirect() {
-  return <Redirect href="/menus/weekly" />;
-}
+export { default } from '../menus/weekly/index';


### PR DESCRIPTION
## Summary

- PR 1-1 で `(tabs)/menus.tsx` を `Redirect` 化した副作用として、`/menus/weekly` に遷移するとタブバー (bottom nav) が消える問題が発生していた
- `(tabs)/menus.tsx` を `Redirect` から `WeeklyScreen` の re-export に変更し、タブ階層内で weekly コンテンツを描画することでタブバーを保持するよう修正
- WEB の `MainLayout.tsx` が全 `(main)` ページで bottom nav を表示する仕様と挙動を統一

## 変更ファイル

- `apps/mobile/app/(tabs)/menus.tsx` — `Redirect` → `WeeklyScreen` re-export に変更 (4行 → 1行)

## 修正方針

推奨方針 (★) を採用:
```tsx
// 変更前
import { Redirect } from 'expo-router';
export default function MenusTabRedirect() {
  return <Redirect href="/menus/weekly" />;
}

// 変更後
export { default } from '../menus/weekly/index';
```

`/menus/weekly` の実コンテンツを `(tabs)` 階層下で直接描画するため、Expo Router のタブバーが維持される。

## Test plan

- [ ] アプリ起動 → 「献立」タブをタップ → weekly コンテンツが表示される
- [ ] weekly 画面でタブバーが表示されていること
- [ ] モーダル (AddMealModal 等) open 時、タブバー上に overlay されること
- [ ] 他タブ (ホーム、比較、マイページ) のタブバー表示に影響がないこと
- [ ] tsc エラーが変更前後で増えていないこと (既存エラーのみ)