### PR TITLE
feat: App に Noto Sans JP を導入し WEB とフォントを統一

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,16 +1,25 @@
+import {
+  NotoSansJP_400Regular,
+  NotoSansJP_500Medium,
+  NotoSansJP_700Bold,
+  useFonts,
+} from '@expo-google-fonts/noto-sans-jp';
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as SplashScreen from 'expo-splash-screen';
 import { Stack } from "expo-router";
 import { useEffect } from "react";
 import { LogBox } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
+import { registerAndSaveExpoPushToken } from "../src/lib/pushNotifications";
+import { AuthProvider, useAuth } from "../src/providers/AuthProvider";
+import { ProfileProvider } from "../src/providers/ProfileProvider";
+
 // E2E テスト中に LogBox の自動ポップアップがタップを横取りして失敗するため抑制する
 // (console.error は引き続き Metro ログに出力される)
 LogBox.ignoreAllLogs();
 
-import { registerAndSaveExpoPushToken } from "../src/lib/pushNotifications";
-import { AuthProvider, useAuth } from "../src/providers/AuthProvider";
-import { ProfileProvider } from "../src/providers/ProfileProvider";
+SplashScreen.preventAutoHideAsync();
 
 const PUSH_TOKEN_REGISTERED_KEY = "push_token_registered_v1";
 
@@ -38,6 +47,20 @@ function PushTokenRegistrar() {
 }
 
 export default function RootLayout() {
+  const [fontsLoaded] = useFonts({
+    NotoSansJP_400Regular,
+    NotoSansJP_500Medium,
+    NotoSansJP_700Bold,
+  });
+
+  useEffect(() => {
+    if (fontsLoaded) {
+      SplashScreen.hideAsync();
+    }
+  }, [fontsLoaded]);
+
+  if (!fontsLoaded) return null;
+
   return (
     <SafeAreaProvider>
       <AuthProvider>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@expo-google-fonts/noto-sans-jp": "^0.4.3",
     "@homegohan/core": "*",
     "@homegohan/shared": "*",
     "@react-native-async-storage/async-storage": "2.1.2",
@@ -22,6 +23,7 @@
     "expo-constants": "~17.1.8",
     "expo-device": "~7.1.4",
     "expo-file-system": "~18.0.12",
+    "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
     "expo-image-manipulator": "~13.1.7",
     "expo-image-picker": "~16.1.4",
@@ -30,6 +32,7 @@
     "expo-notifications": "~0.31.5",
     "expo-router": "~5.1.11",
     "expo-sharing": "~13.0.1",
+    "expo-splash-screen": "~0.30.10",
     "expo-web-browser": "~15.0.0",
     "react": "19.0.0",
     "react-native": "0.79.6",
@@ -42,13 +45,13 @@
   },
   "devDependencies": {
     "@testing-library/jest-native": "^5.4.3",
-    "resolve-from": "^5.0.0",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^30.0.0",
     "@types/react": "~19.0.10",
     "jest": "~29.7.0",
     "jest-expo": "~53.0.14",
     "react-test-renderer": "^19.0.0",
+    "resolve-from": "^5.0.0",
     "typescript": "~5.8.3"
   }
 }

