### PR TITLE
feat: meals スキャンタブにネイティブカメラ + AI 解析ブリッジを実装 (Phase B-2)

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -78,12 +78,6 @@ export default function TabsLayout() {
           ),
           tabBarLabel: () => null,
         }}
-        listeners={{
-          tabPress: (e) => {
-            e.preventDefault();
-            router.push("/meals/new");
-          },
-        }}
       />
       <Tabs.Screen
         name="favorites"

--- a/apps/mobile/app/(tabs)/meals.tsx
+++ b/apps/mobile/app/(tabs)/meals.tsx
@@ -1,8 +1,133 @@
-import { View } from "react-native";
-import { colors } from "../../src/theme";
+import { useState } from 'react';
+import { View, Text, Pressable, ActivityIndicator, Alert } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { colors } from '../../src/theme/colors';
 
-// スキャンタブ - タップ時にlistenersで/meals/newに遷移するため、
-// この画面自体は空（表示されない）
-export default function MealsTab() {
-  return <View style={{ flex: 1, backgroundColor: colors.bg }} />;
+export default function MealsScanTab() {
+  const router = useRouter();
+  const [analyzing, setAnalyzing] = useState(false);
+
+  const pickAndAnalyze = async (source: 'camera' | 'library') => {
+    let result: ImagePicker.ImagePickerResult;
+
+    if (source === 'camera') {
+      const perm = await ImagePicker.requestCameraPermissionsAsync();
+      if (!perm.granted) {
+        Alert.alert('権限が必要です', 'カメラへのアクセスを許可してください。');
+        return;
+      }
+      result = await ImagePicker.launchCameraAsync({
+        base64: true,
+        quality: 0.7,
+        mediaTypes: ['images'] as any,
+      });
+    } else {
+      const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!perm.granted) {
+        Alert.alert('権限が必要です', '写真ライブラリへのアクセスを許可してください。');
+        return;
+      }
+      result = await ImagePicker.launchImageLibraryAsync({
+        base64: true,
+        quality: 0.7,
+        mediaTypes: ['images'] as any,
+      });
+    }
+
+    if (result.canceled || !result.assets?.[0]?.base64) return;
+
+    setAnalyzing(true);
+    try {
+      const base64 = result.assets[0].base64!;
+      const webUrl = process.env.EXPO_PUBLIC_WEB_URL ?? 'https://homegohan-app.vercel.app';
+      const response = await fetch(`${webUrl}/api/ai/analyze-meal-photo`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          images: [{ base64, mimeType: 'image/jpeg' }],
+        }),
+      });
+
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error((err as any)?.error ?? `HTTP ${response.status}`);
+      }
+
+      const data = await response.json();
+      const prefill = encodeURIComponent(JSON.stringify(data));
+      router.push(`/web-prefill?path=/meals/new&prefill=${prefill}`);
+    } catch (e) {
+      Alert.alert('解析失敗', String(e));
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: 20,
+        gap: 16,
+        backgroundColor: colors.bg,
+      }}
+    >
+      <Text style={{ fontSize: 18, fontWeight: '700', color: colors.text, marginBottom: 24 }}>
+        食事を記録
+      </Text>
+
+      <Pressable
+        testID="meals-scan-camera"
+        onPress={() => pickAndAnalyze('camera')}
+        disabled={analyzing}
+        style={{
+          flexDirection: 'row',
+          gap: 8,
+          padding: 16,
+          backgroundColor: colors.accent,
+          borderRadius: 12,
+          width: '100%',
+          justifyContent: 'center',
+          alignItems: 'center',
+          opacity: analyzing ? 0.6 : 1,
+        }}
+      >
+        <Ionicons name="camera" size={20} color="#FFF" />
+        <Text style={{ color: '#FFF', fontWeight: '700', fontSize: 15 }}>撮影する</Text>
+      </Pressable>
+
+      <Pressable
+        testID="meals-scan-library"
+        onPress={() => pickAndAnalyze('library')}
+        disabled={analyzing}
+        style={{
+          flexDirection: 'row',
+          gap: 8,
+          padding: 16,
+          backgroundColor: colors.card,
+          borderRadius: 12,
+          width: '100%',
+          justifyContent: 'center',
+          alignItems: 'center',
+          borderWidth: 1,
+          borderColor: colors.border,
+          opacity: analyzing ? 0.6 : 1,
+        }}
+      >
+        <Ionicons name="image-outline" size={20} color={colors.text} />
+        <Text style={{ color: colors.text, fontWeight: '700', fontSize: 15 }}>ライブラリから選ぶ</Text>
+      </Pressable>
+
+      {analyzing && (
+        <View style={{ marginTop: 24, alignItems: 'center' }}>
+          <ActivityIndicator size="large" color={colors.accent} />
+          <Text style={{ marginTop: 8, color: colors.textMuted }}>AI が解析中...</Text>
+        </View>
+      )}
+    </View>
+  );
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -76,6 +76,7 @@ export default function RootLayout() {
             <Stack.Screen name="(support)" />
             <Stack.Screen name="(super-admin)" />
             <Stack.Screen name="meals/new" options={{ presentation: "modal" }} />
+            <Stack.Screen name="web-prefill" options={{ presentation: "modal", title: "食事記録" }} />
           </Stack>
         </ProfileProvider>
       </AuthProvider>

--- a/apps/mobile/app/web-prefill.tsx
+++ b/apps/mobile/app/web-prefill.tsx
@@ -1,0 +1,15 @@
+import { useLocalSearchParams } from 'expo-router';
+import { WebViewScreen } from '../src/components/web/WebViewScreen';
+
+/**
+ * ネイティブ側で AI 解析した結果を Web の /meals/new に渡す中継画面。
+ * クエリパラメータ:
+ *   path    - Web 側のパス (例: /meals/new)
+ *   prefill - encodeURIComponent(JSON.stringify(analysisResult))
+ */
+export default function WebPrefillScreen() {
+  const { path, prefill } = useLocalSearchParams<{ path: string; prefill: string }>();
+  const resolvedPath = path ?? '/meals/new';
+  const query = prefill ? `&prefill=${prefill}` : '';
+  return <WebViewScreen path={`${resolvedPath}?mode=app${query}`} />;
+}

--- a/apps/mobile/src/components/web/WebViewScreen.tsx
+++ b/apps/mobile/src/components/web/WebViewScreen.tsx
@@ -14,7 +14,12 @@ interface Props {
 export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
   const webViewRef = useRef<WebView>(null);
   const [loading, setLoading] = useState(true);
-  const url = `${WEB_BASE_URL}${path}?mode=app`;
+  // path に既に mode=app が含まれている場合は重複付与しない
+  const alreadyHasMode = path.includes('mode=app');
+  const separator = path.includes('?') ? '&' : '?';
+  const url = alreadyHasMode
+    ? `${WEB_BASE_URL}${path}`
+    : `${WEB_BASE_URL}${path}${separator}mode=app`;
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: '#FFF' }} edges={['top']}>

