### PR TITLE
fix: analyze-meal-photo conflict マーカー解決

### DIFF
--- a/supabase/functions/analyze-meal-photo/index.ts
+++ b/supabase/functions/analyze-meal-photo/index.ts
@@ -105,13 +105,8 @@ Deno.serve(async (req) => {
       })
     }
 
-<<<<<<< Updated upstream
-    // 非同期でバックグラウンドタスクを実行
-    analyzeMealPhotoBackgroundTask({ 
-=======
     // 非同期でバックグラウンドタスクを実行（EdgeRuntime.waitUntil で Edge が早期終了しないよう登録）
     const backgroundPromise = analyzeMealPhotoBackgroundTask({
->>>>>>> Stashed changes
       images: imageDataArray,
       mealId,
       mealType,


### PR DESCRIPTION
## Summary

- `supabase/functions/analyze-meal-photo/index.ts` の L108-114 に残っていた git conflict マーカー (`<<<<<<< Updated upstream` / `>>>>>>> Stashed changes`) を削除
- `EdgeRuntime.waitUntil(backgroundPromise)` を使う **Stashed changes 側**を採用
- conflict マーカーが残ったままだと Deno のパースエラー or 古い deploy バイナリのままとなり、画像認識結果 (dishes) が返らず結果画面が空になる

## Test plan

- [ ] `grep -n '<<<<<<< \|^=======$\|>>>>>>> ' supabase/functions/analyze-meal-photo/index.ts` でゼロ件確認
- [ ] Supabase Edge Function 再 deploy 後に空 body で curl → 400/422 返ること確認