### PR TITLE
feat(mobile): Ionicons を lucide-react-native に置換しWEBアイコンと統一

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -1,7 +1,31 @@
-import { Ionicons } from "@expo/vector-icons";
+import {
+  AlertCircle,
+  ArrowDown,
+  ArrowUp,
+  BarChart3,
+  BookOpen,
+  Check,
+  CheckCircle,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  CircleEllipsis,
+  Coffee,
+  CloudMoon,
+  Heart,
+  Moon,
+  Pencil,
+  Plus,
+  Sparkles,
+  Sun,
+  SunMedium,
+  Trash2,
+  X,
+} from "lucide-react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { router } from "expo-router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -381,11 +405,11 @@ function NutritionBottomSheet({ visible, onClose, day, dateLabel, radarKeys, wee
         {/* Header */}
         <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", padding: spacing.lg, borderBottomWidth: 1, borderBottomColor: colors.border }}>
           <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
-            <Ionicons name="bar-chart" size={18} color={colors.accent} />
+            <BarChart3 size={18} color={colors.accent} />
             <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>{dateLabel} の栄養分析</Text>
           </View>
           <Pressable testID="weekly-nutrition-sheet-close" onPress={onClose} hitSlop={8}>
-            <Ionicons name="close" size={22} color={colors.textMuted} />
+            <X size={22} color={colors.textMuted} />
           </Pressable>
         </View>
         <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
@@ -397,7 +421,7 @@ function NutritionBottomSheet({ visible, onClose, day, dateLabel, radarKeys, wee
           <View style={{ gap: spacing.md }}>
             <View style={{ backgroundColor: colors.successLight, borderRadius: radius.lg, padding: spacing.md, gap: spacing.sm }}>
               <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
-                <Ionicons name="heart" size={14} color={colors.success} />
+                <Heart size={14} color={colors.success} />
                 <Text style={{ fontSize: 12, fontWeight: "600", color: colors.success }}>褒めポイント</Text>
                 {(praiseComment || adviceText) && !isLoadingFeedback && (
                   <Pressable onPress={() => { const mc = meals.filter((m) => m.dish_name).length; if (day) fetchFeedback(day.day_date, totals, mc, true); }}
@@ -420,7 +444,7 @@ function NutritionBottomSheet({ visible, onClose, day, dateLabel, radarKeys, wee
             {(adviceText || isLoadingFeedback) && (
               <View style={{ backgroundColor: colors.accentLight, borderRadius: radius.lg, padding: spacing.md, gap: spacing.sm }}>
                 <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
-                  <Ionicons name="sparkles" size={14} color={colors.accent} />
+                  <Sparkles size={14} color={colors.accent} />
                   <Text style={{ fontSize: 12, fontWeight: "600", color: colors.accent }}>改善アドバイス</Text>
                 </View>
                 {isLoadingFeedback ? (
@@ -543,12 +567,12 @@ const DOW = ["月", "火", "水", "木", "金", "土", "日"];
 // 表示順: breakfast / lunch / dinner / snack / midnight_snack
 const MEAL_ORDER = MEAL_ORDER_SHARED;
 
-const MEAL_CONFIG: Record<string, { icon: keyof typeof Ionicons.glyphMap; label: string; color: string }> = {
-  breakfast: { icon: "sunny", label: "朝食", color: "#FF9800" },
-  lunch: { icon: "partly-sunny", label: "昼食", color: "#4CAF50" },
-  snack: { icon: "cafe", label: "おやつ", color: "#E91E63" },
-  dinner: { icon: "moon", label: "夕食", color: "#7C4DFF" },
-  midnight_snack: { icon: "cloudy-night", label: "夜食", color: "#3F51B5" },
+const MEAL_CONFIG: Record<string, { Icon: React.ComponentType<any>; label: string; color: string }> = {
+  breakfast: { Icon: Sun, label: "朝食", color: "#FF9800" },
+  lunch: { Icon: SunMedium, label: "昼食", color: "#4CAF50" },
+  snack: { Icon: Coffee, label: "おやつ", color: "#E91E63" },
+  dinner: { Icon: Moon, label: "夕食", color: "#7C4DFF" },
+  midnight_snack: { Icon: CloudMoon, label: "夜食", color: "#3F51B5" },
 };
 
 // MODE_CONFIG — @homegohan/shared の抽象キーを App 用の実色値に変換
@@ -1297,11 +1321,11 @@ export default function WeeklyMenuPage() {
         }}
       >
         <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
-          <Ionicons
-            name={isCalendarExpanded ? "chevron-up" : "chevron-down"}
-            size={14}
-            color={colors.textMuted}
-          />
+          {isCalendarExpanded ? (
+            <ChevronUp size={14} color={colors.textMuted} />
+          ) : (
+            <ChevronDown size={14} color={colors.textMuted} />
+          )}
           <Text style={{ fontSize: 13, fontWeight: "600", color: colors.text }}>
             {displayMonth.getFullYear()}年{displayMonth.getMonth() + 1}月
           </Text>
@@ -1315,7 +1339,7 @@ export default function WeeklyMenuPage() {
               }}
               style={{ padding: 4 }}
             >
-              <Ionicons name="chevron-back" size={14} color={colors.textMuted} />
+              <ChevronLeft size={14} color={colors.textMuted} />
             </Pressable>
             <Pressable
               onPress={e => {
@@ -1324,7 +1348,7 @@ export default function WeeklyMenuPage() {
               }}
               style={{ padding: 4 }}
             >
-              <Ionicons name="chevron-forward" size={14} color={colors.textMuted} />
+              <ChevronRight size={14} color={colors.textMuted} />
             </Pressable>
           </View>
         )}
@@ -1421,7 +1445,7 @@ export default function WeeklyMenuPage() {
       ) : error ? (
         <Card testID="weekly-error-banner" variant="error">
           <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
-            <Ionicons name="alert-circle" size={20} color={colors.error} />
+            <AlertCircle size={20} color={colors.error} />
             <Text style={{ flex: 1, color: colors.error, fontSize: 13 }}>{error}</Text>
           </View>
           <Button size="sm" variant="ghost" onPress={() => { setError(null); loadData(); }}>再読み込み</Button>
@@ -1458,7 +1482,7 @@ export default function WeeklyMenuPage() {
                 opacity: pressed ? 0.7 : 1,
               })}
             >
-              <Ionicons name="chevron-back" size={16} color={colors.textMuted} />
+              <ChevronLeft size={16} color={colors.textMuted} />
               <Text style={{ fontSize: 8, color: colors.textMuted, marginTop: 2 }}>前の週</Text>
             </Pressable>
 
@@ -1505,7 +1529,7 @@ export default function WeeklyMenuPage() {
                       <Text style={{ fontSize: 8, fontWeight: "700", color: "#fff" }}>今日</Text>
                     </View>
                   ) : completedAll ? (
-                    <Ionicons name="checkmark-circle" size={12} color={selected ? "#fff" : colors.success} />
+                    <CheckCircle size={12} color={selected ? "#fff" : colors.success} />
                   ) : hasGenerating ? (
                     <ActivityIndicator size={10} color={selected ? "#fff" : (accentColor ?? colors.accent)} />
                   ) : (
@@ -1530,7 +1554,7 @@ export default function WeeklyMenuPage() {
                 opacity: pressed ? 0.7 : 1,
               })}
             >
-              <Ionicons name="chevron-forward" size={16} color={colors.textMuted} />
+              <ChevronRight size={16} color={colors.textMuted} />
               <Text style={{ fontSize: 8, color: colors.textMuted, marginTop: 2 }}>翌週</Text>
             </Pressable>
           </View>
@@ -1558,12 +1582,12 @@ export default function WeeklyMenuPage() {
                     borderWidth: 1, borderColor: colors.accent,
                   }}
                 >
-                  <Ionicons name="bar-chart" size={13} color={colors.accent} />
+                  <BarChart3 size={13} color={colors.accent} />
                   <Text style={{ fontSize: 12, fontWeight: "600", color: colors.accent }}>栄養</Text>
                 </Pressable>
                 <Button testID="weekly-request-button" size="sm" variant="ghost" onPress={() => router.push("/menus/weekly/request")}>
                   <View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
-                    <Ionicons name="sparkles" size={14} color={colors.accent} />
+                    <Sparkles size={14} color={colors.accent} />
                     <Text style={{ fontSize: 12, fontWeight: "600", color: colors.accent }}>AIで再生成</Text>
                   </View>
                 </Button>
@@ -1608,7 +1632,7 @@ export default function WeeklyMenuPage() {
                 return null;
               })}
               {sortedMeals.map((m) => {
-                const mealCfg = MEAL_CONFIG[m.meal_type] ?? { icon: "ellipse", label: m.meal_type, color: colors.textMuted };
+                const mealCfg = MEAL_CONFIG[m.meal_type] ?? { Icon: CircleEllipsis, label: m.meal_type, color: colors.textMuted };
                 const modeCfg = MODE_CONFIG[m.mode ?? "cook"] ?? MODE_CONFIG.cook;
                 const isGenerating = m.is_generating;
                 const isExpanded = expandedMealId === m.id;
@@ -1641,7 +1665,7 @@ export default function WeeklyMenuPage() {
                             opacity: isFirstInGroup ? 0.3 : 1,
                           }}
                         >
-                          <Ionicons name="arrow-up" size={12} color={isFirstInGroup ? colors.border : colors.textLight} />
+                          <ArrowUp size={12} color={isFirstInGroup ? colors.border : colors.textLight} />
                         </Pressable>
                         <Pressable
                           testID={`meal-reorder-down-${m.id}`}
@@ -1659,7 +1683,7 @@ export default function WeeklyMenuPage() {
                             opacity: isLastInGroup ? 0.3 : 1,
                           }}
                         >
-                          <Ionicons name="arrow-down" size={12} color={isLastInGroup ? colors.border : colors.textLight} />
+                          <ArrowDown size={12} color={isLastInGroup ? colors.border : colors.textLight} />
                         </Pressable>
                       </View>
                     )}
@@ -1694,11 +1718,11 @@ export default function WeeklyMenuPage() {
                           }}
                         >
                           {m.is_completed ? (
-                            <Ionicons name="checkmark" size={24} color="#fff" />
+                            <Check size={24} color="#fff" />
                           ) : isGenerating ? (
                             <ActivityIndicator size="small" color="#fff" />
                           ) : (
-                            <Ionicons name={mealCfg.icon} size={22} color="#fff" />
+                            <mealCfg.Icon size={22} color="#fff" />
                           )}
                         </View>
 
@@ -1733,9 +1757,9 @@ export default function WeeklyMenuPage() {
                           ) : isGenerating ? (
                             <StatusBadge variant="generating" label="生成中" />
                           ) : (
-                            <Ionicons name="checkmark-circle-outline" size={22} color={colors.textMuted} />
+                            <CheckCircle size={22} color={colors.textMuted} />
                           )}
-                          <Ionicons name="chevron-down" size={14} color={colors.textMuted} />
+                          <ChevronDown size={14} color={colors.textMuted} />
                         </View>
                       </Pressable>
                     )}
