### PR TITLE
fix(weekly): SafeAreaView(top)でステータスバー重複を解消

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -11,6 +11,7 @@ import {
   Text,
   View,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import Svg, { Circle, Line, Polygon, Text as SvgText } from "react-native-svg";
 
 import { NUTRIENT_DEFINITIONS, type NutrientDefinition, MODE_CONFIG as MODE_CONFIG_SHARED, MEAL_ORDER as MEAL_ORDER_SHARED, type MealType } from "@homegohan/shared";
@@ -1183,7 +1184,7 @@ export default function WeeklyMenuPage() {
   }
 
   return (
-    <View testID="weekly-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
+    <SafeAreaView testID="weekly-screen" edges={["top"]} style={{ flex: 1, backgroundColor: colors.bg }}>
       <WeeklyHeader
         weekRangeLabel={weekRangeLabel}
         weeklyStats={weeklyStats}
@@ -2035,6 +2036,6 @@ export default function WeeklyMenuPage() {
         visible={activeModal === 'fridge'}
         onClose={() => setActiveModal(null)}
       />
-    </View>
+    </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary

- 献立画面 (`apps/mobile/app/menus/weekly/index.tsx`) の root `View` を `SafeAreaView` (edges=`['top']`) に置き換え
- `react-native-safe-area-context` から `SafeAreaView` をインポート追加
- ヘッダー「献立表」「自炊率 0% 平均 0 kcal」がステータスバー(時計表示部分)と重なって見えない問題を修正

## Test plan

- [ ] iOS/Android 実機または Simulator でステータスバー下に正しく余白が入ることを確認
- [ ] ホーム画面と同様の表示になることを確認