### PR TITLE
fix: AI FAB による iOS 黒画面を修正

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -31,79 +31,79 @@ export default function TabsLayout() {
   }
 
   return (
-    <>
+    <View style={{ flex: 1 }}>
       <Tabs
-      screenOptions={{
-        headerShown: false,
-        tabBarStyle: {
-          backgroundColor: colors.card,
-          borderTopColor: colors.border,
-          height: 88,
-          paddingBottom: 30,
-          paddingTop: 8,
-        },
-        tabBarActiveTintColor: colors.accent,
-        tabBarInactiveTintColor: colors.textMuted,
-        tabBarLabelStyle: { fontSize: 11, fontWeight: "600" },
-      }}
-    >
-      <Tabs.Screen
-        name="home"
-        options={{
-          title: "ホーム",
-          tabBarIcon: ({ color, size }) => <Ionicons name="home" size={size} color={color} />,
-          tabBarButtonTestID: "tab-home",
+        screenOptions={{
+          headerShown: false,
+          tabBarStyle: {
+            backgroundColor: colors.card,
+            borderTopColor: colors.border,
+            height: 88,
+            paddingBottom: 30,
+            paddingTop: 8,
+          },
+          tabBarActiveTintColor: colors.accent,
+          tabBarInactiveTintColor: colors.textMuted,
+          tabBarLabelStyle: { fontSize: 11, fontWeight: "600" },
         }}
-      />
-      <Tabs.Screen
-        name="menus"
-        options={{
-          title: "献立",
-          tabBarIcon: ({ color, size }) => <Ionicons name="book-outline" size={size} color={color} />,
-          tabBarButtonTestID: "tab-menus",
-        }}
-      />
-      <Tabs.Screen
-        name="meals"
-        options={{
-          title: "スキャン",
-          tabBarIcon: () => (
-            <View style={{
-              width: 48, height: 48, borderRadius: 24,
-              backgroundColor: colors.text, alignItems: "center", justifyContent: "center",
-              marginBottom: 16,
-            }}>
-              <Ionicons name="scan" size={24} color="#fff" />
-            </View>
-          ),
-          tabBarLabel: () => null,
-        }}
-      />
-      <Tabs.Screen
-        name="favorites"
-        options={{ href: null }}
-      />
-      <Tabs.Screen
-        name="comparison"
-        options={{
-          title: "比較",
-          tabBarIcon: ({ color, size }) => <Ionicons name="bar-chart" size={size} color={color} />,
-          tabBarButtonTestID: "tab-comparison",
-        }}
-      />
-      <Tabs.Screen
-        name="profile"
-        options={{
-          title: "マイページ",
-          tabBarIcon: ({ color, size }) => <Ionicons name="person" size={size} color={color} />,
-          tabBarButtonTestID: "tab-profile",
-        }}
-      />
-      {/* タブバーに表示しないが(tabs)グループ内に必要なファイル */}
-      <Tabs.Screen name="health" options={{ href: null }} />
-      <Tabs.Screen name="settings" options={{ href: null }} />
-    </Tabs>
-    <AIFloatingFab />
-    </>
+      >
+        <Tabs.Screen
+          name="home"
+          options={{
+            title: "ホーム",
+            tabBarIcon: ({ color, size }) => <Ionicons name="home" size={size} color={color} />,
+            tabBarButtonTestID: "tab-home",
+          }}
+        />
+        <Tabs.Screen
+          name="menus"
+          options={{
+            title: "献立",
+            tabBarIcon: ({ color, size }) => <Ionicons name="book-outline" size={size} color={color} />,
+            tabBarButtonTestID: "tab-menus",
+          }}
+        />
+        <Tabs.Screen
+          name="meals"
+          options={{
+            title: "スキャン",
+            tabBarIcon: () => (
+              <View style={{
+                width: 48, height: 48, borderRadius: 24,
+                backgroundColor: colors.text, alignItems: "center", justifyContent: "center",
+                marginBottom: 16,
+              }}>
+                <Ionicons name="scan" size={24} color="#fff" />
+              </View>
+            ),
+            tabBarLabel: () => null,
+          }}
+        />
+        <Tabs.Screen
+          name="favorites"
+          options={{ href: null }}
+        />
+        <Tabs.Screen
+          name="comparison"
+          options={{
+            title: "比較",
+            tabBarIcon: ({ color, size }) => <Ionicons name="bar-chart" size={size} color={color} />,
+            tabBarButtonTestID: "tab-comparison",
+          }}
+        />
+        <Tabs.Screen
+          name="profile"
+          options={{
+            title: "マイページ",
+            tabBarIcon: ({ color, size }) => <Ionicons name="person" size={size} color={color} />,
+            tabBarButtonTestID: "tab-profile",
+          }}
+        />
+        {/* タブバーに表示しないが(tabs)グループ内に必要なファイル */}
+        <Tabs.Screen name="health" options={{ href: null }} />
+        <Tabs.Screen name="settings" options={{ href: null }} />
+      </Tabs>
+      <AIFloatingFab />
+    </View>
   );
 }

--- a/apps/mobile/src/components/ai/AIFloatingFab.tsx
+++ b/apps/mobile/src/components/ai/AIFloatingFab.tsx
@@ -1,111 +1,74 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { LinearGradient } from "expo-linear-gradient";
-import { Sparkles } from "lucide-react-native";
-import React, { useEffect, useRef, useState } from "react";
-import {
-  Animated,
-  Dimensions,
-  PanResponder,
-} from "react-native";
-
-import { colors, shadows } from "../../theme";
-import { AIAdvisorSheet } from "./AIAdvisorSheet";
-
-// ============================================================
-// Constants
-// ============================================================
+import React, { useState, useRef, useEffect } from 'react';
+import { Animated, PanResponder, useWindowDimensions, View } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Sparkles } from 'lucide-react-native';
+import { colors } from '../../theme/colors';
+import { AIAdvisorSheet } from './AIAdvisorSheet';
 
 const FAB_SIZE = 56;