@@ -1769,11 +1793,11 @@ export default function WeeklyMenuPage() {
                             }}
                           >
                             {m.is_completed ? (
-                              <Ionicons name="checkmark" size={24} color="#fff" />
+                              <Check size={24} color="#fff" />
                             ) : isGenerating ? (
                               <ActivityIndicator size="small" color="#fff" />
                             ) : (
-                              <Ionicons name={mealCfg.icon} size={22} color="#fff" />
+                              <mealCfg.Icon size={22} color="#fff" />
                             )}
                           </View>
                           <View style={{ flex: 1, gap: 3 }}>
@@ -1790,7 +1814,7 @@ export default function WeeklyMenuPage() {
                               ) : null}
                             </View>
                           </View>
-                          <Ionicons name="chevron-up" size={14} color={colors.textMuted} />
+                          <ChevronUp size={14} color={colors.textMuted} />
                         </Pressable>
 
                         {/* dishes 一覧: 各 dish タップで RecipeModal open */}
@@ -1823,10 +1847,10 @@ export default function WeeklyMenuPage() {
                                   borderColor: colors.border,
                                 })}
                               >
-                                <Ionicons name="book-outline" size={14} color={colors.accent} />
+                                <BookOpen size={14} color={colors.accent} />
                                 <Text style={{ flex: 1, fontSize: 13, color: colors.text }}>{dish.name}</Text>
                                 {dish.role ? <RoleBadge role={dish.role} /> : null}
