### PR TITLE
fix: Vercel 型エラー修正 (recharts formatter)

### DIFF
--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -211,7 +211,7 @@ export default function AdminDashboard() {
                       borderRadius: '8px',
                       boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
                     }}
-                    formatter={(value: number | undefined) => [value ?? 0, '完了数']}
+                    formatter={(value) => [typeof value === 'number' ? value : Number(value) || 0, '完了数']}
                   />
                   <Line
                     type="monotone"
@@ -263,7 +263,7 @@ export default function AdminDashboard() {
                       border: '1px solid #e5e7eb',
                       borderRadius: '8px',
                     }}
-                    formatter={(value: number | undefined) => [(value ?? 0).toLocaleString(), '件']}
+                    formatter={(value) => [(typeof value === 'number' ? value : Number(value) || 0).toLocaleString(), '件']}
                   />
                   <Legend />
                 </PieChart>


### PR DESCRIPTION
## Summary

- `recharts` の `Tooltip` コンポーネントの `formatter` prop に `(value: number | undefined)` という型アノテーションを付けていたが、recharts の型定義では `ValueType = number | string | Array<...>` を受け取る仕様のため型エラーが発生していた
- `typeof value === 'number'` チェックに変更し、型アノテーションを削除することで recharts の型と互換にした
- `npx tsc --noEmit` でエラーなし確認済み

## 変更ファイル

- `src/app/(admin)/admin/page.tsx` L214, L266

## Test plan

- [ ] Vercel deploy で型エラーが出ないことを確認
- [ ] admin ダッシュボードの Tooltip が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)