### PR TITLE
fix: expo-file-system 18.0→18.1 更新で ExpoAppDelegate SwiftEmitModule エラーを解消

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -22,7 +22,7 @@
     "expo": "~53.0.0",
     "expo-constants": "~17.1.8",
     "expo-device": "~7.1.4",
-    "expo-file-system": "~18.0.12",
+    "expo-file-system": "~18.1.0",
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
     "expo-image-manipulator": "~13.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "expo": "~53.0.0",
         "expo-constants": "~17.1.8",
         "expo-device": "~7.1.4",
-        "expo-file-system": "~18.0.12",
+        "expo-file-system": "~18.1.0",
         "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
         "expo-image-manipulator": "~13.1.7",
@@ -103,19 +103,6 @@
       "dependencies": {
         "@expo/config": "~11.0.13",
         "@expo/env": "~1.0.7"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
-    "apps/mobile/node_modules/expo-file-system": {
-      "version": "18.0.12",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.0.12.tgz",
-      "integrity": "sha512-HAkrd/mb8r+G3lJ9MzmGeuW2B+BxQR1joKfeCyY4deLl1zoZ48FrAWjgZjHK9aHUVhJ0ehzInu/NQtikKytaeg==",
-      "license": "MIT",
-      "dependencies": {
-        "web-streams-polyfill": "^3.3.2"
       },
       "peerDependencies": {
         "expo": "*",


### PR DESCRIPTION
## 問題

xcodebuild で以下のエラーが発生し BUILD FAILED になっていた:

```
node_modules/expo-file-system/ios/FileSystemModule.swift:10:84: error: cannot find 'ExpoAppDelegate' in scope
```

## 原因

expo-file-system@18.0.12 の FileSystemModule.swift が ExpoAppDelegate.getSubscriberOfType(...) を参照していたが、expo-modules-core@2.5.0 では ExpoAppDelegate クラスが廃止され ExpoAppDelegateSubscriberRepository に変更された。expo-file-system@18.1.x でこの変更に追従済み。

## 修正内容

- apps/mobile/package.json: expo-file-system ~18.0.12 -> ~18.1.0
- package-lock.json: apps/mobile/node_modules/expo-file-system (18.0.12) のローカルコピーを削除し、root の node_modules/expo-file-system@18.1.11 を参照
- pod install 実行済み (Podfile.lock: ../node_modules -> ../../../node_modules に更新)

## 検証

- xcodebuild build -> BUILD SUCCEEDED
- xcrun simctl install + launch でシミュレーター起動確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)