### PR TITLE
fix: タブ再タップ時の WebView URL リセットを tabPress イベントで実装

### DIFF
--- a/apps/mobile/src/components/web/WebViewScreen.tsx
+++ b/apps/mobile/src/components/web/WebViewScreen.tsx
@@ -1,8 +1,8 @@
-import React, { useRef, useState, useEffect, useCallback } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { WebView } from 'react-native-webview';
-import { useFocusEffect } from 'expo-router';
+import { useNavigation } from 'expo-router';
 import { colors } from '../../theme/colors';
 import { supabase } from '../../lib/supabase';
 
@@ -20,29 +20,30 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
   const webViewRef = useRef<WebView>(null);
   const [uri, setUri] = useState<string | null>(null);
   const [injectedJS, setInjectedJS] = useState<string>('');
-  // 初回フォーカスをスキップするためのフラグ
-  const isFirstFocus = useRef(true);
+  const navigation = useNavigation();
 
   // タブ再タップ時に WebView を初期 URL にリセットする
-  useFocusEffect(useCallback(() => {
-    if (isFirstFocus.current) {
-      isFirstFocus.current = false;
-      return;
-    }
-    // 2 回目以降のフォーカス = 他タブから戻ってきた / タブ再タップ
-    const alreadyHasMode = path.includes('mode=app');
-    const separator = path.includes('?') ? '&' : '?';
-    const targetPath = alreadyHasMode ? path : `${path}${separator}mode=app`;
-    const targetUrl = `${WEB_BASE_URL}${targetPath}`;
-    webViewRef.current?.injectJavaScript(`
-      (function() {
-        if (window.location.href !== '${targetUrl}') {
-          window.location.href = '${targetUrl}';
-        }
-      })();
-      true;
-    `);
-  }, [path]));
+  // tabPress は同じタブを再タップした際にも発火するため useFocusEffect より確実
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('tabPress' as any, () => {
+      // isFocused() が true = 既にアクティブなタブを再タップした
+      if (navigation.isFocused()) {
+        const alreadyHasMode = path.includes('mode=app');
+        const separator = path.includes('?') ? '&' : '?';
+        const targetPath = alreadyHasMode ? path : `${path}${separator}mode=app`;
+        const targetUrl = `${WEB_BASE_URL}${targetPath}`;
+        webViewRef.current?.injectJavaScript(`
+          (function() {
+            if (window.location.href !== '${targetUrl}') {
+              window.location.href = '${targetUrl}';
+            }
+          })();
+          true;
+        `);
+      }
+    });
+    return unsubscribe;
+  }, [navigation, path]);
 
   useEffect(() => {
     const init = async () => {


### PR DESCRIPTION
## 問題

PR #754 で実装した「タブ再タップ → WebView URL リセット」が機能していなかった。

`useFocusEffect` はタブ切替時のみ発動し、**同じタブを再タップした場合はフォーカス継続のため発動しない**。

## 変更内容

- `useFocusEffect` + `isFirstFocus` フラグの実装を削除
- `navigation.addListener('tabPress')` によるイベント検知に変更
- `navigation.isFocused() === true` の条件でアクティブタブの再タップを判定
- `useNavigation` (expo-router) を import、`useCallback` / `useFocusEffect` は削除

## 動作

- タブを再タップした際に `tabPress` イベントが発火
- `isFocused()` が true (= 既にアクティブなタブ) の場合のみ WebView を初期 URL にリセット
- `@react-navigation/bottom-tabs` の `tabPress` イベントを Expo Router 経由で利用

## テスト計画

- [ ] ホームタブを開いた状態でホームタブをもう一度タップ → WebView が初期 URL にリセットされること
- [ ] 別タブに切り替えてからホームタブに戻る → リセットが発生すること (tabPress で isFocused=false の場合はスキップ)
- [ ] 各タブ (home / menus / comparison / profile) で同様に動作すること