### PR TITLE
fix: Web 側 React レイヤーで NativeApp タブ遷移 click handler を追加

### DIFF
--- a/src/app/(main)/MainLayout.tsx
+++ b/src/app/(main)/MainLayout.tsx
@@ -9,6 +9,7 @@ import AIChatBubble from "@/components/AIChatBubble";
 import { createClient } from "@/lib/supabase/client";
 import { clearUserScopedLocalStorage } from "@/lib/user-storage";
 import { useNativeAppMode } from "@/hooks/useNativeAppMode";
+import { NativeAppTabRouter } from "@/components/native-app/NativeAppTabRouter";
 
 // ロール別の管理メニュー
 const ADMIN_MENU_ITEMS: Record<string, { href: string; label: string; icon: string; color: string }> = {
@@ -174,6 +175,7 @@ export default function MainLayout({
 
   return (
     <div className="flex min-h-screen bg-gray-50">
+      <NativeAppTabRouter />
       
       {/* デスクトップ用サイドバー (Hidden on Mobile) */}
       <aside className="hidden lg:flex flex-col w-64 fixed inset-y-0 left-0 bg-white border-r border-gray-100 z-50 shadow-sm">

--- a/src/components/native-app/NativeAppTabRouter.tsx
+++ b/src/components/native-app/NativeAppTabRouter.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useNativeAppMode } from '@/hooks/useNativeAppMode';
+
+const TAB_PATHS = ['/menus', '/meals/new', '/comparison', '/profile', '/home'];
+
+function findTabFor(pathname: string): string | null {
+  return TAB_PATHS.find(p => pathname === p || pathname.startsWith(p + '/')) ?? null;
+}
+
+export function NativeAppTabRouter() {
+  const isNativeApp = useNativeAppMode();
+
+  useEffect(() => {
+    if (!isNativeApp) return;
+    if (typeof window === 'undefined') return;
+
+    const handleClick = (e: MouseEvent) => {
+      let node = e.target as HTMLElement | null;
+      while (node && node !== document.body) {
+        if (node.tagName === 'A') break;
+        node = node.parentElement;
+      }
+      if (!node || node.tagName !== 'A') return;
+
+      const link = node as HTMLAnchorElement;
+      try {
+        const url = new URL(link.href, window.location.origin);
+        if (url.origin !== window.location.origin) return;
+
+        const targetPath = url.pathname;
+        const currentPath = window.location.pathname;
+        const currentTab = findTabFor(currentPath);
+        const targetTab = findTabFor(targetPath);
+
+        // 同じタブ内のナビゲーション → 素通し
+        if (targetTab && currentTab && targetTab === currentTab) return;
+        // 別タブへの遷移
+        if (targetTab && targetTab !== currentTab) {
+          e.preventDefault();
+          e.stopPropagation();
+          const w = window as unknown as { ReactNativeWebView?: { postMessage: (s: string) => void } };
+          w.ReactNativeWebView?.postMessage(JSON.stringify({
+            type: 'tab-navigate',
+            path: targetTab,
+            fullPath: targetPath + url.search,
+          }));
+        }
+      } catch {
+        // URL parse 失敗 → 素通し
+      }
+    };
+
+    document.addEventListener('click', handleClick, true);
+    return () => document.removeEventListener('click', handleClick, true);
+  }, [isNativeApp]);
+
+  return null;
+}


### PR DESCRIPTION
## 概要

PR #771 の WebView inject script が実機で機能しないケースへの二重防御として、Web 側 React コンポーネントに click handler を追加。

## 変更内容

- src/components/native-app/NativeAppTabRouter.tsx 新規追加
- src/app/(main)/MainLayout.tsx に NativeAppTabRouter を追加

## 解決する問題

Next.js ハイドレーション後のイベントリスナー登録と WebView injectedJavaScript 実行タイミングの競合を回避。React ライフサイクル内で確実に動作する。

## テスト計画

- [ ] mode=app で開き、別タブリンクをタップ → tab-navigate が postMessage されることを確認
- [ ] 同タブ内リンクは通常通り Next.js Router でナビゲートされることを確認
- [ ] Vercel デプロイ後の実機 WebView で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)