### PR TITLE
fix(weekly): 朝食/昼食/夕食の空スロット常時表示とAIバナーを実装

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -18,6 +18,8 @@ import { NUTRIENT_DEFINITIONS, type NutrientDefinition, MODE_CONFIG as MODE_CONF
 import { Button, Card, EmptyState, LoadingState, StatusBadge } from "../../../src/components/ui";
 import { AddMealModal } from "../../../src/components/menu/AddMealModal";
 import { AddMealSlotModal } from "../../../src/components/menu/AddMealSlotModal";
+import { EmptySlot } from "../../../src/components/menu/EmptySlot";
+import { EmptySlotAIBanner } from "../../../src/components/menu/EmptySlotAIBanner";
 import { ConfirmDeleteModal } from "../../../src/components/menu/ConfirmDeleteModal";
 import { ImproveMealModal } from "../../../src/components/menu/ImproveMealModal";
 import { ProgressTodoCard } from "../../../src/components/menu/ProgressTodoCard";
@@ -828,6 +830,21 @@ export default function WeeklyMenuPage() {
 
   const selectedDay = useMemo(() => days.find((d) => d.day_date === selectedDate) ?? null, [days, selectedDate]);
 
+  const emptySlotCount = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    let count = 0;
+    for (const day of days) {
+      const dayDate = new Date(day.day_date + "T00:00:00");
+      if (dayDate < today) continue;
+      const filledTypes = new Set(day.planned_meals.map((m) => m.meal_type));
+      for (const type of ["breakfast", "lunch", "dinner"]) {
+        if (!filledTypes.has(type)) count++;
+      }
+    }
+    return count;
+  }, [days]);
+
   function shiftWeek(delta: number) {
     const d = new Date(weekStart);
     d.setDate(d.getDate() + delta * 7);
@@ -1400,16 +1417,6 @@ export default function WeeklyMenuPage() {
           </View>
           <Button size="sm" variant="ghost" onPress={() => { setError(null); loadData(); }}>再読み込み</Button>
         </Card>
-      ) : !plan ? (
-        <View style={{ gap: spacing.lg, paddingTop: spacing["3xl"] }}>
-          <EmptyState
-            icon={<Ionicons name="restaurant-outline" size={48} color={colors.textMuted} />}
-            message="この週の献立がまだありません"
-          />
-          <Button testID="weekly-request-button" onPress={() => router.push("/menus/weekly/request")}>
-            AIで週間献立を作成
-          </Button>
-        </View>
       ) : (
         <>
           {/* AI生成中プログレス */}
@@ -1474,6 +1481,12 @@ export default function WeeklyMenuPage() {
             })}
           </View>
 
