### PR TITLE
fix: navigate-back postMessage を RN で処理

### DIFF
--- a/apps/mobile/src/components/web/WebViewScreen.tsx
+++ b/apps/mobile/src/components/web/WebViewScreen.tsx
@@ -233,6 +233,13 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
                   router.push(matched.tab as any);
                 }, 0);
               }
+            } else if (data.type === 'navigate-back') {
+              // × ボタンや戻るボタン用: Expo Router の history を使って前画面に戻る
+              if (router.canGoBack()) {
+                router.back();
+              } else {
+                router.push('/(tabs)/home' as any);
+              }
             }
           } catch {
             // JSON パース失敗は無視


### PR DESCRIPTION
## 概要

PR #776 で WEB 側 `/meals/new` の × ボタンが `ReactNativeWebView.postMessage({type:'navigate-back'})` を送るように対応されたが、RN 側 (WebViewScreen.tsx) に `navigate-back` 受信ハンドラが未実装だったため、× ボタンが機能していなかった。

## 変更内容

`apps/mobile/src/components/web/WebViewScreen.tsx` の `onMessage` ハンドラに `navigate-back` ブランチを追加。

- `router.canGoBack()` が true の場合: `router.back()` で Expo Router の history を使って前画面に戻る
- `router.canGoBack()` が false の場合: `/(tabs)/home` にフォールバック

## テスト方法

1. ホームタブから献立タブに切り替えて `/meals/new` を開く
2. × ボタンをタップ → 前の画面 (ホームタブ) に戻ることを確認
3. 献立タブで直接 `/meals/new` を開く
4. × ボタンをタップ → 献立一覧に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)