### PR TITLE
fix(mobile): 食事カードのビビッドカラーアイコンを廃止しWEB仕様に統一

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -34,7 +34,7 @@ import { RegenerateMealModal } from "../../../src/components/menu/RegenerateMeal
 import { PantryModal } from "../../../src/components/menu/PantryModal";
 import { ShoppingListModal } from "../../../src/components/menu/ShoppingListModal";
 import { useV4MenuGeneration } from "../../../src/hooks/useV4MenuGeneration";
-import { colors, spacing, radius, shadows } from "../../../src/theme";
+import { colors, spacing, radius } from "../../../src/theme";
 import { getApi, getApiBaseUrl } from "../../../src/lib/api";
 import { supabase } from "../../../src/lib/supabase";
 import { useProfile } from "../../../src/providers/ProfileProvider";
@@ -377,7 +377,7 @@ function NutritionBottomSheet({ visible, onClose, day, dateLabel, radarKeys, wee
   return (
     <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
       <Pressable style={{ flex: 1, backgroundColor: "rgba(0,0,0,0.4)" }} onPress={onClose} />
-      <View testID="weekly-nutrition-sheet" style={{ backgroundColor: colors.bg, borderTopLeftRadius: radius["2xl"], borderTopRightRadius: radius["2xl"], maxHeight: "85%", ...shadows.lg }}>
+      <View testID="weekly-nutrition-sheet" style={{ backgroundColor: colors.bg, borderTopLeftRadius: radius["2xl"], borderTopRightRadius: radius["2xl"], maxHeight: "85%" }}>
         {/* Header */}
         <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", padding: spacing.lg, borderBottomWidth: 1, borderBottomColor: colors.border }}>
           <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
@@ -543,12 +543,12 @@ const DOW = ["月", "火", "水", "木", "金", "土", "日"];
 // 表示順: breakfast / lunch / dinner / snack / midnight_snack
 const MEAL_ORDER = MEAL_ORDER_SHARED;
 
-const MEAL_CONFIG: Record<string, { icon: keyof typeof Ionicons.glyphMap; label: string; color: string }> = {
-  breakfast: { icon: "sunny", label: "朝食", color: "#FF9800" },
-  lunch: { icon: "partly-sunny", label: "昼食", color: "#4CAF50" },
-  snack: { icon: "cafe", label: "おやつ", color: "#E91E63" },
-  dinner: { icon: "moon", label: "夕食", color: "#7C4DFF" },
-  midnight_snack: { icon: "cloudy-night", label: "夜食", color: "#3F51B5" },
+const MEAL_CONFIG: Record<string, { icon: keyof typeof Ionicons.glyphMap; label: string }> = {
+  breakfast: { icon: "sunny", label: "朝食" },
+  lunch: { icon: "partly-sunny", label: "昼食" },
+  snack: { icon: "cafe", label: "おやつ" },
+  dinner: { icon: "moon", label: "夕食" },
+  midnight_snack: { icon: "cloudy-night", label: "夜食" },
 };
 
 // MODE_CONFIG — @homegohan/shared の抽象キーを App 用の実色値に変換
@@ -1608,7 +1608,6 @@ export default function WeeklyMenuPage() {
                 return null;
               })}
               {sortedMeals.map((m) => {
-                const mealCfg = MEAL_CONFIG[m.meal_type] ?? { icon: "ellipse", label: m.meal_type, color: colors.textMuted };
                 const modeCfg = MODE_CONFIG[m.mode ?? "cook"] ?? MODE_CONFIG.cook;
                 const isGenerating = m.is_generating;
                 const isExpanded = expandedMealId === m.id;
@@ -1682,25 +1681,10 @@ export default function WeeklyMenuPage() {
                           ...(pressed ? { opacity: 0.9 } : {}),
                         })}
                       >
-                        {/* 食事タイプアイコン */}
-                        <View
-                          style={{
-                            width: 44,
-                            height: 44,
-                            borderRadius: radius.md,
-                            backgroundColor: m.is_completed ? colors.success : mealCfg.color,
-                            alignItems: "center",
-                            justifyContent: "center",
-                          }}
-                        >
-                          {m.is_completed ? (
-                            <Ionicons name="checkmark" size={24} color="#fff" />
-                          ) : isGenerating ? (
-                            <ActivityIndicator size="small" color="#fff" />
-                          ) : (
-                            <Ionicons name={mealCfg.icon} size={22} color="#fff" />
-                          )}
-                        </View>
+                        {/* 食事タイプラベル (WEB 合わせ: テキストのみ) */}
+                        <Text style={{ fontSize: 12, fontWeight: "700", color: colors.textMuted, width: 28, textAlign: "center" }}>
+                          {mealLabel}
+                        </Text>
 
                         {/* 情報 */}
                         <View style={{ flex: 1, gap: 3 }}>
@@ -1709,7 +1693,6 @@ export default function WeeklyMenuPage() {
                           </Text>
                           {m.role ? <RoleBadge role={m.role} /> : null}
                           <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
-                            <Text style={{ fontSize: 12, color: colors.textMuted }}>{mealLabel}</Text>
                             <View
                               style={{
                                 backgroundColor: modeCfg.bg,
@@ -1758,30 +1741,15 @@ export default function WeeklyMenuPage() {
                           onPress={() => setExpandedMealId(null)}
                           style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}
                         >
-                          <View
-                            style={{
-                              width: 44,
-                              height: 44,
-                              borderRadius: radius.md,
-                              backgroundColor: m.is_completed ? colors.success : mealCfg.color,
-                              alignItems: "center",
-                              justifyContent: "center",
-                            }}
-                          >
-                            {m.is_completed ? (
-                              <Ionicons name="checkmark" size={24} color="#fff" />
-                            ) : isGenerating ? (
-                              <ActivityIndicator size="small" color="#fff" />
-                            ) : (
-                              <Ionicons name={mealCfg.icon} size={22} color="#fff" />
-                            )}
-                          </View>
+                          {/* 食事タイプラベル (WEB 合わせ: テキストのみ) */}
+                          <Text style={{ fontSize: 12, fontWeight: "700", color: colors.textMuted, width: 28, textAlign: "center" }}>
+                            {mealLabel}
+                          </Text>
                           <View style={{ flex: 1, gap: 3 }}>
                             <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }} numberOfLines={1}>
                               {isGenerating ? "生成中..." : m.dish_name || "（未設定）"}
                             </Text>
                             <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
-                              <Text style={{ fontSize: 12, color: colors.textMuted }}>{mealLabel}</Text>
                               <View style={{ backgroundColor: modeCfg.bg, paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 }}>
                                 <Text style={{ fontSize: 10, fontWeight: "700", color: modeCfg.color }}>{modeCfg.label}</Text>
                               </View>
@@ -2086,7 +2054,6 @@ export default function WeeklyMenuPage() {
           backgroundColor: colors.accent,
           alignItems: "center",
           justifyContent: "center",
-          ...shadows.md,
           opacity: pressed ? 0.85 : 1,
         })}
       >

--- a/apps/mobile/src/components/menu/EmptySlot.tsx
+++ b/apps/mobile/src/components/menu/EmptySlot.tsx
@@ -16,13 +16,10 @@ interface Props {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function EmptySlot({ mealType, dayId, dayDate: _dayDate, onPress, isGenerating = false, mealLabel }: Props) {
-  const mealCfgColor = MEAL_COLORS[mealType] ?? colors.textMuted;
-  const mealCfgIcon = MEAL_ICONS[mealType] ?? "ellipse";
-
+export function EmptySlot({ mealType: _mealType, dayId, dayDate: _dayDate, onPress, isGenerating = false, mealLabel }: Props) {
   return (
     <Pressable
-      testID={`empty-slot-${dayId}-${mealType}`}
+      testID={`empty-slot-${dayId}-${_mealType}`}
       onPress={onPress}
       style={({ pressed }) => ({
         flexDirection: "row",
@@ -40,22 +37,21 @@ export function EmptySlot({ mealType, dayId, dayDate: _dayDate, onPress, isGener
         borderStyle: "dashed",
       })}
     >
-      {/* 食事タイプアイコン */}
+      {/* 食事タイプアイコン (グレー小型) */}
       <View
         style={{
-          width: 44,
-          height: 44,
-          borderRadius: radius.md,
-          backgroundColor: mealCfgColor,
+          width: 28,
+          height: 28,
+          borderRadius: radius.sm,
+          backgroundColor: colors.border,
           alignItems: "center",
           justifyContent: "center",
-          opacity: isGenerating ? 0.8 : 0.3,
         }}
       >
         {isGenerating ? (
-          <ActivityIndicator size="small" color="#fff" />
+          <ActivityIndicator size="small" color={colors.textMuted} />
         ) : (
-          <Ionicons name={mealCfgIcon} size={22} color="#fff" />
+          <Ionicons name="add" size={16} color={colors.textMuted} />
         )}
       </View>
 
@@ -63,26 +59,7 @@ export function EmptySlot({ mealType, dayId, dayDate: _dayDate, onPress, isGener
       <Text style={{ flex: 1, fontSize: 14, color: isGenerating ? colors.accent : colors.textMuted }}>
         {isGenerating ? "AI が生成中..." : `+ ${mealLabel}を追加`}
       </Text>
-
-      {!isGenerating && (
-        <Ionicons name="add-circle-outline" size={20} color={colors.textMuted} />
-      )}
     </Pressable>
   );
 }
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-const MEAL_COLORS: Record<string, string> = {
-  breakfast: "#FF9800",
-  lunch: "#4CAF50",
-  dinner: "#7C4DFF",
-  snack: "#E91E63",
-};
-
-const MEAL_ICONS: Record<string, keyof typeof Ionicons.glyphMap> = {
-  breakfast: "sunny",
-  lunch: "partly-sunny",
-  dinner: "moon",
-  snack: "cafe",
-};


### PR DESCRIPTION
## Summary

- CollapsedMealCard / ExpandedMealCard の 44×44 カラーボックスアイコン (#FF9800/#4CAF50/#7C4DFF/#E91E63) を削除
- 代替として左端にテキストラベル(朝/昼/夕など)を表示し、WEB の `CollapsedMealCard` と同じ構成に統一
- EmptySlot のビビッド色背景アイコンをグレー 28×28 小型アイコンに変更、`MEAL_COLORS` / `MEAL_ICONS` 定数を削除
- `MEAL_CONFIG` から `color` プロパティを削除(label のみ残存)
- `NutritionBottomSheet` の `shadows.lg` と FAB の `shadows.md` を削除
- 不要になった `shadows` インポートを除去

## Test plan

- [ ] 週間メニュー画面の折り畳みカードに 44×44 カラーボックスが表示されないこと
- [ ] 左端に「朝」「昼」「夕」テキストラベルが表示されること
- [ ] モードバッジ (cook/quick/buy/out) が引き続き小型 pill で表示されること
- [ ] kcal 表示が右端に残ること
- [ ] 展開時カードも同様にカラーボックスなし、テキストラベルありであること
- [ ] EmptySlot がグレー小型アイコン + 「+ XX を追加」テキストで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)