### PR TITLE
chore: EAS TestFlight 配布環境セットアップ

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -50,8 +50,10 @@
     ],
     "extra": {
       "eas": {
-        "projectId": ""
-      }
-    }
+        "projectId": "ce2a0961-4696-472c-8377-a3f83cecdff5"
+      },
+      "router": {}
+    },
+    "owner": "nvidia.homeftp.net"
   }
 }

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -47,9 +47,9 @@
   "submit": {
     "production": {
       "ios": {
-        "appleId": "REPLACE_WITH_APPLE_ID@example.com",
+        "appleId": "hori@hori.tech",
         "ascAppId": "REPLACE_WITH_APP_STORE_CONNECT_APP_ID",
-        "appleTeamId": "REPLACE_WITH_APPLE_TEAM_ID"
+        "appleTeamId": "PW644RQ3ZR"
       },
       "android": {
         "serviceAccountKeyPath": "../../secrets/google-play-service-account.json",
@@ -59,9 +59,9 @@
     },
     "preview": {
       "ios": {
-        "appleId": "REPLACE_WITH_APPLE_ID@example.com",
+        "appleId": "hori@hori.tech",
         "ascAppId": "REPLACE_WITH_APP_STORE_CONNECT_APP_ID",
-        "appleTeamId": "REPLACE_WITH_APPLE_TEAM_ID"
+        "appleTeamId": "PW644RQ3ZR"
       },
       "android": {
         "serviceAccountKeyPath": "../../secrets/google-play-service-account.json",


### PR DESCRIPTION
## Summary

- `eas.json` の `submit.production.ios` と `submit.preview.ios` に `appleId` (`hori@hori.tech`) と `appleTeamId` (`PW644RQ3ZR`) を設定
- `ascAppId` は App Store Connect でアプリ作成後に別 PR で更新予定のためプレースホルダー維持
- `app.json` の `extra.eas.projectId` を EAS init で生成した `ce2a0961-4696-472c-8377-a3f83cecdff5` に更新
- Expo プロジェクト `owner` を `nvidia.homeftp.net` に設定

## Test plan

- [ ] `eas.json` に正しい appleId / appleTeamId が設定されていること
- [ ] `app.json` の projectId が空でないこと
- [ ] ascAppId が `REPLACE_WITH_APP_STORE_CONNECT_APP_ID` のままであること (後続作業)

🤖 Generated with [Claude Code](https://claude.com/claude-code)