### PR TITLE
feat(ai): AIChatBubble 相当の floating sheet を App に移植

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -5,6 +5,7 @@ import { ActivityIndicator, View } from "react-native";
 import { colors } from "../../src/theme";
 import { useAuth } from "../../src/providers/AuthProvider";
 import { useProfile } from "../../src/providers/ProfileProvider";
+import { AIFloatingFab } from "../../src/components/ai/AIFloatingFab";
 
 export default function TabsLayout() {
   const { session, isLoading } = useAuth();
@@ -30,7 +31,8 @@ export default function TabsLayout() {
   }
 
   return (
-    <Tabs
+    <>
+      <Tabs
       screenOptions={{
         headerShown: false,
         tabBarStyle: {
@@ -107,5 +109,7 @@ export default function TabsLayout() {
       <Tabs.Screen name="health" options={{ href: null }} />
       <Tabs.Screen name="settings" options={{ href: null }} />
     </Tabs>
+      <AIFloatingFab />
+    </>
   );
 }

--- a/apps/mobile/src/components/ai/AIAdvisorSheet.tsx
+++ b/apps/mobile/src/components/ai/AIAdvisorSheet.tsx
@@ -1,0 +1,655 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import { colors, radius, shadows, spacing } from "../../theme";
+import { getApi, getApiBaseUrl } from "../../lib/api";
+import { supabase } from "../../lib/supabase";
+import { AIDayMenuModal } from "./AIDayMenuModal";
+
+// ============================================================
+// Types
+// ============================================================
+
+type Message = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  createdAt: string;
+};
+
+type Session = {
+  id: string;
+  title: string;
+  messageCount: number;
+  status?: string;
+};
+
+// ============================================================
+// Constants
+// ============================================================
+
+const WELCOME_MESSAGE: Message = {
+  id: "welcome",
+  role: "assistant",
+  content:
+    "こんにちは！🍳 ほめゴハンのAIアドバイザーです。\n\n食事や栄養のことで気になることがあれば、何でも聞いてくださいね。献立の提案や、買い物リストの作成もお手伝いできますよ！",
+  createdAt: new Date().toISOString(),
+};
+
+const QUICK_QUESTIONS = [
+  "献立を提案してほしい",
+  "冷蔵庫の食材で作れるものは?",
+  "今日の栄養バランスは?",
+  "来週の献立を作りたい",
+];
+
+// ============================================================
+// Props
+// ============================================================
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+// ============================================================
+// Component
+// ============================================================
+
+export const AIAdvisorSheet: React.FC<Props> = ({ visible, onClose }) => {
+  const [messages, setMessages] = useState<Message[]>([WELCOME_MESSAGE]);
+  const [inputText, setInputText] = useState("");
+  const [sending, setSending] = useState(false);
+  const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
+  const [streamingContent, setStreamingContent] = useState<string | null>(null);
+  const [dayMenuModalVisible, setDayMenuModalVisible] = useState(false);
+
+  const scrollRef = useRef<ScrollView>(null);
+
+  // セッション初期化
+  useEffect(() => {
+    if (visible && !currentSessionId) {
+      initSession();
+    }
+  }, [visible]);
+
+  // メッセージ追加時にスクロール
+  useEffect(() => {
+    const t = setTimeout(() => {
+      scrollRef.current?.scrollToEnd({ animated: true });
+    }, 100);
+    return () => clearTimeout(t);
+  }, [messages.length, streamingContent]);
+
+  async function initSession() {
+    try {
+      const api = getApi();
+      // 既存アクティブセッション取得
+      const res = await api.get<{ sessions: Session[] }>(
+        "/api/ai/consultation/sessions?status=active"
+      );
+      const sessions = res.sessions ?? [];
+      if (sessions.length > 0) {
+        setCurrentSessionId(sessions[0].id);
+        // 既存メッセージを読み込む
+        const msgRes = await api.get<{ messages: Message[] }>(
+          `/api/ai/consultation/sessions/${sessions[0].id}/messages`
+        );
+        const loaded = msgRes.messages ?? [];
+        if (loaded.length > 0) {
+          setMessages(loaded);
+        } else {
+          setMessages([WELCOME_MESSAGE]);
+        }
+      } else {
+        // 新規セッション作成
+        const createRes = await api.post<{
+          success: boolean;
+          session: { id: string };
+        }>("/api/ai/consultation/sessions", { title: "AI相談" });
+        setCurrentSessionId(createRes.session.id);
+        setMessages([WELCOME_MESSAGE]);
+      }
+    } catch {
+      // セッション作成失敗時はウェルカムメッセージだけ表示
+      setMessages([WELCOME_MESSAGE]);
+    }
+  }
+
+  async function sendMessage(text: string) {
+    const trimmed = text.trim();
+    if (!trimmed || sending) return;
+
+    setSending(true);
+    setInputText("");
+    setStreamingContent(null);
+
+    const optimistic: Message = {
+      id: `local-${Date.now()}`,
+      role: "user",
+      content: trimmed,
+      createdAt: new Date().toISOString(),
+    };
+    setMessages((prev) => [...prev, optimistic]);
+
+    try {
+      // セッションがなければ作成
+      let sessionId = currentSessionId;
+      if (!sessionId) {
+        const api = getApi();
+        const createRes = await api.post<{
+          success: boolean;
+          session: { id: string };
+        }>("/api/ai/consultation/sessions", { title: "AI相談" });
+        sessionId = createRes.session.id;
+        setCurrentSessionId(sessionId);
+      }
+
+      // SSEストリーミング送信
+      const { data: sessionData } = await supabase.auth.getSession();
+      const token = sessionData.session?.access_token ?? null;
+      const baseUrl = getApiBaseUrl();
+      const url = `${baseUrl}/api/ai/consultation/sessions/${sessionId}/messages?stream=true`;
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 26000);
+
+      let res: Response;
+      try {
+        res = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({ message: trimmed }),
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timeoutId);
+      }
+
+      if (!res.ok) {
+        const errText = await res.text().catch(() => "");
+        throw new Error(`HTTP ${res.status}: ${errText}`);
+      }
+
+      if (!res.body) {
+        // SSE非対応環境: メッセージ一覧を再取得
+        const api = getApi();
+        const msgRes = await api.get<{ messages: Message[] }>(
+          `/api/ai/consultation/sessions/${sessionId}/messages`
+        );
+        setMessages(msgRes.messages ?? [WELCOME_MESSAGE]);
+        return;
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let accumulated = "";
+      let finalHandled = false;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const raw = line.slice(6);
+          if (raw === "[DONE]") continue;
+
+          let parsed: any;
+          try {
+            parsed = JSON.parse(raw);
+          } catch {
+            continue;
+          }
+
+          const chunk = parsed?.choices?.[0]?.delta?.content;
+          if (chunk) {
+            accumulated += chunk;
+            setStreamingContent(accumulated);
+            continue;
+          }
+
+          if (parsed?.aiMessage) {
+            finalHandled = true;
+            setStreamingContent(null);
+            const aiMsg: Message = {
+              id: parsed.aiMessage.id ?? `ai-${Date.now()}`,
+              role: "assistant",
+              content: parsed.aiMessage.content ?? accumulated,
+              createdAt: parsed.aiMessage.createdAt ?? new Date().toISOString(),
+            };
+            setMessages((prev) => {
+              const withoutOptimistic = prev.filter(
+                (m) => !m.id.startsWith("local-")
+              );
+              const userMsg: Message = parsed.userMessage
+                ? {
+                    id: parsed.userMessage.id,
+                    role: "user",
+                    content: parsed.userMessage.content ?? trimmed,
+                    createdAt:
+                      parsed.userMessage.createdAt ?? new Date().toISOString(),
+                  }
+                : optimistic;
+              return [...withoutOptimistic, userMsg, aiMsg];
+            });
+          }
+        }
+      }
+
+      if (!finalHandled) {
+        setStreamingContent(null);
+        if (accumulated) {
+          const aiMsg: Message = {
+            id: `ai-${Date.now()}`,
+            role: "assistant",
+            content: accumulated,
+            createdAt: new Date().toISOString(),
+          };
+          setMessages((prev) => {
+            const withoutOptimistic = prev.filter(
+              (m) => !m.id.startsWith("local-")
+            );
+            return [...withoutOptimistic, optimistic, aiMsg];
+          });
+        } else {
+          // 蓄積なし: 一覧再取得
+          const api = getApi();
+          const msgRes = await api.get<{ messages: Message[] }>(
+            `/api/ai/consultation/sessions/${sessionId}/messages`
+          );
+          setMessages(msgRes.messages ?? [WELCOME_MESSAGE]);
+        }
+      }
+    } catch (e: any) {
+      setStreamingContent(null);
+      if (e?.name === "AbortError") {
+        Alert.alert("タイムアウト", "応答がタイムアウトしました。しばらく待ってから再度お試しください。");
+      } else {
+        Alert.alert("エラー", e?.message ?? "送信に失敗しました。");
+      }
+      setMessages((prev) => prev.filter((m) => !m.id.startsWith("local-")));
+    } finally {
+      setSending(false);
+    }
+  }
+
+  function handleQuickQuestion(question: string) {
+    sendMessage(question);
+  }
+
+  function handleClose() {
+    onClose();
+  }
+
+  // ウェルカムメッセージのみの状態かどうか
+  const isWelcomeOnly =
+    messages.length === 1 && messages[0].id === "welcome";
+
+  return (
+    <>
+      <Modal
+        testID="ai-advisor-sheet"
+        visible={visible}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={handleClose}
+      >
+        <KeyboardAvoidingView
+          style={styles.container}
+          behavior={Platform.OS === "ios" ? "padding" : "height"}
+          keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 20}
+        >
+          {/* ヘッダー */}
+          <View style={styles.header}>
+            <View style={styles.headerLeft}>
+              <View style={styles.headerIcon}>
+                <Ionicons name="sparkles" size={16} color={colors.accent} />
+              </View>
+              <View>
+                <Text style={styles.headerTitle}>AIアドバイザー</Text>
+                <Text style={styles.headerSubtitle}>いつでも相談できます</Text>
+              </View>
+            </View>
+            <Pressable
+              testID="ai-close-btn"
+              onPress={handleClose}
+              style={styles.closeButton}
+            >
+              <Ionicons name="close" size={20} color={colors.textLight} />
+            </Pressable>
+          </View>
+
+          {/* メッセージリスト */}
+          <ScrollView
+            ref={scrollRef}
+            style={styles.messageList}
+            contentContainerStyle={styles.messageListContent}
+            showsVerticalScrollIndicator={false}
+          >
+            {messages.map((msg) => (
+              <MessageBubble key={msg.id} message={msg} />
+            ))}
+
+            {/* ストリーミング中の仮メッセージ */}
+            {streamingContent != null && (
+              <MessageBubble
+                key="streaming"
+                message={{
+                  id: "streaming",
+                  role: "assistant",
+                  content: streamingContent,
+                  createdAt: new Date().toISOString(),
+                }}
+                isStreaming
+              />
+            )}
+
+            {/* クイック質問チップ (ウェルカムのみ表示時) */}
+            {isWelcomeOnly && (
+              <View style={styles.quickQuestions}>
+                {QUICK_QUESTIONS.map((q, i) => (
+                  <Pressable
+                    key={i}
+                    testID={`ai-quick-question-${i}`}
+                    onPress={() => handleQuickQuestion(q)}
+                    style={styles.quickChip}
+                  >
+                    <Text style={styles.quickChipText}>{q}</Text>
+                  </Pressable>
+                ))}
+              </View>
+            )}
+          </ScrollView>
+
+          {/* クイックアクションバー */}
+          <View style={styles.actionBar}>
+            <Pressable
+              testID="ai-day-menu-btn"
+              onPress={() => setDayMenuModalVisible(true)}
+              style={styles.dayMenuBtn}
+            >
+              <Ionicons name="calendar" size={14} color={colors.accent} />
+              <Text style={styles.dayMenuBtnText}>1日献立を作成</Text>
+            </Pressable>
+          </View>
+
+          {/* 入力欄 */}
+          <View style={styles.inputRow}>
+            <TextInput
+              testID="ai-input"
+              style={styles.input}
+              value={inputText}
+              onChangeText={setInputText}
+              placeholder="メッセージを入力..."
+              placeholderTextColor={colors.textMuted}
+              multiline
+              maxLength={1000}
+              editable={!sending}
+            />
+            <Pressable
+              testID="ai-send-btn"
+              onPress={() => sendMessage(inputText)}
+              disabled={!inputText.trim() || sending}
+              style={[
+                styles.sendButton,
+                (!inputText.trim() || sending) && styles.sendButtonDisabled,
+              ]}
+            >
+              {sending ? (
+                <ActivityIndicator size="small" color="#FFF" />
+              ) : (
+                <Ionicons name="send" size={16} color="#FFF" />
+              )}
+            </Pressable>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+
+      {/* 1日献立モーダル */}
+      <AIDayMenuModal
+        visible={dayMenuModalVisible}
+        onClose={() => setDayMenuModalVisible(false)}
+      />
+    </>
+  );
+};
+
+// ============================================================
+// MessageBubble
+// ============================================================
+
+interface MessageBubbleProps {
+  message: Message;
+  isStreaming?: boolean;
+}
+
+const MessageBubble: React.FC<MessageBubbleProps> = ({
+  message,
+  isStreaming,
+}) => {
+  const isUser = message.role === "user";
+  return (
+    <View
+      style={[
+        styles.bubbleWrapper,
+        isUser ? styles.bubbleWrapperUser : styles.bubbleWrapperAssistant,
+      ]}
+    >
+      <View
+        style={[
+          styles.bubble,
+          isUser ? styles.bubbleUser : styles.bubbleAssistant,
+        ]}
+      >
+        <Text
+          style={[
+            styles.bubbleText,
+            isUser ? styles.bubbleTextUser : styles.bubbleTextAssistant,
+          ]}
+        >
+          {message.content}
+          {isStreaming && (
+            <Text style={styles.cursor}>▌</Text>
+          )}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+// ============================================================
+// Styles
+// ============================================================
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    backgroundColor: colors.card,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    ...shadows.sm,
+  },
+  headerLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  headerIcon: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: colors.accentLight,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  headerTitle: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: colors.text,
+  },
+  headerSubtitle: {
+    fontSize: 11,
+    color: colors.textMuted,
+  },
+  closeButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: colors.bg,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  messageList: {
+    flex: 1,
+  },
+  messageListContent: {
+    padding: spacing.md,
+    gap: spacing.sm,
+  },
+  bubbleWrapper: {
+    flexDirection: "row",
+    marginVertical: spacing.xs / 2,
+  },
+  bubbleWrapperUser: {
+    justifyContent: "flex-end",
+  },
+  bubbleWrapperAssistant: {
+    justifyContent: "flex-start",
+  },
+  bubble: {
+    maxWidth: "80%",
+    borderRadius: radius.lg,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  bubbleUser: {
+    backgroundColor: colors.accent,
+    borderBottomRightRadius: radius.xs,
+  },
+  bubbleAssistant: {
+    backgroundColor: colors.card,
+    borderBottomLeftRadius: radius.xs,
+    ...shadows.sm,
+  },
+  bubbleText: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  bubbleTextUser: {
+    color: "#FFF",
+  },
+  bubbleTextAssistant: {
+    color: colors.text,
+  },
+  cursor: {
+    color: colors.accent,
+  },
+  quickQuestions: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+    marginTop: spacing.sm,
+  },
+  quickChip: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    backgroundColor: colors.card,
+    borderRadius: radius.full,
+    borderWidth: 1,
+    borderColor: colors.accent,
+    ...shadows.sm,
+  },
+  quickChipText: {
+    fontSize: 12,
+    color: colors.accent,
+    fontWeight: "600",
+  },
+  actionBar: {
+    flexDirection: "row",
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
+    backgroundColor: colors.card,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    gap: spacing.sm,
+  },
+  dayMenuBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.accent,
+  },
+  dayMenuBtnText: {
+    fontSize: 12,
+    color: colors.accent,
+    fontWeight: "600",
+  },
+  inputRow: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    backgroundColor: colors.card,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    gap: spacing.sm,
+  },
+  input: {
+    flex: 1,
+    minHeight: 40,
+    maxHeight: 100,
+    backgroundColor: colors.bg,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    fontSize: 14,
+    color: colors.text,
+  },
+  sendButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: colors.accent,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  sendButtonDisabled: {
+    backgroundColor: colors.textMuted,
+  },
+});

