### PR TITLE
fix(mobile): 曜日タブ選択日の背景色をaccentカラーに統一

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -1489,7 +1489,7 @@ export default function WeeklyMenuPage() {
                     paddingVertical: spacing.sm,
                     paddingHorizontal: 2,
                     borderRadius: radius.lg,
-                    backgroundColor: selected ? (accentColor ?? colors.accent) : "transparent",
+                    backgroundColor: selected ? colors.accent : "transparent",
                     ...(pressed ? { opacity: 0.9 } : {}),
                   })}
                 >


### PR DESCRIPTION
## Summary

- 曜日タブで祝日・日曜日を選択した際に背景色が `colors.danger`（赤）になっていた問題を修正
- 選択時の `backgroundColor` を常に `colors.accent`（`#E07A5F` サーモンオレンジ）に統一
- 非選択時の曜日文字色（祝日・日曜→danger赤、土曜→blue）は従来どおり維持

## 変更ファイル

- `apps/mobile/app/menus/weekly/index.tsx` L1492

## Test plan

- [ ] 通常曜日（月〜金）を選択 → サーモン背景・白文字
- [ ] 日曜日を選択 → サーモン背景・白文字（修正前は赤背景）
- [ ] 祝日を選択 → サーモン背景・白文字（修正前は赤背景）
- [ ] 土曜日を選択 → サーモン背景・白文字（修正前は青背景）
- [ ] 非選択時: 祝日・日曜→赤文字、土曜→青文字（変更なし）
- [ ] 今日タブ（非選択）: accent枠 + accent文字（変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)