### PR TITLE
fix: TestFlight 4 件不具合 (写真/買物リスト/エクスポート/横スク)

### DIFF
--- a/apps/mobile/src/components/web/WebViewScreen.tsx
+++ b/apps/mobile/src/components/web/WebViewScreen.tsx
@@ -2,7 +2,9 @@ import React, { useRef, useState, useEffect } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { WebView } from 'react-native-webview';
-import { useNavigation, useRouter } from 'expo-router';
+import { useNavigation, useRouter, useLocalSearchParams } from 'expo-router';
+import * as FileSystem from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
 import { colors } from '../../theme/colors';
 import { supabase } from '../../lib/supabase';
 
@@ -108,6 +110,10 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
   const navigation = useNavigation();
   const router = useRouter();
 
+  // Fix 2: tab-navigate で fullPath (クエリ付き) を受け取った場合に初期 URL を上書き
+  const params = useLocalSearchParams<{ initialPath?: string }>();
+  const effectivePath = params.initialPath ?? path;
+
   // タブ再タップ時に WebView を初期 URL にリセットする
   // tabPress は同じタブを再タップした際にも発火するため useFocusEffect より確実
   useEffect(() => {
@@ -118,11 +124,11 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
         const separator = path.includes('?') ? '&' : '?';
         const targetPath = alreadyHasMode ? path : `${path}${separator}mode=app`;
         const targetUrl = `${WEB_BASE_URL}${targetPath}`;
+        // window.location.replace で履歴を残さず初期 URL に置換してフレッシュな state に戻す
+        // (写真撮影デッドロック対策: step state や input キャッシュをリセット)
         webViewRef.current?.injectJavaScript(`
           (function() {
-            if (window.location.href !== '${targetUrl}') {
-              window.location.href = '${targetUrl}';
-            }
+            window.location.replace('${targetUrl}');
           })();
           true;
         `);
@@ -136,12 +142,12 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
       const { data: { session } } = await supabase.auth.getSession();
       if (session?.access_token && session?.refresh_token) {
         // bridge URL に access/refresh token + next path を埋め込む
-        // path に既に mode=app が含まれている場合は重複付与しない
-        const alreadyHasMode = path.includes('mode=app');
-        const separator = path.includes('?') ? '&' : '?';
+        // effectivePath に既に mode=app が含まれている場合は重複付与しない
+        const alreadyHasMode = effectivePath.includes('mode=app');
+        const separator = effectivePath.includes('?') ? '&' : '?';
         const nextPath = alreadyHasMode
-          ? path
-          : `${path}${separator}mode=app`;
+          ? effectivePath
+          : `${effectivePath}${separator}mode=app`;
         const next = encodeURIComponent(nextPath);
         const bridgeUrl = `${WEB_BASE_URL}/auth/native-bridge?access_token=${session.access_token}&refresh_token=${session.refresh_token}&next=${next}`;
         setUri(bridgeUrl);
@@ -174,21 +180,21 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
           true;
         `);
       } else {
-        // セッションなし → 直接 path (mode=app 付き)
-        const alreadyHasMode = path.includes('mode=app');
-        const separator = path.includes('?') ? '&' : '?';
+        // セッションなし → 直接 effectivePath (mode=app 付き)
+        const alreadyHasMode = effectivePath.includes('mode=app');
+        const separator = effectivePath.includes('?') ? '&' : '?';
         const directUrl = alreadyHasMode
-          ? `${WEB_BASE_URL}${path}`
-          : `${WEB_BASE_URL}${path}${separator}mode=app`;
+          ? `${WEB_BASE_URL}${effectivePath}`
+          : `${WEB_BASE_URL}${effectivePath}${separator}mode=app`;
         setUri(directUrl);
         setInjectedJS('');
       }
     };
     init();
-  }, [path]);
+  }, [effectivePath]);
 
-  // path からクエリ・ハッシュを除いた純粋なパス部分
-  const currentTabRoot = path.split('?')[0].split('#')[0];
+  // effectivePath からクエリ・ハッシュを除いた純粋なパス部分
+  const currentTabRoot = effectivePath.split('?')[0].split('#')[0];
 
   if (!uri) {
     return (
@@ -230,7 +236,16 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
               const matched = TAB_ROUTES.find((t) => t.pathPrefix === data.path);
               if (matched) {
                 setTimeout(() => {
-                  router.push(matched.tab as any);
+                  // Fix 2: fullPath (クエリパラメータ含む) を initialPath として渡すことで
+                  // 買い物リストのモーダル等を開くクエリが失われないようにする
+                  if (data.fullPath && data.fullPath !== data.path) {
+                    router.push({
+                      pathname: matched.tab as any,
+                      params: { initialPath: data.fullPath },
+                    });
+                  } else {
+                    router.push(matched.tab as any);
+                  }
                 }, 0);
               }
             } else if (data.type === 'navigate-back') {
@@ -240,6 +255,27 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
               } else {
                 router.push('/(tabs)/home' as any);
               }
+            } else if (data.type === 'download') {
+              // Fix 3: iOS WebView でのエクスポート対応
+              // Web 側から postMessage で受け取ったファイル内容を expo-sharing で保存・共有
+              const { filename, content, mimeType } = data;
+              (async () => {
+                try {
+                  const filePath = `${FileSystem.documentDirectory}${filename}`;
+                  await FileSystem.writeAsStringAsync(filePath, content, {
+                    encoding: FileSystem.EncodingType.UTF8,
+                  });
+                  const isAvailable = await Sharing.isAvailableAsync();
+                  if (isAvailable) {
+                    await Sharing.shareAsync(filePath, {
+                      mimeType,
+                      dialogTitle: filename,
+                    });
+                  }
+                } catch (e) {
+                  console.error('[WebViewScreen] download failed', e);
+                }
+              })();
             }
           } catch {
             // JSON パース失敗は無視

--- a/src/app/(main)/meals/new/page.tsx
+++ b/src/app/(main)/meals/new/page.tsx
@@ -323,6 +323,20 @@ export default function MealCaptureModal() {
 
   // ネイティブアプリから渡される AI 解析済みデータを prefill として受け取る
   const searchParams = useSearchParams();
+
+  // mode=app かつ prefill なし の場合、mount 時に step をリセット
+  // タブバー中央ボタン再タップ → WebView reload → page remount の際に前の state が残らないよう
+  useEffect(() => {
+    const modeParam = searchParams.get('mode');
+    const prefillParam = searchParams.get('prefill');
+    if (modeParam === 'app' && !prefillParam) {
+      setStep('mode-select');
+      setPhotoFiles([]);
+      setPhotoPreviews([]);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     const prefillParam = searchParams.get('prefill');
     if (!prefillParam) return;
@@ -370,12 +384,14 @@ export default function MealCaptureModal() {
     if (files && files.length > 0) {
       const newFiles = Array.from(files);
       setPhotoFiles(prev => [...prev, ...newFiles]);
-      
+
       newFiles.forEach(file => {
         const url = URL.createObjectURL(file);
         setPhotoPreviews(prev => [...prev, url]);
       });
     }
+    // 同じファイルを再度選択できるように input をリセット
+    e.target.value = '';
   };
   
   // 写真を削除
@@ -1025,7 +1041,7 @@ export default function MealCaptureModal() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col" style={{ background: colors.bg }}>
+    <div className="min-h-screen flex flex-col overflow-x-hidden" style={{ background: colors.bg }}>
       {/* ヘッダー */}
       <div className="sticky top-0 z-50 px-4 py-3 flex items-center justify-between" style={{ background: colors.card, borderBottom: `1px solid ${colors.border}` }}>
         <button onClick={handleClose} className="w-10 h-10 rounded-full flex items-center justify-center" style={{ background: colors.bg }}>
@@ -1713,7 +1729,7 @@ export default function MealCaptureModal() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -20 }}
-            className="flex-1 p-4 overflow-auto"
+            className="flex-1 p-4 overflow-y-auto overflow-x-hidden"
           >
             {/* 写真プレビュー */}
             {photoPreviews.length > 0 && (
@@ -1821,7 +1837,7 @@ export default function MealCaptureModal() {
                     {healthData.totalCholesterol && (
                       <div className="text-center">
                         <p style={{ fontSize: 14, fontWeight: 700, color: colors.text, margin: 0 }}>{healthData.totalCholesterol}</p>
-                        <p style={{ fontSize: 9, color: colors.textMuted, margin: 0 }}>総コレステロール</p>
+                        <p style={{ fontSize: 9, color: colors.textMuted, margin: 0 }} className="break-all">総コレステロール</p>
                       </div>
                     )}
                   </div>

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -7,6 +7,7 @@ import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 import { clearUserScopedLocalStorage, broadcastSignOut } from "@/lib/user-storage";
 import { requestNotificationPermission } from "@/lib/local-notification";
+import { useNativeAppMode } from "@/hooks/useNativeAppMode";
 
 type WeekStartDay = 'sunday' | 'monday';
 
@@ -39,7 +40,19 @@ const Switch = ({
 export default function SettingsPage() {
   const router = useRouter();
   const supabase = createClient();
+  const isNativeApp = useNativeAppMode();
   const [showLogoutModal, setShowLogoutModal] = useState(false);
+
+  // Fix 3: mode=app 時は postMessage で RN に転送 (iOS WebView では <a download> が動作しないため)
+  const postMessageDownload = (filename: string, content: string, mimeType: string) => {
+    const w = window as unknown as { ReactNativeWebView?: { postMessage: (s: string) => void } };
+    w.ReactNativeWebView?.postMessage(JSON.stringify({
+      type: 'download',
+      filename,
+      content,
+      mimeType,
+    }));
+  };
 
   const [settings, setSettings] = useState({
     notifications: true,
@@ -144,16 +157,23 @@ export default function SettingsPage() {
         }
         throw new Error(`Export failed: ${res.status}`);
       }
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
       const today = new Date().toISOString().slice(0, 10);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `homegohan-export-${today}.json`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
+      const filename = `homegohan-export-${today}.json`;
+      if (isNativeApp) {
+        // Fix 3: iOS WebView では Blob URL が使えないので RN へ転送
+        const text = await res.text();
+        postMessageDownload(filename, text, 'application/json');
+      } else {
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+      }
     } catch (err) {
       console.error(err);
       alert('エクスポートに失敗しました。時間をおいて再度お試しください。');
@@ -175,16 +195,23 @@ export default function SettingsPage() {
         }
         throw new Error(`CSV export failed: ${res.status}`);
       }
-      const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
       const today = new Date().toISOString().slice(0, 10);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `homegohan-meals-${today}.csv`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
+      const filename = `homegohan-meals-${today}.csv`;
+      if (isNativeApp) {
+        // Fix 3: iOS WebView では Blob URL が使えないので RN へ転送
+        const text = await res.text();
+        postMessageDownload(filename, text, 'text/csv');
+      } else {
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+      }
     } catch (err) {
       console.error(err);
       alert('CSVエクスポートに失敗しました。時間をおいて再度お試しください。');


### PR DESCRIPTION
## 概要

TestFlight で報告された 4 件の不具合を一括修正します。

## 修正内容

### Fix 1: 写真撮影デッドロック
- `src/app/(main)/meals/new/page.tsx`
  - `handlePhotoSelect` に `e.target.value = ''` を追加し、同じファイルを再選択できるようにリセット
  - mount 時 (`mode=app` かつ `prefill` なし) に `step` / `photoFiles` / `photoPreviews` をリセット
- `apps/mobile/src/components/web/WebViewScreen.tsx`
  - tabPress ハンドラで `window.location.replace()` を使いフレッシュな state に戻す (履歴を残さず置換)

### Fix 2: 買い物リストのクエリ消失
- `apps/mobile/src/components/web/WebViewScreen.tsx`
  - `tab-navigate` で `fullPath` (クエリパラメータ込み) を `initialPath` として Expo Router params に渡す
  - `useLocalSearchParams` で `initialPath` を取得し URL 構築に使用 (`effectivePath`)

### Fix 3: エクスポート不動 (iOS WebView)
- `src/app/(main)/settings/page.tsx`
  - `useNativeAppMode` を追加し、`mode=app` 時は `postMessage` で RN に転送
- `apps/mobile/src/components/web/WebViewScreen.tsx`
  - `onMessage` に `download` タイプを追加。`expo-file-system` + `expo-sharing` で保存・共有

### Fix 4: 横スクロール (健康診断結果)
- `src/app/(main)/meals/new/page.tsx`
  - ルート `<div>` に `overflow-x-hidden` を追加
  - health-result の `<motion.div>` を `overflow-y-auto overflow-x-hidden` に変更
  - 「総コレステロール」ラベルに `break-all` を追加

## テスト

- [x] `npm run build` → `Compiled successfully` 確認 (EXIT=0)
- [x] RN `tsc --noEmit` → WebViewScreen 新規エラーなし