### PR TITLE
chore: test:e2e:mvp スクリプト追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:e2e:mvp": "playwright test tests/e2e/0[1-5]-*.spec.ts --reporter=list",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:report": "playwright show-report tests/e2e/.report",

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -41,8 +41,16 @@ test("...", async ({ authedPage }) => {
 
 ## NPM スクリプト
 
+| コマンド | 内容 |
+|---------|------|
+| `npm run test:e2e:mvp` | **MVP 5 spec のみ** (推奨、30秒以内) |
+| `npm run test:e2e` | 全 spec (探索系含む) |
+| `npm run test:e2e:ui` | UI モード (デバッグ用) |
+| `npm run test:e2e:report` | 前回レポート表示 |
+
 ```bash
-npm run test:e2e            # CLI 実行 (デフォルト: 本番 URL)
+npm run test:e2e:mvp        # MVP 5 spec のみ実行 (PR 前チェックに最適)
+npm run test:e2e            # CLI 実行 (デフォルト: 本番 URL、全 spec)
 npm run test:e2e:ui         # UI モード (推奨・デバッグ向け)
 npm run test:e2e:headed     # ブラウザ表示
 npm run test:e2e:report     # 前回レポート表示


### PR DESCRIPTION
## Summary

- `npm run test:e2e:mvp` を `package.json` に追加 (`tests/e2e/0[1-5]-*.spec.ts --reporter=list`)
- MVP 5 spec (01-login / 02-meal-photo / 03-ai-advisor / 04-menu-page / 05-shopping-list) のみを実行、30 秒以内
- `tests/e2e/README.md` の NPM スクリプト表に `test:e2e:mvp` を追記

## Test plan

- [ ] `npm run test:e2e:mvp -- --list` で 5 tests in 5 files が表示されることを確認
- [ ] `npm run test:e2e` が従来どおり全 spec を対象とすることを確認