### PR TITLE
fix: マイページ・比較タブでタブバーが消える問題を修正

### DIFF
--- a/apps/mobile/app/(tabs)/comparison.tsx
+++ b/apps/mobile/app/(tabs)/comparison.tsx
@@ -1,5 +1,1 @@
-import { Redirect } from "expo-router";
-
-export default function ComparisonTab() {
-  return <Redirect href="/comparison" />;
-}
+export { default } from '../comparison/index';

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -1,5 +1,1 @@
-import { Redirect } from "expo-router";
-
-export default function ProfileTab() {
-  return <Redirect href="/profile" />;
-}
+export { default } from '../profile/index';


### PR DESCRIPTION
## Summary
- `(tabs)/profile.tsx` と `(tabs)/comparison.tsx` が `Redirect` で tabs 階層外に飛んでいたためタブバーが消失していた
- PR #702 で `menus.tsx` に施したのと同じパターン: `Redirect` を `re-export` に変更
- tabs レイアウト内でコンテンツをレンダリングするようになりタブバーが保持される

## 変更ファイル
- `apps/mobile/app/(tabs)/profile.tsx`
- `apps/mobile/app/(tabs)/comparison.tsx`

## Test plan
- [ ] マイページタブを開いてタブバーが表示されることを確認
- [ ] 比較タブを開いてタブバーが表示されることを確認
- [ ] 他タブへの遷移が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)