### PR TITLE
perf: RadarChart アニメ削除で JS スレッド負荷を解消

### DIFF
--- a/apps/mobile/app/menus/weekly/index.tsx
+++ b/apps/mobile/app/menus/weekly/index.tsx
@@ -29,8 +29,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   ActivityIndicator,
   Alert,
-  Animated,
-  Easing,
   Modal,
   Pressable,
   ScrollView,
@@ -282,39 +280,13 @@ function NutritionRadarChartSvg({ totals, nutrientKeys, size = 220 }: RadarChart
   const avgPct = Math.round(pcts.reduce((s, v) => s + v, 0) / pcts.length);
   const labelFontSize = Math.max(9, size * 0.06);
 
-  // ── アニメーション ──────────────────────────────────────────
-  const progressAnim = useRef(new Animated.Value(0)).current;
-  const [animatedPolygon, setAnimatedPolygon] = useState<string>("");
-  const [animatedDots, setAnimatedDots] = useState<{ x: number; y: number }[]>([]);
-
-  const currentKey = nutrientKeys.join(",") + JSON.stringify(totals);
-  const prevKeyRef = useRef<string>("");
-
-  useEffect(() => {
-    if (prevKeyRef.current === currentKey) return;
-    prevKeyRef.current = currentKey;
-
-    progressAnim.setValue(0);
-
-    const id = progressAnim.addListener(({ value }) => {
-      const pts = nutrientKeys.map((key, i) => {
-        const pct = Math.min(driPercent(key, totals[key] as number), MAX_PCT);
-        const r = (pct / MAX_PCT) * maxRadius * value;
-        return { x: cx + r * Math.cos(angleOf(i)), y: cy + r * Math.sin(angleOf(i)) };
-      });
-      setAnimatedPolygon(pts.map((p) => `${p.x},${p.y}`).join(" "));
-      setAnimatedDots(pts);
-    });
-
-    Animated.timing(progressAnim, {
-      toValue: 1,
-      duration: 600,
-      easing: Easing.out(Easing.cubic),
-      useNativeDriver: false,
-    }).start();
-
-    return () => { progressAnim.removeListener(id); };
-  }, [currentKey]);
+  // 静的 polygon (アニメなし、JS スレッド負荷を排除)
+  const dataPoints = nutrientKeys.map((key, i) => {
+    const pct = Math.min(driPercent(key, totals[key] as number), MAX_PCT);
+    const r = (pct / MAX_PCT) * maxRadius;
+    return { x: cx + r * Math.cos(angleOf(i)), y: cy + r * Math.sin(angleOf(i)) };
+  });
+  const dataPolygon = dataPoints.map((p) => `${p.x},${p.y}`).join(" ");
 
   return (
     <View style={{ alignItems: "center", width: size, height: size }}>
@@ -326,10 +298,8 @@ function NutritionRadarChartSvg({ totals, nutrientKeys, size = 220 }: RadarChart
         {spokes.map((p, i) => (
           <Line key={`s${i}`} x1={cx} y1={cy} x2={p.x} y2={p.y} stroke="#E8E8E8" strokeWidth={1} />
         ))}
-        {animatedPolygon ? (
-          <Polygon points={animatedPolygon} fill={`${colors.accent}40`} stroke={colors.accent} strokeWidth={2} />
-        ) : null}
-        {animatedDots.map((p, i) => (
+        <Polygon points={dataPolygon} fill={`${colors.accent}40`} stroke={colors.accent} strokeWidth={2} />
+        {dataPoints.map((p, i) => (
           <Circle key={`d${i}`} cx={p.x} cy={p.y} r={3} fill={colors.accent} />
         ))}
         {nutrientKeys.map((key, i) => {

--- a/apps/mobile/src/components/menu/RadarChart.tsx
+++ b/apps/mobile/src/components/menu/RadarChart.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Animated, Easing, Text, View } from 'react-native';
+import React from 'react';
+import { Text, View } from 'react-native';
 import Svg, {
   Circle,
   Line,
@@ -89,43 +89,13 @@ export const RadarChart: React.FC<RadarChartProps> = ({
 
   const labelFontSize = Math.max(7, Math.min(9, size / 26));
 
-  // ── アニメーション ──────────────────────────────────────────
-  const progressAnim = useRef(new Animated.Value(0)).current;
-  const [animatedPolygon, setAnimatedPolygon] = useState<string>('');
-  const [animatedDots, setAnimatedDots] = useState<{ x: number; y: number }[]>([]);
-
-  // keys/values が変わったらアニメーションをリセットして再実行
-  const keysRef = useRef<string>('');
-  const currentKey = nutrientKeys.join(',') + JSON.stringify(totals);
-
-  useEffect(() => {
-    if (keysRef.current === currentKey) return;
-    keysRef.current = currentKey;
-
-    progressAnim.setValue(0);
-
-    const id = progressAnim.addListener(({ value }) => {
-      const pts = nutrientKeys.map((key, i) => {
-        const pct = Math.min(getDriPercent(key, totals[key] ?? 0), MAX_PCT);
-        const r = (pct / MAX_PCT) * maxRadius * value;
-        const p = { x: cx + r * Math.cos(angleOf(i)), y: cy + r * Math.sin(angleOf(i)) };
-        return p;
-      });
-      setAnimatedPolygon(pts.map((p) => `${p.x},${p.y}`).join(' '));
-      setAnimatedDots(pts);
-    });
-
-    Animated.timing(progressAnim, {
-      toValue: 1,
-      duration: 600,
-      easing: Easing.out(Easing.cubic),
-      useNativeDriver: false,
-    }).start();
-
-    return () => {
-      progressAnim.removeListener(id);
-    };
-  }, [currentKey]);
+  // 静的 polygon (アニメなし、JS スレッド負荷を排除)
+  const dataPoints = nutrientKeys.map((key, i) => {
+    const pct = Math.min(getDriPercent(key, totals[key] ?? 0), MAX_PCT);
+    const r = (pct / MAX_PCT) * maxRadius;
+    return { x: cx + r * Math.cos(angleOf(i)), y: cy + r * Math.sin(angleOf(i)) };
+  });
+  const dataPolygon = dataPoints.map((p) => `${p.x},${p.y}`).join(' ');
 
   return (
     <View style={{ alignItems: 'center', width: size, height: size }}>
@@ -157,15 +127,13 @@ export const RadarChart: React.FC<RadarChartProps> = ({
             strokeWidth={1}
           />
         ))}
-        {animatedPolygon ? (
-          <Polygon
-            points={animatedPolygon}
-            fill="rgba(224,122,95,0.25)"
-            stroke={colors.accent}
-            strokeWidth={2}
-          />
-        ) : null}
-        {animatedDots.map((p, i) => (
+        <Polygon
+          points={dataPolygon}
+          fill="rgba(224,122,95,0.25)"
+          stroke={colors.accent}
+          strokeWidth={2}
+        />
+        {dataPoints.map((p, i) => (
           <Circle key={`d${i}`} cx={p.x} cy={p.y} r={3} fill={colors.accent} />
         ))}
         {nutrientKeys.map((key, i) => {


### PR DESCRIPTION
## 概要

PR #736 で実装した RadarChart のアニメーション（`Animated.Value.addListener` + `setState`）が 60 fps で JS スレッドを専有し、App 全体の動作を重くしていた問題を修正。

## 変更内容

- `Animated.Value.addListener` で毎フレーム `setState` → React re-render していたロジックを**完全削除**（Option A: アニメ完全削除）
- `progressAnim`, `animatedPolygon`, `animatedDots` の state / ref をすべて除去
- `Animated`, `Easing` の import を削除
- 代わりに `dataPoints` / `dataPolygon` を props から直接計算する静的描画に切り替え

## 対象ファイル

- `apps/mobile/src/components/menu/RadarChart.tsx`
- `apps/mobile/app/menus/weekly/index.tsx` (NutritionRadarChartSvg)

## Before / After

| 項目 | Before | After |
|------|--------|-------|
| JS スレッド負荷 | 60 fps × setState | 0 (静的) |
| re-render 回数 | アニメ中 ~36 回 (600ms) | データ変化時のみ |
| アニメーション | あり | なし (静的表示) |

## 型チェック

```
tsc --noEmit: エラー 0 件
```