--- a/apps/mobile/src/components/ai/AIDayMenuModal.tsx
+++ b/apps/mobile/src/components/ai/AIDayMenuModal.tsx
@@ -1,0 +1,261 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import { colors, radius, shadows, spacing } from "../../theme";
+import { useV4MenuGeneration } from "../../hooks/useV4MenuGeneration";
+
+// ============================================================
+// Props
+// ============================================================
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+// ============================================================
+// Component
+// ============================================================
+
+export const AIDayMenuModal: React.FC<Props> = ({ visible, onClose }) => {
+  // 今日の日付をデフォルト
+  const today = new Date().toISOString().slice(0, 10);
+  const [selectedDate, setSelectedDate] = useState(today);
+  const [dateError, setDateError] = useState<string | null>(null);
+
+  const { generate, isGenerating } = useV4MenuGeneration({
+    onGenerationStart: () => {
+      Alert.alert(
+        "献立生成開始",
+        "1日分の献立を生成しています。しばらくお待ちください。"
+      );
+      onClose();
+    },
+    onError: (err) => {
+      Alert.alert("エラー", err ?? "献立の生成に失敗しました。");
+    },
+  });
+
+  function validateDate(value: string): boolean {
+    // YYYY-MM-DD 形式チェック
+    const regex = /^\d{4}-\d{2}-\d{2}$/;
+    if (!regex.test(value)) {
+      setDateError("日付は YYYY-MM-DD 形式で入力してください");
+      return false;
+    }
+    const d = new Date(value);
+    if (isNaN(d.getTime())) {
+      setDateError("有効な日付を入力してください");
+      return false;
+    }
+    setDateError(null);
+    return true;
+  }
+
+  async function handleGenerate() {
+    if (!validateDate(selectedDate)) return;
+
+    const mealTypes = ["breakfast", "lunch", "dinner"] as const;
+    const targetSlots = mealTypes.map((mealType) => ({
+      date: selectedDate,
+      mealType,
+    }));
+
+    await generate({
+      targetSlots,
+      constraints: {},
+      note: "",
+      ultimateMode: false,
+      resolveExistingMeals: false,
+    });
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="fade"
+      transparent
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.sheet}>
+          {/* ヘッダー */}
+          <View style={styles.header}>
+            <View style={styles.headerLeft}>
+              <Ionicons name="calendar" size={18} color={colors.accent} />
+              <Text style={styles.headerTitle}>1日献立を作成</Text>
+            </View>
+            <Pressable onPress={onClose} style={styles.closeBtn}>
+              <Ionicons name="close" size={18} color={colors.textLight} />
+            </Pressable>
+          </View>
+
+          {/* 日付入力 */}
+          <View style={styles.body}>
+            <Text style={styles.label}>対象日</Text>
+            <TextInput
+              style={[styles.dateInput, dateError != null && styles.dateInputError]}
+              value={selectedDate}
+              onChangeText={(v) => {
+                setSelectedDate(v);
+                if (dateError) validateDate(v);
+              }}
+              placeholder="YYYY-MM-DD"
+              placeholderTextColor={colors.textMuted}
+              keyboardType="numeric"
+              maxLength={10}
+            />
+            {dateError != null && (
+              <Text style={styles.errorText}>{dateError}</Text>
+            )}
+            <Text style={styles.hint}>朝・昼・夕の3食分を自動生成します</Text>
+          </View>
+
+          {/* ボタン */}
+          <View style={styles.footer}>
+            <Pressable onPress={onClose} style={styles.cancelBtn}>
+              <Text style={styles.cancelBtnText}>キャンセル</Text>
+            </Pressable>
+            <Pressable
+              onPress={handleGenerate}
+              disabled={isGenerating}
+              style={[styles.generateBtn, isGenerating && styles.generateBtnDisabled]}
+            >
+              {isGenerating ? (
+                <ActivityIndicator size="small" color="#FFF" />
+              ) : (
+                <Text style={styles.generateBtnText}>作成する</Text>
+              )}
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+// ============================================================
+// Styles
+// ============================================================
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.4)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: spacing.lg,
+  },
+  sheet: {
+    width: "100%",
+    backgroundColor: colors.card,
+    borderRadius: radius.xl,
+    overflow: "hidden",
+    ...shadows.md,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+  },
+  headerTitle: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: colors.text,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: colors.bg,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  body: {
+    padding: spacing.lg,
+    gap: spacing.sm,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: colors.textLight,
+    marginBottom: spacing.xs,
+  },
+  dateInput: {
+    height: 44,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingHorizontal: spacing.md,
+    fontSize: 15,
+    color: colors.text,
+    backgroundColor: colors.bg,
+  },
+  dateInputError: {
+    borderColor: colors.error,
+  },
+  errorText: {
+    fontSize: 12,
+    color: colors.error,
+  },
+  hint: {
+    fontSize: 12,
+    color: colors.textMuted,
+    marginTop: spacing.xs,
+  },
+  footer: {
+    flexDirection: "row",
+    gap: spacing.sm,
+    padding: spacing.lg,
+    paddingTop: 0,
+  },
+  cancelBtn: {
+    flex: 1,
+    height: 44,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cancelBtnText: {
+    fontSize: 14,
+    color: colors.textLight,
+    fontWeight: "600",
+  },
+  generateBtn: {
+    flex: 2,
+    height: 44,
+    borderRadius: radius.md,
+    backgroundColor: colors.accent,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  generateBtnDisabled: {
+    backgroundColor: colors.textMuted,
+  },
+  generateBtnText: {
+    fontSize: 14,
+    color: "#FFF",
+    fontWeight: "700",
+  },
+});

