### PR TITLE
fix: bare workflow 向けに runtimeVersion を固定文字列へ変更

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -28,9 +28,7 @@
         "NSPhotoLibraryAddUsageDescription": "解析結果の保存のために写真ライブラリへ追加する場合があります。"
       },
       "icon": "./assets/icon-ios.png",
-      "runtimeVersion": {
-        "policy": "appVersion"
-      }
+      "runtimeVersion": "1.0.0"
     },
     "android": {
       "package": "com.homegohan.app",
@@ -46,9 +44,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#E07A5F"
       },
-      "runtimeVersion": {
-        "policy": "appVersion"
-      }
+      "runtimeVersion": "1.0.0"
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
## 概要

- `apps/mobile/ios/` ディレクトリが存在する bare workflow 環境では `{ "policy": "appVersion" }` 文法が使えず EAS build が失敗していた
- iOS・Android 両方の `runtimeVersion` を `"1.0.0"` (固定文字列) に変更
- `updates.enabled: false` / `checkAutomatically: "NEVER"` / `updates.url` は維持

## 変更箇所

`apps/mobile/app.json`

```diff
-  "runtimeVersion": { "policy": "appVersion" }  // ios
+  "runtimeVersion": "1.0.0"

-  "runtimeVersion": { "policy": "appVersion" }  // android
+  "runtimeVersion": "1.0.0"
```