### PR TITLE
feat: ネイティブ認証維持 + Supabase session token WebView bridge (Phase B-3)

### DIFF
--- a/apps/mobile/src/components/web/WebViewScreen.tsx
+++ b/apps/mobile/src/components/web/WebViewScreen.tsx
@@ -1,8 +1,9 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { WebView } from 'react-native-webview';
 import { colors } from '../../theme/colors';
+import { supabase } from '../../lib/supabase';
 
 const WEB_BASE_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'https://homegohan-app.vercel.app';
 
@@ -13,20 +14,51 @@ interface Props {
 
 export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
   const webViewRef = useRef<WebView>(null);
-  const [loading, setLoading] = useState(true);
-  // path に既に mode=app が含まれている場合は重複付与しない
-  const alreadyHasMode = path.includes('mode=app');
-  const separator = path.includes('?') ? '&' : '?';
-  const url = alreadyHasMode
-    ? `${WEB_BASE_URL}${path}`
-    : `${WEB_BASE_URL}${path}${separator}mode=app`;
+  const [uri, setUri] = useState<string | null>(null);
+
+  useEffect(() => {
+    const init = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (session?.access_token && session?.refresh_token) {
+        // bridge URL に access/refresh token + next path を埋め込む
+        // path に既に mode=app が含まれている場合は重複付与しない
+        const alreadyHasMode = path.includes('mode=app');
+        const separator = path.includes('?') ? '&' : '?';
+        const nextPath = alreadyHasMode
+          ? path
+          : `${path}${separator}mode=app`;
+        const next = encodeURIComponent(nextPath);
+        const bridgeUrl = `${WEB_BASE_URL}/auth/native-bridge?access_token=${session.access_token}&refresh_token=${session.refresh_token}&next=${next}`;
+        setUri(bridgeUrl);
+      } else {
+        // セッションなし → 直接 path (mode=app 付き)
+        const alreadyHasMode = path.includes('mode=app');
+        const separator = path.includes('?') ? '&' : '?';
+        const directUrl = alreadyHasMode
+          ? `${WEB_BASE_URL}${path}`
+          : `${WEB_BASE_URL}${path}${separator}mode=app`;
+        setUri(directUrl);
+      }
+    };
+    init();
+  }, [path]);
+
+  if (!uri) {
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: '#FFF' }} edges={['top']}>
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+          <ActivityIndicator size="large" color={colors.accent} />
+        </View>
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: '#FFF' }} edges={['top']}>
       <WebView
         ref={webViewRef}
         testID={testID ?? 'webview-screen'}
-        source={{ uri: url }}
+        source={{ uri }}
         sharedCookiesEnabled={true}
         thirdPartyCookiesEnabled={true}
         contentInsetAdjustmentBehavior="never"
@@ -34,8 +66,6 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
         javaScriptEnabled={true}
         startInLoadingState={true}
         pullToRefreshEnabled={true}
-        onLoadStart={() => setLoading(true)}
-        onLoadEnd={() => setLoading(false)}
         onMessage={(_event) => {
           // ネイティブからのメッセージ受信 (撮影結果等)
           // TODO: Phase B-2 で実装

--- a/src/app/(auth)/auth/native-bridge/route.ts
+++ b/src/app/(auth)/auth/native-bridge/route.ts
@@ -1,0 +1,64 @@
+import { createClient } from '@/lib/supabase/server'
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+
+/**
+ * ネイティブアプリからの認証ブリッジ
+ *
+ * ネイティブ側で取得した Supabase session token を受け取り、
+ * Web 側の Cookie に setSession() でセッションを設定してから next へリダイレクトする。
+ *
+ * フロー:
+ *   1. ネイティブ: supabase.auth.getSession() → access_token / refresh_token 取得
+ *   2. WebView が /auth/native-bridge?access_token=X&refresh_token=Y&next=/home?mode=app を開く
+ *   3. このルートが setSession() を呼び Cookie に session 保存
+ *   4. next パスへ redirect → 以降の WebView ナビゲーションは Cookie session 共有で認証済み
+ */
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url)
+  const accessToken = url.searchParams.get('access_token')
+  const refreshToken = url.searchParams.get('refresh_token')
+  const next = url.searchParams.get('next') ?? '/home?mode=app'
+
+  if (!accessToken || !refreshToken) {
+    console.warn('[auth/native-bridge] Missing access_token or refresh_token, redirecting to login')
+    return NextResponse.redirect(new URL('/login', req.url))
+  }
+
+  const cookieStore = cookies()
+  const supabase = createClient(cookieStore)
+
+  const { error } = await supabase.auth.setSession({
+    access_token: accessToken,
+    refresh_token: refreshToken,
+  })
+
+  if (error) {
+    console.error('[auth/native-bridge] setSession error:', error.message)
+    return NextResponse.redirect(new URL('/login', req.url))
+  }
+
+  // next は相対パスまたは絶対 URL のどちらも受け付けるが、
+  // セキュリティのため同一オリジン内パスのみ許可する
+  let redirectUrl: URL
+  try {
+    // next が '/' で始まる相対パスの場合は同一オリジンとみなす
+    if (next.startsWith('/')) {
+      redirectUrl = new URL(next, req.url)
+    } else {
+      // 絶対 URL の場合はオリジンが一致するか検証
+      const parsed = new URL(next)
+      const reqOrigin = new URL(req.url).origin
+      if (parsed.origin !== reqOrigin) {
+        console.warn('[auth/native-bridge] Cross-origin redirect blocked:', next)
+        redirectUrl = new URL('/home?mode=app', req.url)
+      } else {
+        redirectUrl = parsed
+      }
+    }
+  } catch {
+    redirectUrl = new URL('/home?mode=app', req.url)
+  }
+
+  return NextResponse.redirect(redirectUrl)
+}


### PR DESCRIPTION
## Summary

- ネイティブログイン UI (login.tsx) を維持したまま、Supabase session token を WebView へ bridge する方式に切り替え
- `WebViewScreen` が `supabase.auth.getSession()` でネイティブ session を取得し、`/auth/native-bridge` 経由で Web 側 Cookie に session を確立
- Web 側に `/auth/native-bridge` Route Handler を新規追加し、`setSession()` で Cookie session を保存してから `next` パラメータのページへリダイレクト

## 変更ファイル

- `apps/mobile/src/components/web/WebViewScreen.tsx` — token bridge URL 生成ロジックを追加
- `src/app/(auth)/auth/native-bridge/route.ts` — 新規 Route Handler

## Test plan

- [ ] ネイティブアプリでログイン → `(tabs)/home` に遷移 → WebView が `/auth/native-bridge` を経由してから `/home?mode=app` を表示することを確認
- [ ] セッションなし状態では直接 `path?mode=app` にアクセスすることを確認（/login へリダイレクト）
- [ ] WebView 内の複数タブ遷移で Cookie session が維持されることを確認
- [ ] Cross-origin な `next` パラメータが `/home?mode=app` にフォールバックすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)