### PR TITLE
fix: RecipeModal を WEB 仕様に合わせてリライト

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -50,7 +50,7 @@ import { ConfirmDeleteModal } from "../../../src/components/menu/ConfirmDeleteMo
 import { ImproveMealModal } from "../../../src/components/menu/ImproveMealModal";
 import { ProgressTodoCard } from "../../../src/components/menu/ProgressTodoCard";
 import { RoleBadge } from "../../../src/components/menu/RoleBadge";
-import { RecipeModal, type RecipeModalMeal } from "../../../src/components/menu/RecipeModal";
+import { RecipeModal, type RecipeModalDish } from "../../../src/components/menu/RecipeModal";
 import { ServingsModal } from "../../../src/components/menu/ServingsModal";
 import { StatsModal, type NutrientValues, type WeekNutrientData } from "../../../src/components/menu/StatsModal";
 import { WeeklyHeader } from "../../../src/components/menu/WeeklyHeader";
@@ -710,7 +710,7 @@ export default function WeeklyMenuPage() {
   const [addMealModalMealType, setAddMealModalMealType] = useState<MealType>("dinner");
 
   // RecipeModal state
-  const [recipeModalMeal, setRecipeModalMeal] = useState<RecipeModalMeal | null>(null);
+  const [recipeModalMeal, setRecipeModalMeal] = useState<RecipeModalDish | null>(null);
 
   // 展開中の食事カード ID (WEB 仕様と同様のインライン展開)
   const [expandedMealId, setExpandedMealId] = useState<string | null>(null);
@@ -1916,16 +1916,44 @@ export default function WeeklyMenuPage() {
                               <Pressable
                                 key={idx}
                                 onPress={() => setRecipeModalMeal({
-                                  id: m.id,
-                                  dish_name: dish.name,
-                                  calories_kcal: m.calories_kcal,
-                                  protein_g: m.protein_g,
-                                  fat_g: m.fat_g,
-                                  carbs_g: m.carbs_g,
-                                  ingredients: dish.ingredients ?? m.ingredients ?? undefined,
-                                  recipe_steps: dish.recipeSteps ?? m.recipe_steps ?? undefined,
-                                  dishes: [dish],
+                                  mealId: m.id,
+                                  name: dish.name,
                                   role: dish.role ?? m.role ?? undefined,
+                                  kcal: m.calories_kcal,
+                                  imageUrl: null,
+                                  imageStatus: null,
+                                  ingredientsMd: dish.ingredientsMd ?? undefined,
+                                  recipeStepsMd: dish.recipeStepsMd ?? undefined,
+                                  ingredients: dish.ingredients ?? m.ingredients ?? undefined,
+                                  recipeSteps: dish.recipeSteps ?? m.recipe_steps ?? undefined,
+                                  nutrients: {
+                                    caloriesKcal: m.calories_kcal,
+                                    proteinG: m.protein_g,
+                                    fatG: m.fat_g,
+                                    carbsG: m.carbs_g,
+                                    fiberG: m.fiber_g,
+                                    sugarG: m.sugar_g,
+                                    sodiumG: m.sodium_g,
+                                    potassiumMg: m.potassium_mg,
+                                    calciumMg: m.calcium_mg,
+                                    magnesiumMg: m.magnesium_mg,
+                                    phosphorusMg: m.phosphorus_mg,
+                                    ironMg: m.iron_mg,
+                                    zincMg: m.zinc_mg,
+                                    iodineUg: m.iodine_ug,
+                                    vitaminAUg: m.vitamin_a_ug,
+                                    vitaminB1Mg: m.vitamin_b1_mg,
+                                    vitaminB2Mg: m.vitamin_b2_mg,
+                                    vitaminB6Mg: m.vitamin_b6_mg,
+                                    vitaminB12Ug: m.vitamin_b12_ug,
+                                    vitaminCMg: m.vitamin_c_mg,
+                                    vitaminDUg: m.vitamin_d_ug,
+                                    vitaminEMg: m.vitamin_e_mg,
+                                    vitaminKUg: m.vitamin_k_ug,
+                                    folicAcidUg: m.folic_acid_ug,
+                                    saturatedFatG: m.saturated_fat_g,
+                                    cholesterolMg: m.cholesterol_mg,
+                                  },
                                 })}
                                 style={({ pressed }) => ({
                                   flexDirection: "row",
@@ -1952,16 +1980,44 @@ export default function WeeklyMenuPage() {
                         {dishesArray.length === 0 && (
                           <Pressable
                             onPress={() => setRecipeModalMeal({
-                              id: m.id,
-                              dish_name: m.dish_name,
-                              calories_kcal: m.calories_kcal,
-                              protein_g: m.protein_g,
-                              fat_g: m.fat_g,
-                              carbs_g: m.carbs_g,
-                              ingredients: m.ingredients ?? undefined,
-                              recipe_steps: m.recipe_steps ?? undefined,
-                              dishes: m.dishes ?? undefined,
+                              mealId: m.id,
+                              name: m.dish_name,
                               role: m.role ?? undefined,
+                              kcal: m.calories_kcal,
+                              imageUrl: null,
+                              imageStatus: null,
+                              ingredientsMd: undefined,
+                              recipeStepsMd: undefined,
+                              ingredients: m.ingredients ?? undefined,
+                              recipeSteps: m.recipe_steps ?? undefined,
+                              nutrients: {
+                                caloriesKcal: m.calories_kcal,
+                                proteinG: m.protein_g,
+                                fatG: m.fat_g,
+                                carbsG: m.carbs_g,
+                                fiberG: m.fiber_g,
+                                sugarG: m.sugar_g,
+                                sodiumG: m.sodium_g,
+                                potassiumMg: m.potassium_mg,
+                                calciumMg: m.calcium_mg,
+                                magnesiumMg: m.magnesium_mg,
+                                phosphorusMg: m.phosphorus_mg,
+                                ironMg: m.iron_mg,
+                                zincMg: m.zinc_mg,
+                                iodineUg: m.iodine_ug,
+                                vitaminAUg: m.vitamin_a_ug,
+                                vitaminB1Mg: m.vitamin_b1_mg,
+                                vitaminB2Mg: m.vitamin_b2_mg,
+                                vitaminB6Mg: m.vitamin_b6_mg,
+                                vitaminB12Ug: m.vitamin_b12_ug,
+                                vitaminCMg: m.vitamin_c_mg,
+                                vitaminDUg: m.vitamin_d_ug,
+                                vitaminEMg: m.vitamin_e_mg,
+                                vitaminKUg: m.vitamin_k_ug,
+                                folicAcidUg: m.folic_acid_ug,
+                                saturatedFatG: m.saturated_fat_g,
+                                cholesterolMg: m.cholesterol_mg,
+                              },
                             })}
                             style={({ pressed }) => ({
                               flexDirection: "row",
@@ -2253,7 +2309,7 @@ export default function WeeklyMenuPage() {
       {/* レシピ詳細モーダル */}
       <RecipeModal
         visible={recipeModalMeal !== null}
-        meal={recipeModalMeal}
+        dish={recipeModalMeal}
         onClose={() => setRecipeModalMeal(null)}
       />
       <RegenerateMealModal

--- a/apps/mobile/src/components/menu/RecipeModal.tsx
+++ b/apps/mobile/src/components/menu/RecipeModal.tsx
@@ -1,7 +1,9 @@
+import { NUTRIENT_DEFINITIONS } from "@homegohan/shared";
 import { Ionicons } from "@expo/vector-icons";
 import React, { useState } from "react";
 import {
   Alert,
+  Image,
   Modal,
   Pressable,
   SafeAreaView,
@@ -13,90 +15,145 @@ import {
 
 import { getApi } from "../../lib/api";
 import { colors, radius, spacing } from "../../theme";
+import { RoleBadge } from "./RoleBadge";
 
 // ============================================================
 // Types
 // ============================================================
 
-interface DishDetail {
-  name: string;
-  role?: string;
-  ingredients?: string[];
-  ingredientsMd?: string;
-  recipeSteps?: string[];
-  recipeStepsMd?: string;
+export interface RecipeModalDishNutrients {
+  caloriesKcal?: number | null;
+  proteinG?: number | null;
+  fatG?: number | null;
+  carbsG?: number | null;
+  fiberG?: number | null;
+  sugarG?: number | null;
+  sodiumG?: number | null;
+  potassiumMg?: number | null;
+  calciumMg?: number | null;
+  magnesiumMg?: number | null;
+  phosphorusMg?: number | null;
+  ironMg?: number | null;
+  zincMg?: number | null;
+  iodineUg?: number | null;
+  vitaminAUg?: number | null;
+  vitaminB1Mg?: number | null;
+  vitaminB2Mg?: number | null;
+  vitaminB6Mg?: number | null;
+  vitaminB12Ug?: number | null;
+  vitaminCMg?: number | null;
+  vitaminDUg?: number | null;
+  vitaminEMg?: number | null;
+  vitaminKUg?: number | null;
+  folicAcidUg?: number | null;
+  saturatedFatG?: number | null;
+  cholesterolMg?: number | null;
 }
 
-export interface RecipeModalMeal {
-  id: string;
-  dish_name: string;
-  calories_kcal: number | null;
-  protein_g: number | null;
-  fat_g: number | null;
-  carbs_g: number | null;
-  ingredients?: string[];
-  recipe_steps?: string[] | null;
-  dishes?: DishDetail[] | null;
+export interface RecipeModalDish {
+  /** meal の DB id (like/shopping API 用) */
+  mealId: string;
+  name: string;
   role?: string | null;
+  kcal?: number | null;
+  imageUrl?: string | null;
+  imageStatus?: string | null;
+  ingredientsMd?: string | null;
+  recipeStepsMd?: string | null;
+  ingredients?: string[] | null;
+  recipeSteps?: string[] | null;
+  nutrients?: RecipeModalDishNutrients | null;
 }
 
 interface Props {
   visible: boolean;
-  meal: RecipeModalMeal | null;
+  dish: RecipeModalDish | null;
   onClose: () => void;
 }
 
 // ============================================================
-// Helpers
+// Markdown パーサー
 // ============================================================
 
-function renderIngredients(dish: DishDetail, fallback?: string[]): string[] | null {
-  if (dish.ingredientsMd) return null; // handled separately
-  if (dish.ingredients && dish.ingredients.length > 0) return dish.ingredients;
-  if (fallback && fallback.length > 0) return fallback;
-  return null;
-}
-
-function renderSteps(dish: DishDetail, fallback?: string[] | null): string[] | null {
-  if (dish.recipeStepsMd) return null; // handled separately
-  if (dish.recipeSteps && dish.recipeSteps.length > 0) return dish.recipeSteps;
-  if (fallback && fallback.length > 0) return fallback;
-  return null;
-}
-
-function collectIngredients(meal: RecipeModalMeal): Array<{ name: string }> {
-  const all: string[] = [];
-
-  if (meal.dishes && meal.dishes.length > 0) {
-    meal.dishes.forEach((dish) => {
-      if (dish.ingredients) all.push(...dish.ingredients);
-    });
+/**
+ * Markdown テーブル形式の材料データをパースする
+ * 例:
+ * | 材料 | 分量 |
+ * |------|------|
+ * | 卵 | 2個 |
+ */
+const parseIngredientsTable = (md: string): { name: string; amount: string }[] => {
+  if (!md) return [];
+  const lines = md.split("\n").filter((l) => {
+    const trimmed = l.trim();
+    return trimmed && !trimmed.startsWith("|--") && !trimmed.startsWith("|:-");
+  });
+  const results: { name: string; amount: string }[] = [];
+  for (const line of lines) {
+    const cells = line.split("|").map((c) => c.trim()).filter((c) => c);
+    if (cells.length < 2) continue;
+    // ヘッダー行スキップ (材料 / 分量)
+    if (cells[0] === "材料" || cells[0] === "食材") continue;
+    results.push({ name: cells[0], amount: cells[1] });
   }
+  return results;
+};
 
-  if (all.length === 0 && meal.ingredients) {
-    all.push(...meal.ingredients);
-  }
+/**
+ * 番号付きリスト形式の作り方ステップをパースする
+ * 例: "1. 野菜を切る。"
+ * ingredients 配列もフォールバックとして使用する
+ */
+const parseRecipeSteps = (md: string): string[] => {
+  if (!md) return [];
+  return md
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => /^\d+\./.test(l));
+};
 
-  return all.map((name) => ({ name }));
-}
+/**
+ * ingredients 配列から材料リストを生成する (ingredientsMd がない場合のフォールバック)
+ */
+const buildIngredientsFromArray = (arr: string[]): { name: string; amount: string }[] => {
+  return arr.filter((s) => s).map((s) => ({ name: s, amount: "" }));
+};
+
+/**
+ * recipeSteps 配列をパースする (recipeStepsMd がない場合のフォールバック)
+ */
+const buildStepsFromArray = (arr: string[]): string[] => {
+  return arr
+    .filter((s) => s)
+    .map((s, i) => `${i + 1}. ${s.replace(/^\d+\.\s*/, "")}`);
+};
+
+// ============================================================
+// サブコンポーネント
+// ============================================================
+
+const SectionHeader: React.FC<{ icon: string; title: string }> = ({ icon, title }) => (
+  <View style={styles.sectionHeader}>
+    <Text style={styles.sectionIcon}>{icon}</Text>
+    <Text style={styles.sectionTitle}>{title}</Text>
+  </View>
+);
 
 // ============================================================
 // Component
 // ============================================================
 
-export const RecipeModal: React.FC<Props> = ({ visible, meal, onClose }) => {
+export const RecipeModal: React.FC<Props> = ({ visible, dish, onClose }) => {
   const [favorited, setFavorited] = useState(false);
   const [isAddingToShopping, setIsAddingToShopping] = useState(false);
 
-  // Reset favorited state when meal changes
   React.useEffect(() => {
-    if (meal) {
+    if (dish) {
       setFavorited(false);
-      // Fetch current like status
       const fetchLikeStatus = async () => {
         try {
           const api = getApi();
-          const res = await api.get<{ liked: boolean }>(`/api/recipes/${meal.id}/like`);
+          const res = await api.get<{ liked: boolean }>(`/api/recipes/${dish.mealId}/like`);
           setFavorited(res.liked);
         } catch {
           // ignore
@@ -104,35 +161,47 @@ export const RecipeModal: React.FC<Props> = ({ visible, meal, onClose }) => {
       };
       fetchLikeStatus();
     }
-  }, [meal?.id]);
+  }, [dish?.mealId]);
 
   const toggleFavorite = async () => {
-    if (!meal) return;
+    if (!dish) return;
     const prev = favorited;
-    setFavorited(!prev); // 楽観的更新
+    setFavorited(!prev);
     try {
       const api = getApi();
       if (!prev) {
-        await api.post(`/api/recipes/${meal.id}/like`, {});
+        await api.post(`/api/recipes/${dish.mealId}/like`, {});
       } else {
-        await api.del(`/api/recipes/${meal.id}/like`);
+        await api.del(`/api/recipes/${dish.mealId}/like`);
       }
     } catch {
-      setFavorited(prev); // revert
+      setFavorited(prev);
     }
   };
 
   const addToShopping = async () => {
-    if (!meal) return;
+    if (!dish) return;
     setIsAddingToShopping(true);
     try {
-      const ingredients = collectIngredients(meal);
-      if (ingredients.length === 0) {
+      // ingredientsMd or ingredients からリストを収集
+      let ingredientNames: string[] = [];
+      const parsedFromMd = dish.ingredientsMd
+        ? parseIngredientsTable(dish.ingredientsMd)
+        : [];
+      if (parsedFromMd.length > 0) {
+        ingredientNames = parsedFromMd.map((i) => i.name);
+      } else if (dish.ingredients && dish.ingredients.length > 0) {
+        ingredientNames = dish.ingredients;
+      }
+
+      if (ingredientNames.length === 0) {
         Alert.alert("材料情報なし", "この料理には材料情報がありません。");
         return;
       }
       const api = getApi();
-      await api.post("/api/shopping-list/add-recipe", { ingredients });
+      await api.post("/api/shopping-list/add-recipe", {
+        ingredients: ingredientNames.map((name) => ({ name })),
+      });
       Alert.alert("追加しました", "材料を買い物リストに追加しました。");
     } catch {
       Alert.alert("エラー", "買い物リストへの追加に失敗しました。");
@@ -141,22 +210,21 @@ export const RecipeModal: React.FC<Props> = ({ visible, meal, onClose }) => {
     }
   };
 
-  if (!meal) return null;
+  if (!dish) return null;
 
-  const dishes: DishDetail[] =
-    meal.dishes && meal.dishes.length > 0
-      ? meal.dishes
-      : [
-          {
-            name: meal.dish_name,
-            role: meal.role ?? undefined,
-            ingredients: meal.ingredients,
-            recipeSteps: meal.recipe_steps ?? undefined,
-          },
-        ];
+  // 材料データ解決
+  const ingredientRows: { name: string; amount: string }[] = dish.ingredientsMd
+    ? parseIngredientsTable(dish.ingredientsMd)
+    : dish.ingredients && dish.ingredients.length > 0
+    ? buildIngredientsFromArray(dish.ingredients)
+    : [];
 
-  const hasNutrition =
-    meal.protein_g != null || meal.fat_g != null || meal.carbs_g != null;
+  // 作り方データ解決
+  const stepLines: string[] = dish.recipeStepsMd
+    ? parseRecipeSteps(dish.recipeStepsMd)
+    : dish.recipeSteps && dish.recipeSteps.length > 0
+    ? buildStepsFromArray(dish.recipeSteps)
+    : [];
 
   return (
     <Modal
@@ -170,35 +238,25 @@ export const RecipeModal: React.FC<Props> = ({ visible, meal, onClose }) => {
           {/* ヘッダー */}
           <View style={styles.header}>
             <View style={styles.headerLeft}>
+              <Ionicons name="book-outline" size={18} color={colors.accent} />
               <Text style={styles.title} numberOfLines={2}>
-                {meal.dish_name}
+                {dish.name}
               </Text>
-              {meal.calories_kcal != null && (
-                <View style={styles.calorieRow}>
-                  <Ionicons name="flame-outline" size={13} color={colors.textMuted} />
-                  <Text style={styles.calorieText}>{meal.calories_kcal} kcal</Text>
-                </View>
-              )}
             </View>
-            <View style={styles.headerRight}>
-              {/* お気に入りボタン */}
-              <Pressable
-                testID="recipe-favorite-btn"
-                onPress={toggleFavorite}
-                style={[styles.iconBtn, favorited && styles.iconBtnActive]}
-                accessibilityLabel={favorited ? "お気に入りから削除" : "お気に入りに追加"}
-              >
-                <Ionicons
-                  name={favorited ? "heart" : "heart-outline"}
-                  size={20}
-                  color={favorited ? "#FF6B6B" : colors.textMuted}
-                />
-              </Pressable>
-              {/* 閉じるボタン */}
-              <Pressable onPress={onClose} style={styles.iconBtn}>
-                <Ionicons name="close" size={20} color={colors.textMuted} />
-              </Pressable>
-            </View>
+            <Pressable onPress={onClose} style={styles.closeBtn}>
+              <Ionicons name="close" size={20} color={colors.textMuted} />
+            </Pressable>
+          </View>
+
+          {/* バッジ行: 役割 + kcal */}
+          <View style={styles.badgeRow}>
+            {dish.role ? <RoleBadge role={dish.role} /> : null}
+            {dish.kcal != null && (
+              <View style={styles.kcalBadge}>
+                <Ionicons name="flame-outline" size={12} color={colors.textMuted} />
+                <Text style={styles.kcalText}>{dish.kcal} kcal</Text>
+              </View>
+            )}
           </View>
 
           <ScrollView
@@ -206,102 +264,116 @@ export const RecipeModal: React.FC<Props> = ({ visible, meal, onClose }) => {
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
           >
-            {/* dishes 一覧 */}
-            {dishes.map((dish, index) => (
-              <View key={index} testID={`recipe-dish-${index}`} style={styles.dishBlock}>
-                {/* 料理名 */}
-                <Text style={styles.dishName}>
-                  {dish.name || meal.dish_name}
-                </Text>
-
-                {/* 材料 */}
-                <Text style={styles.sectionLabel}>🥕 材料</Text>
-                {dish.ingredientsMd ? (
-                  <View style={styles.mdBlock}>
-                    <Text style={styles.mdText}>{dish.ingredientsMd}</Text>
-                  </View>
+            {/* AI 料理画像 */}
+            {(dish.imageUrl || dish.imageStatus) && (
+              <View style={styles.imageSection}>
+                {dish.imageUrl ? (
+                  <Image source={{ uri: dish.imageUrl }} style={styles.dishImage} resizeMode="cover" />
                 ) : (
-                  (() => {
-                    const ings = renderIngredients(dish, meal.ingredients);
-                    return ings ? (
-                      <View style={styles.ingredientList}>
-                        {ings.map((ing, i) => (
-                          <Text key={i} style={styles.ingredientItem}>
-                            ・{ing}
-                          </Text>
-                        ))}
-                      </View>
-                    ) : (
-                      <Text style={styles.emptyText}>材料情報なし</Text>
-                    );
-                  })()
-                )}
-
-                {/* 作り方 */}
-                <Text style={[styles.sectionLabel, { marginTop: spacing.md }]}>
-                  👨‍🍳 作り方
-                </Text>
-                {dish.recipeStepsMd ? (
-                  <View style={styles.mdBlock}>
-                    <Text style={styles.mdText}>{dish.recipeStepsMd}</Text>
+                  <View style={styles.imagePlaceholder}>
+                    <Ionicons name="image-outline" size={32} color={colors.textMuted} />
+                    <Text style={styles.placeholderText}>料理画像を生成中です</Text>
+                    <Text style={styles.placeholderSubtext}>AIが料理画像を生成しています。</Text>
                   </View>
-                ) : (
-                  (() => {
-                    const steps = renderSteps(
-                      dish,
-                      meal.recipe_steps ?? undefined
-                    );
-                    return steps ? (
-                      <View style={styles.stepList}>
-                        {steps.map((step, i) => (
-                          <View key={i} style={styles.stepRow}>
-                            <View style={styles.stepNum}>
-                              <Text style={styles.stepNumText}>{i + 1}</Text>
-                            </View>
-                            <Text style={styles.stepText}>{step}</Text>
-                          </View>
-                        ))}
-                      </View>
-                    ) : (
-                      <Text style={styles.emptyText}>
-                        レシピはAI献立を生成すると自動で作成されます。
-                      </Text>
-                    );
-                  })()
                 )}
               </View>
-            ))}
+            )}
 
-            {/* 栄養サマリー */}
-            {hasNutrition && (
-              <View style={styles.nutritionBlock}>
-                <Text style={styles.sectionLabel}>📊 栄養</Text>
-                <View style={styles.nutritionRow}>
-                  {meal.protein_g != null && (
-                    <View style={styles.nutritionItem}>
-                      <Text style={styles.nutritionValue}>{meal.protein_g.toFixed(1)}g</Text>
-                      <Text style={styles.nutritionLabel}>タンパク質</Text>
-                    </View>
-                  )}
-                  {meal.fat_g != null && (
-                    <View style={styles.nutritionItem}>
-                      <Text style={styles.nutritionValue}>{meal.fat_g.toFixed(1)}g</Text>
-                      <Text style={styles.nutritionLabel}>脂質</Text>
-                    </View>
-                  )}
-                  {meal.carbs_g != null && (
-                    <View style={styles.nutritionItem}>
-                      <Text style={styles.nutritionValue}>{meal.carbs_g.toFixed(1)}g</Text>
-                      <Text style={styles.nutritionLabel}>炭水化物</Text>
-                    </View>
-                  )}
+            {/* この料理の栄養素 */}
+            {dish.nutrients && (
+              <View style={styles.section}>
+                <SectionHeader icon="📊" title="この料理の栄養素" />
+                <View style={styles.nutrientsGrid}>
+                  {NUTRIENT_DEFINITIONS.map((def) => {
+                    const raw = (dish.nutrients as Record<string, number | null | undefined>)?.[def.key];
+                    const value = raw ?? 0;
+                    const displayValue =
+                      value === 0
+                        ? "-"
+                        : def.decimals === 0
+                        ? String(Math.round(value))
+                        : value.toFixed(def.decimals).replace(/\.?0+$/, "");
+                    return (
+                      <View key={def.key} style={styles.nutrientItem}>
+                        <Text style={styles.nutrientLabel} numberOfLines={1}>
+                          {def.label}
+                        </Text>
+                        <Text style={styles.nutrientValue}>
+                          {displayValue}
+                          {value !== 0 ? def.unit : ""}
+                        </Text>
+                      </View>
+                    );
+                  })}
                 </View>
               </View>
             )}
+
+            {/* 材料 */}
+            <View style={styles.section}>
+              <SectionHeader icon="🥕" title="材料" />
+              {ingredientRows.length > 0 ? (
+                <View style={styles.ingredientsTable}>
+                  <View style={styles.tableHeaderRow}>
+                    <Text style={[styles.tableHeaderCell, { flex: 2 }]}>材料</Text>
+                    <Text style={[styles.tableHeaderCell, { flex: 1 }]}>分量</Text>
+                  </View>
+                  {ingredientRows.map((ing, i) => (
+                    <View
+                      key={i}
+                      style={[
+                        styles.tableRow,
+                        i % 2 === 0 ? styles.tableRowEven : styles.tableRowOdd,
+                      ]}
+                    >
+                      <Text style={[styles.tableCell, { flex: 2 }]}>{ing.name}</Text>
+                      <Text style={[styles.tableCell, { flex: 1 }]}>{ing.amount}</Text>
+                    </View>
+                  ))}
+                </View>
+              ) : (
+                <Text style={styles.emptyText}>材料情報なし</Text>
+              )}
+            </View>
+
+            {/* 作り方 */}
+            <View style={styles.section}>
+              <SectionHeader icon="👨‍🍳" title="作り方" />
+              {stepLines.length > 0 ? (
+                <View style={styles.stepList}>
+                  {stepLines.map((step, i) => (
+                    <View key={i} style={styles.stepRow}>
+                      <View style={styles.stepNum}>
+                        <Text style={styles.stepNumText}>{i + 1}</Text>
+                      </View>
+                      <Text style={styles.stepText}>
+                        {step.replace(/^\d+\.\s*/, "")}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              ) : (
+                <Text style={styles.emptyText}>
+                  レシピはAI献立を生成すると自動で作成されます。
+                </Text>
+              )}
+            </View>
           </ScrollView>
 
-          {/* 買い物リストに追加 */}
+          {/* フッター固定 */}
           <View style={styles.footer}>
+            <Pressable
+              testID="recipe-favorite-btn"
+              onPress={toggleFavorite}
+              style={[styles.favoriteBtn, favorited && styles.favoriteBtnActive]}
+              accessibilityLabel={favorited ? "お気に入りから削除" : "お気に入りに追加"}
+            >
+              <Ionicons
+                name={favorited ? "heart" : "heart-outline"}
+                size={22}
+                color={favorited ? "#FF6B6B" : colors.textMuted}
+              />
+            </Pressable>
             <Pressable
               testID="recipe-add-to-shopping-btn"
               onPress={addToShopping}
@@ -333,48 +405,50 @@ const styles = StyleSheet.create({
   },
   header: {
     flexDirection: "row",
-    alignItems: "flex-start",
+    alignItems: "center",
     justifyContent: "space-between",
     paddingHorizontal: spacing.lg,
     paddingTop: spacing.lg,
-    paddingBottom: spacing.md,
+    paddingBottom: spacing.sm,
     borderBottomWidth: 1,
     borderBottomColor: colors.border,
+    gap: spacing.sm,
   },
   headerLeft: {
     flex: 1,
-    gap: 4,
-  },
-  headerRight: {
     flexDirection: "row",
     alignItems: "center",
     gap: spacing.sm,
-    marginLeft: spacing.sm,
   },
   title: {
-    fontSize: 18,
+    flex: 1,
+    fontSize: 16,
     fontWeight: "700",
     color: colors.text,
   },
-  calorieRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 4,
-  },
-  calorieText: {
-    fontSize: 13,
-    color: colors.textMuted,
-  },
-  iconBtn: {
-    width: 36,
-    height: 36,
+  closeBtn: {
+    width: 32,
+    height: 32,
     borderRadius: radius.full,
     backgroundColor: colors.bg,
     alignItems: "center",
     justifyContent: "center",
   },
-  iconBtnActive: {
-    backgroundColor: "#FFF0F0",
+  badgeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+  },
+  kcalBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 3,
+  },
+  kcalText: {
+    fontSize: 12,
+    color: colors.textMuted,
   },
   scrollArea: {
     flexShrink: 1,
@@ -382,38 +456,104 @@ const styles = StyleSheet.create({
   scrollContent: {
     padding: spacing.lg,
     gap: spacing.lg,
+    paddingBottom: spacing.xl,
   },
-  dishBlock: {
+  // 画像
+  imageSection: {
+    borderRadius: radius.lg,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  dishImage: {
+    width: "100%",
+    height: 192,
+  },
+  imagePlaceholder: {
+    height: 192,
+    backgroundColor: colors.bg,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: spacing.xs,
+  },
+  placeholderText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: colors.textMuted,
+  },
+  placeholderSubtext: {
+    fontSize: 12,
+    color: colors.textMuted,
+  },
+  // セクション共通
+  section: {
     gap: spacing.sm,
   },
-  dishName: {
-    fontSize: 15,
+  sectionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  sectionIcon: {
+    fontSize: 14,
+  },
+  sectionTitle: {
+    fontSize: 13,
     fontWeight: "700",
     color: colors.text,
-    marginBottom: 2,
   },
-  sectionLabel: {
-    fontSize: 13,
+  // 栄養素グリッド
+  nutrientsGrid: {
+    backgroundColor: colors.bg,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    flexDirection: "row",
+    flexWrap: "wrap",
+  },
+  nutrientItem: {
+    width: "33.33%",
+    paddingVertical: 4,
+    paddingHorizontal: spacing.xs,
+  },
+  nutrientLabel: {
+    fontSize: 10,
+    color: colors.textMuted,
+  },
+  nutrientValue: {
+    fontSize: 11,
     fontWeight: "600",
     color: colors.text,
   },
-  mdBlock: {
-    backgroundColor: colors.bg,
+  // 材料テーブル
+  ingredientsTable: {
     borderRadius: radius.md,
-    padding: spacing.md,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: colors.border,
   },
-  mdText: {
-    fontSize: 13,
+  tableHeaderRow: {
+    flexDirection: "row",
+    backgroundColor: colors.bg,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+  },
+  tableHeaderCell: {
+    fontSize: 12,
+    fontWeight: "700",
     color: colors.text,
-    lineHeight: 20,
   },
-  ingredientList: {
+  tableRow: {
+    flexDirection: "row",
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+  },
+  tableRowEven: {
+    backgroundColor: colors.card,
+  },
+  tableRowOdd: {
     backgroundColor: colors.bg,
-    borderRadius: radius.md,
-    padding: spacing.md,
-    gap: 4,
   },
-  ingredientItem: {
+  tableCell: {
     fontSize: 13,
     color: colors.text,
   },
@@ -422,6 +562,7 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     fontStyle: "italic",
   },
+  // 作り方
   stepList: {
     backgroundColor: colors.bg,
     borderRadius: radius.md,
@@ -454,37 +595,30 @@ const styles = StyleSheet.create({
     color: colors.text,
     lineHeight: 20,
   },
-  nutritionBlock: {
-    gap: spacing.sm,
-  },
-  nutritionRow: {
-    flexDirection: "row",
-    gap: spacing.md,
-  },
-  nutritionItem: {
-    flex: 1,
-    backgroundColor: colors.bg,
-    borderRadius: radius.md,
-    padding: spacing.md,
-    alignItems: "center",
-    gap: 2,
-  },
-  nutritionValue: {
-    fontSize: 16,
-    fontWeight: "700",
-    color: colors.text,
-  },
-  nutritionLabel: {
-    fontSize: 11,
-    color: colors.textMuted,
-  },
+  // フッター
   footer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
     padding: spacing.lg,
     paddingBottom: spacing.xl,
     borderTopWidth: 1,
     borderTopColor: colors.border,
   },
+  favoriteBtn: {
+    width: 44,
+    height: 44,
+    borderRadius: radius.full,
+    backgroundColor: colors.bg,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  favoriteBtnActive: {
+    backgroundColor: "#FFF0F0",
+  },
   shoppingBtn: {
+    flex: 1,
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
@@ -498,7 +632,7 @@ const styles = StyleSheet.create({
     opacity: 0.8,
   },
   shoppingBtnText: {
-    fontSize: 15,
+    fontSize: 14,
     fontWeight: "700",
     color: "#fff",
   },


### PR DESCRIPTION
## Summary

- `ingredientsMd` / `recipeStepsMd` の Markdown パーサーを実装
  - `parseIngredientsTable`: パイプ区切りテーブル → `{ name, amount }[]`
  - `parseRecipeSteps`: 番号付きリスト (1. ステップ) → `string[]`
  - `ingredients[]` / `recipeSteps[]` をフォールバックとして利用
- 26 栄養素グリッド (3列) を RecipeModal 内に追加
- AI 料理画像表示エリア (`imageUrl` あれば表示、なければ「生成中」プレースホルダー)
- フッターをお気に入りボタン (♥) ＋「材料を買い物リストに追加」ボタンの横並びに変更
- Props インタフェースを `meal` 単位から `dish` 単位 (`RecipeModalDish`) へ変更
- `weekly/index.tsx` 側の `setRecipeModalMeal` 呼び出しを新型に合わせて更新 (26 栄養素を `nutrients` として渡す)

## Test plan

- [ ] dish タップで RecipeModal が開くこと
- [ ] `ingredientsMd` があれば材料表が表示されること (材料名 / 分量の2列)
- [ ] `ingredientsMd` がなく `ingredients[]` がある場合は食材名のみ表示されること
- [ ] `recipeStepsMd` があれば番号付きステップが表示されること
- [ ] 両方なければ「材料情報なし」「自動作成」プレースホルダーが出ること
- [ ] 栄養素グリッドが表示されること
- [ ] お気に入りボタンのトグルが動作すること
- [ ] 買い物リスト追加ボタンが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)