### PR TITLE
fix: 全モーダルの bottom sheet バグを pageSheet 表示に統一

### DIFF
--- a/apps/mobile/src/components/menu/AddShoppingModal.tsx
+++ b/apps/mobile/src/components/menu/AddShoppingModal.tsx
@@ -2,8 +2,11 @@ import { Ionicons } from '@expo/vector-icons';
 import React, { useState } from 'react';
 import {
   Alert,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
+  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
@@ -78,12 +81,16 @@ export const AddShoppingModal: React.FC<Props> = ({ visible, onClose, onAdded })
     <Modal
       testID="add-shopping-modal"
       visible={visible}
-      transparent
       animationType="slide"
+      presentationStyle="pageSheet"
       onRequestClose={handleClose}
     >
-      <Pressable style={styles.overlay} onPress={handleClose}>
-        <Pressable style={styles.sheet} onPress={() => {}}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.card }}>
+        <KeyboardAvoidingView
+          style={{ flex: 1 }}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+        >
+        <View style={styles.sheet}>
           {/* ヘッダー */}
           <View style={styles.header}>
             <Text style={styles.title}>買い物アイテム追加</Text>
@@ -170,22 +177,16 @@ export const AddShoppingModal: React.FC<Props> = ({ visible, onClose, onAdded })
               </Text>
             </Pressable>
           </View>
-        </Pressable>
-      </Pressable>
+        </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
     </Modal>
   );
 };
 
 const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    justifyContent: 'flex-end',
-  },
   sheet: {
-    backgroundColor: colors.card,
-    borderTopLeftRadius: radius['2xl'],
-    borderTopRightRadius: radius['2xl'],
+    flex: 1,
     paddingBottom: spacing['2xl'],
   },
   header: {

--- a/apps/mobile/src/components/menu/ManualEditModal.tsx
+++ b/apps/mobile/src/components/menu/ManualEditModal.tsx
@@ -16,8 +16,11 @@ import React, { useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
+  SafeAreaView,
   ScrollView,
   Text,
   TextInput,
@@ -293,24 +296,18 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
         testID="manual-edit-modal"
         visible={visible}
         animationType="slide"
-        transparent
+        presentationStyle="pageSheet"
         onRequestClose={onClose}
       >
-        <View
-          style={{
-            flex: 1,
-            justifyContent: "flex-end",
-            backgroundColor: "rgba(0,0,0,0.4)",
-          }}
-        >
+        <SafeAreaView style={{ flex: 1, backgroundColor: colors.bg }}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : undefined}
+          >
           <View
             style={{
-              backgroundColor: colors.bg,
-              borderTopLeftRadius: radius["2xl"],
-              borderTopRightRadius: radius["2xl"],
-              maxHeight: "92%",
+              flex: 1,
               paddingBottom: spacing["2xl"],
-              ...shadows.lg,
             }}
           >
             {/* ヘッダー */}
@@ -790,7 +787,8 @@ export function ManualEditModal({ visible, meal, onClose, onSave }: Props) {
               </>
             )}
           </View>
-        </View>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
       </Modal>
       <PhotoEditModal
         visible={showPhotoEdit}