--- a/apps/mobile/src/components/ai/AIFloatingFab.tsx
+++ b/apps/mobile/src/components/ai/AIFloatingFab.tsx
@@ -1,0 +1,61 @@
+import { Ionicons } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
+import { useState } from "react";
+import { Pressable, StyleSheet } from "react-native";
+
+import { colors, shadows } from "../../theme";
+import { AIAdvisorSheet } from "./AIAdvisorSheet";
+
+// ============================================================
+// Component
+// ============================================================
+
+export const AIFloatingFab: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <>
+      <Pressable
+        testID="ai-floating-fab"
+        onPress={() => setVisible(true)}
+        style={styles.fab}
+      >
+        <LinearGradient
+          colors={[colors.accent, colors.warning]}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={styles.fabGradient}
+        >
+          <Ionicons name="sparkles" size={20} color="#FFF" />
+        </LinearGradient>
+      </Pressable>
+
+      <AIAdvisorSheet visible={visible} onClose={() => setVisible(false)} />
+    </>
+  );
+};
+
+// ============================================================
+// Styles
+// ============================================================
+
+const styles = StyleSheet.create({
+  fab: {
+    position: "absolute",
+    bottom: 120,
+    right: 16,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    ...shadows.lg,
+    zIndex: 1000,
+    elevation: 10,
+  },
+  fabGradient: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});


