### PR TITLE
feat: AIChatBubble の位置をCookieにも保存してタブ間で共有する

### DIFF
--- a/src/components/AIChatBubble.tsx
+++ b/src/components/AIChatBubble.tsx
@@ -159,6 +159,12 @@ export default function AIChatBubble() {
   const [fabPosition, setFabPosition] = useState<{ x: number; y: number }>(() => {
     if (typeof window === 'undefined') return { x: 16, y: 96 };
     try {
+      // Cookie 優先（タブ間共有）
+      const cookieMatch = document.cookie.match(/aiChatBubblePosition=([^;]+)/);
+      if (cookieMatch) {
+        return JSON.parse(decodeURIComponent(cookieMatch[1]));
+      }
+      // フォールバック: localStorage
       const saved = localStorage.getItem('aiChatBubblePosition');
       if (saved) return JSON.parse(saved);
     } catch {
@@ -838,7 +844,10 @@ export default function AIChatBubble() {
               if (wasDrag) {
                 // ドラッグ終了 → 最終位置を保存 (ref から最新値を取得)
                 try {
-                  localStorage.setItem('aiChatBubblePosition', JSON.stringify(fabPositionRef.current));
+                  const json = JSON.stringify(fabPositionRef.current);
+                  localStorage.setItem('aiChatBubblePosition', json);
+                  // Cookie にも保存（タブ間共有、30日）
+                  document.cookie = `aiChatBubblePosition=${encodeURIComponent(json)}; path=/; max-age=${60 * 60 * 24 * 30}; samesite=lax`;
                 } catch {
                   // ignore
                 }


### PR DESCRIPTION
## Summary

- ドラッグ終了時の位置保存を `localStorage` 単体から **Cookie + localStorage の併用** に変更
- Cookie の属性: `path=/; max-age=2592000 (30日); samesite=lax`（secure は付けない。既存の `sharedCookiesEnabled` 設定でタブ間共有される）
- 位置の読み込み時は **Cookie を優先**し、未設定の場合は localStorage にフォールバック
- これにより `sharedCookiesEnabled: true` の WebView 環境でホームタブとメニュータブの位置が同期される

## Test plan

- [ ] FAB をドラッグして位置を変更する
- [ ] 別タブ（例: メニュータブ）に切り替えてアプリを再表示したとき、同じ位置に FAB が表示されることを確認
- [ ] アプリを再起動したとき、前回位置が復元されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)