### PR TITLE
chore: EAS submit プロファイルに ascAppId を設定

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -48,7 +48,7 @@
     "production": {
       "ios": {
         "appleId": "hori@hori.tech",
-        "ascAppId": "REPLACE_WITH_APP_STORE_CONNECT_APP_ID",
+        "ascAppId": "6766483691",
         "appleTeamId": "PW644RQ3ZR"
       },
       "android": {
@@ -60,7 +60,7 @@
     "preview": {
       "ios": {
         "appleId": "hori@hori.tech",
-        "ascAppId": "REPLACE_WITH_APP_STORE_CONNECT_APP_ID",
+        "ascAppId": "6766483691",
         "appleTeamId": "PW644RQ3ZR"
       },
       "android": {


### PR DESCRIPTION
## Summary

- `eas.json` の `submit.production.ios.ascAppId` および `submit.preview.ios.ascAppId` のプレースホルダー (`REPLACE_WITH_APP_STORE_CONNECT_APP_ID`) を実値 `6766483691` に置換
- `appleId` (`hori@hori.tech`) と `appleTeamId` (`PW644RQ3ZR`) は前回 PR #763 で設定済み
- これで iOS preview / production ビルドの TestFlight 自動提出が可能になる

## Test plan

- [ ] `eas.json` に残存プレースホルダーがないことを確認
- [ ] `eas build --platform ios --profile preview` が credential エラーなく起動できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)