### PR TITLE
fix: AI Advisor アーカイブ失敗を解消

### DIFF
--- a/apps/mobile/src/components/ai/AIAdvisorSheet.tsx
+++ b/apps/mobile/src/components/ai/AIAdvisorSheet.tsx
@@ -237,8 +237,28 @@ export const AIAdvisorSheet: React.FC<Props> = ({ visible, onClose }) => {
     await loadMessages(sessionId);
   }
 
+  async function fetchSessions() {
+    try {
+      const api = getApi();
+      const res = await api.get<{ sessions: Session[] }>(
+        "/api/ai/consultation/sessions?status=all"
+      );
+      setSessions(res.sessions ?? []);
+    } catch {
+      // 取得失敗は無視
+    }
+  }
+
   async function archiveSession() {
     if (!currentSessionId || isClosingSession) return;
+
+    // クライアント側で既に closed か確認
+    const currentSession = sessions.find((s) => s.id === currentSessionId);
+    if (currentSession?.status === "closed") {
+      Alert.alert("情報", "このセッションは既にアーカイブ済みです。");
+      return;
+    }
+
     setIsClosingSession(true);
     try {
       const { data: sessionData } = await supabase.auth.getSession();
@@ -268,8 +288,18 @@ export const AIAdvisorSheet: React.FC<Props> = ({ visible, onClose }) => {
           ]);
         }
         await createNewSession();
+      } else if (res.status === 400) {
+        // Already closed: UI を最新に合わせる
+        Alert.alert("情報", "このセッションは既にアーカイブ済みです。");
+        await fetchSessions();
       } else {
-        Alert.alert("エラー", "セッションのアーカイブに失敗しました。");
+        const err = await res.json().catch(() => ({}));
+        Alert.alert(
+          "エラー",
+          (err as any)?.message ||
+            (err as any)?.error ||
+            "セッションのアーカイブに失敗しました。"
+        );
       }
     } catch {
       Alert.alert("エラー", "セッションのアーカイブに失敗しました。");
@@ -488,7 +518,12 @@ export const AIAdvisorSheet: React.FC<Props> = ({ visible, onClose }) => {
                   <Pressable
                     testID="ai-archive-btn"
                     onPress={archiveSession}
-                    disabled={isClosingSession || !currentSessionId}
+                    disabled={
+                      isClosingSession ||
+                      !currentSessionId ||
+                      sessions.find((s) => s.id === currentSessionId)
+                        ?.status === "closed"
+                    }
                     style={styles.headerActionBtn}
                   >
                     {isClosingSession ? (


### PR DESCRIPTION
## Summary

- `archiveSession` 実行前にクライアント側で `session.status === 'closed'` を確認し、既にアーカイブ済みなら 400 を叩かずに早期 return
- サーバーから 400 (Already closed) が返った場合は「既にアーカイブ済みです」を表示し `fetchSessions()` で一覧を最新化 (UI と DB の乖離を解消)
- `fetchSessions()` ヘルパーを新規追加し、400 ハンドラから再利用
- ヘッダーのアーカイブボタンを `closed` セッション閲覧中は `disabled` に設定

## Root Cause

App 版は archive 後に `createNewSession()` を呼んでいたが、**既に closed のセッションに再度 close を叩くケース** のハンドリングが欠落していた。
セッション一覧を再取得せずに UI を更新していたため、DB 側が `closed` でも UI 上は `active` と見えていた。

## Test plan

- [ ] active セッションのアーカイブボタンを押す → 成功し新規セッションが開く
- [ ] closed セッションを閲覧中はアーカイブボタンが disabled になっている
- [ ] セッション一覧から closed セッションを選択してアーカイブボタンを押す → 「既にアーカイブ済みです」が表示され一覧が更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)