### PR TITLE
fix(mobile): 週間献立の「食事を追加」ボタンを常時表示に統一

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -1907,32 +1907,43 @@ export default function WeeklyMenuPage() {
                 );
               })}
 
-              {/* +食事タイプ追加ボタン — plan 作成済みの day のみ表示 */}
-              {selectedDay?.id && (
-                <View style={{ flexDirection: "row", gap: spacing.sm, flexWrap: "wrap" }}>
-                  <Pressable
-                    testID="weekly-add-meal-type-btn"
-                    onPress={() => {
-                      setAddMealSlotDayId(selectedDay.id as string);
-                      setAddMealSlotVisible(true);
-                    }}
-                    style={({ pressed }) => ({
-                      flexDirection: "row",
-                      alignItems: "center",
-                      gap: 4,
-                      paddingVertical: 6,
-                      paddingHorizontal: 10,
-                      borderRadius: radius.sm,
-                      backgroundColor: pressed ? colors.accentLight : colors.card,
-                      borderWidth: 1,
-                      borderColor: colors.accent,
-                    })}
-                  >
-                    <Ionicons name="add" size={14} color={colors.accent} />
-                    <Text style={{ fontSize: 11, color: colors.accent, fontWeight: "600" }}>食事タイプ追加</Text>
-                  </Pressable>
-                </View>
-              )}
+              {/* +食事を追加ボタン — 常時表示 (WEB仕様に統一) */}
+              <View style={{ flexDirection: "row", gap: spacing.sm, flexWrap: "wrap" }}>
+                <Pressable
+                  testID="weekly-add-meal-type-btn"
+                  onPress={() => {
+                    if (!selectedDay?.id) {
+                      // plan 未作成 → AI 献立作成を促す
+                      Alert.alert(
+                        "週間献立の作成",
+                        "この週の献立がまだ作成されていません。AIに献立を作成してもらいましょう。",
+                        [
+                          { text: "キャンセル", style: "cancel" },
+                          { text: "AIで作成", onPress: () => setShowV4Modal(true) },
+                        ],
+                      );
+                      return;
+                    }
+                    setAddMealSlotDayId(selectedDay.id as string);
+                    setAddMealSlotVisible(true);
+                  }}
+                  style={({ pressed }) => ({
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: 4,
+                    paddingVertical: 6,
+                    paddingHorizontal: 10,
+                    borderRadius: radius.sm,
+                    backgroundColor: pressed ? colors.accentLight : colors.card,
+                    borderWidth: 1,
+                    borderStyle: "dashed",
+                    borderColor: colors.accent,
+                  })}
+                >
+                  <Ionicons name="add" size={14} color={colors.accent} />
+                  <Text style={{ fontSize: 11, color: colors.accent, fontWeight: "600" }}>食事を追加</Text>
+                </Pressable>
+              </View>
             </View>
           )}
         </>


### PR DESCRIPTION
## Summary

- PR #717 で `selectedDay?.id` 存在時のみ表示にしていた「食事タイプ追加」ボタンを、WEB 仕様に合わせて**常時表示**に変更
- plan 未作成時にタップした場合は「AIで作成」Alert を表示する既存パターンを踏襲
- ボタンラベルを「食事タイプ追加」→「食事を追加」に統一 (WEB と一致)
- `borderStyle: dashed` を追加して WEB の EmptySlot スタイルに統一

## 変更ファイル

- `apps/mobile/app/menus/weekly/index.tsx`

## Test plan

- [ ] plan 作成済み週: ボタンが表示され、タップで AddMealSlotModal が開く
- [ ] plan 未作成週: ボタンが表示され、タップで「週間献立の作成」Alert が表示される
- [ ] Alert の「AIで作成」を選択すると AI 献立作成モーダルが開く
- [ ] ボタンのラベルが「食事を追加」になっている (点線枠スタイル)

🤖 Generated with [Claude Code](https://claude.com/claude-code)