### PR TITLE
fix: 画像認識結果消失の真因 useEffect を削除

### DIFF
--- a/src/app/(main)/meals/new/page.tsx
+++ b/src/app/(main)/meals/new/page.tsx
@@ -324,19 +324,6 @@ export default function MealCaptureModal() {
   // ネイティブアプリから渡される AI 解析済みデータを prefill として受け取る
   const searchParams = useSearchParams();
 
-  // mode=app かつ prefill なし の場合、mount 時に step をリセット
-  // タブバー中央ボタン再タップ → WebView reload → page remount の際に前の state が残らないよう
-  useEffect(() => {
-    const modeParam = searchParams.get('mode');
-    const prefillParam = searchParams.get('prefill');
-    if (modeParam === 'app' && !prefillParam) {
-      setStep('mode-select');
-      setPhotoFiles([]);
-      setPhotoPreviews([]);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   useEffect(() => {
     const prefillParam = searchParams.get('prefill');
     if (!prefillParam) return;


### PR DESCRIPTION
## 問題

PR #778 で「写真撮影デッドロック対策」として追加した mount 時 useEffect が裏目に出て、画像認識成功後の `analyzedDishes` 等の state が消失し、結果画面が真っ白になっていた。

```ts
// 削除したコード
useEffect(() => {
  const modeParam = searchParams.get('mode');
  const prefillParam = searchParams.get('prefill');
  if (modeParam === 'app' && !prefillParam) {
    setStep('mode-select');
    setPhotoFiles([]);
    setPhotoPreviews([]);
  }
// eslint-disable-next-line react-hooks/exhaustive-deps
}, []);
```

## 修正内容

上記 useEffect を完全削除。

写真撮影デッドロックは PR #778 の他の対策 (input value="" リセット + RN tabPress reload) でカバー済のため、この useEffect は不要。

## 検証

- `npm run build` EXIT=0
- WEB only fix。App rebuild 不要。