### PR TITLE
fix: 解析結果上部空白を解消 (mode=popLayout)

### DIFF
--- a/src/app/(main)/meals/new/page.tsx
+++ b/src/app/(main)/meals/new/page.tsx
@@ -1064,7 +1064,7 @@ export default function MealCaptureModal() {
         <div className="w-10" />
       </div>
 
-      <AnimatePresence>
+      <AnimatePresence mode="popLayout">
         {/* ステップ0: モード選択 */}
         {step === 'mode-select' && (
           <motion.div


### PR DESCRIPTION
## 問題

PR #788 で `AnimatePresence` の `mode="wait"` を削除したことで画像認識結果の表示は復活したが、step 遷移時に古い `motion.div` が exit アニメーション中に DOM 上に残り、画面上部に約 200-300px の空白が残っていた。

## 修正内容

`<AnimatePresence>` → `<AnimatePresence mode="popLayout">` に変更。

`mode="popLayout"` は exit 中の要素を `position: absolute` 化して layout フローから外すため、新要素が即時フローに入り上部空白が解消される。

## 変更ファイル

- `src/app/(main)/meals/new/page.tsx`: L1067 の `AnimatePresence` に `mode="popLayout"` を追加

## 検証

- `npm run build` EXIT=0 確認済み