### PR TITLE
feat: AIFloatingFab をドラッグ可能にし mode=app 時に WEB バブルを非表示化

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -5,6 +5,7 @@ import { ActivityIndicator, View } from "react-native";
 import { colors } from "../../src/theme";
 import { useAuth } from "../../src/providers/AuthProvider";
 import { useProfile } from "../../src/providers/ProfileProvider";
+import { AIFloatingFab } from "../../src/components/ai/AIFloatingFab";
 
 export default function TabsLayout() {
   const { session, isLoading } = useAuth();
@@ -102,6 +103,7 @@ export default function TabsLayout() {
       <Tabs.Screen name="health" options={{ href: null }} />
       <Tabs.Screen name="settings" options={{ href: null }} />
     </Tabs>
+    <AIFloatingFab />
     </>
   );
 }

--- a/apps/mobile/src/components/ai/AIFloatingFab.tsx
+++ b/apps/mobile/src/components/ai/AIFloatingFab.tsx
@@ -1,10 +1,26 @@
-import { Ionicons } from "@expo/vector-icons";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { LinearGradient } from "expo-linear-gradient";
-import { useState } from "react";
-import { Pressable, StyleSheet } from "react-native";
+import { Sparkles } from "lucide-react-native";
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Animated,
+  Dimensions,
+  PanResponder,
+} from "react-native";
 
 import { colors, shadows } from "../../theme";
 import { AIAdvisorSheet } from "./AIAdvisorSheet";
+
+// ============================================================
+// Constants
+// ============================================================
+
+const FAB_SIZE = 56;
+const STORAGE_KEY = "aiFabPosition";
+const { width: SCREEN_W, height: SCREEN_H } = Dimensions.get("window");
+
+const DEFAULT_X = SCREEN_W - FAB_SIZE - 16;
+const DEFAULT_Y = SCREEN_H - FAB_SIZE - 100;
 
 // ============================================================
 // Component
@@ -13,49 +29,122 @@ import { AIAdvisorSheet } from "./AIAdvisorSheet";
 export const AIFloatingFab: React.FC = () => {
   const [visible, setVisible] = useState(false);
 
+  const pan = useRef(
+    new Animated.ValueXY({ x: DEFAULT_X, y: DEFAULT_Y })
+  ).current;
+
+  const dragStart = useRef<{
+    t: number;
+    x: number;
+    y: number;
+  } | null>(null);
+  const isDraggingRef = useRef(false);
+
+  // mount 時: AsyncStorage から位置を復元
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((saved) => {
+        if (saved) {
+          try {
+            const { x, y } = JSON.parse(saved);
+            pan.setValue({ x, y });
+          } catch {
+            // ignore malformed JSON
+          }
+        }
+      })
+      .catch(() => {
+        // ignore storage error
+      });
+  }, [pan]);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_evt, g) =>
+        Math.abs(g.dx) > 5 || Math.abs(g.dy) > 5,
+
+      onPanResponderGrant: () => {
+        // Animated.ValueXY の内部値を取得するために _value を参照
+        const xVal = (pan.x as any)._value as number;
+        const yVal = (pan.y as any)._value as number;
+        dragStart.current = { t: Date.now(), x: xVal, y: yVal };
+        isDraggingRef.current = false;
+      },
+
+      onPanResponderMove: (_evt, g) => {
+        if (!dragStart.current) return;
+        if (Math.abs(g.dx) > 5 || Math.abs(g.dy) > 5) {
+          isDraggingRef.current = true;
+        }
+        const newX = Math.max(
+          8,
+          Math.min(SCREEN_W - FAB_SIZE - 8, dragStart.current.x + g.dx)
+        );
+        const newY = Math.max(
+          40,
+          Math.min(SCREEN_H - FAB_SIZE - 100, dragStart.current.y + g.dy)
+        );
+        pan.setValue({ x: newX, y: newY });
+      },
+
+      onPanResponderRelease: (_evt, g) => {
+        if (!dragStart.current) return;
+        const elapsed = Date.now() - dragStart.current.t;
+        const moved =
+          Math.abs(g.dx) > 5 || Math.abs(g.dy) > 5 || elapsed > 250;
+
+        if (moved || isDraggingRef.current) {
+          // ドラッグ終了 → 位置を保存
+          const xVal = (pan.x as any)._value as number;
+          const yVal = (pan.y as any)._value as number;
+          AsyncStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ x: xVal, y: yVal })
+          ).catch(() => {
+            // ignore storage error
+          });
+        } else {
+          // タップ → シートを開く
+          setVisible(true);
+        }
+        dragStart.current = null;
+        isDraggingRef.current = false;
+      },
+    })
+  ).current;
+
   return (
     <>
-      <Pressable
+      <Animated.View
         testID="ai-floating-fab"
-        onPress={() => setVisible(true)}
-        style={styles.fab}
+        style={{
+          position: "absolute",
+          left: pan.x,
+          top: pan.y,
+          zIndex: 999,
+          elevation: 10,
+        }}
+        {...panResponder.panHandlers}
       >
         <LinearGradient
           colors={[colors.accent, colors.warning]}
           start={{ x: 0, y: 0 }}
           end={{ x: 1, y: 1 }}
-          style={styles.fabGradient}
+          style={{
+            width: FAB_SIZE,
+            height: FAB_SIZE,
+            borderRadius: FAB_SIZE / 2,
+            alignItems: "center",
+            justifyContent: "center",
+            ...(shadows.lg as object),
+          }}
         >
-          <Ionicons name="sparkles" size={20} color="#FFF" />
+          <Sparkles size={24} color="#FFF" />
         </LinearGradient>
-      </Pressable>
+      </Animated.View>
 
       <AIAdvisorSheet visible={visible} onClose={() => setVisible(false)} />
     </>
   );
 };
