### PR TITLE
fix: ManualEditModal を WEB 仕様に完全クローン化

### DIFF
--- a/apps/mobile/src/components/menu/ManualEditModal.tsx
+++ b/apps/mobile/src/components/menu/ManualEditModal.tsx
@@ -51,6 +51,53 @@ interface Props {
   onSave: (updated: ManualEditMeal) => void;
 }
 
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const MODE_OPTIONS = [
+  {
+    mode: "cook",
+    label: "自炊",
+    icon: "restaurant" as const,
+    bg: colors.successLight,
+    fg: colors.success,
+  },
+  {
+    mode: "quick",
+    label: "時短",
+    icon: "flash" as const,
+    bg: colors.blueLight,
+    fg: colors.blue,
+  },
+  {
+    mode: "buy",
+    label: "買う",
+    icon: "bag" as const,
+    bg: colors.purpleLight,
+    fg: colors.purple,
+  },
+  {
+    mode: "out",
+    label: "外食",
+    icon: "restaurant-outline" as const,
+    bg: colors.warningLight,
+    fg: colors.warning,
+  },
+  {
+    mode: "skip",
+    label: "なし",
+    icon: "remove-circle" as const,
+    bg: "#F5F5F5",
+    fg: colors.textMuted,
+  },
+  {
+    mode: "ai_creative",
+    label: "AI献立",
+    icon: "sparkles" as const,
+    bg: colors.accentLight,
+    fg: colors.accent,
+  },
+] as const;
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function mealToDishes(meal: ManualEditMeal | null): DishItem[] {
@@ -75,13 +122,14 @@ function mealToDishes(meal: ManualEditMeal | null): DishItem[] {
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
+  const [manualMode, setManualMode] = useState<string>("cook");
   const [dishes, setDishes] = useState<DishItem[]>([]);
-  /** カタログ検索中の dish index (null = 非表示) */
-  const [showCatalog, setShowCatalog] = useState<number | null>(null);
   const [catalogQuery, setCatalogQuery] = useState("");
   const [catalogResults, setCatalogResults] = useState<CatalogProduct[]>([]);
   const [isCatalogSearching, setIsCatalogSearching] = useState(false);
   const [catalogError, setCatalogError] = useState("");
+  /** カタログ検索パネルを表示する dish index (null = 非表示) */
+  const [showCatalog, setShowCatalog] = useState<number | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [showPhotoEdit, setShowPhotoEdit] = useState(false);
 
@@ -90,6 +138,7 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
   // モーダルが開いたとき state 初期化
   useEffect(() => {
     if (visible && meal) {
+      setManualMode(meal.mode ?? "cook");
       setDishes(mealToDishes(meal));
       setShowCatalog(null);
       setCatalogQuery("");
@@ -145,11 +194,15 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
   // ─── Dish operations ─────────────────────────────────────────────────────
 
   function updateDish(index: number, d: DishItem) {
-    setDishes((prev: DishItem[]) => prev.map((item: DishItem, i: number) => (i === index ? d : item)));
+    setDishes((prev: DishItem[]) =>
+      prev.map((item: DishItem, i: number) => (i === index ? d : item))
+    );
   }
 
   function removeDish(index: number) {
-    setDishes((prev: DishItem[]) => prev.filter((_: DishItem, i: number) => i !== index));
+    setDishes((prev: DishItem[]) =>
+      prev.filter((_: DishItem, i: number) => i !== index)
+    );
   }
 
   function addDish() {
@@ -188,11 +241,13 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
         dishes: dishesPayload,
         dishName: dishes[0]?.name ?? meal.dish_name,
         caloriesKcal: totalKcal || null,
+        mode: manualMode,
       });
       const updated: ManualEditMeal = {
         ...meal,
         dish_name: dishes[0]?.name ?? meal.dish_name,
         calories_kcal: totalKcal || null,
+        mode: manualMode,
         dishes: dishesPayload.map((d) => ({
           name: d.name,
           role: d.role,
@@ -221,301 +276,522 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
 
   return (
     <>
-    <Modal
-      testID="manual-edit-modal"
-      visible={visible}
-      animationType="slide"
-      transparent
-      onRequestClose={onClose}
-    >
-      <View
-        style={{
-          flex: 1,
-          justifyContent: "flex-end",
-          backgroundColor: "rgba(0,0,0,0.4)",
-        }}
+      <Modal
+        testID="manual-edit-modal"
+        visible={visible}
+        animationType="slide"
+        transparent
+        onRequestClose={onClose}
       >
         <View
           style={{
-            backgroundColor: colors.bg,
-            borderTopLeftRadius: radius["2xl"],
-            borderTopRightRadius: radius["2xl"],
-            maxHeight: "92%",
-            paddingBottom: spacing["2xl"],
-            ...shadows.lg,
+            flex: 1,
+            justifyContent: "flex-end",
+            backgroundColor: "rgba(0,0,0,0.4)",
           }}
         >
-          {/* ヘッダー */}
           <View
             style={{
-              flexDirection: "row",
-              alignItems: "center",
-              justifyContent: "space-between",
-              padding: spacing.lg,
-              borderBottomWidth: 1,
-              borderBottomColor: colors.border,
+              backgroundColor: colors.bg,
+              borderTopLeftRadius: radius["2xl"],
+              borderTopRightRadius: radius["2xl"],
+              maxHeight: "92%",
+              paddingBottom: spacing["2xl"],
+              ...shadows.lg,
             }}
           >
-            <Text style={{ fontSize: 17, fontWeight: "700", color: colors.text }}>
-              手動編集
-            </Text>
-            <Pressable onPress={onClose} hitSlop={8} style={{ padding: 4 }}>
-              <Ionicons name="close" size={22} color={colors.textMuted} />
-            </Pressable>
-          </View>
-
-          {/* カタログ検索パネル */}
-          {showCatalog !== null ? (
-            <View style={{ flex: 1 }}>
-              {/* カタログヘッダー */}
-              <View
-                style={{
-                  flexDirection: "row",
-                  alignItems: "center",
-                  gap: spacing.sm,
-                  padding: spacing.lg,
-                  borderBottomWidth: 1,
-                  borderBottomColor: colors.border,
-                }}
+            {/* ヘッダー */}
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "space-between",
+                padding: spacing.lg,
+                borderBottomWidth: 1,
+                borderBottomColor: colors.border,
+              }}
+            >
+              <Text
+                style={{ fontSize: 17, fontWeight: "700", color: colors.text }}
               >
-                <Pressable onPress={() => setShowCatalog(null)} hitSlop={8}>
-                  <Ionicons name="arrow-back" size={20} color={colors.accent} />
-                </Pressable>
-                <Text style={{ fontSize: 15, fontWeight: "600", color: colors.text }}>
-                  カタログ検索
-                </Text>
-              </View>
+                手動で変更
+              </Text>
+              <Pressable onPress={onClose} hitSlop={8} style={{ padding: 4 }}>
+                <Ionicons name="close" size={22} color={colors.textMuted} />
+              </Pressable>
+            </View>
 
-              {/* 検索入力 */}
-              <View style={{ padding: spacing.lg, gap: spacing.sm }}>
+            {/* カタログ検索パネル */}
+            {showCatalog !== null ? (
+              <View style={{ flex: 1 }}>
+                {/* カタログヘッダー */}
                 <View
                   style={{
                     flexDirection: "row",
                     alignItems: "center",
-                    backgroundColor: colors.card,
-                    borderRadius: radius.lg,
-                    borderWidth: 1,
-                    borderColor: colors.border,
-                    paddingHorizontal: spacing.md,
                     gap: spacing.sm,
+                    padding: spacing.lg,
+                    borderBottomWidth: 1,
+                    borderBottomColor: colors.border,
                   }}
                 >
-                  <Ionicons name="search" size={16} color={colors.textMuted} />
-                  <TextInput
-                    testID="manual-edit-catalog-search-input"
-                    value={catalogQuery}
-                    onChangeText={setCatalogQuery}
-                    placeholder="商品名で検索"
-                    placeholderTextColor={colors.textMuted}
+                  <Pressable onPress={() => setShowCatalog(null)} hitSlop={8}>
+                    <Ionicons
+                      name="arrow-back"
+                      size={20}
+                      color={colors.accent}
+                    />
+                  </Pressable>
+                  <Text
                     style={{
-                      flex: 1,
-                      paddingVertical: spacing.md,
-                      fontSize: 14,
+                      fontSize: 15,
+                      fontWeight: "600",
                       color: colors.text,
                     }}
-                    autoFocus
-                    autoCorrect={false}
-                    autoCapitalize="none"
-                  />
-                  {isCatalogSearching && (
-                    <ActivityIndicator size="small" color={colors.accent} />
-                  )}
+                  >
+                    カタログ検索
+                  </Text>
                 </View>
 
-                {catalogError ? (
-                  <Text style={{ fontSize: 12, color: colors.error }}>{catalogError}</Text>
-                ) : null}
-              </View>
-
-              {/* 検索結果 */}
-              <ScrollView
-                style={{ flex: 1 }}
-                contentContainerStyle={{ paddingHorizontal: spacing.lg, gap: spacing.sm, paddingBottom: spacing.lg }}
-                keyboardShouldPersistTaps="handled"
-              >
-                {catalogResults.map((product, idx) => (
-                  <Pressable
-                    key={product.id}
-                    testID={`manual-edit-catalog-result-${idx}`}
-                    onPress={() => selectCatalogProduct(product)}
+                {/* 検索入力 */}
+                <View style={{ padding: spacing.lg, gap: spacing.sm }}>
+                  <View
                     style={{
-                      padding: spacing.md,
-                      borderRadius: radius.lg,
+                      flexDirection: "row",
+                      alignItems: "center",
                       backgroundColor: colors.card,
+                      borderRadius: radius.lg,
                       borderWidth: 1,
                       borderColor: colors.border,
-                      flexDirection: "row",
-                      alignItems: "flex-start",
-                      justifyContent: "space-between",
-                      gap: spacing.md,
+                      paddingHorizontal: spacing.md,
+                      gap: spacing.sm,
                     }}
                   >
-                    <View style={{ flex: 1 }}>
-                      {product.brandName ? (
-                        <Text style={{ fontSize: 11, color: colors.textMuted, marginBottom: 2 }}>
-                          {product.brandName}
-                        </Text>
-                      ) : null}
-                      <Text style={{ fontSize: 13, fontWeight: "600", color: colors.text }}>
-                        {product.name}
-                      </Text>
-                    </View>
-                    <Text style={{ fontSize: 11, color: colors.textMuted }}>
-                      {product.caloriesKcal ?? "-"} kcal
+                    <Ionicons
+                      name="search"
+                      size={16}
+                      color={colors.textMuted}
+                    />
+                    <TextInput
+                      testID="manual-edit-catalog-search-input"
+                      value={catalogQuery}
+                      onChangeText={setCatalogQuery}
+                      placeholder="商品名で検索"
+                      placeholderTextColor={colors.textMuted}
+                      style={{
+                        flex: 1,
+                        paddingVertical: spacing.md,
+                        fontSize: 14,
+                        color: colors.text,
+                      }}
+                      autoFocus
+                      autoCorrect={false}
+                      autoCapitalize="none"
+                    />
+                    {isCatalogSearching && (
+                      <ActivityIndicator size="small" color={colors.accent} />
+                    )}
+                  </View>
+
+                  {catalogError ? (
+                    <Text style={{ fontSize: 12, color: colors.error }}>
+                      {catalogError}
                     </Text>
-                  </Pressable>
-                ))}
+                  ) : null}
+                </View>
 
-                {!isCatalogSearching && catalogQuery.trim().length >= 2 && catalogResults.length === 0 && !catalogError && (
-                  <Text style={{ fontSize: 13, color: colors.textMuted, textAlign: "center", marginTop: spacing.xl }}>
-                    検索結果がありません
-                  </Text>
-                )}
-              </ScrollView>
-            </View>
-          ) : (
-            /* メイン編集パネル */
-            <>
-              <ScrollView
-                style={{ flex: 1 }}
-                contentContainerStyle={{ padding: spacing.lg, gap: spacing.md }}
-                keyboardShouldPersistTaps="handled"
-              >
-                {/* Dishes リスト */}
-                {dishes.map((dish, i) => (
-                  <DishEditor
-                    key={i}
-                    dish={dish}
-                    index={i}
-                    onChange={(d) => updateDish(i, d)}
-                    onDelete={() => removeDish(i)}
-                    onOpenCatalog={() => {
-                      setShowCatalog(i);
-                      setCatalogQuery(dish.name);
-                      setCatalogResults([]);
-                    }}
-                  />
-                ))}
-
-                {/* + 料理を追加 */}
-                <Pressable
-                  testID="manual-edit-add-dish"
-                  onPress={addDish}
-                  style={{
-                    flexDirection: "row",
-                    alignItems: "center",
-                    justifyContent: "center",
+                {/* 検索結果 */}
+                <ScrollView
+                  style={{ flex: 1 }}
+                  contentContainerStyle={{
+                    paddingHorizontal: spacing.lg,
                     gap: spacing.sm,
-                    paddingVertical: spacing.md,
-                    borderRadius: radius.lg,
-                    borderWidth: 1,
-                    borderColor: colors.accent,
-                    borderStyle: "dashed",
-                    backgroundColor: colors.accentLight,
+                    paddingBottom: spacing.lg,
+                  }}
+                  keyboardShouldPersistTaps="handled"
+                >
+                  {catalogResults.map((product, idx) => (
+                    <Pressable
+                      key={product.id}
+                      testID={`manual-edit-catalog-result-${idx}`}
+                      onPress={() => selectCatalogProduct(product)}
+                      style={{
+                        padding: spacing.md,
+                        borderRadius: radius.lg,
+                        backgroundColor: colors.card,
+                        borderWidth: 1,
+                        borderColor: colors.border,
+                        flexDirection: "row",
+                        alignItems: "flex-start",
+                        justifyContent: "space-between",
+                        gap: spacing.md,
+                      }}
+                    >
+                      <View style={{ flex: 1 }}>
+                        {product.brandName ? (
+                          <Text
+                            style={{
+                              fontSize: 11,
+                              color: colors.textMuted,
+                              marginBottom: 2,
+                            }}
+                          >
+                            {product.brandName}
+                          </Text>
+                        ) : null}
+                        <Text
+                          style={{
+                            fontSize: 13,
+                            fontWeight: "600",
+                            color: colors.text,
+                          }}
+                        >
+                          {product.name}
+                        </Text>
+                      </View>
+                      <Text style={{ fontSize: 11, color: colors.textMuted }}>
+                        {product.caloriesKcal ?? "-"} kcal
+                      </Text>
+                    </Pressable>
+                  ))}
+
+                  {!isCatalogSearching &&
+                    catalogQuery.trim().length >= 2 &&
+                    catalogResults.length === 0 &&
+                    !catalogError && (
+                      <Text
+                        style={{
+                          fontSize: 13,
+                          color: colors.textMuted,
+                          textAlign: "center",
+                          marginTop: spacing.xl,
+                        }}
+                      >
+                        検索結果がありません
+                      </Text>
+                    )}
+                </ScrollView>
+              </View>
+            ) : (
+              /* メイン編集パネル */
+              <>
+                <ScrollView
+                  style={{ flex: 1 }}
+                  contentContainerStyle={{
+                    padding: spacing.lg,
+                    gap: spacing.md,
+                  }}
+                  keyboardShouldPersistTaps="handled"
+                >
+                  {/* ─── タイプ ─── */}
+                  <View>
+                    <Text
+                      style={{
+                        fontSize: 12,
+                        color: colors.textMuted,
+                        marginBottom: spacing.sm,
+                      }}
+                    >
+                      タイプ
+                    </Text>
+                    <View
+                      style={{
+                        flexDirection: "row",
+                        flexWrap: "wrap",
+                        gap: spacing.sm,
+                      }}
+                    >
+                      {MODE_OPTIONS.map((opt) => {
+                        const isSelected = manualMode === opt.mode;
+                        return (
+                          <Pressable
+                            key={opt.mode}
+                            testID={`manual-edit-mode-${opt.mode}`}
+                            onPress={() => setManualMode(opt.mode)}
+                            style={{
+                              flexDirection: "row",
+                              alignItems: "center",
+                              gap: spacing.xs,
+                              paddingHorizontal: spacing.md,
+                              paddingVertical: spacing.sm,
+                              borderRadius: radius.lg,
+                              backgroundColor: isSelected ? opt.bg : colors.card,
+                              borderWidth: 1.5,
+                              borderColor: isSelected ? opt.fg : colors.border,
+                            }}
+                          >
+                            <Ionicons
+                              name={opt.icon}
+                              size={14}
+                              color={isSelected ? opt.fg : colors.textMuted}
+                            />
+                            <Text
+                              style={{
+                                fontSize: 12,
+                                fontWeight: isSelected ? "700" : "500",
+                                color: isSelected ? opt.fg : colors.textMuted,
+                              }}
+                            >
+                              {opt.label}
+                            </Text>
+                          </Pressable>
+                        );
+                      })}
+                    </View>
+                  </View>
+
+                  {/* ─── 市販品・外食メニューから選ぶ ─── */}
+                  <View>
+                    <Text
+                      style={{
+                        fontSize: 12,
+                        color: colors.textMuted,
+                        marginBottom: spacing.sm,
+                      }}
+                    >
+                      市販品・外食メニューから選ぶ
+                    </Text>
+                    <View
+                      style={{
+                        flexDirection: "row",
+                        alignItems: "center",
+                        backgroundColor: colors.card,
+                        borderRadius: radius.lg,
+                        borderWidth: 1,
+                        borderColor: colors.border,
+                        paddingHorizontal: spacing.md,
+                        gap: spacing.sm,
+                      }}
+                    >
+                      <Ionicons
+                        name="search-outline"
+                        size={16}
+                        color={colors.textMuted}
+                      />
+                      <TextInput
+                        testID="manual-edit-search-input"
+                        value={catalogQuery}
+                        onChangeText={setCatalogQuery}
+                        placeholder="商品名で検索"
+                        placeholderTextColor={colors.textMuted}
+                        style={{
+                          flex: 1,
+                          paddingVertical: spacing.md,
+                          fontSize: 14,
+                          color: colors.text,
+                        }}
+                        autoCorrect={false}
+                        autoCapitalize="none"
+                      />
+                      {isCatalogSearching && (
+                        <ActivityIndicator size="small" color={colors.accent} />
+                      )}
+                    </View>
+                    <Text
+                      style={{
+                        fontSize: 11,
+                        color: colors.textMuted,
+                        marginTop: spacing.xs,
+                      }}
+                    >
+                      コンビニだけでなく、今後はスーパーや外食メニューも同じ catalog で追加します。
+                    </Text>
+                    {catalogError ? (
+                      <Text
+                        style={{
+                          fontSize: 12,
+                          color: colors.error,
+                          marginTop: spacing.xs,
+                        }}
+                      >
+                        {catalogError}
+                      </Text>
+                    ) : null}
+                  </View>
+
+                  {/* ─── 料理（複数可） ─── */}
+                  <View>
+                    <View
+                      style={{
+                        flexDirection: "row",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        marginBottom: spacing.sm,
+                      }}
+                    >
+                      <Text style={{ fontSize: 12, color: colors.textMuted }}>
+                        料理（複数可）
+                      </Text>
+                      <Pressable
+                        testID="manual-edit-add-dish"
+                        onPress={addDish}
+                        hitSlop={8}
+                        style={{ flexDirection: "row", alignItems: "center", gap: 2 }}
+                      >
+                        <Ionicons
+                          name="add"
+                          size={14}
+                          color={colors.accent}
+                        />
+                        <Text
+                          style={{
+                            fontSize: 12,
+                            fontWeight: "600",
+                            color: colors.accent,
+                          }}
+                        >
+                          追加
+                        </Text>
+                      </Pressable>
+                    </View>
+
+                    {/* Dishes リスト */}
+                    <View style={{ gap: spacing.sm }}>
+                      {dishes.map((dish, i) => (
+                        <DishEditor
+                          key={i}
+                          dish={dish}
+                          index={i}
+                          onChange={(d) => updateDish(i, d)}
+                          onDelete={() => removeDish(i)}
+                          onOpenCatalog={() => {
+                            setShowCatalog(i);
+                            setCatalogQuery(dish.name);
+                            setCatalogResults([]);
+                          }}
+                        />
+                      ))}
+                    </View>
+                  </View>
+                </ScrollView>
+
+                {/* フッター */}
+                <View
+                  style={{
+                    paddingHorizontal: spacing.lg,
+                    paddingTop: spacing.md,
+                    borderTopWidth: 1,
+                    borderTopColor: colors.border,
+                    gap: spacing.sm,
                   }}
                 >
-                  <Ionicons name="add-circle-outline" size={18} color={colors.accent} />
-                  <Text style={{ fontSize: 14, fontWeight: "600", color: colors.accent }}>
-                    料理を追加
-                  </Text>
-                </Pressable>
-              </ScrollView>
+                  {/* 写真から入力 / AI画像生成 */}
+                  <View style={{ flexDirection: "row", gap: spacing.sm }}>
+                    <Pressable
+                      testID="manual-edit-photo-btn"
+                      onPress={() => setShowPhotoEdit(true)}
+                      style={({ pressed }) => ({
+                        flex: 1,
+                        flexDirection: "row",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        gap: spacing.xs,
+                        paddingVertical: spacing.sm,
+                        borderRadius: radius.lg,
+                        backgroundColor: colors.blueLight,
+                        borderWidth: 1,
+                        borderColor: colors.blue,
+                        opacity: pressed ? 0.7 : 1,
+                      })}
+                    >
+                      <Ionicons
+                        name="camera-outline"
+                        size={16}
+                        color={colors.blue}
+                      />
+                      <Text
+                        style={{
+                          fontSize: 12,
+                          fontWeight: "600",
+                          color: colors.blue,
+                        }}
+                      >
+                        写真から入力
+                      </Text>
+                    </Pressable>
 
-              {/* フッター */}
-              <View
-                style={{
-                  paddingHorizontal: spacing.lg,
-                  paddingTop: spacing.md,
-                  borderTopWidth: 1,
-                  borderTopColor: colors.border,
-                  gap: spacing.sm,
-                }}
-              >
-                {/* 写真解析 / AI 画像生成 */}
-                <View style={{ flexDirection: "row", gap: spacing.sm }}>
+                    <Pressable
+                      testID="manual-edit-image-gen-btn"
+                      disabled
+                      style={{
+                        flex: 1,
+                        flexDirection: "row",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        gap: spacing.xs,
+                        paddingVertical: spacing.sm,
+                        borderRadius: radius.lg,
+                        backgroundColor: colors.accentLight,
+                        borderWidth: 1,
+                        borderColor: colors.accent,
+                        opacity: 0.5,
+                      }}
+                    >
+                      <Ionicons
+                        name="color-palette-outline"
+                        size={16}
+                        color={colors.accent}
+                      />
+                      <Text
+                        style={{
+                          fontSize: 12,
+                          fontWeight: "600",
+                          color: colors.accent,
+                        }}
+                      >
+                        AIで画像生成
+                      </Text>
+                    </Pressable>
+                  </View>
+
+                  {/* 保存ボタン */}
                   <Pressable
-                    testID="manual-edit-photo-btn"
-                    onPress={() => setShowPhotoEdit(true)}
+                    testID="manual-edit-save-btn"
+                    onPress={handleSave}
+                    disabled={isSaving}
                     style={({ pressed }) => ({
-                      flex: 1,
-                      flexDirection: "row",
                       alignItems: "center",
                       justifyContent: "center",
-                      gap: spacing.xs,
-                      paddingVertical: spacing.sm,
+                      paddingVertical: spacing.md,
                       borderRadius: radius.lg,
-                      backgroundColor: colors.blueLight,
-                      borderWidth: 1,
-                      borderColor: colors.border,
-                      opacity: pressed ? 0.7 : 1,
+                      backgroundColor: isSaving
+                        ? colors.textMuted
+                        : colors.accent,
+                      opacity: pressed || isSaving ? 0.8 : 1,
+                      flexDirection: "row",
+                      gap: spacing.sm,
                     })}
                   >
-                    <Ionicons name="camera-outline" size={16} color={colors.blue} />
-                    <Text style={{ fontSize: 12, fontWeight: "600", color: colors.blue }}>
-                      写真解析
-                    </Text>
-                  </Pressable>
-
-                  <Pressable
-                    testID="manual-edit-image-gen-btn"
-                    disabled
-                    style={{
-                      flex: 1,
-                      flexDirection: "row",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      gap: spacing.xs,
-                      paddingVertical: spacing.sm,
-                      borderRadius: radius.lg,
-                      backgroundColor: colors.purpleLight,
-                      borderWidth: 1,
-                      borderColor: colors.border,
-                      opacity: 0.5,
-                    }}
-                  >
-                    <Ionicons name="color-palette-outline" size={16} color={colors.purple} />
-                    <Text style={{ fontSize: 12, fontWeight: "600", color: colors.purple }}>
-                      AI 画像 (準備中)
+                    {isSaving ? (
+                      <ActivityIndicator size="small" color="#fff" />
+                    ) : (
+                      <Ionicons
+                        name="checkmark-circle-outline"
+                        size={18}
+                        color="#fff"
+                      />
+                    )}
+                    <Text
+                      style={{
+                        fontSize: 15,
+                        fontWeight: "700",
+                        color: "#fff",
+                      }}
+                    >
+                      {isSaving ? "保存中..." : "保存する"}
                     </Text>
                   </Pressable>
                 </View>
-
-                {/* 保存ボタン */}
-                <Pressable
-                  testID="manual-edit-save-btn"
-                  onPress={handleSave}
-                  disabled={isSaving}
-                  style={({ pressed }) => ({
-                    alignItems: "center",
-                    justifyContent: "center",
-                    paddingVertical: spacing.md,
-                    borderRadius: radius.lg,
-                    backgroundColor: isSaving ? colors.textMuted : colors.accent,
-                    opacity: pressed || isSaving ? 0.8 : 1,
-                    flexDirection: "row",
-                    gap: spacing.sm,
-                  })}
-                >
-                  {isSaving ? (
-                    <ActivityIndicator size="small" color="#fff" />
-                  ) : (
-                    <Ionicons name="checkmark-circle-outline" size={18} color="#fff" />
-                  )}
-                  <Text style={{ fontSize: 15, fontWeight: "700", color: "#fff" }}>
-                    {isSaving ? "保存中..." : "保存する"}
-                  </Text>
-                </Pressable>
-              </View>
-            </>
-          )}
+              </>
+            )}
+          </View>
         </View>
-      </View>
-    </Modal>
-    <PhotoEditModal
-      visible={showPhotoEdit}
-      onClose={() => setShowPhotoEdit(false)}
-      onResult={handlePhotoResult}
-    />
+      </Modal>
+      <PhotoEditModal
+        visible={showPhotoEdit}
+        onClose={() => setShowPhotoEdit(false)}
+        onResult={handlePhotoResult}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- タイトルを「手動編集」→「手動で変更」に変更
- タイプ選択 6 ボタン (自炊/時短/買う/外食/なし/AI献立) を追加し `manualMode` state で管理
- 市販品・外食メニュー検索セクション (商品名 input + 説明文) をメインパネルに追加
- 料理セクションに「料理（複数可）」ラベルと右上「+ 追加」ボタンを配置
- 写真ボタンを「写真解析」→「写真から入力」、AI ボタンを accentLight/accent 色で「AIで画像生成」に変更
- `handleSave` で `mode` も PATCH リクエストに含めるよう修正
- testID: `manual-edit-mode-{mode}` × 6、`manual-edit-search-input` を追加

## Test plan

- [ ] ManualEditModal を開き、タイプ 6 ボタンが表示されること
- [ ] 各ボタンを押すと選択状態（ハイライト枠線）に切り替わること
- [ ] 商品名検索 input に入力できること
- [ ] 「料理（複数可）」ラベルと「+ 追加」ボタンが表示されること
- [ ] 「+ 追加」で dish 行が追加されること
- [ ] 「写真から入力」ボタンが blueLight/blue で表示されること
- [ ] 「AIで画像生成」ボタンが accentLight/accent で表示されること
- [ ] 「保存する」で mode が PATCH に含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)