-                                <Ionicons name="chevron-forward" size={14} color={colors.textMuted} />
+                                <ChevronRight size={14} color={colors.textMuted} />
                               </Pressable>
                             ))}
                           </View>
@@ -1859,9 +1883,9 @@ export default function WeeklyMenuPage() {
                               borderColor: colors.border,
                             })}
                           >
-                            <Ionicons name="book-outline" size={14} color={colors.accent} />
+                            <BookOpen size={14} color={colors.accent} />
                             <Text style={{ flex: 1, fontSize: 13, color: colors.text }}>レシピを見る</Text>
-                            <Ionicons name="chevron-forward" size={14} color={colors.textMuted} />
+                            <ChevronRight size={14} color={colors.textMuted} />
                           </Pressable>
                         )}
 
@@ -1889,7 +1913,7 @@ export default function WeeklyMenuPage() {
                               borderColor: colors.accent,
                             }}
                           >
-                            <Ionicons name="sparkles" size={16} color={colors.accent} />
+                            <Sparkles size={16} color={colors.accent} />
                             <Text style={{ fontSize: 12, fontWeight: "600", color: colors.accent }}>AIで変更</Text>
                           </Pressable>
                           {/* 手動で修正ボタン */}
@@ -1910,7 +1934,7 @@ export default function WeeklyMenuPage() {
                               borderColor: colors.border,
                             }}
                           >
-                            <Ionicons name="create-outline" size={16} color={colors.textLight} />
+                            <Pencil size={16} color={colors.textLight} />
                             <Text style={{ fontSize: 12, fontWeight: "600", color: colors.textLight }}>手動で修正</Text>
                           </Pressable>
                           {/* 削除ボタン (アイコンのみ) */}
@@ -1929,7 +1953,7 @@ export default function WeeklyMenuPage() {
                               borderColor: colors.danger,
                             }}
                           >
-                            <Ionicons name="trash-outline" size={16} color={colors.danger} />
+                            <Trash2 size={16} color={colors.danger} />
                           </Pressable>
                         </View>
                       </View>
@@ -1960,7 +1984,7 @@ export default function WeeklyMenuPage() {
                       borderColor: colors.accent,
                     })}
                   >
-                    <Ionicons name="add" size={14} color={colors.accent} />
+                    <Plus size={14} color={colors.accent} />
                     <Text style={{ fontSize: 11, color: colors.accent, fontWeight: "600" }}>食事タイプ追加</Text>
                   </Pressable>
                 </View>
@@ -2090,7 +2114,7 @@ export default function WeeklyMenuPage() {
           opacity: pressed ? 0.85 : 1,
         })}
       >