-
-// ============================================================
-// Styles
-// ============================================================
-
-const styles = StyleSheet.create({
-  fab: {
-    position: "absolute",
-    bottom: 120,
-    right: 16,
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    ...shadows.lg,
-    zIndex: 1000,
-    elevation: 10,
-  },
-  fabGradient: {
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-});

--- a/src/components/AIChatBubble.tsx
+++ b/src/components/AIChatBubble.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useV4MenuGeneration } from "@/hooks/useV4MenuGeneration";
 import { notifyMenuGenerated } from "@/lib/local-notification";
+import { useNativeAppMode } from "@/hooks/useNativeAppMode";
 
 // シンプルなマークダウンパーサー
 const parseMarkdown = (text: string): string => {
@@ -139,6 +140,7 @@ const ACTION_LABELS: Record<string, { label: string; icon: any; color: string }>
 };
 
 export default function AIChatBubble() {
+  const isNativeApp = useNativeAppMode();
   const [isMounted, setIsMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [sessions, setSessions] = useState<Session[]>([]);
@@ -785,6 +787,11 @@ export default function AIChatBubble() {
 
   // サーバーサイドでは何もレンダリングしない
   if (!isMounted) {
+    return null;
+  }
+
+  // ネイティブアプリ (mode=app) ではモバイル側の AIFloatingFab に任せる
+  if (isNativeApp) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- **WEB側** (`src/components/AIChatBubble.tsx`): `useNativeAppMode` フックを追加し、`mode=app` 時 (ネイティブアプリ WebView) は `return null` してモバイル実装に委譲
- **ネイティブ側** (`apps/mobile/src/components/ai/AIFloatingFab.tsx`): `PanResponder` + `Animated.ValueXY` によるドラッグ対応を追加。`AsyncStorage` (key: `aiFabPosition`) で位置を永続化し、タップ (<5px & <250ms) とドラッグを判別してシートを開く
- **レイアウト** (`apps/mobile/app/(tabs)/_layout.tsx`): PR #753 で削除された `AIFloatingFab` の import と JSX を再追加。`<Tabs>` の隣に配置してすべてのタブで共通表示

## Test plan

- [ ] iOS/Android シミュレータで FAB が右下に表示されることを確認
- [ ] FAB をドラッグして位置を変更 → アプリ再起動後に位置が復元されることを確認
- [ ] FAB をタップして `AIAdvisorSheet` が開くことを確認
- [ ] WEB で `?mode=app` を付けてアクセスし、AIChatBubble が非表示になることを確認
- [ ] WEB で通常アクセス時は AIChatBubble が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)