### PR TITLE
fix(mobile): plan 未作成週でも AddMealModal を直接開けるように修正

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -667,11 +667,11 @@ export default function WeeklyMenuPage() {
 
   // AddMealSlotModal state
   const [addMealSlotVisible, setAddMealSlotVisible] = useState(false);
-  const [addMealSlotDayId, setAddMealSlotDayId] = useState<string>("");
+  const [addMealSlotDayId, setAddMealSlotDayId] = useState<string | null>(null);
 
   // AddMealModal state
   const [addMealModalVisible, setAddMealModalVisible] = useState(false);
-  const [addMealModalDayId, setAddMealModalDayId] = useState<string>("");
+  const [addMealModalDayId, setAddMealModalDayId] = useState<string | null>(null);
   const [addMealModalDayDate, setAddMealModalDayDate] = useState<string>("");
   const [addMealModalMealType, setAddMealModalMealType] = useState<MealType>("dinner");
 
@@ -1609,19 +1609,8 @@ export default function WeeklyMenuPage() {
                       dayDate={selectedDay.day_date}
                       mealLabel={MEAL_CONFIG[mealType]?.label ?? mealType}
                       onPress={() => {
-                        // plan が未作成の場合 (id が null) は AI 献立作成を促す
-                        if (!selectedDay.id) {
-                          Alert.alert(
-                            "週間献立の作成",
-                            "この週の献立がまだ作成されていません。AIに献立を作成してもらいましょう。",
-                            [
-                              { text: "キャンセル", style: "cancel" },
-                              { text: "AIで作成", onPress: () => setShowV4Modal(true) },
-                            ],
-                          );
-                          return;
-                        }
-                        setAddMealModalDayId(selectedDay.id as string);
+                        // plan 未作成 (id が null) でも AddMealModal を開く — API 側で user_daily_meals を自動作成
+                        setAddMealModalDayId(selectedDay.id ?? null);
                         setAddMealModalDayDate(selectedDay.day_date);
                         setAddMealModalMealType(mealType);
                         setAddMealModalVisible(true);
@@ -1937,19 +1926,8 @@ export default function WeeklyMenuPage() {
                 <Pressable
                   testID="weekly-add-meal-type-btn"
                   onPress={() => {
-                    if (!selectedDay?.id) {
-                      // plan 未作成 → AI 献立作成を促す
-                      Alert.alert(
-                        "週間献立の作成",
-                        "この週の献立がまだ作成されていません。AIに献立を作成してもらいましょう。",
-                        [
-                          { text: "キャンセル", style: "cancel" },
-                          { text: "AIで作成", onPress: () => setShowV4Modal(true) },
-                        ],
-                      );
-                      return;
-                    }
-                    setAddMealSlotDayId(selectedDay.id as string);
+                    // plan 未作成 (id が null) でも AddMealSlotModal を開く
+                    setAddMealSlotDayId(selectedDay?.id ?? "");
                     setAddMealSlotVisible(true);
                   }}
                   style={({ pressed }) => ({
@@ -1982,7 +1960,8 @@ export default function WeeklyMenuPage() {
         dayId={addMealSlotDayId}
         onSelect={(mealType: MealType) => {
           setAddMealSlotVisible(false);
-          setAddMealModalDayId(addMealSlotDayId);
+          // plan 未作成時は addMealSlotDayId が "" になるため null に正規化
+          setAddMealModalDayId(addMealSlotDayId || null);
           setAddMealModalDayDate(selectedDate);
           setAddMealModalMealType(mealType);
           setAddMealModalVisible(true);

--- a/apps/mobile/src/components/menu/AddMealModal.tsx
+++ b/apps/mobile/src/components/menu/AddMealModal.tsx
@@ -55,8 +55,8 @@ interface ActionConfig {
 interface Props {
   visible: boolean;
   onClose: () => void;
-  /** user_daily_meals.id */
-  dayId: string;
+  /** user_daily_meals.id (plan 未作成時は null — API 側で自動作成) */
+  dayId: string | null;
   /** 対応する日付文字列 YYYY-MM-DD (POST に必要) */
   dayDate: string;
   mealType: MealType;

--- a/apps/mobile/src/components/menu/AddMealSlotModal.tsx
+++ b/apps/mobile/src/components/menu/AddMealSlotModal.tsx
@@ -8,7 +8,7 @@ interface Props {
   visible: boolean;
   onClose: () => void;
   onSelect: (mealType: MealType) => void;
-  dayId: string;
+  dayId: string | null;
 }
 
 const TYPES: MealType[] = ["breakfast", "lunch", "dinner", "snack"];


### PR DESCRIPTION
## Summary

- plan 未作成の週で「朝食を追加」などをタップすると Alert「週間献立の作成」が表示されていた問題を修正
- Alert ブロックを削除し、WEB 仕様と同様に AddMealModal を直接表示するよう変更
- API (`POST /api/meal-plans/meals`) は `dayDate` のみで `user_daily_meals` を自動作成するため、`dayId` が null でも meal 追加が完結する
- `AddMealModal.Props.dayId` / `AddMealSlotModal.Props.dayId` を `string | null` に変更し、state 初期値も `null` に統一

## 変更ファイル

- `apps/mobile/app/menus/weekly/index.tsx` — Alert 削除、state 型変更
- `apps/mobile/src/components/menu/AddMealModal.tsx` — props `dayId: string | null`
- `apps/mobile/src/components/menu/AddMealSlotModal.tsx` — props `dayId: string | null`

## Test plan

- [ ] plan 未作成の週で朝食/昼食/夕食の EmptySlot をタップ → AddMealModal が開く
- [ ] AddMealModal で「自炊で追加」などをタップ → meal が追加されリストに表示される
- [ ] plan 未作成の週で「食事を追加」ボタンをタップ → AddMealSlotModal が開き、食事タイプ選択後 AddMealModal が開く
- [ ] plan 作成済みの週では既存挙動と変わらず動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)