### PR TITLE
fix: ネイティブアプリ WebView ロード時の BottomNav フラッシュを解消

### DIFF
--- a/src/app/(main)/MainLayout.tsx
+++ b/src/app/(main)/MainLayout.tsx
@@ -29,9 +29,13 @@ const NAV_ITEMS = [
 /**
  * useNativeAppMode は useSearchParams を使うため Suspense 境界内で呼び出す必要がある。
  * BottomNav コンポーネントに分離することで Suspense を局所化する。
+ *
+ * initialIsNativeApp: SSR 時に server 側 (layout.tsx) で Cookie を読んだ初期値。
+ * これを useState の初期値として渡すことで、ハイドレーション前の HTML から
+ * 既に正しい表示状態が反映され、BottomNav のちらつき (フラッシュ) を防止する。
  */
-function BottomNav({ pathname }: { pathname: string }) {
-  const isNativeApp = useNativeAppMode();
+function BottomNav({ pathname, initialIsNativeApp }: { pathname: string; initialIsNativeApp: boolean }) {
+  const isNativeApp = useNativeAppMode(initialIsNativeApp);
 
   if (isNativeApp) return null;
 
@@ -82,8 +86,10 @@ function BottomNav({ pathname }: { pathname: string }) {
 
 export default function MainLayout({
   children,
+  initialIsNativeApp = false,
 }: {
   children: React.ReactNode
+  initialIsNativeApp?: boolean
 }) {
   const pathname = usePathname();
   const [userRoles, setUserRoles] = useState<string[]>([]);
@@ -249,7 +255,7 @@ export default function MainLayout({
 
       {/* モバイル用ボトムナビゲーション (Floating) — isNativeApp 時は非表示 */}
       <Suspense fallback={null}>
-        <BottomNav pathname={pathname} />
+        <BottomNav pathname={pathname} initialIsNativeApp={initialIsNativeApp} />
       </Suspense>
 
     </div>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -4,8 +4,15 @@
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
+import { cookies } from 'next/headers';
 import MainLayout from './MainLayout';
 
-export default function Layout({ children }: { children: React.ReactNode }) {
-  return <MainLayout>{children}</MainLayout>;
+export default async function Layout({ children }: { children: React.ReactNode }) {
+  // SSR 初回レンダリング時に Cookie を参照し、native アプリモードを判定
+  // middleware が ?mode=app を検出して Cookie をセットするため、
+  // 最初のリクエストから正しい初期値をクライアントへ渡せる
+  const cookieStore = await cookies();
+  const initialIsNativeApp = cookieStore.get('is_native_app')?.value === '1';
+
+  return <MainLayout initialIsNativeApp={initialIsNativeApp}>{children}</MainLayout>;
 }

--- a/src/hooks/useNativeAppMode.ts
+++ b/src/hooks/useNativeAppMode.ts
@@ -17,15 +17,22 @@ function getCookieValue(name: string): string | undefined {
   return match ? match.split('=')[1] : undefined;
 }
 
-export function useNativeAppMode(): boolean {
+/**
+ * @param initialIsNativeApp
+ *   server 側 (layout.tsx) で Cookie を読んだ初期値。
+ *   これを useState の初期値として使うことで、SSR HTML とクライアント初回 render が
+ *   一致し、BottomNav のフラッシュ (一瞬表示 → 消える) を防止できる。
+ *   省略時はクライアント側の Cookie / sessionStorage / URL params のみで判定する。
+ */
+export function useNativeAppMode(initialIsNativeApp?: boolean): boolean {
   const searchParams = useSearchParams();
 
-  // 初期値として Cookie を読む。
-  // クライアント初回レンダリング (hydration) 時点でブラウザが Cookie を持っていれば
-  // useState(false) → true の遷移が起きず bottom nav のちらつきを防止できる。
-  // SSR では document が存在しないため false のままにする (SSR は Cookie を読めない)。
+  // 初期値の優先順位:
+  //   1. server から渡された initialIsNativeApp (SSR Cookie 判定済み)
+  //   2. クライアント側の document.cookie (ハイドレーション後の2回目以降)
+  // これにより SSR → ハイドレーションのフラッシュを防止する。
   const [isNativeApp, setIsNativeApp] = useState<boolean>(
-    () => getCookieValue(COOKIE_NAME) === '1',
+    () => initialIsNativeApp ?? getCookieValue(COOKIE_NAME) === '1',
   );
 
   useEffect(() => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,22 @@ import { type NextRequest } from 'next/server'
 import { updateSession } from '@/lib/supabase/middleware'
 
 export async function middleware(request: NextRequest) {
-  return await updateSession(request)
+  const res = await updateSession(request)
+
+  // ?mode=app が付いていれば is_native_app Cookie をセット
+  // これにより SSR 初回レンダリング時に cookies() で native 判定できる
+  const isAppMode = request.nextUrl.searchParams.get('mode') === 'app'
+  const existingCookie = request.cookies.get('is_native_app')?.value
+  if (isAppMode && existingCookie !== '1') {
+    res.cookies.set('is_native_app', '1', {
+      maxAge: 60 * 60 * 24 * 30,
+      httpOnly: false,
+      sameSite: 'lax',
+      path: '/',
+    })
+  }
+
+  return res
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

- `src/middleware.ts`: `?mode=app` クエリパラメータを検出し `is_native_app=1` Cookie を即時セット (Supabase auth 処理は保持)
- `src/app/(main)/layout.tsx`: server component として `cookies()` で `is_native_app` を読み取り `initialIsNativeApp` を `MainLayout` へ props として渡す
- `src/app/(main)/MainLayout.tsx`: `BottomNav` に `initialIsNativeApp` props を追加し `useNativeAppMode` へ伝播
- `src/hooks/useNativeAppMode.ts`: `initialIsNativeApp` 引数を追加し `useState` 初期値に server 側判定値を優先使用

## フラッシュ解消の仕組み

従来: SSR 時点では Cookie/sessionStorage/URL params が読めず `isNativeApp=false` → BottomNav が SSR HTML に含まれる → ハイドレーション後 `true` に切り替わり消える = フラッシュ

修正後:
1. middleware が `?mode=app` を検出して Cookie をセット (同一レスポンスで返却)
2. layout.tsx (server) が `cookies()` で Cookie を読んで `initialIsNativeApp=true` を取得
3. その値を `BottomNav` → `useNativeAppMode` の `useState` 初期値として渡す
4. SSR HTML 生成時から `isNativeApp=true` として扱われるため BottomNav が HTML に含まれない → フラッシュなし

## Test plan

- [ ] `?mode=app` 付き URL でアクセス → レスポンスヘッダーに `Set-Cookie: is_native_app=1` が含まれること
- [ ] ネイティブ WebView で起動 → BottomNav が一瞬も表示されないこと
- [ ] 通常ブラウザでアクセス → BottomNav が正常に表示されること
- [ ] 認証フロー (ログイン・ログアウト) が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)