--- a/src/app/(main)/meals/new/layout.tsx
+++ b/src/app/(main)/meals/new/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 
 export const metadata: Metadata = {
   title: "食事を記録",
@@ -10,6 +11,7 @@ export default function NewMealLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  // useSearchParams を使うため Suspense でラップ
+  return <Suspense>{children}</Suspense>;
 }
 

--- a/src/app/(main)/meals/new/page.tsx
+++ b/src/app/(main)/meals/new/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { resolveClassifyPhotoType } from "@/lib/ai/image-recognition";
 import { logToServer } from "@/lib/db-logger";
 import type { CatalogDishMatch, CatalogProductSummary } from "@/types/catalog";
@@ -320,6 +320,33 @@ export default function MealCaptureModal() {
   });
   
   const [isSaving, setIsSaving] = useState(false);
+
+  // ネイティブアプリから渡される AI 解析済みデータを prefill として受け取る
+  const searchParams = useSearchParams();
+  useEffect(() => {
+    const prefillParam = searchParams.get('prefill');
+    if (!prefillParam) return;
+    try {
+      const data = JSON.parse(decodeURIComponent(prefillParam));
+      if (data && typeof data === 'object') {
+        if (Array.isArray(data.dishes)) setAnalyzedDishes(data.dishes);
+        if (typeof data.totalCalories === 'number') setTotalCalories(data.totalCalories);
+        if (typeof data.totalProtein === 'number') setTotalProtein(data.totalProtein);
+        if (typeof data.totalCarbs === 'number') setTotalCarbs(data.totalCarbs);
+        if (typeof data.totalFat === 'number') setTotalFat(data.totalFat);
+        if (typeof data.overallScore === 'number') setOverallScore(data.overallScore);
+        if (typeof data.vegScore === 'number') setVegScore(data.vegScore);
+        if (typeof data.praiseComment === 'string') setPraiseComment(data.praiseComment);
+        if (typeof data.nutritionTip === 'string') setNutritionTip(data.nutritionTip);
+        if (typeof data.nutritionalAdvice === 'string') setNutritionalAdvice(data.nutritionalAdvice);
+        if (Array.isArray(data.catalogMatches)) setCatalogMatches(data.catalogMatches);
+        setStep('result');
+      }
+    } catch {
+      // 無効な prefill は無視して通常フローへ
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // analyzing ステップに 45 秒の上限タイマー — タイムアウト時は classify-failed に遷移
   useEffect(() => {


### PR DESCRIPTION
## Summary

- meals タブタップ → ネイティブカメラ/ライブラリ選択 UI を直接表示 (従来の `/meals/new` WebView への即時 redirect を廃止)
- 撮影 or ライブラリ選択 → `expo-image-picker` (base64) → POST `/api/ai/analyze-meal-photo` で AI 解析 → 結果を URL クエリ `prefill` として Web の `/meals/new` に渡す
- 新規画面 `app/web-prefill.tsx` を modal Stack として追加し、解析済みデータを WebView に中継
- Web 側 `/meals/new/page.tsx` に `useSearchParams` + prefill 受け取り `useEffect` を追加し、解析結果を state に展開して `result` ステップを直接表示

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `apps/mobile/app/(tabs)/meals.tsx` | ネイティブカメラ UI に全面置換 |
| `apps/mobile/app/(tabs)/_layout.tsx` | meals の `listeners` (tabPress redirect) を削除 |
| `apps/mobile/app/_layout.tsx` | `web-prefill` を modal Stack に追加 |
| `apps/mobile/app/web-prefill.tsx` | 新規作成 — WebViewScreen 中継画面 |
| `apps/mobile/src/components/web/WebViewScreen.tsx` | `mode=app` 二重付与防止ロジック追加 |
| `src/app/(main)/meals/new/page.tsx` | `useSearchParams` + prefill useEffect 追加 |
| `src/app/(main)/meals/new/layout.tsx` | `Suspense` ラップ追加 |

## Test plan

- [ ] スキャンタブをタップ → ネイティブカメラ UI が表示されること
- [ ] 「撮影する」タップ → カメラ権限ダイアログ → 撮影 → ローディング → `/meals/new` (result ステップ) に遷移すること
- [ ] 「ライブラリから選ぶ」タップ → ライブラリ権限ダイアログ → 選択 → 同上
- [ ] 解析失敗時は Alert が表示されること
- [ ] Web ブラウザで `/meals/new?prefill=<encoded>` にアクセス → result ステップが表示されること
- [ ] `prefill` なしで `/meals/new` にアクセス → 通常の mode-select ステップが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)