### PR TITLE
fix: 手動で修正ボタンをManualEditModalで開くよう修正

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -57,6 +57,7 @@ import { NutritionDetailModal } from "../../../src/components/menu/NutritionDeta
 import { RegenerateMealModal } from "../../../src/components/menu/RegenerateMealModal";
 import { PantryModal } from "../../../src/components/menu/PantryModal";
 import { ShoppingListModal } from "../../../src/components/menu/ShoppingListModal";
+import { ManualEditModal, type ManualEditMeal } from "../../../src/components/menu/ManualEditModal";
 import { useV4MenuGeneration } from "../../../src/hooks/useV4MenuGeneration";
 import { colors, spacing, radius } from "../../../src/theme";
 import { getApi, getApiBaseUrl } from "../../../src/lib/api";
@@ -684,6 +685,10 @@ export default function WeeklyMenuPage() {
   // RegenerateMealModal state
   const [showRegenerateModal, setShowRegenerateModal] = useState(false);
   const [selectedMealForRegen, setSelectedMealForRegen] = useState<PlannedMealRow | null>(null);
+
+  // ManualEditModal state
+  const [showManualEditModal, setShowManualEditModal] = useState(false);
+  const [manualEditTargetMeal, setManualEditTargetMeal] = useState<ManualEditMeal | null>(null);
 
   // 日別栄養サマリー 3 段階 UX
   const [dayNutritionExpanded, setDayNutritionExpanded] = useState(false);
@@ -1977,7 +1982,10 @@ export default function WeeklyMenuPage() {
                           {/* 手動で修正ボタン */}
                           <Pressable
                             testID={`meal-action-manual-${m.id}`}
-                            onPress={() => router.push(`/meals/${m.id}/edit`)}
+                            onPress={() => {
+                              setManualEditTargetMeal(m);
+                              setShowManualEditModal(true);
+                            }}
                             style={{
                               flex: 1,
                               flexDirection: "row",
@@ -2170,6 +2178,21 @@ export default function WeeklyMenuPage() {
       <PantryModal
         visible={activeModal === 'fridge'}
         onClose={() => setActiveModal(null)}
+      />
+
+      {/* 手動編集モーダル */}
+      <ManualEditModal
+        visible={showManualEditModal}
+        meal={manualEditTargetMeal}
+        onClose={() => {
+          setShowManualEditModal(false);
+          setManualEditTargetMeal(null);
+        }}
+        onSave={() => {
+          setShowManualEditModal(false);
+          setManualEditTargetMeal(null);
+          loadData();
+        }}
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary

- `apps/mobile/app/menus/weekly/index.tsx` の「手動で修正」ボタン (`testID: meal-action-manual-{id}`) が `router.push('/meals/:id/edit')` で旧ナビゲーション画面を開いていた不具合を修正
- PR #715 で実装済みの `ManualEditModal` を import し、ボタン `onPress` でモーダルを open するよう変更
- 保存後は `loadData()` でウィークリーリストを再取得してUIを更新

## 変更ファイル

- `apps/mobile/app/menus/weekly/index.tsx`
  - `ManualEditModal`, `ManualEditMeal` の import 追加
  - `showManualEditModal` / `manualEditTargetMeal` state 追加
  - ボタン `onPress` を `router.push` から `setManualEditTargetMeal(m) + setShowManualEditModal(true)` に変更
  - JSX 末尾に `<ManualEditModal>` 追加 (pageSheet presentationStyle は ManualEditModal 側で設定済み)

## Test plan

- [ ] 週次メニュー画面で食事カードを展開 → 「手動で修正」ボタンをタップ
- [ ] ManualEditModal (タイプ選択 / 料理複数 / 写真入力 / 保存) がページシートで開くことを確認
- [ ] 旧 `/meals/:id/edit` 画面に遷移しないことを確認
- [ ] 保存後に週次リストが自動更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)