### PR TITLE
fix: 献立画面の固定領域とスクロール領域の背景色を分離

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -1343,7 +1343,7 @@ export default function WeeklyMenuPage() {
   }
 
   return (
-    <SafeAreaView testID="weekly-screen" edges={["top"]} style={{ flex: 1, backgroundColor: colors.bg }}>
+    <SafeAreaView testID="weekly-screen" edges={["top"]} style={{ flex: 1, backgroundColor: colors.card }}>
       <WeeklyHeader
         weekRangeLabel={weekRangeLabel}
         weeklyStats={weeklyStats}
@@ -1382,7 +1382,7 @@ export default function WeeklyMenuPage() {
             paddingVertical: spacing.sm,
             paddingHorizontal: spacing.sm,
             borderRadius: radius.md,
-            backgroundColor: colors.bg,
+            backgroundColor: colors.card,
           }}
         >
           <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
@@ -1607,7 +1607,7 @@ export default function WeeklyMenuPage() {
         />
       </View>
 
-      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
+      <ScrollView style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
       {isLoading ? (
         <LoadingState />
       ) : error ? (


### PR DESCRIPTION
## Summary

- SafeAreaView（全体）の背景を `colors.bg`（薄グレー）から `colors.card`（白）に変更
- 月カレンダー展開バー Pressable の背景も `colors.bg` → `colors.card` に変更
- ScrollView に `backgroundColor: colors.bg` を明示し、スクロール領域を薄グレーに

WEB版と同様に、固定領域（ヘッダー・月バー・週日付タブ・AIバナー）が白背景、食事カード以下のスクロール領域が薄グレー（#F7F6F3）になるよう視覚的差別化を実装。

## Test plan

- [ ] 献立画面を開いて固定領域（ヘッダー〜AIバナー）が白背景であることを確認
- [ ] スクロール領域（食事カード以下）が薄グレー背景であることを確認
- [ ] 月カレンダー展開時も白背景が維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)