### PR TITLE
fix: WebView bottom nav フラッシュを Cookie ベース判定で解消

### DIFF
--- a/src/app/(auth)/auth/native-bridge/route.ts
+++ b/src/app/(auth)/auth/native-bridge/route.ts
@@ -60,5 +60,17 @@ export async function GET(req: NextRequest) {
     redirectUrl = new URL('/home?mode=app', req.url)
   }
 
-  return NextResponse.redirect(redirectUrl)
+  const response = NextResponse.redirect(redirectUrl)
+
+  // WebView セッション中は is_native_app Cookie を設定する。
+  // これにより SSR 初回レンダリング時から bottom nav を非表示にでき、
+  // クライアント hydration 後のちらつき (flash) を防ぐ。
+  response.cookies.set('is_native_app', '1', {
+    maxAge: 60 * 60 * 24 * 30, // 30 日
+    httpOnly: false,            // クライアント側 (document.cookie) からも読み取り可能
+    sameSite: 'lax',
+    path: '/',
+  })
+
+  return response
 }

--- a/src/hooks/useNativeAppMode.ts
+++ b/src/hooks/useNativeAppMode.ts
@@ -3,10 +3,30 @@ import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 
 const STORAGE_KEY = 'isNativeApp';
+const COOKIE_NAME = 'is_native_app';
+
+/**
+ * `document.cookie` 文字列から指定キーの値を取得するユーティリティ。
+ * SSR 環境では `document` が存在しないため undefined を返す。
+ */
+function getCookieValue(name: string): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  const match = document.cookie
+    .split('; ')
+    .find((row) => row.startsWith(name + '='));
+  return match ? match.split('=')[1] : undefined;
+}
 
 export function useNativeAppMode(): boolean {
   const searchParams = useSearchParams();
-  const [isNativeApp, setIsNativeApp] = useState(false);
+
+  // 初期値として Cookie を読む。
+  // クライアント初回レンダリング (hydration) 時点でブラウザが Cookie を持っていれば
+  // useState(false) → true の遷移が起きず bottom nav のちらつきを防止できる。
+  // SSR では document が存在しないため false のままにする (SSR は Cookie を読めない)。
+  const [isNativeApp, setIsNativeApp] = useState<boolean>(
+    () => getCookieValue(COOKIE_NAME) === '1',
+  );
 
   useEffect(() => {
     // SSR ガード
@@ -20,7 +40,13 @@ export function useNativeAppMode(): boolean {
       return;
     }
 
-    // 2. sessionStorage から復元
+    // 2. Cookie 判定 (bridge route 経由で設定された場合)
+    if (getCookieValue(COOKIE_NAME) === '1') {
+      setIsNativeApp(true);
+      return;
+    }
+
+    // 3. sessionStorage から復元 (フォールバック)
     const stored = sessionStorage.getItem(STORAGE_KEY);
     setIsNativeApp(stored === '1');
   }, [searchParams]);


### PR DESCRIPTION
## Summary

- `apps/web/src/app/(auth)/auth/native-bridge/route.ts`: setSession 後の redirect response に `is_native_app=1` Cookie を設定(30日間, httpOnly: false, sameSite: lax)
- `apps/web/src/hooks/useNativeAppMode.ts`: `useState` の初期値を `document.cookie` から読む lazy initializer に変更し、hydration 時の first render からCookieを参照可能に。`useEffect` 内にも Cookie 判定を追加、sessionStorage はフォールバックに格下げ

## 問題

PR #745 で実装した sessionStorage / URL パラメータ判定は `useEffect` 内で動作するため、SSR → hydration の間に `isNativeApp = false` の初期状態が画面に描画されてしまい、bottom nav が一瞬表示される(フラッシュ)問題があった。

## 解決方針

- `native-bridge` route を経由すると `is_native_app=1` Cookie がブラウザに保存される
- `useNativeAppMode` の `useState` 初期値関数で `document.cookie` を読むことで、クライアント side の first render 時点(hydrationの最初)から `true` が返る
- SSR では `document` が未定義なので `false` のまま(SSR での Cookie 読み取りは Server Component 化が必要だが、今回は最小変更で対応)
- 既存の sessionStorage / URL パラメータ対応はフォールバックとして維持

## Test plan

- [ ] ネイティブアプリ WebView から `/auth/native-bridge` 経由でログインし、`is_native_app=1` Cookie が付与されることを確認
- [ ] WebView 内でページ遷移しても bottom nav が表示されないことを確認(フラッシュなし)
- [ ] 通常のブラウザからアクセスした場合、bottom nav が正常に表示されることを確認
- [ ] URL に `?mode=app` が付いた場合も従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)