### PR TITLE
fix: ネイティブ AIFloatingFab を tabs レイアウトから削除

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -5,7 +5,6 @@ import { ActivityIndicator, View } from "react-native";
 import { colors } from "../../src/theme";
 import { useAuth } from "../../src/providers/AuthProvider";
 import { useProfile } from "../../src/providers/ProfileProvider";
-import { AIFloatingFab } from "../../src/components/ai/AIFloatingFab";
 
 export default function TabsLayout() {
   const { session, isLoading } = useAuth();
@@ -103,7 +102,6 @@ export default function TabsLayout() {
       <Tabs.Screen name="health" options={{ href: null }} />
       <Tabs.Screen name="settings" options={{ href: null }} />
     </Tabs>
-      <AIFloatingFab />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- `apps/mobile/app/(tabs)/_layout.tsx` から `AIFloatingFab` の import と JSX タグを削除
- WebView 内の Web 版 `AIChatBubble` (apps/web/src/app/(main)/MainLayout.tsx) に一本化し、重複表示を解消
- `AIFloatingFab.tsx` / `AIAdvisorSheet.tsx` のファイル本体は将来用に保持

## Test plan

- [ ] モバイルアプリを起動し、タブ画面に AIFloatingFab が表示されないことを確認
- [ ] WebView 内の Web 版 AIChatBubble が従来通り表示されることを確認
- [ ] 各タブ間の遷移が正常に動作することを確認