### PR TITLE
fix: AnimatePresence 完全削除でボタンクリック復旧

### DIFF
--- a/src/app/(main)/meals/new/page.tsx
+++ b/src/app/(main)/meals/new/page.tsx
@@ -1064,8 +1064,7 @@ export default function MealCaptureModal() {
         <div className="w-10" />
       </div>
 
-      <AnimatePresence mode="popLayout">
-        {/* ステップ0: モード選択 */}
+      {/* ステップ0: モード選択 */}
         {step === 'mode-select' && (
           <motion.div
             key="mode-select"
@@ -2302,7 +2301,6 @@ export default function MealCaptureModal() {
             </motion.div>
           </motion.div>
         )}
-      </AnimatePresence>
     </div>
   );
 }


### PR DESCRIPTION
## 問題

`<AnimatePresence mode="popLayout">` が 2 点の理由で破綻し、step 切替後のボタンがクリック不能になっていた。

1. exit 中の `motion.div` が `position:absolute` で新 step のボタン上に被さり、クリックイベントを吸収
2. L2275 の体重成功モーダル (`showWeightSuccessModal`) が `key` なし `motion.div` として AnimatePresence 内に混入し、child 計算が壊れて exit が無限残留

## 修正

`<AnimatePresence mode="popLayout">` および `</AnimatePresence>` の開閉タグ 2 行を削除。

- 各 step の `motion.div` の enter アニメーション (`initial`/`animate`) はそのまま残る
- step 切替は即時 unmount/mount になり、クリック吸収が発生しない
- 体重成功モーダルの混入問題も同時に解消

## 影響範囲

`src/app/(main)/meals/new/page.tsx` のみ。Vercel 自動デプロイで反映。

## 検証

`npm run build` EXIT=0 確認済み。