### PR TITLE
feat: WebView の localStorage に Supabase session を注入しクライアント SDK の認証を保証

### DIFF
--- a/apps/mobile/src/components/web/WebViewScreen.tsx
+++ b/apps/mobile/src/components/web/WebViewScreen.tsx
@@ -6,6 +6,9 @@ import { colors } from '../../theme/colors';
 import { supabase } from '../../lib/supabase';
 
 const WEB_BASE_URL = process.env.EXPO_PUBLIC_WEB_URL ?? 'https://homegohan-app.vercel.app';
+const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL ?? '';
+// "https://abc123.supabase.co" → "abc123"
+const PROJECT_REF = SUPABASE_URL.replace('https://', '').split('.')[0];
 
 interface Props {
   path: string;  // 例 '/home', '/menus/weekly'
@@ -15,6 +18,7 @@ interface Props {
 export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
   const webViewRef = useRef<WebView>(null);
   const [uri, setUri] = useState<string | null>(null);
+  const [injectedJS, setInjectedJS] = useState<string>('');
 
   useEffect(() => {
     const init = async () => {
@@ -30,6 +34,34 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
         const next = encodeURIComponent(nextPath);
         const bridgeUrl = `${WEB_BASE_URL}/auth/native-bridge?access_token=${session.access_token}&refresh_token=${session.refresh_token}&next=${next}`;
         setUri(bridgeUrl);
+
+        // localStorage 注入: クライアント Supabase JS SDK が参照するキーに session を書き込む
+        // SSR middleware は Cookie で動作するが、クライアント側 SDK は localStorage を参照するため両方設定が必要
+        const storageKey = `sb-${PROJECT_REF}-auth-token`;
+        const sessionPayload = JSON.stringify({
+          access_token: session.access_token,
+          refresh_token: session.refresh_token,
+          expires_at: session.expires_at,
+          expires_in: session.expires_in,
+          token_type: 'bearer',
+          user: session.user,
+          provider_token: session.provider_token ?? null,
+          provider_refresh_token: session.provider_refresh_token ?? null,
+        });
+        // JS 文字列リテラル内で安全に使えるよう バックスラッシュ・シングルクォートをエスケープ
+        const escapedPayload = sessionPayload
+          .replace(/\\/g, '\\\\')
+          .replace(/'/g, "\\'");
+        setInjectedJS(`
+          (function() {
+            try {
+              window.localStorage.setItem('${storageKey}', '${escapedPayload}');
+            } catch (e) {
+              // localStorage 書き込み失敗時は Cookie 経由で認証継続
+            }
+          })();
+          true;
+        `);
       } else {
         // セッションなし → 直接 path (mode=app 付き)
         const alreadyHasMode = path.includes('mode=app');
@@ -38,6 +70,7 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
           ? `${WEB_BASE_URL}${path}`
           : `${WEB_BASE_URL}${path}${separator}mode=app`;
         setUri(directUrl);
+        setInjectedJS('');
       }
     };
     init();
@@ -59,6 +92,7 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
         ref={webViewRef}
         testID={testID ?? 'webview-screen'}
         source={{ uri }}
+        injectedJavaScriptBeforeContentLoaded={injectedJS || undefined}
         sharedCookiesEnabled={true}
         thirdPartyCookiesEnabled={true}
         contentInsetAdjustmentBehavior="never"


### PR DESCRIPTION
## Summary

- `WebViewScreen` の `useEffect` 内で `supabase.auth.getSession()` 取得後、`injectedJavaScriptBeforeContentLoaded` を使って `sb-{PROJECT_REF}-auth-token` キーを WebView の localStorage に書き込む
- これにより **SSR middleware (Cookie)** に加え、**クライアント側 Supabase JS SDK (localStorage)** の両方で認証済み状態を保証
- セッションなし時は localStorage 注入をスキップし、Cookie 経由の既存フローを維持
- `PROJECT_REF` は `EXPO_PUBLIC_SUPABASE_URL` から動的に抽出 (`https://abc123.supabase.co` → `abc123`)

## 変更ファイル

- `apps/mobile/src/components/web/WebViewScreen.tsx`

## Test plan

- [ ] iOS Simulator (C6D1DAF1) で BUILD SUCCEEDED 確認済み
- [ ] アプリ起動確認済み (PID 8025)
- [ ] ログイン済み状態で WebView を開き、クライアント側 SDK が認証済みで動作することを確認
- [ ] セッションなし状態で WebView を開き、localStorage 注入がスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)