### PR TITLE
revert: PR #750 auth bypass 取り消し

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,87 +1,108 @@
 import { Ionicons } from "@expo/vector-icons";
-import { Tabs } from "expo-router";
-import { View } from "react-native";
+import { Tabs, Redirect, router } from "expo-router";
+import { ActivityIndicator, View } from "react-native";
 
 import { colors } from "../../src/theme";
+import { useAuth } from "../../src/providers/AuthProvider";
+import { useProfile } from "../../src/providers/ProfileProvider";
 import { AIFloatingFab } from "../../src/components/ai/AIFloatingFab";
 
-// 認証ガードを削除: 認証は WebView 内 (Web 版の middleware) で処理する。
-// ネイティブ側でのセッションチェック・onboarding リダイレクトはすべて廃止。
-
 export default function TabsLayout() {
+  const { session, isLoading } = useAuth();
+  const { isLoading: profileLoading, profile } = useProfile();
+
+  if (isLoading || profileLoading) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.bg }}>
+        <ActivityIndicator size="large" color={colors.accent} />
+      </View>
+    );
+  }
+
+  if (!session) return <Redirect href="/" />;
+
+  // profileがnullの場合（ロード直後等）はリダイレクトせずそのまま表示
+  if (profile && !profile.onboardingCompletedAt) {
+    if (profile.onboardingStartedAt) {
+      return <Redirect href="/onboarding/resume" />;
+    } else {
+      return <Redirect href="/onboarding/welcome" />;
+    }
+  }
+
   return (
     <>
       <Tabs
-        screenOptions={{
-          headerShown: false,
-          tabBarStyle: {
-            backgroundColor: colors.card,
-            borderTopColor: colors.border,
-            height: 88,
-            paddingBottom: 30,
-            paddingTop: 8,
-          },
-          tabBarActiveTintColor: colors.accent,
-          tabBarInactiveTintColor: colors.textMuted,
-          tabBarLabelStyle: { fontSize: 11, fontWeight: "600" },
+      screenOptions={{
+        headerShown: false,
+        tabBarStyle: {
+          backgroundColor: colors.card,
+          borderTopColor: colors.border,
+          height: 88,
+          paddingBottom: 30,
+          paddingTop: 8,
+        },
+        tabBarActiveTintColor: colors.accent,
+        tabBarInactiveTintColor: colors.textMuted,
+        tabBarLabelStyle: { fontSize: 11, fontWeight: "600" },
+      }}
+    >
+      <Tabs.Screen
+        name="home"
+        options={{
+          title: "ホーム",
+          tabBarIcon: ({ color, size }) => <Ionicons name="home" size={size} color={color} />,
+          tabBarButtonTestID: "tab-home",
         }}
-      >
-        <Tabs.Screen
-          name="home"
-          options={{
-            title: "ホーム",
-            tabBarIcon: ({ color, size }) => <Ionicons name="home" size={size} color={color} />,
-            tabBarButtonTestID: "tab-home",
-          }}
-        />
-        <Tabs.Screen
-          name="menus"
-          options={{
-            title: "献立",
-            tabBarIcon: ({ color, size }) => <Ionicons name="book-outline" size={size} color={color} />,
-            tabBarButtonTestID: "tab-menus",
-          }}
-        />
-        <Tabs.Screen
-          name="meals"
-          options={{
-            title: "スキャン",
-            tabBarIcon: () => (
-              <View style={{
-                width: 48, height: 48, borderRadius: 24,
-                backgroundColor: colors.text, alignItems: "center", justifyContent: "center",
-                marginBottom: 16,
-              }}>
-                <Ionicons name="scan" size={24} color="#fff" />
-              </View>
-            ),
-            tabBarLabel: () => null,
-          }}
-        />
-        <Tabs.Screen
-          name="favorites"
-          options={{ href: null }}
-        />
-        <Tabs.Screen
-          name="comparison"
-          options={{
-            title: "比較",
-            tabBarIcon: ({ color, size }) => <Ionicons name="bar-chart" size={size} color={color} />,
-            tabBarButtonTestID: "tab-comparison",
-          }}
-        />
-        <Tabs.Screen
-          name="profile"
-          options={{
-            title: "マイページ",
-            tabBarIcon: ({ color, size }) => <Ionicons name="person" size={size} color={color} />,
-            tabBarButtonTestID: "tab-profile",
-          }}
-        />
-        {/* タブバーに表示しないが(tabs)グループ内に必要なファイル */}
-        <Tabs.Screen name="health" options={{ href: null }} />
-        <Tabs.Screen name="settings" options={{ href: null }} />
-      </Tabs>
+      />
+      <Tabs.Screen
+        name="menus"
+        options={{
+          title: "献立",
+          tabBarIcon: ({ color, size }) => <Ionicons name="book-outline" size={size} color={color} />,
+          tabBarButtonTestID: "tab-menus",
+        }}
+      />
+      <Tabs.Screen
+        name="meals"
+        options={{
+          title: "スキャン",
+          tabBarIcon: () => (
+            <View style={{
+              width: 48, height: 48, borderRadius: 24,
+              backgroundColor: colors.text, alignItems: "center", justifyContent: "center",
+              marginBottom: 16,
+            }}>
+              <Ionicons name="scan" size={24} color="#fff" />
+            </View>
+          ),
+          tabBarLabel: () => null,
+        }}
+      />
+      <Tabs.Screen
+        name="favorites"
+        options={{ href: null }}
+      />
+      <Tabs.Screen
+        name="comparison"
+        options={{
+          title: "比較",
+          tabBarIcon: ({ color, size }) => <Ionicons name="bar-chart" size={size} color={color} />,
+          tabBarButtonTestID: "tab-comparison",
+        }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{
+          title: "マイページ",
+          tabBarIcon: ({ color, size }) => <Ionicons name="person" size={size} color={color} />,
+          tabBarButtonTestID: "tab-profile",
+        }}
+      />
+      {/* タブバーに表示しないが(tabs)グループ内に必要なファイル */}
+      <Tabs.Screen name="health" options={{ href: null }} />
+      <Tabs.Screen name="settings" options={{ href: null }} />
+    </Tabs>
       <AIFloatingFab />
     </>
   );

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,7 +1,82 @@
-import { Redirect } from 'expo-router';
+import { Ionicons } from "@expo/vector-icons";
+import { Link, Redirect } from "expo-router";
+import { ActivityIndicator, Pressable, Text, View } from "react-native";
 
-// 認証は WebView 内 (Web 版の middleware) で処理するため、
-// 起動時に直接 (tabs)/home へリダイレクト
+import { colors, spacing, shadows, radius } from "../src/theme";
+import { useAuth } from "../src/providers/AuthProvider";
+import { useProfile } from "../src/providers/ProfileProvider";
+
 export default function Index() {
-  return <Redirect href="/(tabs)/home" />;
+  const { session, isLoading: authLoading } = useAuth();
+  const { profile, isLoading: profileLoading } = useProfile();
+
+  if (authLoading || (session && profileLoading)) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.bg }}>
+        <ActivityIndicator testID="welcome-loading" color={colors.accent} size="large" />
+      </View>
+    );
+  }
+
+  if (session && !profile?.onboardingCompletedAt) return <Redirect href="/onboarding" />;
+  if (session && profile?.onboardingCompletedAt) return <Redirect href="/(tabs)/home" />;
+
+  return (
+    <View testID="welcome-screen" style={{ flex: 1, backgroundColor: "#FFF7ED" }}>
+      {/* ヒーロー */}
+      <View style={{ flex: 1, justifyContent: "center", alignItems: "center", paddingHorizontal: spacing.xl }}>
+        <View style={{
+          width: 80, height: 80, borderRadius: 24,
+          backgroundColor: colors.accent, alignItems: "center", justifyContent: "center",
+          marginBottom: spacing.lg, ...shadows.lg,
+        }}>
+          <Ionicons name="restaurant" size={40} color="#fff" />
+        </View>
+        <Text style={{ fontSize: 36, fontWeight: "900", color: colors.text, marginBottom: spacing.sm }}>
+          ほめゴハン
+        </Text>
+        <Text style={{ fontSize: 15, color: colors.textLight, textAlign: "center", lineHeight: 22 }}>
+          AIで食事管理をもっと簡単に。{"\n"}写真で記録、献立提案、健康サポートまで。
+        </Text>
+      </View>
+
+      {/* アクション */}
+      <View style={{ paddingHorizontal: spacing.xl, paddingBottom: 60, gap: spacing.md }}>
+        <Link href="/login" asChild>
+          <Pressable testID="welcome-login-button" style={{
+            backgroundColor: colors.accent, borderRadius: radius.lg,
+            paddingVertical: 16, alignItems: "center", ...shadows.md,
+          }}>
+            <Text style={{ color: "#fff", fontSize: 16, fontWeight: "800" }}>ログイン</Text>
+          </Pressable>
+        </Link>
+
+        <Link href="/signup" asChild>
+          <Pressable testID="welcome-signup-button" style={{
+            backgroundColor: colors.card, borderRadius: radius.lg,
+            paddingVertical: 16, alignItems: "center",
+            borderWidth: 1.5, borderColor: colors.accent,
+          }}>
+            <Text style={{ color: colors.accent, fontSize: 16, fontWeight: "800" }}>新規登録</Text>
+          </Pressable>
+        </Link>
+
+        <View style={{
+          flexDirection: "row", justifyContent: "center", gap: spacing.lg,
+          marginTop: spacing.md,
+        }}>
+          {[
+            { href: "/about", label: "アプリについて" },
+            { href: "/pricing", label: "料金" },
+            { href: "/terms", label: "利用規約" },
+            { href: "/privacy", label: "プライバシー" },
+          ].map((item) => (
+            <Link key={item.href} href={item.href as any}>
+              <Text style={{ fontSize: 12, color: colors.textMuted }}>{item.label}</Text>
+            </Link>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
 }


### PR DESCRIPTION
## Summary

- PR #750 で削除されたネイティブ認証ガードを復元
- PR #749 (token bridge) を維持しつつ、ネイティブ認証 + WebView bridge 構成に戻す

### 変更内容

- `apps/mobile/app/index.tsx`: ウェルカム画面 + `useAuth`/`useProfile` セッション確認 + onboarding redirect を復元
- `apps/mobile/app/(tabs)/_layout.tsx`: `!session → /` リダイレクト + `onboardingCompletedAt` チェックを復元

### 起動フロー

```
アプリ起動
→ ネイティブ ウェルカム画面 (ログイン/新規登録ボタン)
→ ログインボタン → ネイティブ login 画面
→ ログイン成功 → (tabs)
→ WebView が token bridge 経由で認証済み Cookie を受け取り Web 版表示
```

## Test plan

- [x] BUILD SUCCEEDED (xcodebuild Debug Simulator)
- [x] 起動 → ネイティブウェルカム画面が表示されること (スクリーンショット確認済み)
- [ ] ログインボタン → ネイティブ login 画面に遷移すること
- [ ] ログイン → (tabs) → WebView が token bridge 経由で認証済み状態で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)