+          {/* AI バナー — 空欄件数表示 */}
+          <EmptySlotAIBanner
+            emptySlotCount={emptySlotCount}
+            onPress={() => setShowV4Modal(true)}
+          />
+
           {/* 選択日のサマリ */}
           {selectedDay && daySummary.total > 0 && (
             <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
@@ -1504,9 +1517,30 @@ export default function WeeklyMenuPage() {
             </View>
           )}
 
-          {/* 食事一覧 */}
-          {sortedMeals.length > 0 ? (
+          {/* 食事一覧 — 朝食/昼食/夕食スロットを常時表示 */}
+          {selectedDay && (
             <View style={{ gap: spacing.md }}>
+              {(["breakfast", "lunch", "dinner"] as const).map((mealType) => {
+                const m = sortedMeals.find((meal) => meal.meal_type === mealType);
+                if (!m) {
+                  return (
+                    <EmptySlot
+                      key={mealType}
+                      mealType={mealType}
+                      dayId={selectedDay.id}
+                      dayDate={selectedDay.day_date}
+                      mealLabel={MEAL_CONFIG[mealType]?.label ?? mealType}
+                      onPress={() => {
+                        setAddMealModalDayId(selectedDay.id);
+                        setAddMealModalDayDate(selectedDay.day_date);
+                        setAddMealModalMealType(mealType);
+                        setAddMealModalVisible(true);
+                      }}
+                    />
+                  );
+                }
+                return null;
+              })}
               {sortedMeals.map((m) => {
                 const mealCfg = MEAL_CONFIG[m.meal_type] ?? { icon: "ellipse", label: m.meal_type, color: colors.textMuted };
                 const modeCfg = MODE_CONFIG[m.mode ?? "cook"] ?? MODE_CONFIG.cook;
@@ -1837,51 +1871,6 @@ export default function WeeklyMenuPage() {
                   </Pressable>
                 </View>
               )}
-            </View>
-          ) : (
-            <View style={{ gap: spacing.sm }}>
-              {MEAL_ORDER.slice(0, 3).map((mealType) => (
-                <Pressable
-                  key={mealType}
-                  testID={`weekly-empty-slot-${selectedDay?.id ?? ""}-${mealType}`}
-                  onPress={() => {
-                    if (!selectedDay) return;
-                    setAddMealModalDayId(selectedDay.id);
-                    setAddMealModalDayDate(selectedDay.day_date);
-                    setAddMealModalMealType(mealType);
-                    setAddMealModalVisible(true);
-                  }}
-                  style={({ pressed }) => ({
-                    flexDirection: "row",
-                    alignItems: "center",
-                    gap: spacing.md,
-                    padding: spacing.lg,
-                    backgroundColor: pressed ? colors.card : colors.bg,
-                    borderRadius: radius.lg,
-                    borderWidth: 1,
-                    borderColor: colors.border,
-                    borderStyle: "dashed",
-                  })}
-                >
-                  <View
-                    style={{
-                      width: 44,
-                      height: 44,
-                      borderRadius: radius.md,
-                      backgroundColor: MEAL_CONFIG[mealType]?.color ?? colors.textMuted,
-                      alignItems: "center",
-                      justifyContent: "center",
-                      opacity: 0.3,
-                    }}
-                  >
-                    <Ionicons name={MEAL_CONFIG[mealType]?.icon ?? "ellipse"} size={22} color="#fff" />
-                  </View>
-                  <Text style={{ flex: 1, fontSize: 14, color: colors.textMuted }}>
-                    {MEAL_CONFIG[mealType]?.label ?? mealType} を追加
-                  </Text>
-                  <Ionicons name="add-circle-outline" size={20} color={colors.textMuted} />
-                </Pressable>
-              ))}
             </View>
           )}
         </>

--- a/apps/mobile/src/components/menu/EmptySlot.tsx
+++ b/apps/mobile/src/components/menu/EmptySlot.tsx
@@ -1,0 +1,88 @@
+import { Ionicons } from "@expo/vector-icons";
+import { ActivityIndicator, Pressable, Text, View } from "react-native";
+
+import { colors, radius, spacing } from "../../theme";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  mealType: "breakfast" | "lunch" | "dinner" | "snack";
+  dayId: string;
+  dayDate: string;
+  onPress: () => void;
+  isGenerating?: boolean;
+  mealLabel: string;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function EmptySlot({ mealType, dayId, dayDate: _dayDate, onPress, isGenerating = false, mealLabel }: Props) {
+  const mealCfgColor = MEAL_COLORS[mealType] ?? colors.textMuted;
+  const mealCfgIcon = MEAL_ICONS[mealType] ?? "ellipse";
+
+  return (
+    <Pressable
+      testID={`empty-slot-${dayId}-${mealType}`}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        flexDirection: "row",
+        alignItems: "center",
+        gap: spacing.md,
+        padding: spacing.lg,
+        backgroundColor: isGenerating
+          ? colors.accentLight
+          : pressed
+          ? colors.card
+          : colors.bg,
+        borderRadius: radius.lg,
+        borderWidth: 2,
+        borderColor: isGenerating ? colors.accent : colors.border,
+        borderStyle: "dashed",
+      })}
+    >
+      {/* 食事タイプアイコン */}
+      <View
+        style={{
+          width: 44,
+          height: 44,
+          borderRadius: radius.md,
+          backgroundColor: mealCfgColor,
+          alignItems: "center",
+          justifyContent: "center",
+          opacity: isGenerating ? 0.8 : 0.3,
+        }}
+      >
+        {isGenerating ? (
+          <ActivityIndicator size="small" color="#fff" />
+        ) : (
+          <Ionicons name={mealCfgIcon} size={22} color="#fff" />
+        )}
+      </View>
+
+      {/* テキスト */}
+      <Text style={{ flex: 1, fontSize: 14, color: isGenerating ? colors.accent : colors.textMuted }}>
+        {isGenerating ? "AI が生成中..." : `+ ${mealLabel}を追加`}
+      </Text>
+
+      {!isGenerating && (
+        <Ionicons name="add-circle-outline" size={20} color={colors.textMuted} />
+      )}
+    </Pressable>
+  );
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const MEAL_COLORS: Record<string, string> = {
+  breakfast: "#FF9800",
+  lunch: "#4CAF50",
+  dinner: "#7C4DFF",
+  snack: "#E91E63",
+};
+
+const MEAL_ICONS: Record<string, keyof typeof Ionicons.glyphMap> = {
+  breakfast: "sunny",
+  lunch: "partly-sunny",
+  dinner: "moon",
+  snack: "cafe",
+};

--- a/apps/mobile/src/components/menu/EmptySlotAIBanner.tsx
+++ b/apps/mobile/src/components/menu/EmptySlotAIBanner.tsx
@@ -1,0 +1,60 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Pressable, Text, View } from "react-native";
+
+import { colors, radius, spacing } from "../../theme";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  emptySlotCount: number;
+  onPress: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function EmptySlotAIBanner({ emptySlotCount, onPress }: Props) {
+  const hasEmpty = emptySlotCount > 0;
+
+  return (
+    <Pressable
+      testID="empty-slot-ai-banner"
+      onPress={onPress}
+      style={({ pressed }) => ({
+        flexDirection: "row",
+        alignItems: "center",
+        gap: spacing.sm,
+        paddingVertical: spacing.md,
+        paddingHorizontal: spacing.lg,
+        backgroundColor: hasEmpty
+          ? colors.accentLight
+          : colors.card,
+        borderRadius: radius.lg,
+        borderWidth: 1,
+        borderColor: hasEmpty ? colors.accent : colors.border,
+        opacity: pressed ? 0.85 : 1,
+      })}
+    >
+      <Ionicons
+        name="sparkles"
+        size={16}
+        color={hasEmpty ? colors.accent : colors.textMuted}
+      />
+      <View style={{ flex: 1 }}>
+        {hasEmpty ? (
+          <Text style={{ fontSize: 14, fontWeight: "600", color: colors.accent }}>
+            空欄{emptySlotCount}件 → AIに埋めてもらう
+          </Text>
+        ) : (
+          <Text style={{ fontSize: 14, fontWeight: "600", color: colors.textMuted }}>
+            AI献立アシスタント
+          </Text>
+        )}
+      </View>
+      <Ionicons
+        name="chevron-forward"
+        size={16}
+        color={hasEmpty ? colors.accent : colors.textMuted}
+      />
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## Summary

- **EmptySlot コンポーネント新設** (`apps/mobile/src/components/menu/EmptySlot.tsx`): 点線ボーダー(dashed)・食事タイプアイコン・「+ {mealLabel}を追加」テキストで空スロットを表示。タップで AddMealModal を開く。`isGenerating` 時はスピナーとアクセント背景に切り替わる
- **EmptySlotAIBanner コンポーネント新設** (`apps/mobile/src/components/menu/EmptySlotAIBanner.tsx`): 今日以降の空欄数を「空欄N件 → AIに埋めてもらう」として表示し、タップで V4GenerateModal を起動。0件時は「AI献立アシスタント」表示
- **emptySlotCount useMemo 追加** (`weekly/index.tsx`): 今日以降の日付で breakfast/lunch/dinner の未入力スロット数を計算
- **レンダリングロジック変更** (`weekly/index.tsx`): `!plan` の EmptyState ブランチを削除し、plan の有無によらず朝食/昼食/夕食の3スロットを常時表示。meal があればカード、なければ EmptySlot を表示

## Test plan

- [ ] `plan` がある週: 朝食/昼食/夕食で未設定のスロットに EmptySlot が表示される
- [ ] `plan` がない週: 日付タブが表示されず selectedDay = null のためスロット表示はスキップされ、AIバナーのみ表示
- [ ] EmptySlot タップ → AddMealModal が正しい dayId/dayDate/mealType で開く
- [ ] AIバナーの「空欄N件」が今日以降の未入力朝食/昼食/夕食数と一致する
- [ ] AIバナータップ → V4GenerateModal が開く
- [ ] 既存の食事カード・「食事タイプ追加」ボタンの動作に影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)