### PR TITLE
fix: .easignore の src/ を /src/ に修正し apps/mobile/src を EAS アーカイブに含める

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -4,12 +4,12 @@ homegohan-app/
 # Root の node_modules (EAS が apps/mobile/node_modules を別途 install するため不要)
 node_modules/
 
-# Web アプリのビルド成果物
+# Web アプリのビルド成果物 (ルート直下のみ除外、apps/mobile/src 等は除外しない)
 .next/
 .vercel/
-src/
-public/
-supabase/
+/src/
+/public/
+/supabase/
 
 # テスト / playwright
 tests/


### PR DESCRIPTION
## 問題

EAS Build `91532872-236e-41e2-9c3f-ff2043e011f9` が EAGER_BUNDLE フェーズで失敗。

```
Error: Unable to resolve module ../../src/providers/AuthProvider from
/Users/expo/workingdir/build/apps/mobile/app/(admin)/_layout.tsx
```

## 根本原因

`.easignore` の `src/` パターンがルートの Web 用 `src/` だけでなく、すべての `src/` ディレクトリにマッチしていた。

除外されていたディレクトリ:
- `apps/mobile/src/` (providers, hooks, lib など全ソース)
- `packages/core/src/`
- `packages/shared/src/` (EASログで `packages/shared/src/index.ts` が存在しないと警告)

EAS がリポジトリをアーカイブする際に `apps/mobile/src/` が除外されるため、Metro Bundler がモジュールを解決できずバンドルが失敗した。

## 修正

```diff
-.next/
-.vercel/
-src/
-public/
-supabase/
+.next/
+.vercel/
+/src/
+/public/
+/supabase/
```

先頭に `/` を付けることで `.gitignore` スタイルのルート相対マッチになり、`apps/mobile/src/` や `packages/*/src/` は除外されなくなる。

## 検証

- ローカル `npm ci` EXIT=0 確認済み