-const STORAGE_KEY = "aiFabPosition";
-const { width: SCREEN_W, height: SCREEN_H } = Dimensions.get("window");
-
-const DEFAULT_X = SCREEN_W - FAB_SIZE - 16;
-const DEFAULT_Y = SCREEN_H - FAB_SIZE - 100;
-
-// ============================================================
-// Component
-// ============================================================
+const STORAGE_KEY = 'aiFabPosition';
 
 export const AIFloatingFab: React.FC = () => {
+  const { width: SCREEN_W, height: SCREEN_H } = useWindowDimensions();
   const [visible, setVisible] = useState(false);
 
-  const pan = useRef(
-    new Animated.ValueXY({ x: DEFAULT_X, y: DEFAULT_Y })
-  ).current;
+  const defaultX = SCREEN_W - FAB_SIZE - 16;
+  const defaultY = SCREEN_H - FAB_SIZE - 100;
 
-  const dragStart = useRef<{
-    t: number;
-    x: number;
-    y: number;
-  } | null>(null);
+  const pan = useRef(new Animated.ValueXY({ x: defaultX, y: defaultY })).current;
+  // 位置を独自 ref で追跡 (._value 内部 API を避ける)
+  const posRef = useRef({ x: defaultX, y: defaultY });
+  const dragStart = useRef<{ t: number; x: number; y: number } | null>(null);
   const isDraggingRef = useRef(false);
 
-  // mount 時: AsyncStorage から位置を復元
+  // 初回 mount: AsyncStorage から復元
   useEffect(() => {
-    AsyncStorage.getItem(STORAGE_KEY)
-      .then((saved) => {
-        if (saved) {
-          try {
-            const { x, y } = JSON.parse(saved);
+    AsyncStorage.getItem(STORAGE_KEY).then(saved => {
+      if (saved) {
+        try {
+          const { x, y } = JSON.parse(saved);
+          if (typeof x === 'number' && typeof y === 'number') {
             pan.setValue({ x, y });
-          } catch {
-            // ignore malformed JSON
+            posRef.current = { x, y };
           }
+        } catch {
+          // ignore malformed JSON
         }
-      })
-      .catch(() => {
-        // ignore storage error
-      });
-  }, [pan]);
+      }
+    }).catch(() => {
+      // ignore storage error
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const panResponder = useRef(
     PanResponder.create({
       onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: (_evt, g) =>
-        Math.abs(g.dx) > 5 || Math.abs(g.dy) > 5,
-
+      onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dx) > 5 || Math.abs(g.dy) > 5,
       onPanResponderGrant: () => {
-        // Animated.ValueXY の内部値を取得するために _value を参照
-        const xVal = (pan.x as any)._value as number;
-        const yVal = (pan.y as any)._value as number;
-        dragStart.current = { t: Date.now(), x: xVal, y: yVal };
+        dragStart.current = { t: Date.now(), x: posRef.current.x, y: posRef.current.y };
         isDraggingRef.current = false;
       },
-
-      onPanResponderMove: (_evt, g) => {
+      onPanResponderMove: (_, g) => {
         if (!dragStart.current) return;
         if (Math.abs(g.dx) > 5 || Math.abs(g.dy) > 5) {
           isDraggingRef.current = true;
         }
-        const newX = Math.max(
-          8,
-          Math.min(SCREEN_W - FAB_SIZE - 8, dragStart.current.x + g.dx)
-        );
-        const newY = Math.max(
-          40,
-          Math.min(SCREEN_H - FAB_SIZE - 100, dragStart.current.y + g.dy)
-        );
+        const newX = dragStart.current.x + g.dx;
+        const newY = dragStart.current.y + g.dy;
         pan.setValue({ x: newX, y: newY });
+        posRef.current = { x: newX, y: newY };
       },
-
-      onPanResponderRelease: (_evt, g) => {
-        if (!dragStart.current) return;
-        const elapsed = Date.now() - dragStart.current.t;
-        const moved =
-          Math.abs(g.dx) > 5 || Math.abs(g.dy) > 5 || elapsed > 250;
-
-        if (moved || isDraggingRef.current) {
-          // ドラッグ終了 → 位置を保存
-          const xVal = (pan.x as any)._value as number;
-          const yVal = (pan.y as any)._value as number;
-          AsyncStorage.setItem(
-            STORAGE_KEY,
-            JSON.stringify({ x: xVal, y: yVal })
-          ).catch(() => {
-            // ignore storage error
-          });
+      onPanResponderRelease: () => {
+        if (isDraggingRef.current) {
+          // クランプして保存
+          const clampedX = Math.max(8, Math.min((SCREEN_W || 400) - FAB_SIZE - 8, posRef.current.x));
+          const clampedY = Math.max(40, Math.min((SCREEN_H || 800) - FAB_SIZE - 100, posRef.current.y));
+          pan.setValue({ x: clampedX, y: clampedY });
+          posRef.current = { x: clampedX, y: clampedY };
+          AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ x: clampedX, y: clampedY })).catch(() => {});
         } else {
-          // タップ → シートを開く
           setVisible(true);
         }
         dragStart.current = null;
@@ -119,31 +82,40 @@ export const AIFloatingFab: React.FC = () => {
       <Animated.View
         testID="ai-floating-fab"
         style={{
-          position: "absolute",
-          left: pan.x,
-          top: pan.y,
+          position: 'absolute',
+          transform: [{ translateX: pan.x }, { translateY: pan.y }],
+          left: 0,
+          top: 0,
           zIndex: 999,
-          elevation: 10,
         }}
         {...panResponder.panHandlers}
       >
-        <LinearGradient
-          colors={[colors.accent, colors.warning]}
-          start={{ x: 0, y: 0 }}
-          end={{ x: 1, y: 1 }}
+        <View
           style={{
             width: FAB_SIZE,
             height: FAB_SIZE,
             borderRadius: FAB_SIZE / 2,
-            alignItems: "center",
-            justifyContent: "center",
-            ...(shadows.lg as object),
+            overflow: 'hidden',
+            shadowColor: '#000',
+            shadowOpacity: 0.2,
+            shadowRadius: 8,
+            shadowOffset: { width: 0, height: 4 },
+            elevation: 6,
           }}
         >
-          <Sparkles size={24} color="#FFF" />
-        </LinearGradient>
+          <LinearGradient
+            colors={[colors.accent, colors.warning]}
+            style={{
+              width: FAB_SIZE,
+              height: FAB_SIZE,
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            <Sparkles size={24} color="#FFF" />
+          </LinearGradient>
+        </View>
       </Animated.View>
-
       <AIAdvisorSheet visible={visible} onClose={() => setVisible(false)} />
     </>
   );


### PR DESCRIPTION
## Summary

- `(tabs)/_layout.tsx`: expo-router の `Tabs` を Fragment (`<>`) でラップしていた問題を修正。`View (flex:1)` に変更し、Tabs が正しくレンダリングされるよう対応
- `AIFloatingFab.tsx`: `Dimensions.get('window')` のモジュールスコープ呼び出しを `useWindowDimensions()` フックに変更し、初期座標が NaN/0 になるリスクを排除
- `AIFloatingFab.tsx`: `(pan.x as any)._value` という Animated の内部 API 参照を `posRef` による独自位置トラッキングに置き換え、New Architecture (JSI) 対応を実現

## Test plan

- [ ] iOS Simulator で黒画面が表示されないことを確認
- [ ] AI FAB がドラッグ可能であること、位置が AsyncStorage に保存・復元されることを確認
- [ ] AI FAB タップで AIAdvisorSheet が開くことを確認
- [ ] Android でも動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)