### PR TITLE
fix(mobile): 週間献立の曜日タブをWEB同様の7日固定横並びに変更

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -1423,8 +1423,8 @@ export default function WeeklyMenuPage() {
             </View>
           )}
 
-          {/* 日付セレクタ — 横並び丸型ピル */}
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: spacing.sm }}>
+          {/* 日付セレクタ — 7日固定横並び (flex均等配置) */}
+          <View style={{ flexDirection: "row" }}>
             {days.map((d) => {
               const selected = d.day_date === selectedDate;
               const dow = getDayOfWeek(d.day_date);
@@ -1444,34 +1444,31 @@ export default function WeeklyMenuPage() {
                   testID={`weekly-day-tab-${d.day_date}`}
                   onPress={() => setSelectedDate(d.day_date)}
                   style={({ pressed }) => ({
+                    flex: 1,
                     alignItems: "center",
                     gap: 4,
                     paddingVertical: spacing.sm,
-                    paddingHorizontal: spacing.md,
+                    paddingHorizontal: 2,
                     borderRadius: radius.lg,
-                    backgroundColor: selected ? (accentColor ?? colors.accent) : colors.card,
-                    borderWidth: 1,
-                    borderColor: selected ? (accentColor ?? colors.accent) : (accentColor ? `${accentColor}33` : colors.border),
-                    minWidth: 48,
-                    ...shadows.sm,
+                    backgroundColor: selected ? (accentColor ?? colors.accent) : "transparent",
                     ...(pressed ? { opacity: 0.9 } : {}),
                   })}
                 >
-                  <Text style={{ fontSize: 11, fontWeight: "600", color: selected ? "#fff" : (accentColor ?? colors.textMuted) }}>{dow}</Text>
-                  <Text style={{ fontSize: 16, fontWeight: "800", color: selected ? "#fff" : (accentColor ?? colors.text) }}>{dayNum}</Text>
+                  <Text style={{ fontSize: 9, color: selected ? "rgba(255,255,255,0.7)" : colors.textMuted }}>{dayNum}</Text>
+                  <Text style={{ fontSize: 13, fontWeight: "600", color: selected ? "#fff" : (accentColor ?? colors.text) }}>{dow}</Text>
                   {completedAll ? (
-                    <Ionicons name="checkmark-circle" size={14} color={selected ? "#fff" : colors.success} />
+                    <Ionicons name="checkmark-circle" size={12} color={selected ? "#fff" : colors.success} />
                   ) : hasGenerating ? (
-                    <ActivityIndicator size={12} color={selected ? "#fff" : (accentColor ?? colors.accent)} />
+                    <ActivityIndicator size={10} color={selected ? "#fff" : (accentColor ?? colors.accent)} />
                   ) : (
-                    <Text style={{ fontSize: 10, color: selected ? "rgba(255,255,255,0.7)" : colors.textMuted }}>
+                    <Text style={{ fontSize: 9, color: selected ? "rgba(255,255,255,0.7)" : colors.textMuted }}>
                       {d.planned_meals.length}食
                     </Text>
                   )}
                 </Pressable>
               );
             })}
-          </ScrollView>
+          </View>
 
           {/* 選択日のサマリ */}
           {selectedDay && daySummary.total > 0 && (


### PR DESCRIPTION
## Summary

- 週間献立画面の曜日タブを横スクロール ScrollView から flex 均等配置の固定横並びに変更
- 各日付ピルに `flex: 1` を付与し、画面幅に7日が均等に収まるレイアウトを実現
- WEB版 (src/app/(main)/menus/weekly/page.tsx) の日付タブと同様のスタイルに統一
  - 選択時: 背景色で強調 (accent / accentColor)
  - 非選択時: 透明背景のシンプルなスタイル
  - 日付 (上) → 曜日 (中) → 食数/状態 (下) の縦並び表示順をWEBと一致させた

## Test plan

- [ ] アプリを起動し、週間献立画面で7日のタブが均等横並びで表示されることを確認
- [ ] 各タブをタップして選択状態が切り替わることを確認
- [ ] 祝日/日曜日 (赤系)、土曜日 (青系) のアクセントカラーが正しく表示されることを確認
- [ ] 全完了日のチェックマーク、生成中のインジケーターが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)