### PR TITLE
chore: EAS ビルドアーカイブ縮小のため .easignore を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ apps/mobile/.expo
 apps/mobile/dist
 apps/mobile/web-build
 apps/mobile/.eas*
+!apps/mobile/.easignore
 
 # データセット（CSVは大きいのでGitに含めない）
 data/raw/

--- a/apps/mobile/.easignore
+++ b/apps/mobile/.easignore
@@ -1,0 +1,40 @@
+# Build artifacts
+ios/build/
+ios/Pods/
+ios/DerivedData/
+android/build/
+android/app/build/
+android/.gradle/
+android/.idea/
+
+# Native dependencies (re-installed by EAS)
+node_modules/
+
+# Caches
+.expo/
+.expo-shared/
+.metro-cache/
+.gradle/
+.cxx/
+
+# Test artifacts
+coverage/
+*.log
+maestro-output/
+.maestro/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/
+*.swp
+
+# Source maps (regenerated)
+*.map
+
+# Local env (sensitive, EAS env vars used instead)
+.env.local
+.env.*.local


### PR DESCRIPTION
## Summary

- `apps/mobile/.easignore` を新規追加し、EAS ビルド時のアーカイブから不要ファイルを除外
- 対象: `ios/Pods/`, `android/build/`, `node_modules/`, `.expo/`, キャッシュ類など
- 現状 1.4 GB のアーカイブが 50–200 MB 程度に縮小する見込み
- ルート `.gitignore` の `apps/mobile/.eas*` パターンが `.easignore` も除外していたため、`!apps/mobile/.easignore` の例外行を追加

## 背景

`.easignore` がない場合は `.gitignore` がフォールバックとして使われる。
ただし `ios/Pods/` は `apps/mobile/ios/.gitignore` で除外されているが、
EAS がそれを参照していない可能性があるため、`.easignore` で明示的に列挙する。

## Test plan

- [ ] このPRマージ後の次回 `eas build` でアーカイブサイズが大幅に縮小することを確認
- [ ] ビルドが正常に完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)