--- a/apps/mobile/src/components/menu/NutritionDetailModal.tsx
+++ b/apps/mobile/src/components/menu/NutritionDetailModal.tsx
@@ -15,6 +15,7 @@ import {
   ActivityIndicator,
   Modal,
   Pressable,
+  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
@@ -244,12 +245,11 @@ export const NutritionDetailModal: React.FC<Props> = ({
         testID="nutrition-detail-modal"
         visible={visible}
         animationType="slide"
-        transparent
-        statusBarTranslucent
+        presentationStyle="pageSheet"
         onRequestClose={onClose}
       >
-        <View style={styles.backdrop}>
-          <View style={styles.sheet}>
+        <SafeAreaView style={{ flex: 1, backgroundColor: colors.bg }}>
+          <View style={{ flex: 1 }}>
             {/* Header */}
             <View style={styles.header}>
               <View style={styles.headerLeft}>
@@ -382,7 +382,7 @@ export const NutritionDetailModal: React.FC<Props> = ({
               <View style={styles.bottomPad} />
             </ScrollView>
           </View>
-        </View>
+        </SafeAreaView>
       </Modal>
 
       {/* 献立改善モーダル */}
@@ -400,22 +400,6 @@ export const NutritionDetailModal: React.FC<Props> = ({
 // ============================================================
 
 const styles = StyleSheet.create({
-  backdrop: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    justifyContent: 'flex-end',
-  },
-  sheet: {
-    backgroundColor: colors.bg,
-    borderTopLeftRadius: radius['2xl'],
-    borderTopRightRadius: radius['2xl'],
-    maxHeight: '92%',
-    shadowColor: '#000',
-    shadowOpacity: 0.15,
-    shadowRadius: 16,
-    shadowOffset: { width: 0, height: -4 },
-    elevation: 12,
-  },
   header: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/apps/mobile/src/components/menu/PantryModal.tsx
+++ b/apps/mobile/src/components/menu/PantryModal.tsx
@@ -5,6 +5,7 @@ import {
   Alert,
   Modal,
   Pressable,
+  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
@@ -75,10 +76,10 @@ export const PantryModal: React.FC<Props> = ({ visible, onClose }) => {
         testID="pantry-modal"
         visible={visible}
         animationType="slide"
-        transparent
+        presentationStyle="pageSheet"
         onRequestClose={onClose}
       >
-        <View style={styles.overlay}>
+        <SafeAreaView style={{ flex: 1, backgroundColor: colors.card }}>
           <View style={styles.sheet}>
             {/* Header */}
             <View style={styles.header}>
@@ -134,7 +135,7 @@ export const PantryModal: React.FC<Props> = ({ visible, onClose }) => {
               </ScrollView>
             )}
           </View>
-        </View>
+        </SafeAreaView>
       </Modal>
 
       <AddFridgeModal
@@ -147,16 +148,8 @@ export const PantryModal: React.FC<Props> = ({ visible, onClose }) => {
 };
 
 const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    justifyContent: 'flex-end',
-  },
   sheet: {
-    backgroundColor: colors.card,
-    borderTopLeftRadius: radius.xl,
-    borderTopRightRadius: radius.xl,
-    maxHeight: '80%',
+    flex: 1,
   },
   header: {
     flexDirection: 'row',

--- a/apps/mobile/src/components/menu/PhotoEditModal.tsx
+++ b/apps/mobile/src/components/menu/PhotoEditModal.tsx
@@ -5,8 +5,11 @@ import {
   ActivityIndicator,
   Alert,
   Image,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
+  SafeAreaView,
   ScrollView,
   Text,
   View,
@@ -99,25 +102,17 @@ export function PhotoEditModal({ visible, onClose, onResult }: Props) {
     <Modal
       visible={visible}
       animationType="slide"
-      transparent
+      presentationStyle="pageSheet"
       onRequestClose={handleClose}
     >
-      <View
-        style={{
-          flex: 1,
-          justifyContent: "flex-end",
-          backgroundColor: "rgba(0,0,0,0.4)",
-        }}
-      >
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.bg }}>
+        <KeyboardAvoidingView
+          style={{ flex: 1 }}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+        >
         <View
           testID="photo-edit-modal"
-          style={{
-            backgroundColor: colors.bg,
-            borderTopLeftRadius: radius["2xl"],
-            borderTopRightRadius: radius["2xl"],
-            maxHeight: "90%",
-            ...shadows.lg,
-          }}
+          style={{ flex: 1 }}
         >
           {/* ヘッダー */}
           <View
@@ -336,7 +331,8 @@ export function PhotoEditModal({ visible, onClose, onResult }: Props) {
             </Pressable>
           </View>
         </View>
-      </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
     </Modal>
   );
 }

--- a/apps/mobile/src/components/menu/RecipeModal.tsx
+++ b/apps/mobile/src/components/menu/RecipeModal.tsx
@@ -4,6 +4,7 @@ import {
   Alert,
   Modal,
   Pressable,
+  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
@@ -11,7 +12,7 @@ import {
 } from "react-native";
 
 import { getApi } from "../../lib/api";
-import { colors, radius, shadows, spacing } from "../../theme";
+import { colors, radius, spacing } from "../../theme";
 
 // ============================================================
 // Types
@@ -160,13 +161,12 @@ export const RecipeModal: React.FC<Props> = ({ visible, meal, onClose }) => {
   return (
     <Modal
       visible={visible}
-      transparent
       animationType="slide"
+      presentationStyle="pageSheet"
       onRequestClose={onClose}
     >
-      <View testID="recipe-modal" style={styles.overlay}>
-        <Pressable style={styles.backdrop} onPress={onClose} />
-        <View style={styles.sheet}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.card }}>
+        <View testID="recipe-modal" style={styles.sheet}>
           {/* ヘッダー */}
           <View style={styles.header}>
             <View style={styles.headerLeft}>
@@ -318,7 +318,7 @@ export const RecipeModal: React.FC<Props> = ({ visible, meal, onClose }) => {
             </Pressable>
           </View>
         </View>
-      </View>
+      </SafeAreaView>
     </Modal>
   );
 };
@@ -328,20 +328,8 @@ export const RecipeModal: React.FC<Props> = ({ visible, meal, onClose }) => {
 // ============================================================
 
 const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    justifyContent: "flex-end",
-  },
-  backdrop: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(0,0,0,0.5)",
-  },
   sheet: {
-    backgroundColor: colors.card,
-    borderTopLeftRadius: radius.xl,
-    borderTopRightRadius: radius.xl,
-    maxHeight: "85%",
-    ...shadows.lg,
+    flex: 1,
   },
   header: {
     flexDirection: "row",

--- a/apps/mobile/src/components/menu/RegenerateMealModal.tsx
+++ b/apps/mobile/src/components/menu/RegenerateMealModal.tsx
@@ -2,8 +2,11 @@ import { Sparkles, X } from "lucide-react-native";
 import React, { useState } from "react";
 import {
   ActivityIndicator,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
+  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
@@ -115,96 +118,101 @@ export const RegenerateMealModal: React.FC<Props> = ({ visible, meal, onClose })
     <Modal
       visible={visible}
       animationType="slide"
-      transparent
+      presentationStyle="pageSheet"
       onRequestClose={handleClose}
     >
-      <View style={styles.backdrop}>
-        <View testID="regenerate-meal-modal" style={styles.container}>
-          {/* Header */}
-          <View style={styles.header}>
-            <Text style={styles.title}>✨ {mealLabel}をAIで変更</Text>
-            <Pressable
-              testID="regenerate-meal-close"
-              onPress={handleClose}
-              style={styles.closeBtn}
-            >
-              <X size={20} color={colors.textLight} />
-            </Pressable>
-          </View>
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.card }}>
+        <KeyboardAvoidingView
+          style={{ flex: 1 }}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+        >
+          <View testID="regenerate-meal-modal" style={{ flex: 1 }}>
+            {/* Header */}
+            <View style={styles.header}>
+              <Text style={styles.title}>✨ {mealLabel}をAIで変更</Text>
+              <Pressable
+                testID="regenerate-meal-close"
+                onPress={handleClose}
+                style={styles.closeBtn}
+              >
+                <X size={20} color={colors.textLight} />
+              </Pressable>
+            </View>
 
-          <ScrollView
-            style={styles.body}
-            contentContainerStyle={styles.bodyContent}
-            keyboardShouldPersistTaps="handled"
-          >
-            {/* 現在の献立 */}
-            <View style={styles.section}>
-              <Text style={styles.sectionLabel}>現在の献立</Text>
-              <View style={styles.currentMealBox}>
-                <Text style={styles.currentMealName}>{mealName}</Text>
+            <ScrollView
+              style={styles.body}
+              contentContainerStyle={styles.bodyContent}
+              keyboardShouldPersistTaps="handled"
+            >
+              {/* 現在の献立 */}
+              <View style={styles.section}>
+                <Text style={styles.sectionLabel}>現在の献立</Text>
+                <View style={styles.currentMealBox}>
+                  <Text style={styles.currentMealName}>{mealName}</Text>
+                </View>
               </View>
-            </View>
 
-            {/* 条件 4 ボタン */}
-            <View style={styles.section}>
-              <Text style={styles.sectionLabel}>新しい条件を指定（複数選択可）</Text>
-              {CONDITIONS.map(c => {
-                const active = selectedConditions.includes(c.key);
-                return (
-                  <Pressable
-                    key={c.key}
-                    testID={`regenerate-condition-${c.key}`}
-                    onPress={() => toggleCondition(c.key)}
-                    style={[
-                      styles.conditionBtn,
-                      active ? styles.conditionBtnActive : styles.conditionBtnInactive,
-                    ]}
-                  >
-                    <Text style={[
-                      styles.conditionLabel,
-                      { color: active ? "#FFF" : colors.accent },
-                    ]}>{c.label}</Text>
-                  </Pressable>
-                );
-              })}
-            </View>
+              {/* 条件 4 ボタン */}
+              <View style={styles.section}>
+                <Text style={styles.sectionLabel}>新しい条件を指定（複数選択可）</Text>
+                {CONDITIONS.map(c => {
+                  const active = selectedConditions.includes(c.key);
+                  return (
+                    <Pressable
+                      key={c.key}
+                      testID={`regenerate-condition-${c.key}`}
+                      onPress={() => toggleCondition(c.key)}
+                      style={[
+                        styles.conditionBtn,
+                        active ? styles.conditionBtnActive : styles.conditionBtnInactive,
+                      ]}
+                    >
+                      <Text style={[
+                        styles.conditionLabel,
+                        { color: active ? "#FFF" : colors.accent },
+                      ]}>{c.label}</Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
 
-            {/* リクエスト */}
-            <View style={styles.section}>
-              <Text style={styles.sectionLabel}>リクエスト（任意）</Text>
-              <TextInput
-                testID="regenerate-meal-note"
-                multiline
-                numberOfLines={3}
-                value={note}
-                onChangeText={setNote}
-                placeholder="例: もっとヘルシーに、魚料理がいい..."
-                placeholderTextColor={colors.textMuted}
-                style={styles.textarea}
-              />
-            </View>
-          </ScrollView>
+              {/* リクエスト */}
+              <View style={styles.section}>
+                <Text style={styles.sectionLabel}>リクエスト（任意）</Text>
+                <TextInput
+                  testID="regenerate-meal-note"
+                  multiline
+                  numberOfLines={3}
+                  value={note}
+                  onChangeText={setNote}
+                  placeholder="例: もっとヘルシーに、魚料理がいい..."
+                  placeholderTextColor={colors.textMuted}
+                  style={styles.textarea}
+                />
+              </View>
+            </ScrollView>
 
-          {/* Submit */}
-          <View style={styles.footer}>
-            <Pressable
-              testID="regenerate-meal-submit"
-              onPress={submit}
-              disabled={submitting}
-              style={[styles.submitBtn, submitting && styles.submitBtnDisabled]}
-            >
-              {submitting ? (
-                <ActivityIndicator color="#FFF" />
-              ) : (
-                <>
-                  <Sparkles size={18} color="#FFF" />
-                  <Text style={styles.submitText}>AIで別の献立に変更</Text>
-                </>
-              )}
-            </Pressable>
+            {/* Submit */}
+            <View style={styles.footer}>
+              <Pressable
+                testID="regenerate-meal-submit"
+                onPress={submit}
+                disabled={submitting}
+                style={[styles.submitBtn, submitting && styles.submitBtnDisabled]}
+              >
+                {submitting ? (
+                  <ActivityIndicator color="#FFF" />
+                ) : (
+                  <>
+                    <Sparkles size={18} color="#FFF" />
+                    <Text style={styles.submitText}>AIで別の献立に変更</Text>
+                  </>
+                )}
+              </Pressable>
+            </View>
           </View>
-        </View>
-      </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
     </Modal>
   );
 };
@@ -214,17 +222,6 @@ export const RegenerateMealModal: React.FC<Props> = ({ visible, meal, onClose })
 // ============================================================
 
 const styles = StyleSheet.create({
-  backdrop: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.4)",
-    justifyContent: "flex-end",
-  },
-  container: {
-    backgroundColor: colors.card,
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
-    maxHeight: "80%",
-  },
   header: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/src/components/menu/ServingsModal.tsx
+++ b/apps/mobile/src/components/menu/ServingsModal.tsx
@@ -3,8 +3,11 @@ import { useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
+  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
@@ -98,10 +101,14 @@ export const ServingsModal: React.FC<Props> = ({
     <Modal
       visible={visible}
       animationType="slide"
-      transparent
+      presentationStyle="pageSheet"
       onRequestClose={onClose}
     >
-      <View style={styles.backdrop}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.bg }}>
+        <KeyboardAvoidingView
+          style={{ flex: 1 }}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+        >
         <View testID="servings-modal" style={styles.container}>
           {/* ヘッダー */}
           <View style={styles.header}>
@@ -234,26 +241,18 @@ export const ServingsModal: React.FC<Props> = ({
             )}
           </Pressable>
         </View>
-      </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
     </Modal>
   );
 };
 
 const styles = StyleSheet.create({
-  backdrop: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.4)",
-    justifyContent: "flex-end",
-  },
   container: {
-    backgroundColor: colors.bg,
-    borderTopLeftRadius: radius["2xl"],
-    borderTopRightRadius: radius["2xl"],
+    flex: 1,
     paddingHorizontal: spacing.lg,
     paddingTop: spacing.lg,
     paddingBottom: spacing.xl,
-    maxHeight: "90%",
-    ...shadows.lg,
   },
   header: {
     flexDirection: "row",

--- a/apps/mobile/src/components/menu/ShoppingListModal.tsx
+++ b/apps/mobile/src/components/menu/ShoppingListModal.tsx
@@ -3,9 +3,9 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
-  Dimensions,
   Modal,
   Pressable,
+  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
@@ -14,11 +14,9 @@ import {
 
 import { getApi, getApiBaseUrl } from '../../lib/api';
 import { supabase } from '../../lib/supabase';
-import { colors, radius, shadows, spacing, typography } from '../../theme';
+import { colors, radius, spacing, typography } from '../../theme';
 import { AddShoppingModal } from './AddShoppingModal';
 import { type ShoppingItemData, ShoppingItem } from './ShoppingItem';
-
-const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 
 // スーパーの動線に合わせたカテゴリ順序
 const CATEGORY_ORDER = [
@@ -228,12 +226,12 @@ export const ShoppingListModal: React.FC<Props> = ({
       <Modal
         testID="shopping-list-modal"
         visible={visible}
-        transparent
         animationType="slide"
+        presentationStyle="pageSheet"
         onRequestClose={onClose}
       >
-        <Pressable style={styles.overlay} onPress={onClose}>
-          <Pressable style={styles.sheet} onPress={() => {}}>
+        <SafeAreaView style={{ flex: 1, backgroundColor: colors.card }}>
+          <View style={styles.sheet}>
             {/* ヘッダー */}
             <View style={styles.header}>
               <View style={styles.headerLeft}>
@@ -338,8 +336,8 @@ export const ShoppingListModal: React.FC<Props> = ({
                 )}
               </Pressable>
             </View>
-          </Pressable>
-        </Pressable>
+          </View>
+        </SafeAreaView>
       </Modal>
 
       {/* 追加モーダル (ShoppingListModal の上にスタック) */}
@@ -356,17 +354,8 @@ export const ShoppingListModal: React.FC<Props> = ({
 };
 
 const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-    justifyContent: 'flex-end',
-  },
   sheet: {
-    backgroundColor: colors.card,
-    borderTopLeftRadius: radius['2xl'],
-    borderTopRightRadius: radius['2xl'],
-    maxHeight: SCREEN_HEIGHT * 0.85,
-    ...shadows.md,
+    flex: 1,
   },
   header: {
     flexDirection: 'row',

--- a/apps/mobile/src/components/menu/StatsModal.tsx
+++ b/apps/mobile/src/components/menu/StatsModal.tsx
@@ -4,6 +4,7 @@ import {
   ActivityIndicator,
   Modal,
   Pressable,
+  SafeAreaView,
   ScrollView,
   StyleSheet,
   Text,
@@ -744,12 +745,11 @@ export const StatsModal: React.FC<StatsModalProps> = ({
     <Modal
       visible={visible}
       animationType="slide"
-      transparent
+      presentationStyle="pageSheet"
       onRequestClose={onClose}
-      statusBarTranslucent
     >
-      <View style={styles.backdrop}>
-        <View testID="stats-modal" style={styles.container}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: colors.bg }}>
+        <View testID="stats-modal" style={{ flex: 1 }}>
           {/* ヘッダー */}
           <View style={styles.header}>
             <Ionicons name="bar-chart" size={18} color={colors.accent} />
@@ -809,25 +809,12 @@ export const StatsModal: React.FC<StatsModalProps> = ({
             />
           )}
         </View>
-      </View>
+      </SafeAreaView>
     </Modal>
   );
 };
 
 const styles = StyleSheet.create({
-  backdrop: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.45)',
-    justifyContent: 'flex-end',
-  },
-  container: {
-    backgroundColor: colors.bg,
-    borderTopLeftRadius: radius['2xl'],
-    borderTopRightRadius: radius['2xl'],
-    maxHeight: '92%',
-    flex: 1,
-    ...shadows.lg,
-  },
   header: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
## Summary

- `transparent + flex-end + maxHeight` による bottom sheet 形式が iOS で画面全体を覆わないバグを 10 モーダルで一括修正
- PR #724/#731 と同パターンで `presentationStyle="pageSheet"` に統一
- backdrop/overlay の Pressable 構造を削除し、`SafeAreaView` + `KeyboardAvoidingView` でラップ

## 修正対象モーダル

| モーダル | 修正内容 |
|---------|--------|
| RegenerateMealModal | pageSheet + SafeAreaView + KeyboardAvoidingView |
| PhotoEditModal | pageSheet + SafeAreaView + KeyboardAvoidingView |
| ManualEditModal | pageSheet + SafeAreaView + KeyboardAvoidingView |
| StatsModal | pageSheet + SafeAreaView |
| NutritionDetailModal | pageSheet + SafeAreaView |
| ServingsModal | pageSheet + SafeAreaView + KeyboardAvoidingView |
| ShoppingListModal | pageSheet + SafeAreaView (backdrop Pressable 削除) |
| AddShoppingModal | pageSheet + SafeAreaView + KeyboardAvoidingView (backdrop Pressable 削除) |
| PantryModal | pageSheet + SafeAreaView |
| RecipeModal | pageSheet + SafeAreaView (overlay+backdrop Pressable 削除) |

## 変更なし (center dialog 形式を維持)

- ImproveMealModal — `justifyContent: 'center'` のセンターダイアログ
- ConfirmDeleteModal — 確認ダイアログ、`animationType="fade"` で維持
- AddFridgeModal — `justifyContent: 'center'` のセンターダイアログ

## Test plan

- [ ] iOS シミュレーターで各モーダルが全画面 pageSheet として表示されることを確認
- [ ] フォームモーダル (Regenerate / Photo / Manual / Servings / AddShopping) でキーボード表示時にコンテンツが押し上げられることを確認
- [ ] ShoppingList / Pantry / Recipe モーダルでスクロールが正常に動作することを確認
- [ ] ImproveMeal / ConfirmDelete / AddFridge が引き続き center dialog として表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)