### PR TITLE
fix: 写真モード選択 × ボタンで前画面に戻る

### DIFF
--- a/src/app/(main)/meals/new/page.tsx
+++ b/src/app/(main)/meals/new/page.tsx
@@ -1010,7 +1010,18 @@ export default function MealCaptureModal() {
 
   // 閉じる
   const handleClose = () => {
-    router.back();
+    // WebView ネイティブアプリ環境では ReactNativeWebView に back メッセージを送る
+    const w = window as unknown as { ReactNativeWebView?: { postMessage: (s: string) => void } };
+    if (w.ReactNativeWebView) {
+      w.ReactNativeWebView.postMessage(JSON.stringify({ type: 'navigate-back' }));
+      return;
+    }
+    // Web 環境: history があれば戻る、なければ home へ
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/home');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary

- WebView タブ独立環境 (PR #772) では `/meals/new` が history root として開かれるため `router.back()` が無効になっていた
- `handleClose` を以下のロジックに変更:
  1. `ReactNativeWebView` が存在する場合 → `navigate-back` を postMessage 送信
  2. 通常 Web: `window.history.length > 1` なら `router.back()`、それ以外は `router.push('/home')`

## Test plan

- [ ] ブラウザ直接アクセス時: × で前のページに戻ること
- [ ] ブラウザで直接 URL アクセス (history なし): × で `/home` に遷移すること
- [ ] ネイティブアプリ WebView: × タップで前のタブ/画面に戻ること

## 影響範囲

`src/app/(main)/meals/new/page.tsx` の `handleClose` 関数のみ。他画面・ロジックへの影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)