-        <Ionicons name="sparkles" size={24} color="#fff" />
+        <Sparkles size={24} color="#fff" />
       </Pressable>
 
       {/* 人数設定モーダル */}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -34,6 +34,7 @@
     "expo-sharing": "~13.0.1",
     "expo-splash-screen": "~0.30.10",
     "expo-web-browser": "~15.0.0",
+    "lucide-react-native": "^1.14.0",
     "react": "19.0.0",
     "react-native": "0.79.6",
     "react-native-safe-area-context": "5.4.0",

--- a/apps/mobile/src/components/menu/AddMealModal.tsx
+++ b/apps/mobile/src/components/menu/AddMealModal.tsx
@@ -1,5 +1,16 @@
-import { Ionicons } from "@expo/vector-icons";
-import { useEffect, useRef, useState } from "react";
+import {
+  CheckCircle,
+  ChefHat,
+  FastForward,
+  Search,
+  Sparkles,
+  Store,
+  UtensilsCrossed,
+  X,
+  XCircle,
+  Zap,
+} from "lucide-react-native";
+import React, { useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -35,7 +46,7 @@ type ActionMode = "cook" | "quick" | "buy" | "out" | "ai_creative";
 interface ActionConfig {
   mode: ActionMode;
   label: string;
-  icon: keyof typeof Ionicons.glyphMap;
+  Icon: React.ComponentType<any>;
   bgColor: string;
   textColor: string;
   outline?: boolean;
@@ -60,35 +71,35 @@ const ACTIONS: ActionConfig[] = [
   {
     mode: "cook",
     label: "自炊で追加",
-    icon: "restaurant-outline",
+    Icon: ChefHat,
     bgColor: colors.successLight,
     textColor: colors.success,
   },
   {
     mode: "quick",
     label: "時短で追加",
-    icon: "flash-outline",
+    Icon: Zap,
     bgColor: colors.blueLight,
     textColor: colors.blue,
   },
   {
     mode: "buy",
     label: "買うで追加",
-    icon: "bag-handle-outline",
+    Icon: Store,
     bgColor: colors.purpleLight,
     textColor: colors.purple,
   },
   {
     mode: "out",
     label: "外食で追加",
-    icon: "fork-knife-outline" as keyof typeof Ionicons.glyphMap,
+    Icon: UtensilsCrossed,
     bgColor: colors.warningLight,
     textColor: colors.warning,
   },
   {
     mode: "ai_creative",
     label: "AI献立で追加",
-    icon: "sparkles" as keyof typeof Ionicons.glyphMap,
+    Icon: Sparkles,
     bgColor: colors.accentLight,
     textColor: colors.accent,
   },
@@ -242,7 +253,7 @@ export function AddMealModal({
               {mealLabel}を追加
             </Text>
             <Pressable onPress={onClose} hitSlop={8} style={{ padding: 4 }}>
-              <Ionicons name="close" size={22} color={colors.textMuted} />
+              <X size={22} color={colors.textMuted} />
             </Pressable>
           </View>
 
@@ -269,7 +280,7 @@ export function AddMealModal({
                 gap: spacing.sm,
               }}
             >
-              <Ionicons name="search" size={16} color={colors.textMuted} />
+              <Search size={16} color={colors.textMuted} />
               <TextInput
                 testID="add-meal-search-input"
                 value={query}
@@ -377,7 +388,7 @@ export function AddMealModal({
                   borderColor: colors.purple,
                 }}
               >
-                <Ionicons name="checkmark-circle" size={16} color={colors.purple} />
+                <CheckCircle size={16} color={colors.purple} />
                 <Text style={{ flex: 1, fontSize: 13, color: colors.text, fontWeight: "600" }}>
                   {selectedProduct.name}
                 </Text>
@@ -389,7 +400,7 @@ export function AddMealModal({
                   }}
                   hitSlop={8}
                 >
-                  <Ionicons name="close-circle" size={16} color={colors.textMuted} />
+                  <XCircle size={16} color={colors.textMuted} />
                 </Pressable>
               </View>
             )}
@@ -415,7 +426,7 @@ export function AddMealModal({
                   {isSubmitting ? (
                     <ActivityIndicator size="small" color={action.textColor} />
                   ) : (
-                    <Ionicons name={action.icon} size={20} color={action.textColor} />
+                    <action.Icon size={20} color={action.textColor} />
                   )}
                   <Text style={{ fontSize: 14, fontWeight: "500", color: action.textColor }}>
                     {action.label}
@@ -440,11 +451,7 @@ export function AddMealModal({
                   opacity: pressed || isSubmitting ? 0.7 : 1,
                 })}
               >
-                <Ionicons
-                  name={"sparkles" as keyof typeof Ionicons.glyphMap}
-                  size={20}
-                  color={colors.accent}
-                />
+                <Sparkles size={20} color={colors.accent} />
                 <Text style={{ fontSize: 14, fontWeight: "500", color: colors.accent }}>
                   AIに提案してもらう
                 </Text>

--- a/apps/mobile/src/components/menu/ConfirmDeleteModal.tsx
+++ b/apps/mobile/src/components/menu/ConfirmDeleteModal.tsx
@@ -1,4 +1,4 @@
-import { Ionicons } from "@expo/vector-icons";
+import { Trash2 } from "lucide-react-native";
 import {
   Modal,
   Pressable,
@@ -29,7 +29,7 @@ export function ConfirmDeleteModal({ visible, mealName, onCancel, onConfirm }: P
         <View testID="confirm-delete-modal" style={styles.container}>
           {/* アイコン */}
           <View style={styles.iconWrapper}>
-            <Ionicons name="trash" size={32} color={colors.error} />
+            <Trash2 size={32} color={colors.error} />
           </View>
 
           {/* タイトル */}
@@ -61,7 +61,7 @@ export function ConfirmDeleteModal({ visible, mealName, onCancel, onConfirm }: P
                 pressed && styles.confirmButtonPressed,
               ]}
             >
-              <Ionicons name="trash-outline" size={16} color="#fff" />
+              <Trash2 size={16} color="#fff" />
               <Text style={styles.confirmText}>削除する</Text>
             </Pressable>
           </View>

--- a/apps/mobile/src/components/menu/DishEditor.tsx
+++ b/apps/mobile/src/components/menu/DishEditor.tsx
@@ -1,4 +1,4 @@
-import { Ionicons } from "@expo/vector-icons";
+import { Search, Trash2 } from "lucide-react-native";
 import { Pressable, Text, TextInput, View } from "react-native";
 
 import { getDishConfig } from "@homegohan/shared";
@@ -61,7 +61,7 @@ export function DishEditor({ dish, index, onChange, onDelete, onOpenCatalog }: P
             borderRadius: radius.sm,
           }}
         >
-          <Ionicons name="trash-outline" size={16} color={colors.error} />
+          <Trash2 size={16} color={colors.error} />
         </Pressable>
       </View>
 
@@ -154,7 +154,7 @@ export function DishEditor({ dish, index, onChange, onDelete, onOpenCatalog }: P
           paddingVertical: spacing.xs,
         }}
       >
-        <Ionicons name="search-outline" size={13} color={colors.accent} />
+        <Search size={13} color={colors.accent} />
         <Text style={{ fontSize: 12, color: colors.accent, fontWeight: "600" }}>
           カタログから検索
         </Text>

--- a/apps/mobile/src/components/menu/ManualEditModal.tsx
+++ b/apps/mobile/src/components/menu/ManualEditModal.tsx
@@ -1,5 +1,18 @@
-import { Ionicons } from "@expo/vector-icons";
-import { useEffect, useRef, useState } from "react";
+import {
+  Camera,
+  CheckCircle,
+  ChefHat,
+  FastForward,
+  Palette,
+  Plus,
+  Search,
+  Sparkles,
+  Store,
+  UtensilsCrossed,
+  X,
+  Zap,
+} from "lucide-react-native";
+import React, { useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -57,42 +70,42 @@ const MODE_OPTIONS = [
   {
     mode: "cook",
     label: "自炊",
-    icon: "restaurant" as const,
+    Icon: ChefHat,
     bg: colors.successLight,
     fg: colors.success,
   },
   {
     mode: "quick",
     label: "時短",
-    icon: "flash" as const,
+    Icon: Zap,
     bg: colors.blueLight,
     fg: colors.blue,
   },
   {
     mode: "buy",
     label: "買う",
-    icon: "bag" as const,
+    Icon: Store,
     bg: colors.purpleLight,
     fg: colors.purple,
   },
   {
     mode: "out",
     label: "外食",
-    icon: "restaurant-outline" as const,
+    Icon: UtensilsCrossed,
     bg: colors.warningLight,
     fg: colors.warning,
   },
   {
     mode: "skip",
     label: "なし",
-    icon: "remove-circle" as const,
+    Icon: FastForward,
     bg: "#F5F5F5",
     fg: colors.textMuted,
   },
   {
     mode: "ai_creative",
     label: "AI献立",
-    icon: "sparkles" as const,
+    Icon: Sparkles,
     bg: colors.accentLight,
     fg: colors.accent,
   },
@@ -317,7 +330,7 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
                 手動で変更
               </Text>
               <Pressable onPress={onClose} hitSlop={8} style={{ padding: 4 }}>
-                <Ionicons name="close" size={22} color={colors.textMuted} />
+                <X size={22} color={colors.textMuted} />
               </Pressable>
             </View>
 
@@ -336,8 +349,7 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
                   }}
                 >
                   <Pressable onPress={() => setShowCatalog(null)} hitSlop={8}>
-                    <Ionicons
-                      name="arrow-back"
+                    <X
                       size={20}
                       color={colors.accent}
                     />
@@ -367,8 +379,7 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
                       gap: spacing.sm,
                     }}
                   >
-                    <Ionicons
-                      name="search"
+                    <Search
                       size={16}
                       color={colors.textMuted}
                     />
@@ -520,8 +531,7 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
                               borderColor: isSelected ? opt.fg : colors.border,
                             }}
                           >
