### PR TITLE
fix: インラインカードのレーダーチャートをWEBと同等のサイズ・ラベルに修正

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -280,7 +280,7 @@ function NutritionRadarChartSvg({ totals, nutrientKeys, size = 220 }: RadarChart
     Math.min(driPercent(key, totals[key] as number), MAX_PCT)
   );
   const avgPct = Math.round(pcts.reduce((s, v) => s + v, 0) / pcts.length);
-  const labelFontSize = Math.max(7, Math.min(9, size / 26));
+  const labelFontSize = Math.max(9, size * 0.06);
 
   // ── アニメーション ──────────────────────────────────────────
   const progressAnim = useRef(new Animated.Value(0)).current;
@@ -1682,7 +1682,7 @@ export default function WeeklyMenuPage() {
                       <NutritionRadarChartSvg
                         totals={dayNutritionData.totals}
                         nutrientKeys={radarChartNutrients}
-                        size={100}
+                        size={170}
                       />
                     </View>
                     {/* 右: 6 栄養素バー */}


### PR DESCRIPTION
## Summary

- インラインカード内の `NutritionRadarChartSvg` の `size` を `100` → `170` に変更し、WEB版 (約160-180px) と同等のレーダーチャートサイズを実現
- `labelFontSize` の計算式を `Math.max(7, Math.min(9, size/26))` から `Math.max(9, size * 0.06)` に変更し、size に応じてラベルが適切にスケールするよう修正
  - size=100 では 7px 固定 → size=170 では 10.2px になりフル名ラベルが読みやすくなる
- ラベルは既に `def?.label` (フル名) を使用していたため変更不要

## 変更ファイル

- `apps/mobile/app/menus/weekly/index.tsx`

## Test plan

- [ ] インライン栄養カードを展開してレーダーチャートが 170px 相当で表示されることを確認
- [ ] ラベル (エネルギー/タンパク質/脂質/炭水化物/食物繊維/ビタミンC等) がフル名で読み取れることを確認
- [ ] 中央の平均達成率テキストが正常に表示されることを確認
- [ ] 右の栄養バーと横並びレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)