### PR TITLE
feat: タブ再タップ時に WebView を初期 URL にリセット

### DIFF
--- a/apps/mobile/src/components/web/WebViewScreen.tsx
+++ b/apps/mobile/src/components/web/WebViewScreen.tsx
@@ -1,7 +1,8 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, useCallback } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { WebView } from 'react-native-webview';
+import { useFocusEffect } from 'expo-router';
 import { colors } from '../../theme/colors';
 import { supabase } from '../../lib/supabase';
 
@@ -19,6 +20,29 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
   const webViewRef = useRef<WebView>(null);
   const [uri, setUri] = useState<string | null>(null);
   const [injectedJS, setInjectedJS] = useState<string>('');
+  // 初回フォーカスをスキップするためのフラグ
+  const isFirstFocus = useRef(true);
+
+  // タブ再タップ時に WebView を初期 URL にリセットする
+  useFocusEffect(useCallback(() => {
+    if (isFirstFocus.current) {
+      isFirstFocus.current = false;
+      return;
+    }
+    // 2 回目以降のフォーカス = 他タブから戻ってきた / タブ再タップ
+    const alreadyHasMode = path.includes('mode=app');
+    const separator = path.includes('?') ? '&' : '?';
+    const targetPath = alreadyHasMode ? path : `${path}${separator}mode=app`;
+    const targetUrl = `${WEB_BASE_URL}${targetPath}`;
+    webViewRef.current?.injectJavaScript(`
+      (function() {
+        if (window.location.href !== '${targetUrl}') {
+          window.location.href = '${targetUrl}';
+        }
+      })();
+      true;
+    `);
+  }, [path]));
 
   useEffect(() => {
     const init = async () => {


### PR DESCRIPTION
## Summary

- `WebViewScreen.tsx` に `useFocusEffect` + `injectJavaScript` (案 B) を実装
- タブが再フォーカスされた際、WebView の現在 URL が初期 URL と異なれば `window.location.href` でリダイレクト
- `isFirstFocus` ref で初回マウント時はスキップし、通常の内部リンク遷移を妨げない設計

## 再現ケース

1. マイページを開く → `/profile/edit` へ内部遷移
2. 献立タブをタップ
3. マイページタブを再タップ
4. **Before**: `/profile/edit` のまま
5. **After**: `/profile` (初期 URL) に戻る

## Test plan

- [ ] マイページ → `/profile/edit` 遷移 → 他タブ → マイページ再タップ → `/profile` に戻ることを確認
- [ ] 初回マウント時に余分なリダイレクトが発生しないことを確認
- [ ] 他タブ (ホーム、献立等) でも同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)