### PR TITLE
feat: WebViewタブ独立性・写真ダイアログ日本語化・カメラ終了ボタン修正

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -23,6 +23,8 @@
     "ios": {
       "bundleIdentifier": "com.homegohan.app",
       "infoPlist": {
+        "CFBundleDevelopmentRegion": "ja",
+        "CFBundleLocalizations": ["ja", "en"],
         "NSCameraUsageDescription": "食事写真を撮影するためにカメラを使用します。",
         "NSPhotoLibraryUsageDescription": "食事写真を選択するために写真ライブラリを使用します。",
         "NSPhotoLibraryAddUsageDescription": "解析結果の保存のために写真ライブラリへ追加する場合があります。"

--- a/apps/mobile/src/components/web/WebViewScreen.tsx
+++ b/apps/mobile/src/components/web/WebViewScreen.tsx
@@ -1,8 +1,8 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { WebView } from 'react-native-webview';
-import { useNavigation } from 'expo-router';
+import { WebView, ShouldStartLoadRequest } from 'react-native-webview';
+import { useNavigation, useRouter } from 'expo-router';
 import { colors } from '../../theme/colors';
 import { supabase } from '../../lib/supabase';
 
@@ -16,11 +16,22 @@ interface Props {
   testID?: string;
 }
 
+// 各タブの「所有する」パス prefix と Expo Router タブルート のマッピング
+// path は各タブの root path (サブパスも含む前方一致で判定)
+const TAB_ROUTES: Array<{ pathPrefix: string; tab: string }> = [
+  { pathPrefix: '/menus', tab: '/(tabs)/menus' },
+  { pathPrefix: '/meals', tab: '/(tabs)/meals' },
+  { pathPrefix: '/comparison', tab: '/(tabs)/comparison' },
+  { pathPrefix: '/profile', tab: '/(tabs)/profile' },
+  { pathPrefix: '/home', tab: '/(tabs)/home' },
+];
+
 export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
   const webViewRef = useRef<WebView>(null);
   const [uri, setUri] = useState<string | null>(null);
   const [injectedJS, setInjectedJS] = useState<string>('');
   const navigation = useNavigation();
+  const router = useRouter();
 
   // タブ再タップ時に WebView を初期 URL にリセットする
   // tabPress は同じタブを再タップした際にも発火するため useFocusEffect より確実
@@ -101,6 +112,55 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
     init();
   }, [path]);
 
+  // Fix 1: タブ独立性
+  // 別タブのパスへのナビゲーションを interceptして router.push でタブ切り替えを行う
+  const onShouldStartLoadWithRequest = (request: ShouldStartLoadRequest): boolean => {
+    try {
+      const url = new URL(request.url);
+      const webBaseUrl = new URL(WEB_BASE_URL);
+
+      // 自ドメイン以外 (外部リンク) はそのまま許可
+      if (url.origin !== webBaseUrl.origin) return true;
+
+      const targetPath = url.pathname;
+
+      // このタブが所有する path prefix を特定する
+      // path prop からクエリ・ハッシュを除いた純粋なパス部分を取得
+      const currentTabPath = path.split('?')[0].split('#')[0];
+
+      // 現在のタブが所有するパス (同じタブ内ナビゲーション) → 許可
+      if (
+        targetPath === currentTabPath ||
+        targetPath.startsWith(currentTabPath + '/')
+      ) {
+        return true;
+      }
+
+      // auth 関連パス (native-bridge 等) は WebView 内で処理
+      if (targetPath.startsWith('/auth/')) return true;
+
+      // 別タブのパスに該当する場合 → router.push でタブ切り替え、WebView では読み込まない
+      const matched = TAB_ROUTES.find(
+        (t) =>
+          targetPath === t.pathPrefix ||
+          targetPath.startsWith(t.pathPrefix + '/')
+      );
+      if (matched) {
+        // setTimeout でナビゲーションを非同期化し、WebView コールバック中の直接呼び出しを避ける
+        setTimeout(() => {
+          router.push(matched.tab as any);
+        }, 0);
+        return false;
+      }
+
+      // それ以外 (未マッピングのパス) は WebView 内で許可
+      return true;
+    } catch {
+      // URL パース失敗時は安全側でそのまま許可
+      return true;
+    }
+  };
+
   if (!uri) {
     return (
       <SafeAreaView style={{ flex: 1, backgroundColor: '#FFF' }} edges={['top']}>
@@ -125,6 +185,14 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
         javaScriptEnabled={true}
         startInLoadingState={true}
         pullToRefreshEnabled={true}
+        // Fix 1: 別タブへのリンクをタブ切り替えに変換
+        onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
+        // Fix 3: iOS 18 カメラバツボタン workaround
+        // <input type="file"> 経由カメラの dismiss が効かないケースへの対処
+        // 根本解決は次 PR で expo-image-picker ネイティブブリッジ実装予定
+        // TODO: Phase B-2 で <input type="file"> を expo-image-picker bridge に置換
+        allowsInlineMediaPlayback={true}
+        mediaPlaybackRequiresUserAction={false}
         onMessage={(_event) => {
           // ネイティブからのメッセージ受信 (撮影結果等)
           // TODO: Phase B-2 で実装


### PR DESCRIPTION
## 概要

WebView ハイブリッド構成の 3 つの UX 問題を修正します。

## Fix 1: タブ独立性 (最優先)

`WebViewScreen.tsx` に `onShouldStartLoadWithRequest` を追加。

- 別タブの path prefix (例: `/menus`) へのリンクを WebView 内で読み込まずに `router.push` でタブ切り替えへ変換
- TAB_ROUTES テーブルで各タブが所有するパス prefix とExpo Router タブルートをマッピング
- 同タブ内ナビゲーション・auth パス・外部ドメインはそのまま許可
- setTimeout で非同期化し WebView コールバック中のルーター呼び出しを安定化

## Fix 2: 写真選択ダイアログ日本語化

`apps/mobile/app.json` の `ios.infoPlist` に追加:
- `CFBundleDevelopmentRegion: "ja"`
- `CFBundleLocalizations: ["ja", "en"]`

iOS 設定が日本語の場合、`<input type="file">` で表示される ActionSheet が日本語になります。

## Fix 3: iOS 18 カメラバツボタン workaround

WebView props に `allowsInlineMediaPlayback={true}` と `mediaPlaybackRequiresUserAction={false}` を追加。

iOS 18 で `<input type="file" accept="image/*">` 経由のカメラ起動時に dismiss ボタンが効かない既知問題への対処。根本解決は次 PR で expo-image-picker ネイティブブリッジ実装予定。

## テスト方法

1. `eas build --platform ios --profile preview` でビルド後、TestFlight でインストール
2. ホームタブの「献立表を見る」リンクをタップ → 献立タブに切り替わること
3. 食事記録タブで写真選択ダイアログ → 日本語表示であること (iOS 設定が日本語の場合)
4. カメラ画面の ❌ ボタンで WebView に戻れること