### PR TITLE
fix: ホーム画面のAI FABが2個表示される問題を修正

### DIFF
--- a/apps/mobile/app/(tabs)/home.tsx
+++ b/apps/mobile/app/(tabs)/home.tsx
@@ -1116,20 +1116,6 @@ export default function HomeScreen() {
         </View>
       </Modal>
 
-      {/* ========== AIフローティングボタン ========== */}
-      <Pressable
-        testID="home-ai-fab"
-        onPress={() => router.push("/ai")}
-        style={{
-          position: "absolute", bottom: 100, right: spacing.lg,
-          width: 56, height: 56, borderRadius: 28,
-          backgroundColor: colors.accent, alignItems: "center", justifyContent: "center",
-          ...shadows.lg,
-        }}
-      >
-        <Ionicons name="chatbubble-ellipses" size={24} color="#fff" />
-      </Pressable>
-
       {/* ========== チェックインフィードバックトースト ========== */}
       {checkinFeedback && (
         <Animated.View


### PR DESCRIPTION
## Summary

- `home.tsx` 内の旧AIフローティングボタン（Pressable, testID=`home-ai-fab`）を削除
- `tabs/_layout.tsx` に配置済みの `AIFloatingFab`（PR #719）のみに一本化
- FABの二重表示（💬 赤系丸ボタン + ✨ グラデーション）を解消

## Test plan

- [ ] ホーム画面でAI FABが1個だけ表示されることを確認
- [ ] FABタップで `/ai` 画面に遷移することを確認
- [ ] tsc: home.tsx に新規エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)