### PR TITLE
fix(mobile): AIバナータップでV4GenerateModalが開かない問題を修正

### DIFF
--- a/apps/mobile/src/components/menu/V4GenerateModal.tsx
+++ b/apps/mobile/src/components/menu/V4GenerateModal.tsx
@@ -383,7 +383,8 @@ export function V4GenerateModal({
     <Modal
       visible={visible}
       transparent
-      animationType="fade"
+      animationType="slide"
+      presentationStyle="overFullScreen"
       onRequestClose={handleClose}
       testID="v4-modal"
     >


### PR DESCRIPTION
## Summary

- iOS では `transparent` な React Native `Modal` に `presentationStyle="overFullScreen"` が必須。未設定の場合、背景透過が無効になりモーダルが正しく表示されない
- `V4GenerateModal` の `animationType` を `"fade"` → `"slide"` に変更し、bottom sheet のスライドインアニメーションに統一
- `EmptySlotAIBanner` の `onPress={() => setShowV4Modal(true)}` は PR #709 から正しく実装済み。バナー自体に問題はなく、モーダル側の表示設定が原因

## Root Cause

```tsx
// Before (iOS で transparent が機能せず非表示になる)
<Modal visible={visible} transparent animationType="fade" ...>

// After (overFullScreen で transparent が正常動作)
<Modal visible={visible} transparent animationType="slide" presentationStyle="overFullScreen" ...>
```

## Test plan

- [ ] `empty-slot-ai-banner` をタップ → `V4GenerateModal` (AIアシスタント) がスライドアップで表示される
- [ ] モーダル内に「AIアシスタント」タイトル、4モードボタン、条件ピルが表示される
- [ ] `ai-floating-fab` (右下 FAB) をタップ → `AIAdvisorSheet` が開く (V4GenerateModal は開かない)
- [ ] バックドロップタップまたは × ボタンでモーダルが閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)