### PR TITLE
fix: planned_meals 400 / weekly_menu_requests 406 / マイページ横スク

### DIFF
--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -320,7 +320,7 @@ function ProfilePageContent() {
   // 旧: 全画面スピナーで LCP 要素が隠れていた → 削除
 
   return (
-    <div className="min-h-screen bg-gray-50 pb-40">
+    <div className="min-h-screen bg-gray-50 pb-40 overflow-x-hidden">
 
       {/* ヘッダーエリア (#188: 常に即時レンダリング → LCP 改善) */}
       {/* 他ページ (home 等) と同じ薄いグラデーション背景に統一 */}

--- a/src/app/api/ai/consultation/sessions/[sessionId]/messages/route.ts
+++ b/src/app/api/ai/consultation/sessions/[sessionId]/messages/route.ts
@@ -81,8 +81,8 @@ async function buildSystemPrompt(supabase: any, userId: string): Promise<string>
     // 3. 明日〜1週間の献立
     supabase.from('planned_meals').select(`
       id, meal_type, dish_name, calories_kcal, is_completed, mode,
-      user_daily_meals!inner(day_date)
-    `).eq('user_id', userId)
+      user_daily_meals!inner(day_date, user_id)
+    `).eq('user_daily_meals.user_id', userId)
       .gt('user_daily_meals.day_date', today)
       .lte('user_daily_meals.day_date', oneWeekLater.toISOString().split('T')[0])
       .limit(30),
@@ -90,8 +90,8 @@ async function buildSystemPrompt(supabase: any, userId: string): Promise<string>
     // 4. 過去14日の食事
     supabase.from('planned_meals').select(`
       id, meal_type, dish_name, dishes, calories_kcal, protein_g, fat_g, carbs_g, is_completed, mode,
-      user_daily_meals!inner(day_date)
-    `).eq('user_id', userId)
+      user_daily_meals!inner(day_date, user_id)
+    `).eq('user_daily_meals.user_id', userId)
       .gte('user_daily_meals.day_date', fourteenDaysAgo.toISOString().split('T')[0])
       .lt('user_daily_meals.day_date', today)
       .limit(50),

--- a/src/app/api/ai/consultation/sessions/route.ts
+++ b/src/app/api/ai/consultation/sessions/route.ts
@@ -74,9 +74,9 @@ export async function POST(request: Request) {
         calories_kcal,
         protein_g,
         is_completed,
-        user_daily_meals!inner(day_date)
+        user_daily_meals!inner(day_date, user_id)
       `)
-      .eq('user_id', user.id)
+      .eq('user_daily_meals.user_id', user.id)
       .gte('user_daily_meals.day_date', sevenDaysAgo.toISOString().split('T')[0])
       .limit(30);
 

--- a/src/app/api/ai/menu/weekly/status/route.ts
+++ b/src/app/api/ai/menu/weekly/status/route.ts
@@ -23,15 +23,14 @@ export async function GET(request: Request) {
       .select('id, status, error_message, updated_at, mode, start_date, target_meal_id, progress')
       .eq('id', requestId)
       .eq('user_id', user.id)
-      .single();
+      .maybeSingle();
 
     if (error) throw error;
 
     if (!request) {
       return NextResponse.json({
-        status: 'failed',
-        errorMessage: 'Request not found',
-        updatedAt: new Date().toISOString(),
+        status: 'not_found',
+        requestId,
       });
     }
 


### PR DESCRIPTION
## 概要

本番で頻発していた API エラーと UI バグを一括修正。

## 修正内容

### Fix 1: `planned_meals` 400 エラー解消

`planned_meals` テーブルから `user_id` カラムが `date-based migration` で削除済みだが、`.eq('user_id', user.id)` でフィルタリングしていたため 400 が発生。

`user_daily_meals!inner(day_date, user_id)` の embedded filter 経由に修正。

**修正ファイル:**
- `src/app/api/ai/consultation/sessions/route.ts` L79
- `src/app/api/ai/consultation/sessions/[sessionId]/messages/route.ts` L85, L94

### Fix 2: `weekly_menu_requests` 406 エラー解消

存在しない `requestId` でポーリングした際、`.single()` が 406 を返す問題を `.maybeSingle()` に変更して対処。

**修正ファイル:**
- `src/app/api/ai/menu/weekly/status/route.ts`

### Fix 3: マイページ横スクロール解消

iPhone WebView でマイページ `/profile` が左右にスクロールできてしまう問題を、ルート div に `overflow-x-hidden` を追加して解消。

**修正ファイル:**
- `src/app/(main)/profile/page.tsx`

## ビルド確認

`npm run build` EXIT=0 (既存の Supabase env 未設定によるプリレンダリングエラーは今回の修正と無関係)

## デプロイ

Web only → Vercel 自動デプロイ → App rebuild 不要