### PR TITLE
fix(menu): 人数設定ボタンをフローティングからShoppingListModalヘッダーに移動

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -1816,6 +1816,7 @@ export default function WeeklyMenuPage() {
         onClose={() => setActiveModal(null)}
         onOpenAdd={() => {}}
         onOpenRange={() => setActiveModal(null)}
+        onOpenServings={() => setShowServingsModal(true)}
       />
 
       {/* 献立を改善モーダル */}
@@ -1875,26 +1876,6 @@ export default function WeeklyMenuPage() {
         })}
       >
         <Ionicons name="sparkles" size={24} color="#fff" />
-      </Pressable>
-
-      {/* 人数設定フローティングボタン */}
-      <Pressable
-        testID="weekly-servings-btn"
-        onPress={() => setShowServingsModal(true)}
-        style={{
-          position: "absolute",
-          bottom: 24 + 56 + 12,
-          right: spacing.lg,
-          backgroundColor: colors.accent,
-          borderRadius: 28,
-          width: 56,
-          height: 56,
-          alignItems: "center",
-          justifyContent: "center",
-          ...shadows.lg,
-        }}
-      >
-        <Ionicons name="people-outline" size={24} color="#FFF" />
       </Pressable>
 
       {/* 人数設定モーダル */}

--- a/apps/mobile/src/components/menu/ShoppingListModal.tsx
+++ b/apps/mobile/src/components/menu/ShoppingListModal.tsx
@@ -66,12 +66,14 @@ interface Props {
   onClose: () => void;
   onOpenAdd: () => void;   // ShoppingListModal 内で AddShoppingModal を開く場合の外部トリガー (未使用だが設計書 props 準拠)
   onOpenRange: () => void; // 再生成モーダル (本 PR では placeholder)
+  onOpenServings?: () => void; // 人数設定モーダルを開く
 }
 
 export const ShoppingListModal: React.FC<Props> = ({
   visible,
   onClose,
   onOpenRange,
+  onOpenServings,
 }) => {
   const [items, setItems] = useState<ShoppingItemData[]>([]);
   const [loading, setLoading] = useState(false);
@@ -238,9 +240,21 @@ export const ShoppingListModal: React.FC<Props> = ({
                 <Ionicons name="cart" size={18} color={colors.accent} />
                 <Text style={styles.headerTitle}>買い物リスト</Text>
               </View>
-              <Pressable onPress={onClose} style={styles.closeBtn} hitSlop={8}>
-                <Ionicons name="close" size={18} color={colors.textLight} />
-              </Pressable>
+              <View style={styles.headerRight}>
+                {onOpenServings && (
+                  <Pressable
+                    testID="shopping-list-servings-btn"
+                    onPress={onOpenServings}
+                    style={styles.servingsBtn}
+                    hitSlop={8}
+                  >
+                    <Ionicons name="people-outline" size={20} color={colors.textLight} />
+                  </Pressable>
+                )}
+                <Pressable onPress={onClose} style={styles.closeBtn} hitSlop={8}>
+                  <Ionicons name="close" size={18} color={colors.textLight} />
+                </Pressable>
+              </View>
             </View>
 
             {/* サブタイトル */}
@@ -367,6 +381,19 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.sm,
+  },
+  headerRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  servingsBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: radius.full,
+    backgroundColor: colors.bg,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   headerTitle: {
     ...typography.h3,


### PR DESCRIPTION
## 概要

WEB 版との UI 統一のため、人数設定ボタンの位置を変更した。

## 変更内容

- 画面右下のフローティング「人数設定」ボタン (`weekly-servings-btn`, 56x56) を削除
- `ShoppingListModal` のヘッダー右側に `people-outline` アイコンボタンを追加
  - testID: `shopping-list-servings-btn`
  - onPress で `onOpenServings` callback を呼ぶ
- `ShoppingListModal` に `onOpenServings?: () => void` prop を追加
- `weekly/index.tsx` の `showServingsModal` state / `ServingsModal` はそのまま維持

## テスト計画

- [ ] 買物リストモーダルを開く → ヘッダー右側に人 (people) アイコンが表示される
- [ ] 人アイコンをタップ → ServingsModal が開く
- [ ] フローティングボタンが画面から消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)