### PR TITLE
fix: 解析結果ブロック AnimatePresence mode=wait 削除

### DIFF
--- a/src/app/(main)/meals/new/page.tsx
+++ b/src/app/(main)/meals/new/page.tsx
@@ -1064,7 +1064,7 @@ export default function MealCaptureModal() {
         <div className="w-10" />
       </div>
 
-      <AnimatePresence mode="wait">
+      <AnimatePresence>
         {/* ステップ0: モード選択 */}
         {step === 'mode-select' && (
           <motion.div


### PR DESCRIPTION
## 概要

`/src/app/(main)/meals/new/page.tsx` L1067 の `<AnimatePresence mode="wait">` を削除。

## 真因

`mode="wait"` は前の `motion.div` の exit アニメーション完了まで次の enter をブロックする設定。  
step が `analyzing → result` に遷移する際、ヘッダー部分は更新されるが、`AnimatePresence` 配下の中身 `motion.div` が exit 待ちでブロックされ空白になっていた。

## 変更内容

```tsx
// Before
<AnimatePresence mode="wait">

// After
<AnimatePresence>
```

`mode` 属性を削除してデフォルト動作 (`sync`) に変更。前要素の exit と新要素の enter が並列実行され、中身が即座に表示される。

## 関連

- PR #787 で key 安定化済みだが、`mode="wait"` 自体の exit 待ちが残っており完全には修正されていなかった。
- `npm run build` EXIT=0 確認済み。