--- a/apps/mobile/src/theme/typography.ts
+++ b/apps/mobile/src/theme/typography.ts
@@ -3,34 +3,34 @@ import { colors } from './colors';
 
 export const typography = {
   // --- 設計書 COMMON.md Section 2 準拠 ---
-  h1:       { fontSize: 24, fontWeight: '800' as const, lineHeight: 32 },
-  h2:       { fontSize: 20, fontWeight: '700' as const, lineHeight: 28 },
-  h3:       { fontSize: 16, fontWeight: '700' as const, lineHeight: 22 },
-  body:     { fontSize: 14, fontWeight: '400' as const, lineHeight: 20 },
-  bodyBold: { fontSize: 14, fontWeight: '700' as const, lineHeight: 20 },
-  small:    { fontSize: 12, fontWeight: '400' as const, lineHeight: 16 },
-  smallBold:{ fontSize: 12, fontWeight: '700' as const, lineHeight: 16 },
-  tiny:     { fontSize: 10, fontWeight: '700' as const, lineHeight: 14 },
+  h1:       { fontFamily: 'NotoSansJP_700Bold',    fontSize: 24, lineHeight: 32 },
+  h2:       { fontFamily: 'NotoSansJP_700Bold',    fontSize: 20, lineHeight: 28 },
+  h3:       { fontFamily: 'NotoSansJP_700Bold',    fontSize: 16, lineHeight: 22 },
+  body:     { fontFamily: 'NotoSansJP_400Regular', fontSize: 14, lineHeight: 20 },
+  bodyBold: { fontFamily: 'NotoSansJP_700Bold',    fontSize: 14, lineHeight: 20 },
+  small:    { fontFamily: 'NotoSansJP_400Regular', fontSize: 12, lineHeight: 16 },
+  smallBold:{ fontFamily: 'NotoSansJP_700Bold',    fontSize: 12, lineHeight: 16 },
+  tiny:     { fontFamily: 'NotoSansJP_700Bold',    fontSize: 10, lineHeight: 14 },
 
   // --- 後方互換 (既存スクリーンで参照中のキー) ---
   bodySmall: {
+    fontFamily: 'NotoSansJP_400Regular',
     fontSize: 13,
-    fontWeight: '400',
     color: colors.textMuted,
   } as TextStyle,
   caption: {
+    fontFamily: 'NotoSansJP_500Medium',
     fontSize: 12,
-    fontWeight: '500',
     color: colors.textMuted,
   } as TextStyle,
   label: {
+    fontFamily: 'NotoSansJP_500Medium',
     fontSize: 14,
-    fontWeight: '600',
     color: colors.text,
   } as TextStyle,
   number: {
+    fontFamily: 'NotoSansJP_700Bold',
     fontSize: 24,
-    fontWeight: '900',
     color: colors.text,
   } as TextStyle,
 } as const;

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
       "name": "homegohan-mobile",
       "version": "0.1.0",
       "dependencies": {
+        "@expo-google-fonts/noto-sans-jp": "^0.4.3",
         "@homegohan/core": "*",
         "@homegohan/shared": "*",
         "@react-native-async-storage/async-storage": "2.1.2",
@@ -60,6 +61,7 @@
         "expo-constants": "~17.1.8",
         "expo-device": "~7.1.4",
         "expo-file-system": "~18.0.12",
+        "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
         "expo-image-manipulator": "~13.1.7",
         "expo-image-picker": "~16.1.4",
@@ -68,6 +70,7 @@
         "expo-notifications": "~0.31.5",
         "expo-router": "~5.1.11",
         "expo-sharing": "~13.0.1",
+        "expo-splash-screen": "~0.30.10",
         "expo-web-browser": "~15.0.0",
         "react": "19.0.0",
         "react-native": "0.79.6",
@@ -2300,6 +2303,12 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@expo-google-fonts/noto-sans-jp": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/noto-sans-jp/-/noto-sans-jp-0.4.3.tgz",
+      "integrity": "sha512-Fl+Z6vtD24HFAYsvzB0S9Nery1ly16B9PesdY0wBd+wEHAvkNglnkTUspU0HqGOubkmoa8zusJrKv6vDx1o70A==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/cli": {
       "version": "0.24.24",
@@ -10773,6 +10782,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-splash-screen": {
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.30.10.tgz",
+      "integrity": "sha512-Tt9va/sLENQDQYeOQ6cdLdGvTZ644KR3YG9aRlnpcs2/beYjOX1LHT510EGzVN9ljUTg+1ebEo5GGt2arYtPjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/prebuild-config": "^9.0.10"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-web-browser": {


### PR DESCRIPTION
## Summary

- `@expo-google-fonts/noto-sans-jp` を追加し、App で Noto Sans JP フォントを使用可能にした
- `apps/mobile/app/_layout.tsx` に `useFonts` / `SplashScreen.preventAutoHideAsync` を追加し、フォントをスプラッシュ画面表示中にプリロードするよう対応
- `apps/mobile/src/theme/typography.ts` の全キーに `fontFamily: NotoSansJP_*` を設定し、`fontWeight` を削除してフォントファミリーで太さを制御するよう変更

## 変更内容

| ファイル | 内容 |
|---|---|
| `apps/mobile/package.json` | `@expo-google-fonts/noto-sans-jp ^0.4.3` を追加 |
| `apps/mobile/app/_layout.tsx` | `useFonts` + `SplashScreen` によるフォントプリロード処理を追加 |
| `apps/mobile/src/theme/typography.ts` | 全スタイルキーに `fontFamily` を追加、`fontWeight` を削除 |

## Test plan

- [ ] iOS シミュレータでフォントが Noto Sans JP で表示されることを確認
- [ ] Android エミュレータでフォントが Noto Sans JP で表示されることを確認
- [ ] スプラッシュ画面がフォントロード完了後に非表示になることを確認
- [ ] 既存スクリーン (週次メニュー、モーダル等) の文字表示に崩れがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)