### PR DESCRIPTION
## Summary

- `AIFloatingFab` を新設: 全タブ画面右下に常駐する floating FAB (accent グラデーション、bottom:120)
- `AIAdvisorSheet` を新設: FAB タップで展開する Modal シート。ウェルカムメッセージ・クイック質問 4 問・SSE ストリーミング送信
- `AIDayMenuModal` を新設: 「1日献立を作成」ボタンから起動する日付入力モーダル。`useV4MenuGeneration` 経由で V4 生成 API を呼ぶ
- `(tabs)/_layout.tsx` に `<AIFloatingFab />` を追加。既存 `weekly-ai-assistant-btn` と重ならない位置 (bottom:120) に配置

## testID 一覧

| testID | 説明 |
|---|---|
| `ai-floating-fab` | 右下 FAB ボタン |
| `ai-advisor-sheet` | チャット Modal |
| `ai-quick-question-{0-3}` | クイック質問チップ |
| `ai-day-menu-btn` | 1日献立作成ボタン |
| `ai-input` | テキスト入力欄 |
| `ai-send-btn` | 送信ボタン |
| `ai-close-btn` | クローズボタン |

## Test plan

- [ ] タブ切り替え時に FAB が常に右下に表示されることを確認
- [ ] FAB タップでチャット Modal が開くことを確認
- [ ] ウェルカムメッセージとクイック質問チップが表示されることを確認
- [ ] クイック質問チップタップで即時送信されることを確認
- [ ] テキスト入力 → 送信でメッセージが送られることを確認
- [ ] 「1日献立を作成」ボタンから日付入力モーダルが開くことを確認
- [ ] 「作成する」で V4 生成 API が呼ばれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)