-                            <Ionicons
-                              name={opt.icon}
+                            <opt.Icon
                               size={14}
                               color={isSelected ? opt.fg : colors.textMuted}
                             />
@@ -563,8 +573,7 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
                         gap: spacing.sm,
                       }}
                     >
-                      <Ionicons
-                        name="search-outline"
+                      <Search
                         size={16}
                         color={colors.textMuted}
                       />
@@ -628,8 +637,7 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
                         hitSlop={8}
                         style={{ flexDirection: "row", alignItems: "center", gap: 2 }}
                       >
-                        <Ionicons
-                          name="add"
+                        <Plus
                           size={14}
                           color={colors.accent}
                         />
@@ -694,8 +702,7 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
                         opacity: pressed ? 0.7 : 1,
                       })}
                     >
-                      <Ionicons
-                        name="camera-outline"
+                      <Camera
                         size={16}
                         color={colors.blue}
                       />
@@ -727,8 +734,7 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
                         opacity: 0.5,
                       }}
                     >
-                      <Ionicons
-                        name="color-palette-outline"
+                      <Palette
                         size={16}
                         color={colors.accent}
                       />
@@ -765,8 +771,7 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
                     {isSaving ? (
                       <ActivityIndicator size="small" color="#fff" />
                     ) : (
-                      <Ionicons
-                        name="checkmark-circle-outline"
+                      <CheckCircle
                         size={18}
                         color="#fff"
                       />

--- a/apps/mobile/src/components/menu/PantryItem.tsx
+++ b/apps/mobile/src/components/menu/PantryItem.tsx
@@ -1,4 +1,4 @@
-import { Ionicons } from '@expo/vector-icons';
+import { Trash2 } from 'lucide-react-native';
 import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
@@ -85,7 +85,7 @@ export const PantryItem: React.FC<Props> = ({ item, onDelete }) => {
           hitSlop={8}
           style={styles.deleteBtn}
         >
-          <Ionicons name="trash-outline" size={16} color={colors.textMuted} />
+          <Trash2 size={16} color={colors.textMuted} />
         </Pressable>
       </View>
     </View>

--- a/apps/mobile/src/components/menu/RegenerateMealModal.tsx
+++ b/apps/mobile/src/components/menu/RegenerateMealModal.tsx
@@ -1,4 +1,4 @@
-import { Ionicons } from "@expo/vector-icons";
+import { Sparkles, X } from "lucide-react-native";
 import React, { useState } from "react";
 import {
   ActivityIndicator,
@@ -128,7 +128,7 @@ export const RegenerateMealModal: React.FC<Props> = ({ visible, meal, onClose })
               onPress={handleClose}
               style={styles.closeBtn}
             >
-              <Ionicons name="close" size={20} color={colors.textLight} />
+              <X size={20} color={colors.textLight} />
             </Pressable>
           </View>
 
@@ -197,7 +197,7 @@ export const RegenerateMealModal: React.FC<Props> = ({ visible, meal, onClose })
                 <ActivityIndicator color="#FFF" />
               ) : (
                 <>
-                  <Ionicons name="sparkles" size={18} color="#FFF" />
+                  <Sparkles size={18} color="#FFF" />
                   <Text style={styles.submitText}>AIで別の献立に変更</Text>
                 </>
               )}

--- a/apps/mobile/src/components/menu/RoleBadge.tsx
+++ b/apps/mobile/src/components/menu/RoleBadge.tsx
@@ -1,9 +1,9 @@
-import { Ionicons } from '@expo/vector-icons';
+import { HelpCircle } from 'lucide-react-native';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { getDishConfig } from '@homegohan/shared';
-import { ICON_MAP_IONICONS } from '../../lib/icon-map';
+import { ICON_MAP_LUCIDE } from '../../lib/icon-map';
 import { colors } from '../../theme/colors';
 import { typography } from '../../theme/typography';
 
@@ -15,11 +15,11 @@ export const RoleBadge: React.FC<Props> = ({ role }) => {
   if (!role) return null;
   const cfg = getDishConfig(role);
   const color = colors[cfg.colorKey as keyof typeof colors] as string;
-  const iconName = ICON_MAP_IONICONS[cfg.iconKey] ?? 'help-circle-outline';
+  const IconComponent = ICON_MAP_LUCIDE[cfg.iconKey] ?? HelpCircle;
 
   return (
     <View testID="role-badge" style={[styles.container, { backgroundColor: color + '22' }]}>
-      <Ionicons name={iconName as any} size={10} color={color} />
+      <IconComponent size={10} color={color} />
       <Text style={[styles.label, { color }]}>{cfg.label}</Text>
     </View>
   );

--- a/apps/mobile/src/components/menu/ShoppingItem.tsx
+++ b/apps/mobile/src/components/menu/ShoppingItem.tsx
@@ -1,4 +1,4 @@
-import { Ionicons } from '@expo/vector-icons';
+import { Check, Trash2 } from 'lucide-react-native';
 import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
@@ -49,7 +49,7 @@ export const ShoppingItem: React.FC<Props> = ({
         hitSlop={8}
       >
         {item.is_checked && (
-          <Ionicons name="checkmark" size={12} color="#fff" />
+          <Check size={12} color="#fff" />
         )}
       </Pressable>
 
@@ -98,7 +98,7 @@ export const ShoppingItem: React.FC<Props> = ({
         style={styles.deleteBtn}
         hitSlop={8}
       >
-        <Ionicons name="trash-outline" size={14} color={colors.textMuted} />
+        <Trash2 size={14} color={colors.textMuted} />
       </Pressable>
     </View>
   );

--- a/apps/mobile/src/components/menu/ShoppingListModal.tsx
+++ b/apps/mobile/src/components/menu/ShoppingListModal.tsx
@@ -1,4 +1,4 @@
-import { Ionicons } from '@expo/vector-icons';
+import { Plus, RefreshCw, ShoppingCart, Trash2, Users, X } from 'lucide-react-native';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
@@ -237,7 +237,7 @@ export const ShoppingListModal: React.FC<Props> = ({
             {/* ヘッダー */}
             <View style={styles.header}>
               <View style={styles.headerLeft}>
-                <Ionicons name="cart" size={18} color={colors.accent} />
+                <ShoppingCart size={18} color={colors.accent} />
                 <Text style={styles.headerTitle}>買い物リスト</Text>
               </View>
               <View style={styles.headerRight}>
@@ -248,11 +248,11 @@ export const ShoppingListModal: React.FC<Props> = ({
                     style={styles.servingsBtn}
                     hitSlop={8}
                   >
-                    <Ionicons name="people-outline" size={20} color={colors.textLight} />
+                    <Users size={20} color={colors.textLight} />
                   </Pressable>
                 )}
                 <Pressable onPress={onClose} style={styles.closeBtn} hitSlop={8}>
-                  <Ionicons name="close" size={18} color={colors.textLight} />
+                  <X size={18} color={colors.textLight} />
                 </Pressable>
               </View>
             </View>
@@ -273,7 +273,7 @@ export const ShoppingListModal: React.FC<Props> = ({
               </View>
             ) : items.length === 0 ? (
               <View style={styles.emptyBox}>
-                <Ionicons name="cart-outline" size={40} color={colors.textMuted} />
+                <ShoppingCart size={40} color={colors.textMuted} />
                 <Text style={styles.emptyText}>買い物リストが空です</Text>
               </View>
             ) : (
@@ -312,7 +312,7 @@ export const ShoppingListModal: React.FC<Props> = ({
                 style={styles.addBtn}
                 onPress={() => setAddModalVisible(true)}
               >
-                <Ionicons name="add" size={14} color={colors.textMuted} />
+                <Plus size={14} color={colors.textMuted} />
                 <Text style={styles.addBtnText}>追加</Text>
               </Pressable>
 
@@ -321,7 +321,7 @@ export const ShoppingListModal: React.FC<Props> = ({
                 style={styles.regenBtn}
                 onPress={onOpenRange}
               >
-                <Ionicons name="refresh" size={14} color="#fff" />
+                <RefreshCw size={14} color="#fff" />
                 <Text style={styles.regenBtnText}>献立から再生成</Text>
               </Pressable>
 
@@ -334,7 +334,7 @@ export const ShoppingListModal: React.FC<Props> = ({
                 {clearingAll ? (
                   <ActivityIndicator size="small" color={colors.textMuted} />
                 ) : (
-                  <Ionicons name="trash-outline" size={16} color={colors.textMuted} />
+                  <Trash2 size={16} color={colors.textMuted} />
                 )}
               </Pressable>
             </View>

--- a/apps/mobile/src/components/menu/WeeklyHeader.tsx
+++ b/apps/mobile/src/components/menu/WeeklyHeader.tsx
@@ -1,4 +1,4 @@
-import { Ionicons } from '@expo/vector-icons';
+import { BarChart3, ChefHat, Flame, Refrigerator, ShoppingCart } from 'lucide-react-native';
 import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
@@ -38,24 +38,24 @@ export const WeeklyHeader: React.FC<Props> = ({
       </View>
       <View style={styles.statsRow}>
         <View style={styles.statItem}>
-          <Ionicons name="restaurant-outline" size={14} color={colors.textLight} />
+          <ChefHat size={14} color={colors.textLight} />
           <Text style={styles.statText}>自炊率 {weeklyStats.cookRate}%</Text>
         </View>
         <View style={styles.statItem}>
-          <Ionicons name="flame-outline" size={14} color={colors.textLight} />
+          <Flame size={14} color={colors.textLight} />
           <Text style={styles.statText}>平均 {weeklyStats.avgKcal} kcal</Text>
         </View>
       </View>
       <View style={styles.actions}>
         <Pressable testID="header-stats-btn" onPress={onPressStats} style={styles.iconBtn}>
-          <Ionicons name="bar-chart" size={20} color={colors.text} />
+          <BarChart3 size={20} color={colors.text} />
         </Pressable>
         <Pressable
           testID="header-fridge-btn"
           onPress={onPressFridge}
           style={[styles.iconBtn, fridgeDanger && styles.iconBtnDanger]}
         >
-          <Ionicons name="nutrition-outline" size={20} color={fridgeDanger ? colors.error : colors.text} />
+          <Refrigerator size={20} color={fridgeDanger ? colors.error : colors.text} />
           {expiringCount > 0 && (
             <View style={styles.badge}>
               <Text style={styles.badgeText}>{expiringCount}</Text>
@@ -63,7 +63,7 @@ export const WeeklyHeader: React.FC<Props> = ({
           )}
         </Pressable>
         <Pressable testID="header-shopping-btn" onPress={onPressShopping} style={styles.iconBtn}>
-          <Ionicons name="cart" size={20} color={colors.text} />
+          <ShoppingCart size={20} color={colors.text} />
           {uncheckedShoppingCount > 0 && (
             <View style={styles.badge}>
               <Text style={styles.badgeText}>{uncheckedShoppingCount}</Text>

--- a/apps/mobile/src/lib/icon-map.ts
+++ b/apps/mobile/src/lib/icon-map.ts
@@ -15,3 +15,22 @@ export const ICON_MAP_IONICONS: Record<string, string> = {
 };
 
 export type DishIconKey = keyof typeof ICON_MAP_IONICONS;
+
+/**
+ * アイコンマップ (lucide-react-native)
+ *
+ * @homegohan/shared の iconKey → lucide-react-native コンポーネントへの解決マップ
+ * WEB (lucide-react) と完全一致するアイコンを使用
+ */
+import { Utensils, Leaf, Soup, Wheat, Salad, Cake, HelpCircle } from 'lucide-react-native';
+import type React from 'react';
+
+export const ICON_MAP_LUCIDE: Record<string, React.ComponentType<any>> = {
+  utensils: Utensils,
+  leaf: Leaf,
+  soup: Soup,      // cafe (コーヒーカップ) から正しい Soup へ
+  wheat: Wheat,    // nutrition から正しい Wheat へ
+  salad: Salad,
+  cake: Cake,
+  help: HelpCircle,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "expo-sharing": "~13.0.1",
         "expo-splash-screen": "~0.30.10",
         "expo-web-browser": "~15.0.0",
+        "lucide-react-native": "^1.14.0",
         "react": "19.0.0",
         "react-native": "0.79.6",
         "react-native-safe-area-context": "5.4.0",
@@ -14458,6 +14459,17 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lucide-react-native": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-react-native/-/lucide-react-native-1.14.0.tgz",
+      "integrity": "sha512-FkOjd4JHIB8SplakHQjeo4RR/5peXtl+PbL+TghQqWzcQ+AKbJ/PFl5xEnerLtSQ4EIq6B9uXblY7QSyKg05WQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-native": "*",
+        "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/magic-string": {


### PR DESCRIPTION
## Summary

- `lucide-react-native` をインストール (`react-native-svg` は既存のため追加不要)
- `icon-map.ts` に `ICON_MAP_LUCIDE` を追加し、`soup: cafe→Soup`、`wheat: nutrition→Wheat` の誤対応を修正
- menu ドメインの主要コンポーネント計 13 ファイルで Ionicons を lucide に置換 (約 60 箇所)

## 変更対象ファイル

| ファイル | 主な変更内容 |
|---|---|
| `src/lib/icon-map.ts` | `ICON_MAP_LUCIDE` 追加 |
| `WeeklyHeader.tsx` | ChefHat / Flame / BarChart3 / Refrigerator / ShoppingCart |
| `RoleBadge.tsx` | `ICON_MAP_IONICONS` → `ICON_MAP_LUCIDE` (コンポーネント描画) |
| `menus/weekly/index.tsx` | `MEAL_CONFIG` をコンポーネント形式化、全 Ionicons 置換 |
| `RegenerateMealModal.tsx` | X / Sparkles |
| `ManualEditModal.tsx` | MODE_OPTIONS を lucide コンポーネントへ (ChefHat/Zap/Store/UtensilsCrossed/FastForward/Sparkles) |
| `AddMealModal.tsx` | ACTIONS を lucide コンポーネントへ |
| `DishEditor.tsx` | Search / Trash2 |
| `ConfirmDeleteModal.tsx` | Trash2 |
| `ShoppingItem.tsx` | Check / Trash2 |
| `PantryItem.tsx` | Trash2 |
| `ShoppingListModal.tsx` | ShoppingCart / Users / X / Plus / RefreshCw / Trash2 |
| `apps/mobile/package.json` | `lucide-react-native` 追加 |

## Test plan

- [ ] WeeklyHeader の冷蔵庫・買い物カート・統計アイコンが正しく表示される
- [ ] RoleBadge が各 role (utensils/leaf/soup/wheat/salad/cake) で正しいアイコンを表示する
- [ ] soup が Soup (スープ碗)、wheat が Wheat (麦穂) に変わっている
- [ ] 食事カードの展開/折りたたみ矢印が正常動作する
- [ ] AIで変更/手動で修正/削除ボタンのアイコンが表示される
- [ ] モーダルの × ボタンが動作する
- [ ] TypeScript エラーが lucide 関連では 0 件 (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)