### PR TITLE
fix: バナータップでV4Modalがfull screen表示されない問題を修正

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -2076,26 +2076,6 @@ export default function WeeklyMenuPage() {
         />
       )}
 
-      {/* フローティング AI アシスタントボタン */}
-      <Pressable
-        testID="weekly-ai-assistant-btn"
-        onPress={() => setShowV4Modal(true)}
-        style={({ pressed }) => ({
-          position: "absolute",
-          bottom: spacing["2xl"],
-          right: spacing.lg,
-          width: 56,
-          height: 56,
-          borderRadius: 28,
-          backgroundColor: colors.accent,
-          alignItems: "center",
-          justifyContent: "center",
-          opacity: pressed ? 0.85 : 1,
-        })}
-      >
-        <Sparkles size={24} color="#fff" />
-      </Pressable>
-
       {/* 人数設定モーダル */}
       <ServingsModal
         visible={showServingsModal}

--- a/apps/mobile/src/components/menu/V4GenerateModal.tsx
+++ b/apps/mobile/src/components/menu/V4GenerateModal.tsx
@@ -4,7 +4,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   Switch,
@@ -382,72 +384,57 @@ export function V4GenerateModal({
   return (
     <Modal
       visible={visible}
-      transparent
       animationType="slide"
-      presentationStyle="overFullScreen"
+      presentationStyle="pageSheet"
       onRequestClose={handleClose}
       testID="v4-modal"
     >
-      {/* Backdrop */}
-      <Pressable
-        onPress={handleClose}
-        style={{
-          flex: 1,
-          backgroundColor: "rgba(0,0,0,0.5)",
-          justifyContent: "flex-end",
-        }}
+      <KeyboardAvoidingView
+        style={{ flex: 1, backgroundColor: C.bg }}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 20}
       >
-        {/* Sheet */}
-        <Pressable
-          onPress={(e) => e.stopPropagation()}
+        {/* Header */}
+        <View
           style={{
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingHorizontal: spacing.lg,
+            paddingVertical: spacing.md,
+            borderBottomWidth: 1,
+            borderBottomColor: C.border,
             backgroundColor: C.card,
-            borderTopLeftRadius: radius["2xl"],
-            borderTopRightRadius: radius["2xl"],
-            maxHeight: "90%",
-            ...shadows.md,
           }}
         >
-          {/* Header */}
-          <View
+          <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+            <Ionicons name="sparkles" size={20} color={C.accent} />
+            <Text style={{ fontSize: 17, fontWeight: "700", color: C.text }}>
+              AI献立アシスタント
+            </Text>
+          </View>
+          <Pressable
+            onPress={handleClose}
+            hitSlop={8}
             style={{
-              flexDirection: "row",
+              width: 32,
+              height: 32,
+              borderRadius: 16,
+              backgroundColor: C.bg,
               alignItems: "center",
-              justifyContent: "space-between",
-              paddingHorizontal: spacing.lg,
-              paddingVertical: spacing.md,
-              borderBottomWidth: 1,
-              borderBottomColor: C.border,
+              justifyContent: "center",
             }}
           >
-            <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
-              <Ionicons name="sparkles" size={20} color={C.accent} />
-              <Text style={{ fontSize: 17, fontWeight: "700", color: C.text }}>
-                AIアシスタント
-              </Text>
-            </View>
-            <Pressable
-              onPress={handleClose}
-              hitSlop={8}
-              style={{
-                width: 32,
-                height: 32,
-                borderRadius: 16,
-                backgroundColor: C.bg,
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <Ionicons name="close" size={18} color={C.textLight} />
-            </Pressable>
-          </View>
+            <Ionicons name="close" size={18} color={C.textLight} />
+          </Pressable>
+        </View>
 
-          {/* Scrollable content */}
-          <ScrollView
-            style={{ flex: 1 }}
-            contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}
-            keyboardShouldPersistTaps="handled"
-          >
+        {/* Scrollable content */}
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}
+          keyboardShouldPersistTaps="handled"
+        >
             {/* Mode label */}
             <Text style={{ fontSize: 13, fontWeight: "700", color: C.textLight }}>
               何を生成しますか？
@@ -693,8 +680,7 @@ export function V4GenerateModal({
             {/* bottom padding for safe area */}
             <View style={{ height: spacing.xl }} />
           </ScrollView>
-        </Pressable>
-      </Pressable>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary

- **真の原因**: `V4GenerateModal` が `transparent + justifyContent: "flex-end" + maxHeight: "90%"` のbottom sheetスタイルで実装されていたため、バナータップ時に画面下端に細いシートしか表示されなかった
- **二重FAB問題**: `weekly-ai-assistant-btn` フローティングボタン(weekly/index.tsx)が `AIFloatingFab`((tabs)/_layout.tsx)と重なって2つのFABが表示されていた
- `EmptySlotAIBanner.onPress → setShowV4Modal(true)` のロジック自体は正しかった

## Changes

- `V4GenerateModal`: `transparent` + `presentationStyle="overFullScreen"` + Backdrop/Sheet Pressable構造を廃止し、`presentationStyle="pageSheet"` + `KeyboardAvoidingView` のfull screen modalに変更。タイトルも「AIアシスタント」→「AI献立アシスタント」に修正
- `weekly/index.tsx`: `weekly-ai-assistant-btn` フローティングボタン(Pressable + Sparkles)を削除。`AIFloatingFab`と重複していたため

## Test plan

- [ ] 献立画面の「AI献立アシスタント」バナーをタップ → V4Modal が pageSheet (full screen相当) で表示される
- [ ] 1日献立変更 / 空欄埋め / AI献立だけ / 期間指定の4モードが正しく表示される
- [ ] 右下フローティングボタンが1つだけ表示される (AIFloatingFabのみ)
- [ ] AIFloatingFab タップ → AIAdvisorSheet が表示される (既存動作)
- [ ] V4Modal の✕ボタンで閉じられる

🤖 Generated with [Claude Code](https://claude.com/claude-code)