### PR TITLE
fix: 画像認識のモード違い検出 + 真っ白解消

### DIFF
--- a/src/app/(main)/meals/new/page.tsx
+++ b/src/app/(main)/meals/new/page.tsx
@@ -519,13 +519,17 @@ export default function MealCaptureModal() {
         setCatalogMatches(Array.isArray(data.catalogMatches) ? data.catalogMatches : []);
         setStep('result');
       } else {
+        const errBody = await res.json().catch(() => ({}));
         void logToServer('warn', 'meal-photo analysis failed', {
           photoCount: photoFiles.length,
           mealType: selectedMealType,
           status: res.status,
+          error: errBody.error,
         });
-        alert('解析に失敗しました。もう一度お試しください。');
-        setStep('capture');
+        alert(errBody.message || errBody.error || '解析に失敗しました。もう一度お試しください。');
+        setStep('mode-select');
+        setPhotoFiles([]);
+        setPhotoPreviews([]);
       }
     } catch (error) {
       console.error('Analysis error:', error);
@@ -658,8 +662,11 @@ export default function MealCaptureModal() {
         setFridgeSuggestions(data.suggestions || []);
         setStep('fridge-result');
       } else {
-        alert('冷蔵庫の解析に失敗しました。');
-        setStep('capture');
+        const errBody = await res.json().catch(() => ({}));
+        alert(errBody.message || errBody.error || '冷蔵庫の解析に失敗しました。');
+        setStep('mode-select');
+        setPhotoFiles([]);
+        setPhotoPreviews([]);
       }
     } catch (error) {
       console.error('Fridge analysis error:', error);
@@ -694,8 +701,11 @@ export default function MealCaptureModal() {
         setHealthModelUsed(data.modelUsed || '');
         setStep('health-result');
       } else {
-        alert('健康診断結果の解析に失敗しました。');
-        setStep('capture');
+        const errBody = await res.json().catch(() => ({}));
+        alert(errBody.message || errBody.error || '健康診断結果の解析に失敗しました。');
+        setStep('mode-select');
+        setPhotoFiles([]);
+        setPhotoPreviews([]);
       }
     } catch (error) {
       console.error('Health checkup analysis error:', error);
@@ -746,8 +756,11 @@ export default function MealCaptureModal() {
         await fetchWeightHistory();
         setStep('weight-result');
       } else {
-        alert('体重計の読み取りに失敗しました。');
-        setStep('capture');
+        const errBody = await res.json().catch(() => ({}));
+        alert(errBody.message || errBody.error || '体重計の読み取りに失敗しました。');
+        setStep('mode-select');
+        setPhotoFiles([]);
+        setPhotoPreviews([]);
       }
     } catch (error) {
       console.error('Weight scale analysis error:', error);
@@ -1280,6 +1293,24 @@ export default function MealCaptureModal() {
 
         {/* ステップ3: 解析結果 */}
         {step === 'result' && (
+          !analyzedDishes.length ? (
+            <motion.div
+              key="result-empty"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              className="flex-1 flex flex-col items-center justify-center p-8 gap-4"
+            >
+              <div style={{ fontSize: 14, color: colors.textMuted }}>料理を読み取れませんでした</div>
+              <button
+                onClick={() => { setStep('mode-select'); setPhotoFiles([]); setPhotoPreviews([]); setAnalyzedDishes([]); }}
+                className="py-3 px-6 rounded-xl"
+                style={{ background: colors.accent }}
+              >
+                <span style={{ fontSize: 14, fontWeight: 600, color: '#fff' }}>撮り直す</span>
+              </button>
+            </motion.div>
+          ) : (
           <motion.div
             key="result"
             initial={{ opacity: 0, y: 20 }}
@@ -1453,6 +1484,7 @@ export default function MealCaptureModal() {
               <span style={{ fontSize: 14, color: colors.textLight }}>撮り直す</span>
             </button>
           </motion.div>
+          )
         )}
 
         {/* ステップ4: 日時選択 */}
@@ -1590,6 +1622,24 @@ export default function MealCaptureModal() {
 
         {/* 冷蔵庫解析結果 */}
         {step === 'fridge-result' && (
+          !fridgeIngredients.length ? (
+            <motion.div
+              key="fridge-result-empty"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              className="flex-1 flex flex-col items-center justify-center p-8 gap-4"
+            >
+              <div style={{ fontSize: 14, color: colors.textMuted }}>食材を読み取れませんでした</div>
+              <button
+                onClick={() => { setStep('mode-select'); setPhotoFiles([]); setPhotoPreviews([]); }}
+                className="py-3 px-6 rounded-xl"
+                style={{ background: colors.accent }}
+              >
+                <span style={{ fontSize: 14, fontWeight: 600, color: '#fff' }}>撮り直す</span>
+              </button>
+            </motion.div>
+          ) : (
           <motion.div
             key="fridge-result"
             initial={{ opacity: 0, y: 20 }}
@@ -1720,10 +1770,29 @@ export default function MealCaptureModal() {
               <span style={{ fontSize: 14, color: colors.textLight }}>やり直す</span>
             </button>
           </motion.div>
+          )
         )}
 
         {/* 健康診断解析結果 */}
         {step === 'health-result' && (
+          Object.values(healthData ?? {}).every(v => v == null) ? (
+            <motion.div
+              key="health-result-empty"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              className="flex-1 flex flex-col items-center justify-center p-8 gap-4"
+            >
+              <div style={{ fontSize: 14, color: colors.textMuted }}>検査値を読み取れませんでした</div>
+              <button
+                onClick={() => { setStep('mode-select'); setPhotoFiles([]); setPhotoPreviews([]); }}
+                className="py-3 px-6 rounded-xl"
+                style={{ background: colors.accent }}
+              >
+                <span style={{ fontSize: 14, fontWeight: 600, color: '#fff' }}>撮り直す</span>
+              </button>
+            </motion.div>
+          ) : (
           <motion.div
             key="health-result"
             initial={{ opacity: 0, y: 20 }}
@@ -1927,10 +1996,12 @@ export default function MealCaptureModal() {
               <span style={{ fontSize: 14, color: colors.textLight }}>やり直す</span>
             </button>
           </motion.div>
+          )
         )}
 
         {/* 体重計結果 */}
-        {step === 'weight-result' && weightData && (
+        {step === 'weight-result' && (
+          weightData && weightData.weight > 0 ? (
           <motion.div
             key="weight-result"
             initial={{ opacity: 0, y: 20 }}
@@ -2097,6 +2168,24 @@ export default function MealCaptureModal() {
               <span style={{ fontSize: 14, color: colors.textLight }}>やり直す</span>
             </button>
           </motion.div>
+          ) : (
+            <motion.div
+              key="weight-result-empty"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              className="flex-1 flex flex-col items-center justify-center p-8 gap-4"
+            >
+              <div style={{ fontSize: 14, color: colors.textMuted }}>体重を読み取れませんでした</div>
+              <button
+                onClick={() => { setStep('mode-select'); setPhotoFiles([]); setPhotoPreviews([]); setWeightData(null); }}
+                className="py-3 px-6 rounded-xl"
+                style={{ background: colors.accent }}
+              >
+                <span style={{ fontSize: 14, fontWeight: 600, color: '#fff' }}>撮り直す</span>
+              </button>
+            </motion.div>
+          )
         )}
 
         {/* 判別失敗画面 */}

--- a/src/app/api/ai/analyze-fridge/route.ts
+++ b/src/app/api/ai/analyze-fridge/route.ts
@@ -55,6 +55,13 @@ export async function POST(request: Request) {
 
     const analysisResult = normalizeFridgeAnalysisResult(data);
 
+    if (!analysisResult.ingredients?.length) {
+      return NextResponse.json(
+        { error: 'mode_mismatch', message: '食材が読み取れませんでした。冷蔵庫の中身が見える写真を撮り直してください。' },
+        { status: 422 },
+      );
+    }
+
     return NextResponse.json({
       ingredients: analysisResult.ingredients.map((ingredient) => ingredient.name),
       detailedIngredients: analysisResult.ingredients,

--- a/src/app/api/ai/analyze-health-checkup/route.ts
+++ b/src/app/api/ai/analyze-health-checkup/route.ts
@@ -45,6 +45,13 @@ export async function POST(request: Request) {
     const extractedData = normalizeHealthCheckupExtractedData(data);
     const fieldCount = countExtractedHealthFields(extractedData);
 
+    if (fieldCount === 0) {
+      return NextResponse.json(
+        { error: 'mode_mismatch', message: '健康診断結果が読み取れませんでした。健康診断書がはっきり写った写真を撮り直してください。' },
+        { status: 422 },
+      );
+    }
+
     return NextResponse.json({
       extractedData,
       fieldCount,

--- a/src/app/api/ai/analyze-meal-photo/route.ts
+++ b/src/app/api/ai/analyze-meal-photo/route.ts
@@ -111,13 +111,18 @@ export async function POST(request: Request) {
           .filter((name: string) => name.length > 0)
       : [];
 
+    if (!dishNames.length) {
+      return NextResponse.json(
+        { error: 'mode_mismatch', message: '料理が読み取れませんでした。食事が鮮明に写った写真を撮り直してください。' },
+        { status: 422 },
+      );
+    }
+
     let catalogMatches: Awaited<ReturnType<typeof findCatalogCandidatesForDishes>> = [];
-    if (dishNames.length > 0) {
-      try {
-        catalogMatches = await findCatalogCandidatesForDishes(supabase, dishNames, { limitPerDish: 3 });
-      } catch (catalogError) {
-        console.warn('Analyze Meal Photo: catalog lookup skipped', catalogError);
-      }
+    try {
+      catalogMatches = await findCatalogCandidatesForDishes(supabase, dishNames, { limitPerDish: 3 });
+    } catch (catalogError) {
+      console.warn('Analyze Meal Photo: catalog lookup skipped', catalogError);
     }
 
     return NextResponse.json({

--- a/src/app/api/ai/analyze-weight-scale/route.ts
+++ b/src/app/api/ai/analyze-weight-scale/route.ts
@@ -45,9 +45,10 @@ export async function POST(request: Request) {
 
     // 体重が取得できなかった場合
     if (!result.weight || result.weight <= 0) {
-      return NextResponse.json({
-        error: '体重を読み取れませんでした。体重計のディスプレイがはっきり映っている写真を使用してください。',
-      }, { status: 400 });
+      return NextResponse.json(
+        { error: 'mode_mismatch', message: '体重計の表示が読み取れませんでした。数値が鮮明に写った写真を撮り直してください。' },
+        { status: 422 },
+      );
     }
 
     return NextResponse.json(result);

--- a/src/app/api/ai/classify-photo/route.ts
+++ b/src/app/api/ai/classify-photo/route.ts
@@ -338,6 +338,18 @@ export async function POST(request: Request) {
       totalElapsedMs: Date.now() - startedAt,
     });
 
+    if (!result.type || result.type === 'unknown' || (result.confidence ?? 0) < 0.3) {
+      return NextResponse.json(
+        {
+          error: 'unknown_type',
+          message: '写真の種類を判定できませんでした。食事・冷蔵庫・健診結果・体重計のいずれかが鮮明に写った写真を撮り直してください。',
+          ...result,
+          modelUsed: model,
+        },
+        { status: 422 },
+      );
+    }
+
     return NextResponse.json({
       ...result,
       modelUsed: model,


### PR DESCRIPTION
## Summary

- 健診/体重/冷蔵庫/食事/auto-classify の各 API で、解析結果が空でも 200 OK を返す問題 (silent success) を解消
- 各 API: 必須フィールドが空のとき 422 + 日本語エラーメッセージを返すよう変更
- Web クライアント: `!res.ok` 時に API メッセージを `alert()` で表示し、`step='mode-select'` にリセット (写真もクリア)
- Web 結果画面: 万が一空データが来た場合の fallback UI を追加 (「読み取れませんでした」+ 撮り直しボタン)

## 変更ファイル

- `src/app/api/ai/analyze-health-checkup/route.ts` — `fieldCount === 0` で 422
- `src/app/api/ai/analyze-weight-scale/route.ts` — weight <= 0 で 422 (既存 400 → 422 + message 変更)
- `src/app/api/ai/analyze-fridge/route.ts` — `detailedIngredients` 空で 422
- `src/app/api/ai/analyze-meal-photo/route.ts` — `dishes` 空で 422
- `src/app/api/ai/classify-photo/route.ts` — type=unknown or confidence<0.3 で 422
- `src/app/(main)/meals/new/page.tsx` — エラーハンドリング + fallback UI

## Test plan

- [ ] 健診モードで料理の写真 → 「健康診断結果が読み取れませんでした」alert が出て mode-select に戻る
- [ ] 食事モードでカタログ/文書の写真 → 「料理が読み取れませんでした」alert が出て mode-select に戻る
- [ ] 体重計モードで別の写真 → 「体重計の表示が読み取れませんでした」alert
- [ ] 冷蔵庫モードで食材がない写真 → 「食材が読み取れませんでした」alert
- [ ] auto モードで全く関係ない写真 → 「写真の種類を判定できませんでした」alert
- [ ] 正常な写真では従来通り結果画面に遷移する

🤖 Generated with [Claude Code](https://claude.com/claude-code)