### PR TITLE
style: 固定領域とスクロール領域の境界を柔らかく

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -1507,7 +1507,7 @@ export default function WeeklyMenuPage() {
       </View>
 
       {/* 週日付タブ — ScrollView 外で固定 (スクロールしても常に表示) */}
-      <View style={{ paddingHorizontal: spacing.lg }}>
+      <View style={{ paddingHorizontal: spacing.lg, paddingBottom: spacing.md, shadowColor: '#000', shadowOpacity: 0.04, shadowOffset: { width: 0, height: 2 }, shadowRadius: 4, elevation: 2 }}>
         {/* 日付セレクタ — 週ナビ左右端 + 7日タブ中央 */}
         <View style={{ flexDirection: "row", alignItems: "center" }}>
           {/* 前の週ボタン */}
@@ -1607,7 +1607,7 @@ export default function WeeklyMenuPage() {
         />
       </View>
 
-      <ScrollView style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
+      <ScrollView style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ padding: spacing.lg, paddingTop: spacing.md, gap: spacing.lg }}>
       {isLoading ? (
         <LoadingState />
       ) : error ? (


### PR DESCRIPTION
## Summary

- 週献立画面の固定ヘッダー (週タブ・AIバナー) を包む View に `paddingBottom: spacing.md` と subtle drop shadow を追加
- `ScrollView` の `contentContainerStyle` に `paddingTop: spacing.md` を追加
- 白 (固定領域) とグレー (スクロール領域) の直線的な境界を解消し、Web 版と同様の自然な区切りを実現

## Test plan

- [ ] iOS シミュレータで週献立画面を表示し、固定ヘッダー下部に薄いシャドウが表示されることを確認
- [ ] スクロール領域上部に適切な余白があることを確認
- [ ] カレンダー展開/折りたたみ時にレイアウト崩れがないことを確認