### PR TITLE
fix: AddMealModal / AddMealSlotModal を pageSheet で全画面表示に修正

### DIFF
--- a/apps/mobile/src/components/menu/AddMealModal.tsx
+++ b/apps/mobile/src/components/menu/AddMealModal.tsx
@@ -14,8 +14,11 @@ import React, { useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
+  SafeAreaView,
   ScrollView,
   Text,
   TextInput,
@@ -25,7 +28,7 @@ import {
 import type { MealType } from "@homegohan/shared";
 import { MEAL_LABELS } from "@homegohan/shared";
 import { getApi } from "../../lib/api";
-import { colors, radius, shadows, spacing } from "../../theme";
+import { colors, radius, spacing } from "../../theme";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -218,25 +221,13 @@ export function AddMealModal({
       testID="add-meal-modal"
       visible={visible}
       animationType="slide"
-      transparent
+      presentationStyle="pageSheet"
       onRequestClose={onClose}
     >
-      <View
-        style={{
-          flex: 1,
-          justifyContent: "flex-end",
-          backgroundColor: "rgba(0,0,0,0.4)",
-        }}
-      >
-        <View
-          style={{
-            backgroundColor: colors.bg,
-            borderTopLeftRadius: radius["2xl"],
-            borderTopRightRadius: radius["2xl"],
-            maxHeight: "85%",
-            paddingBottom: spacing["2xl"],
-            ...shadows.lg,
-          }}
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.bg }}>
+        <KeyboardAvoidingView
+          style={{ flex: 1 }}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
         >
           {/* ヘッダー */}
           <View
@@ -247,6 +238,7 @@ export function AddMealModal({
               padding: spacing.lg,
               borderBottomWidth: 1,
               borderBottomColor: colors.border,
+              backgroundColor: colors.bg,
             }}
           >
             <Text style={{ fontSize: 17, fontWeight: "700", color: colors.text }}>
@@ -457,9 +449,12 @@ export function AddMealModal({
                 </Text>
               </Pressable>
             </View>
+
+            {/* bottom padding for safe area */}
+            <View style={{ height: spacing.xl }} />
           </ScrollView>
-        </View>
-      </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
     </Modal>
   );
 }

--- a/apps/mobile/src/components/menu/AddMealSlotModal.tsx
+++ b/apps/mobile/src/components/menu/AddMealSlotModal.tsx
@@ -1,8 +1,8 @@
 import { Ionicons } from "@expo/vector-icons";
-import { Modal, Pressable, Text, View } from "react-native";
+import { KeyboardAvoidingView, Modal, Platform, Pressable, SafeAreaView, Text, View } from "react-native";
 
 import { MEAL_LABELS, type MealType } from "@homegohan/shared";
-import { colors, radius, shadows, spacing } from "../../theme";
+import { colors, radius, spacing } from "../../theme";
 
 interface Props {
   visible: boolean;
@@ -35,24 +35,13 @@ export function AddMealSlotModal({ visible, onClose, onSelect, dayId: _dayId }: 
       testID="add-meal-slot-modal"
       visible={visible}
       animationType="slide"
-      transparent
+      presentationStyle="pageSheet"
       onRequestClose={onClose}
     >
-      <View
-        style={{
-          flex: 1,
-          justifyContent: "flex-end",
-          backgroundColor: "rgba(0,0,0,0.4)",
-        }}
-      >
-        <View
-          style={{
-            backgroundColor: colors.bg,
-            borderTopLeftRadius: radius.xl,
-            borderTopRightRadius: radius.xl,
-            paddingBottom: spacing.xl,
-            ...shadows.lg,
-          }}
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.bg }}>
+        <KeyboardAvoidingView
+          style={{ flex: 1 }}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
         >
           {/* ヘッダー */}
           <View
@@ -63,6 +52,7 @@ export function AddMealSlotModal({ visible, onClose, onSelect, dayId: _dayId }: 
               padding: spacing.lg,
               borderBottomWidth: 1,
               borderBottomColor: colors.border,
+              backgroundColor: colors.bg,
             }}
           >
             <Text style={{ fontSize: 17, fontWeight: "700", color: colors.text }}>
@@ -109,8 +99,8 @@ export function AddMealSlotModal({ visible, onClose, onSelect, dayId: _dayId }: 
               </Pressable>
             ))}
           </View>
-        </View>
-      </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
     </Modal>
   );
 }


### PR DESCRIPTION
## 問題

iOS で AddMealModal / AddMealSlotModal を開くと「朝食を追加 ✕」の 1 行しか表示されない。

## 原因

`<Modal transparent={true}>` + `justifyContent: 'flex-end'` + `maxHeight: '85%'` の構造が iOS の presentationStyle と競合し、コンテンツがほぼ見えない状態になっていた。

## 修正内容

PR #724 の V4GenerateModal と同じ手法を適用:

- `transparent` prop を削除
- `presentationStyle="pageSheet"` を追加
- backdrop 用の黒い `View` ラッパーを廃止
- `SafeAreaView` + `KeyboardAvoidingView` でコンテンツをラップ
- 不要になった `shadows` インポートを削除

`AddMealSlotModal`（食事タイプ選択の 1 ステップ目）も同様に修正。

## Test plan

- [ ] iOS シミュレーターで「食事を追加」ボタンをタップし、AddMealSlotModal が全画面 pageSheet で開くことを確認
- [ ] 食事タイプを選択後、AddMealModal（検索 + 6 ボタン）が全画面で開くことを確認
- [ ] × ボタンでモーダルが閉じることを確認
- [ ] テキスト入力時にキーボードが適切に処理されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)