### PR TITLE
docs: 家族管理・組織管理・運営者管理の要件定義書 (3 本)

### DIFF
--- a/docs/requirements/01-family-management.md
+++ b/docs/requirements/01-family-management.md
@@ -1,0 +1,1194 @@
+# 家族管理機能 要件定義書
+
+**ドキュメントバージョン**: 1.0
+**最終更新**: 2026-05-06
+**作成者**: Opus (Claude)
+**ステータス**: ドラフト (レビュー待ち)
+**関連ドキュメント**: `02-organization-management.md`, `03-operator-admin.md`
+
+---
+
+## 1. エグゼクティブサマリー
+
+### 1.1 背景と目的
+
+ほめゴハンは個人ユーザー向けの食事管理アプリとして開発されてきたが、現実の食事は **家族単位** で営まれることが多い。母親が家族 4 人分の献立を考え、父親が買い物に行き、子供が成長期の栄養を必要とする。これらは個人アカウント単位では完結しない。
+
+家族管理機能は、複数の個人アカウントを「家族グループ」としてまとめ、メンバー間で食事記録・献立・買い物リストを共有・閲覧できる仕組みである。同時に、アカウントを持たない子供や高齢者を「管理対象メンバー」として登録し、家族の代表が代理で管理する用途にも対応する。
+
+### 1.2 想定するユーザー像
+
+- **核家族世帯** (親 2 + 子 1〜3): 親が家族全員の献立を一括管理
+- **多世代同居** (祖父母 + 親 + 子): 高齢者の塩分制限と子供の成長期栄養を両立
+- **単身赴任**: 別居家族とも献立や買い物リストを共有
+- **シェアハウス**: 同居人と食材費を分担、当番制で食事担当
+
+### 1.3 ビジネス価値
+
+| 価値 | 説明 |
+|------|------|
+| 利用継続率向上 | 家族で使うと退会しにくい (ネットワーク効果) |
+| 単価向上機会 | 「家族プラン」として有料化の余地 |
+| 法人連携 | 家族健康増進プログラムへの法人契約展開 |
+| 競合差別化 | 個人特化のフードログアプリには無い独自機能 |
+
+### 1.4 現状実装サマリ
+
+調査結果 (2026-05-06):
+
+| 領域 | 状態 |
+|------|------|
+| `family_groups` / `family_members` テーブル | 実装済 |
+| `/api/family/groups` (GET/POST) | 実装済 |
+| `/api/family/members` (GET/POST) | 実装済 |
+| モバイル App `/family` 画面 | 部分実装 |
+| Web 版家族管理画面 | **未実装** |
+| 招待リンク生成・受諾 | **未実装** |
+| メンバー間データ閲覧 | **未実装** |
+| 子供アカウント | **未実装** |
+| 家族プラン課金 | **未実装** |
+
+本要件定義書は、この未実装領域を全て補完し、家族管理機能を完成形にする。
+
+### 1.5 スコープ
+
+#### 含む
+- 家族グループの作成・更新・削除
+- メンバー招待 (Email + リンク)、受諾、参加、退出
+- メンバー間の食事記録閲覧、献立共有
+- 子供アカウント (アカウント無しメンバー → 後でアカウント発行)
+- ロール (オーナー / 管理者 / メンバー / 子供)
+- 通知 (招待・参加・退出)
+- Web + Mobile App 両対応
+- 家族プラン (1 オーナー = 4 メンバー無料、5 人目以降は有料)
+
+#### 含まない
+- 家族グループ間の連合機能 (例: 親戚グループ)
+- 共同決済 / 家計簿連動 (将来検討)
+- 共同買い物カート (本書スコープ外、別 Phase で)
+- グループチャット (家族メンバー間の会話、別機能で)
+
+---
+
+## 2. 用語定義
+
+| 用語 | 定義 |
+|------|------|
+| **家族グループ (Family Group)** | 1 名以上のメンバーで構成される食事管理上の単位。1 ユーザーは 1 グループのみ所属可能 (ver 1.0) |
+| **オーナー (Owner)** | 家族グループ作成者。請求・解散・他全員除名の権限を持つ |
+| **管理者 (Admin)** | オーナーから委任された管理権限を持つメンバー。メンバー追加・削除・献立編集が可能 |
+| **メンバー (Member)** | 一般メンバー。閲覧・自分のデータ更新・献立提案が可能 |
+| **子供メンバー (Child Member)** | アカウントを持たない管理対象メンバー。親が代理で食事を記録 |
+| **ペンディングメンバー (Pending Member)** | 招待は送られたが受諾していないメンバー (アカウントは作成済 or 未作成) |
+| **招待トークン (Invite Token)** | 招待リンクに含まれる一意の文字列。HMAC SHA256 + 期限付き |
+| **管理対象データ (Managed Data)** | 子供メンバーやアカウント未紐付けメンバーの代理記録データ |
+| **共有献立 (Shared Menu)** | グループ全員に表示される共通の週間献立 |
+| **個別献立 (Individual Menu)** | 特定メンバー (アレルギー対応等) のために個別に管理される献立 |
+| **食材按分 (Servings Allocation)** | 1 つのレシピを複数メンバーに対してどう配分するかの定義 |
+
+---
+
+## 3. ペルソナ
+
+### 3.1 ペルソナ A: 田中 美咲 (40 歳、共働き母親、2 児)
+
+**プロフィール**
+- 職業: 会社員 (システムエンジニア)
+- 家族: 夫 (40 歳)、長男 (10 歳)、次男 (6 歳)
+- IT リテラシー: 高 (スマホ・PC 両方使用)
+- 課題: 平日の献立を考えるのが苦痛。子供のアレルギー (卵) と夫の高血圧 (減塩) を両立した献立を毎日作らねばならない
+
+**主要ニーズ**
+- 家族 4 人分の献立を一括生成、メンバー個別の制約 (アレルギー / 減塩) を AI が考慮
+- 夫が買い物に行くとき、共有買い物リストを iPhone でリアルタイム参照
+- 子供の食事記録を親が代理入力 (子供はアカウントなし)
+- 成長期の長男のタンパク質摂取量を週次でモニター
+
+**主要ジャーニー**
+1. ほめゴハンで自分のアカウント作成 → 家族グループ「田中家」作成 (オーナー)
+2. 夫を Email で招待 → 夫がアプリインストール → 受諾 → メンバーとして参加
+3. 長男 (10 歳) を「子供メンバー」として登録 (アカウント無し) → アレルギー: 卵
+4. 次男 (6 歳) も同様に登録
+5. AI に「家族 4 人の今週の献立を作って」と依頼 → 個別制約を考慮した献立生成
+6. 夫が買い物 → 共有リストにチェック → 美咲のアプリでも反映
+
+### 3.2 ペルソナ B: 山田 太郎 (35 歳、単身赴任、別居家族 2 人)
+
+**プロフィール**
+- 職業: 会社員 (営業)
+- 家族: 妻 (33 歳、別居)、長女 (4 歳、別居)
+- IT リテラシー: 中
+- 課題: 単身赴任で自炊が続かない。妻が長女の食事管理を一人で担当しており、栄養バランスが心配
+
+**主要ニーズ**
+- 単身赴任中の自分の食事と、別居家族の食事を 1 つのアプリで把握
+- 妻に長女の食事記録をプッシュ通知で確認
+- 帰省時の食事計画を妻と共同で立てる
+- 長女の月次成長レポートを妻と共有
+
+**主要ジャーニー**
+1. 太郎が家族グループ「山田家」作成 (オーナー)
+2. 妻を招待 → 妻が管理者ロールで参加
+3. 長女 (4 歳) を子供メンバーとして登録
+4. 太郎は赴任先で自分の食事記録、妻は自宅で長女の食事を記録
+5. 太郎のアプリで「家族全員の今週の食事」を閲覧 → 長女の野菜摂取量が少ない日に通知
+6. 帰省週末は共有献立で「家族で食べる料理」を計画
+
+### 3.3 ペルソナ C: 鈴木 健 (68 歳、シニア、配偶者 + 同居娘夫婦)
+
+**プロフィール**
+- 職業: 退職 (元教員)
+- 家族: 妻 (65 歳)、娘 (40 歳)、娘婿 (42 歳)、孫 (8 歳)
+- IT リテラシー: 低 (スマホ操作はできるが PC は苦手)
+- 健康課題: 軽度高血圧 + 糖尿病予備軍 → 減塩 + 糖質制限が必要
+- 課題: 多世代同居で食事の好みが分かれる。健の特殊な食事制限を娘がフォロー
+
+**主要ニーズ**
+- 健の医師指示の塩分・糖質上限を超えないよう毎日チェック
+- 娘 (家族管理者) が両親の食事を代理で確認・調整
+- 孫の成長期栄養を一緒に管理
+- 写真撮影で食事記録 (操作が簡単)
+
+**主要ジャーニー**
+1. 娘がオーナーで家族グループ「鈴木家」作成
+2. 健 (父親) を Email 招待 → 健はメンバーロール
+3. 健は毎食の写真を撮るだけ、AI が自動解析
+4. 娘の管理画面で「父の今日の塩分: 6.8g (目標 6g 超過)」 アラート
+5. 娘が今夜の献立を「減塩版」に切り替え → 家族全員に通知
+
+---
+
+## 4. ユースケース
+
+### 4.1 UC-FAM-01: 家族グループの作成
+
+**アクター**: ユーザー (オーナーになる)
+**事前条件**: ユーザーがログイン済、家族グループ未所属
+**事後条件**: 家族グループが作成され、ユーザーがオーナーとして登録
+
+**フロー**:
+1. ユーザーが Web/Mobile の「家族管理」メニューを開く
+2. 「家族グループを作成」ボタンをタップ
+3. グループ名 (例: 「田中家」)、説明 (任意) を入力
+4. プラン選択 (無料 4 人まで / 家族プラン 8 人まで月額 480 円 等)
+5. 「作成」ボタン → API `POST /api/family/groups`
+6. 作成完了画面に「家族メンバーを招待しよう!」のフォロー UI
+
+**例外フロー**:
+- E1: 既に家族グループに所属中 → エラー「1 グループのみ所属可能」(ver 1.0 制約)
+- E2: グループ名が空・101 文字以上 → バリデーションエラー
+- E3: プラン課金失敗 → 無料プランで作成、後で upgrade 可
+
+### 4.2 UC-FAM-02: メンバー招待 (Email リンク方式)
+
+**アクター**: オーナー or 管理者
+**事前条件**: 家族グループ作成済、招待者がオーナー or 管理者ロール
+**事後条件**: 招待トークン生成、Email 送信、ペンディングメンバー追加
+
+**フロー**:
+1. オーナーが「家族メンバー」画面 → 「招待」ボタン
+2. Email アドレス + ロール (管理者 / メンバー) + ニックネーム (任意) を入力
+3. 「招待を送る」 → API `POST /api/family/invites`
+   - サーバー側でトークン生成 (`crypto.randomBytes(32).toString('hex')`)
+   - `family_invites` テーブルに保存 (期限 7 日)
+   - Email 送信 (Resend / SendGrid 経由)
+   - URL 例: `https://homegohan-app.vercel.app/invite/family/{token}`
+4. 受信者は Email リンクをクリック
+5. アプリ起動 (Mobile) or Web 表示
+6. 受諾画面で「家族グループ「○○家」に招待されています」表示
+7. 「参加する」ボタン → 既存ユーザーならログイン、未登録なら新規登録
+8. 参加完了 → グループメンバー一覧に追加
+
+**例外フロー**:
+- E1: 既に他グループ所属 → 受諾不可、メッセージ表示
+- E2: トークン期限切れ → 「招待が期限切れです」、再送依頼
+- E3: トークン使用済 → 「既に受諾済の招待です」
+
+### 4.3 UC-FAM-03: 子供メンバー登録 (アカウント無し)
+
+**アクター**: オーナー or 管理者
+**事前条件**: 家族グループ作成済
+**事後条件**: アカウント無しメンバーが追加 (`family_members.user_id = null`)
+
+**フロー**:
+1. 「メンバー追加」 → 「子供 / アカウント無しで追加」選択
+2. 名前、続柄 (息子/娘/祖父/祖母/etc.)、生年月日、性別、身長・体重 (任意)、アレルギー、嫌いな食べ物、健康状態
+3. 「追加」 → API `POST /api/family/members` with `user_id: null`
+4. メンバー一覧に表示 (アバター + 名前 + 「アカウントなし」表示)
+
+**将来拡張**:
+- 子供が大きくなりアカウント発行 → 既存 family_member レコードと紐付け
+
+### 4.4 UC-FAM-04: メンバー除名
+
+**アクター**: オーナー (管理者は同ロールメンバー除名のみ可、オーナー除名不可)
+**事前条件**: 対象メンバーがグループ所属
+**事後条件**: メンバーがグループから除外 (`is_active = false`)
+
+**フロー**:
+1. メンバー一覧で対象メンバー長押し → 「除名」
+2. 確認モーダル: 「○○さんを家族から外します。記録した食事データはどうしますか?」
+   - オプション A: 「メンバーには残す (履歴として参照可)」
+   - オプション B: 「完全に削除する」
+3. 確定 → API `DELETE /api/family/members/{id}`
+4. 通知: 除名されたメンバーに「家族グループから外されました」push 通知
+
+### 4.5 UC-FAM-05: メンバー間食事記録閲覧
+
+**アクター**: 任意のメンバー (権限による制限あり)
+**事前条件**: 同一グループ所属、対象メンバーの食事記録あり
+**事後条件**: 食事記録一覧 / 詳細を閲覧
+
+**フロー**:
+1. 「家族メンバー」一覧で他メンバーをタップ
+2. メンバー詳細画面に「今週の食事」「栄養トレンド」「健康状態」表示
+3. 食事カード一覧 → タップで詳細
+4. プライバシー設定 (個人で「食事記録を家族に公開しない」設定可)
+
+**権限ロジック**:
+- オーナー: 全メンバー閲覧可
+- 管理者: 全メンバー閲覧可 (子供メンバー含む)
+- メンバー: 公開設定したメンバーのみ閲覧可
+- 子供メンバー: 自分のみ (ただし子供はアカウントなしなので閲覧者にはならない)
+
+### 4.6 UC-FAM-06: 共有献立 / 個別献立
+
+**アクター**: オーナー or 管理者
+**事前条件**: グループ所属メンバー 2 人以上
+**事後条件**: 週間献立が共有 (グループ全員) or 個別 (特定メンバー) で生成
+
+**フロー (共有献立)**:
+1. 献立生成 UI で「対象: 家族全員」を選択
+2. 制約 (アレルギー、減塩等) は **全メンバーの和集合** で適用 (誰か 1 人でも卵アレルギーなら卵不使用)
+3. AI 献立生成 → 全員の週間献立に表示
+
+**フロー (個別献立)**:
+1. メンバー詳細画面で「○○の個別献立」生成
+2. 特定メンバーの制約のみで生成
+3. 共有献立とは別タブで表示
+
+### 4.7 UC-FAM-07: メンバー脱退 (本人意思)
+
+**アクター**: メンバー (オーナーは脱退不可、解散のみ)
+**事前条件**: グループ所属
+**事後条件**: グループから脱退 (`is_active = false`)
+
+**フロー**:
+1. 「家族管理」メニュー → 「家族から脱退」
+2. 確認モーダル: 「家族グループから抜けますか? 自分の食事記録は保持されます」
+3. 確定 → API `POST /api/family/members/leave`
+4. 通知: オーナーに「○○さんが家族から脱退しました」
+
+### 4.8 UC-FAM-08: グループ解散 (オーナーのみ)
+
+**アクター**: オーナー
+**事前条件**: ユーザーがオーナー
+**事後条件**: グループ削除、全メンバーが孤立化
+
+**フロー**:
+1. グループ設定 → 「グループを解散」
+2. 警告: 「メンバー全員が家族から離れます。共有献立・買い物リストは削除されます。記録した食事は各個人に残ります」
+3. パスワード再認証
+4. 確定 → API `DELETE /api/family/groups/{id}`
+5. 全メンバーに「家族グループ「○○家」が解散されました」通知
+
+### 4.9 UC-FAM-09: ロール変更
+
+**アクター**: オーナー
+**事前条件**: 対象メンバーがグループ所属
+**事後条件**: 対象メンバーのロールが変更
+
+**フロー**:
+1. メンバー詳細画面 → 「ロール: メンバー」をタップ → 「管理者」に変更
+2. 確認 → API `PATCH /api/family/members/{id}` with `role`
+3. 通知: 対象メンバーに「○○家の管理者に任命されました」
+
+### 4.10 UC-FAM-10: オーナー権限の譲渡
+
+**アクター**: オーナー
+**事前条件**: 管理者がいる
+**事後条件**: オーナーが交代 (元オーナーは管理者になる)
+
+**フロー**:
+1. グループ設定 → 「オーナーを変更」
+2. 譲渡先メンバー (管理者ロールから選択)
+3. パスワード再認証
+4. 確定 → API `POST /api/family/groups/{id}/transfer-owner`
+5. 双方に通知
+
+---
+
+## 5. 機能要件
+
+### 5.1 F-FAM-001: 家族グループ管理
+
+#### 5.1.1 概要
+家族グループを作成・編集・解散できる。1 ユーザー 1 グループ制限。
+
+#### 5.1.2 機能詳細
+
+**作成**
+- グループ名 (必須、1-100 文字)
+- 説明 (任意、500 文字以内)
+- アイコン画像 (任意、デフォルトは家族アイコン)
+- プラン選択 (無料 / 家族プラン)
+
+**編集**
+- オーナーのみ
+- グループ名、説明、アイコン変更可
+- プラン変更は別フロー (UC-FAM-13、本書 Phase 2)
+
+**解散**
+- オーナーのみ
+- パスワード再認証必須
+- 全関連データ (`family_groups`, `family_members`, `family_invites`) を CASCADE 削除
+- ただしメンバーの個人食事記録 (`meals`) は保持
+
+#### 5.1.3 受け入れ基準
+- ✅ オーナーがグループ名を変更すると、全メンバーのアプリで反映される
+- ✅ 既にグループ所属のユーザーが新規グループ作成しようとすると 409 エラー
+- ✅ 解散後は招待トークンも全て無効化される
+
+### 5.2 F-FAM-002: 招待管理
+
+#### 5.2.1 招待方法
+- **Email 招待**: アドレス入力 → 招待メール送信
+- **リンク招待 (Phase 2)**: 招待リンクを生成してオーナーが SNS 等で共有
+- **QR コード (Phase 3)**: 同居家族向けに対面で QR スキャン
+
+#### 5.2.2 招待トークン仕様
+```
+{
+  "id": "uuid",
+  "family_group_id": "uuid (FK)",
+  "email": "string (招待先メアド、未登録 OK)",
+  "role": "admin | member",
+  "token": "string (32 byte hex)",
+  "expires_at": "timestamp (作成 + 7 日)",
+  "accepted_at": "timestamp | null",
+  "created_by": "uuid (FK: auth.users)",
+  "created_at": "timestamp"
+}
+```
+
+#### 5.2.3 招待フロー
+1. オーナーが招待作成 → トークン生成 + Email 送信
+2. 受信者がリンクをクリック → 受諾画面
+3. ログイン (or 新規登録)
+4. 「家族「○○家」に参加する」ボタン
+5. `family_members` レコード作成 + `family_invites.accepted_at` 更新
+
+#### 5.2.4 制約
+- 1 ユーザーは 1 グループのみ → 既に他グループ所属なら受諾不可
+- 招待は 7 日間有効
+- 同一 Email への重複招待は最後の 1 件のみ有効
+- オーナーは同一グループに招待を 100 件まで作成可
+
+#### 5.2.5 受諾完了通知
+- 招待者 (オーナー / 管理者) に push 通知 + Email
+- グループ全員に「○○さんが家族に加わりました」アクティビティ表示
+
+### 5.3 F-FAM-003: メンバー管理
+
+#### 5.3.1 メンバー属性
+- **基本情報**: 名前、続柄、生年月日、性別、身長、体重
+- **食事制約**: アレルギー、嫌いな食べ物、好きな食べ物、辛さ耐性
+- **健康状態**: 健康疾患、服用薬、栄養目標 (減量/維持/増量)
+- **栄養目標**: 1 日のカロリー / タンパク質 / 脂質 / 炭水化物
+- **表示**: 表示順、アクティブ/非アクティブ
+- **アカウント**: `user_id` (null 可)
+
+#### 5.3.2 操作
+- 追加 (アカウント有 / 子供アカウント無)
+- 編集 (オーナー or 管理者 or 本人)
+- 除名 (オーナー or 管理者)
+- 脱退 (本人)
+- ロール変更 (オーナーのみ)
+
+#### 5.3.3 アカウントなし → アカウントあり 紐付け
+- 子供メンバーが成長してアカウント作成 → 既存 `family_members` レコードに `user_id` を紐付ける
+- API: `POST /api/family/members/{id}/link-account`
+- 認証: 本人がログイン中 + メンバー追加した家族のオーナーが承認
+
+### 5.4 F-FAM-004: ロール・権限
+
+| ロール | 説明 |
+|--------|------|
+| **オーナー (owner)** | グループ作成者、全権限 |
+| **管理者 (admin)** | メンバー管理 + 献立編集権限 |
+| **メンバー (member)** | 閲覧 + 自分のデータ更新 |
+| **子供 (child)** | アカウントなし、データ管理対象のみ |
+
+#### 5.4.1 権限マトリクス
+
+| 操作 | オーナー | 管理者 | メンバー | 子供 |
+|------|---------|--------|---------|------|
+| グループ編集 | ✅ | ❌ | ❌ | ❌ |
+| グループ解散 | ✅ | ❌ | ❌ | ❌ |
+| メンバー追加 | ✅ | ✅ | ❌ | ❌ |
+| メンバー除名 (他人) | ✅ | △ (子供のみ) | ❌ | ❌ |
+| 招待送信 | ✅ | ✅ | ❌ | ❌ |
+| ロール変更 | ✅ | ❌ | ❌ | ❌ |
+| オーナー譲渡 | ✅ | ❌ | ❌ | ❌ |
+| 共有献立編集 | ✅ | ✅ | ❌ | ❌ |
+| 共有献立閲覧 | ✅ | ✅ | ✅ | ❌ |
+| 自分の食事記録 | ✅ | ✅ | ✅ | △ (代理) |
+| 他人の食事記録閲覧 | ✅ | ✅ | △ (公開設定次第) | ❌ |
+| 共有買い物リスト編集 | ✅ | ✅ | ✅ | ❌ |
+| プライバシー設定 | ✅ | ✅ | ✅ | ❌ |
+
+### 5.5 F-FAM-005: 共有献立
+
+#### 5.5.1 共有献立とは
+グループ全員の食事として「今週月曜の夕食はカレー」のような **共通の献立** を管理する。
+
+#### 5.5.2 個別献立との違い
+- **共有献立**: グループの全メンバーで共通 (カレーを食べる日)
+- **個別献立**: 特定メンバー専用 (アレルギー対応、ダイエット中の代替食 等)
+
+メンバーは両方を組み合わせて週間献立を構成する。
+
+#### 5.5.3 制約の和集合
+共有献立 AI 生成時は、全メンバーの制約の **和集合** を適用:
+- 例: 美咲 (制約なし) + 夫 (減塩) + 長男 (卵アレルギー) + 次男 (制約なし)
+  → 減塩 AND 卵不使用 で生成
+
+#### 5.5.4 食材按分
+1 つのレシピを家族 4 人で分けるとき、メンバーごとの量を可視化:
+- 例: ハンバーグ 4 個 → 美咲 1 個、夫 1 個、長男 1.5 個、次男 0.5 個
+- メンバーの体重・年齢・栄養目標から自動配分
+- 手動上書きも可
+
+### 5.6 F-FAM-006: 共有買い物リスト
+
+#### 5.6.1 概要
+家族の誰でも編集可能な共通買い物リスト。チェック状態がリアルタイム同期。
+
+#### 5.6.2 機能
+- 買い物リストの自動生成 (共有献立から)
+- 手動追加 (誰でも)
+- チェック / アンチェック
+- 担当者割り当て (任意、「○○が買う」)
+- リアルタイム同期 (Supabase Realtime)
+
+### 5.7 F-FAM-007: 通知
+
+#### 5.7.1 通知種別
+
+| 種別 | 配信先 | 経路 |
+|------|--------|------|
+| 招待を受け取った | 受信者 | Email + Push |
+| 招待が受諾された | 招待者 | Push |
+| メンバーが参加した | グループ全員 | Push (in-app) |
+| メンバーが脱退した | グループ全員 | Push (in-app) |
+| メンバーが除名された | 除名対象 | Push + Email |
+| グループ解散 | 元メンバー全員 | Push + Email |
+| 共有献立が生成された | グループ全員 | Push (任意設定) |
+| 買い物リストに追加された | グループ全員 | Push (任意設定) |
+| 緊急通知 (アレルギー誤食警告) | グループ全員 | Push + 強制表示 |
+
+#### 5.7.2 通知設定
+- ユーザー個別に ON/OFF 可能
+- 種別ごとに Email / Push を選択可
+- 「家族関連」「献立」「買い物リスト」「緊急」のカテゴリ単位
+
+---
+
+## 6. 非機能要件
+
+### 6.1 パフォーマンス
+
+| 指標 | 目標 |
+|------|------|
+| 家族メンバー一覧の表示 | < 500ms (10 人以下) |
+| 招待メール送信 | < 3s (バックグラウンド) |
+| 共有献立生成 | < 30s (4 人家族) |
+| メンバー追加 | < 1s |
+
+### 6.2 拡張性
+
+- 1 グループあたり最大メンバー数: 20 人 (将来 50 人へ拡張可)
+- 1 ユーザーが将来複数グループ所属可能 (Phase 3)
+
+### 6.3 セキュリティ
+
+- 招待トークン: 32 byte (256 bit) ランダム + HMAC 署名
+- メンバー間データ閲覧は RLS で制御
+- 子供メンバーの個人情報 (生年月日・体重) は親のみアクセス可
+- パスワード再認証: グループ解散・オーナー譲渡時必須
+
+### 6.4 プライバシー
+
+- 食事記録の家族公開は **オプトイン** (デフォルト非公開)
+- 健康状態・服薬情報は本人のみ閲覧可 (家族管理者にも非公開デフォルト)
+- アカウント削除時、家族グループ所属情報も自動削除
+
+### 6.5 アクセシビリティ
+
+- スクリーンリーダー対応 (ARIA ラベル)
+- 高齢者向け大文字モード (Accessibility Settings)
+- カラーブラインド対応 (色だけで情報を区別しない)
+
+### 6.6 国際化
+
+- 日本語 (デフォルト)
+- 英語 (Phase 2)
+- 単位系: メートル法 (kg, cm, ml) のみ (英語版でも統一)
+
+---
+
+## 7. データモデル
+
+### 7.1 テーブル定義
+
+#### 7.1.1 `family_groups`
+
+```sql
+CREATE TABLE family_groups (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name          VARCHAR(100) NOT NULL,
+  description   TEXT,
+  icon_url      TEXT,
+  owner_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  plan          VARCHAR(50) NOT NULL DEFAULT 'free' CHECK (plan IN ('free', 'family_basic', 'family_pro')),
+  member_limit  INT NOT NULL DEFAULT 4,
+  settings      JSONB NOT NULL DEFAULT '{}',
+  archived_at   TIMESTAMP WITH TIME ZONE,
+  created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  UNIQUE (owner_id)  -- 1 ユーザー 1 オーナーグループ
+);
+
+CREATE INDEX idx_family_groups_owner ON family_groups(owner_id);
+```
+
+**RLS ポリシー**:
+- SELECT: メンバー全員 (`family_members.user_id = auth.uid()`)
+- UPDATE: オーナー (`owner_id = auth.uid()`)
+- DELETE: オーナー (`owner_id = auth.uid()`)
+- INSERT: 認証済ユーザー (グループ未所属チェック)
+
+#### 7.1.2 `family_members`
+
+```sql
+CREATE TABLE family_members (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_group_id     UUID NOT NULL REFERENCES family_groups(id) ON DELETE CASCADE,
+  user_id             UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  -- 基本情報
+  name                VARCHAR(50) NOT NULL,
+  relation            VARCHAR(50) NOT NULL,  -- 'self', 'spouse', 'child', 'parent', 'sibling', 'other'
+  birth_date          DATE,
+  gender              VARCHAR(20) CHECK (gender IN ('male', 'female', 'other', 'prefer_not_to_say')),
+  -- 身体情報
+  height_cm           NUMERIC(5,2),
+  weight_kg           NUMERIC(5,2),
+  -- 食事関連
+  allergies           TEXT[] DEFAULT '{}',
+  dislikes            TEXT[] DEFAULT '{}',
+  favorite_foods      TEXT[] DEFAULT '{}',
+  diet_style          VARCHAR(50) DEFAULT 'omnivore',  -- 'omnivore', 'pescatarian', 'vegetarian', 'vegan', 'keto', 'halal', 'kosher'
+  spice_tolerance     VARCHAR(20) DEFAULT 'medium',  -- 'mild', 'medium', 'spicy'
+  -- 健康
+  health_conditions   TEXT[] DEFAULT '{}',
+  medications         TEXT[] DEFAULT '{}',
+  daily_calories      INT,
+  protein_ratio       NUMERIC(4,2),  -- 0.10〜0.40
+  -- ロール
+  role                VARCHAR(20) NOT NULL DEFAULT 'member' CHECK (role IN ('owner', 'admin', 'member', 'child')),
+  -- 表示・状態
+  display_order       INT NOT NULL DEFAULT 0,
+  is_active           BOOLEAN NOT NULL DEFAULT TRUE,
+  privacy_settings    JSONB NOT NULL DEFAULT '{"share_meals": false, "share_health": false}',
+  -- メタ
+  created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  -- user_id がある場合は 1 グループ 1 メンバー
+  UNIQUE (family_group_id, user_id) WHERE (user_id IS NOT NULL)
+);
+
+CREATE INDEX idx_family_members_group ON family_members(family_group_id);
+CREATE INDEX idx_family_members_user ON family_members(user_id) WHERE user_id IS NOT NULL;
+CREATE INDEX idx_family_members_active ON family_members(family_group_id, is_active) WHERE is_active = TRUE;
+```
+
+**RLS ポリシー**:
+- SELECT: 同グループメンバー全員
+- UPDATE: 本人 (`user_id = auth.uid()`) or オーナー or 管理者
+- DELETE: オーナー or 管理者
+- INSERT: オーナー or 管理者
+
+#### 7.1.3 `family_invites`
+
+```sql
+CREATE TABLE family_invites (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_group_id   UUID NOT NULL REFERENCES family_groups(id) ON DELETE CASCADE,
+  email             VARCHAR(255) NOT NULL,
+  role              VARCHAR(20) NOT NULL DEFAULT 'member' CHECK (role IN ('admin', 'member')),
+  nickname          VARCHAR(50),
+  token             VARCHAR(64) NOT NULL UNIQUE,
+  expires_at        TIMESTAMP WITH TIME ZONE NOT NULL,
+  accepted_at       TIMESTAMP WITH TIME ZONE,
+  accepted_by       UUID REFERENCES auth.users(id),
+  cancelled_at      TIMESTAMP WITH TIME ZONE,
+  created_by        UUID NOT NULL REFERENCES auth.users(id),
+  created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_family_invites_token ON family_invites(token);
+CREATE INDEX idx_family_invites_email ON family_invites(email);
+CREATE INDEX idx_family_invites_pending ON family_invites(family_group_id) WHERE accepted_at IS NULL AND cancelled_at IS NULL;
+```
+
+**RLS ポリシー**:
+- SELECT (オーナー/管理者): family_group オーナー or 管理者
+- SELECT (受諾用): 認証なし許可、token で個別アクセス (Server Action 経由)
+- UPDATE: 受諾時のみ (Server Action 内)
+- DELETE: オーナー or 作成者
+
+#### 7.1.4 `family_activity_log`
+
+```sql
+CREATE TABLE family_activity_log (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_group_id   UUID NOT NULL REFERENCES family_groups(id) ON DELETE CASCADE,
+  actor_id          UUID REFERENCES auth.users(id),
+  action_type       VARCHAR(50) NOT NULL,  -- 'group_created', 'member_added', 'member_left', 'member_removed', 'role_changed', 'shared_menu_generated', etc.
+  target_id         UUID,
+  details           JSONB DEFAULT '{}',
+  created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_family_activity_group ON family_activity_log(family_group_id, created_at DESC);
+```
+
+#### 7.1.5 `family_shared_menus`
+
+```sql
+CREATE TABLE family_shared_menus (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_group_id   UUID NOT NULL REFERENCES family_groups(id) ON DELETE CASCADE,
+  date              DATE NOT NULL,
+  meal_type         VARCHAR(20) NOT NULL CHECK (meal_type IN ('breakfast', 'lunch', 'dinner', 'snack')),
+  dish_name         VARCHAR(200) NOT NULL,
+  recipe_id         UUID,
+  servings_total    NUMERIC(4,2) NOT NULL DEFAULT 1.0,
+  notes             TEXT,
+  created_by        UUID NOT NULL REFERENCES auth.users(id),
+  created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  UNIQUE (family_group_id, date, meal_type, dish_name)
+);
+```
+
+#### 7.1.6 `family_member_servings`
+
+```sql
+CREATE TABLE family_member_servings (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_shared_menu_id    UUID NOT NULL REFERENCES family_shared_menus(id) ON DELETE CASCADE,
+  family_member_id         UUID NOT NULL REFERENCES family_members(id) ON DELETE CASCADE,
+  servings                 NUMERIC(4,2) NOT NULL DEFAULT 1.0,
+  notes                    TEXT,
+  UNIQUE (family_shared_menu_id, family_member_id)
+);
+```
+
+#### 7.1.7 `family_shopping_lists` / `family_shopping_items`
+
+```sql
+CREATE TABLE family_shopping_lists (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_group_id   UUID NOT NULL UNIQUE REFERENCES family_groups(id) ON DELETE CASCADE,
+  start_date        DATE NOT NULL,
+  end_date          DATE NOT NULL,
+  status            VARCHAR(20) NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'completed', 'archived')),
+  created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE family_shopping_items (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_shopping_list_id  UUID NOT NULL REFERENCES family_shopping_lists(id) ON DELETE CASCADE,
+  ingredient_name          VARCHAR(200) NOT NULL,
+  quantity                 NUMERIC(8,2),
+  unit                     VARCHAR(20),
+  category                 VARCHAR(50),  -- '野菜', '肉', '魚介', '乳製品', etc.
+  is_checked               BOOLEAN NOT NULL DEFAULT FALSE,
+  assignee_id              UUID REFERENCES auth.users(id),  -- 誰が買うか
+  added_by                 UUID NOT NULL REFERENCES auth.users(id),
+  checked_by               UUID REFERENCES auth.users(id),
+  checked_at               TIMESTAMP WITH TIME ZONE,
+  created_at               TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_family_shopping_items_list ON family_shopping_items(family_shopping_list_id);
+CREATE INDEX idx_family_shopping_items_unchecked ON family_shopping_items(family_shopping_list_id) WHERE is_checked = FALSE;
+```
+
+### 7.2 マイグレーション
+
+```sql
+-- migration: 2026MMDDHHMMSS_create_family_management.sql
+-- 上記テーブル定義をすべて含む
+-- 既存 family_groups / family_members は ALTER TABLE で拡張
+```
+
+---
+
+## 8. API 仕様
+
+### 8.1 グループ操作
+
+#### 8.1.1 `POST /api/family/groups`
+**説明**: 家族グループを作成する。
+**認証**: 必須 (Bearer token)
+**リクエスト**:
+```json
+{
+  "name": "田中家",
+  "description": "我が家の食事管理",
+  "icon_url": null,
+  "plan": "free"
+}
+```
+**レスポンス 201**:
+```json
+{
+  "id": "uuid",
+  "name": "田中家",
+  "owner_id": "uuid",
+  "plan": "free",
+  "member_limit": 4,
+  "created_at": "2026-05-06T20:30:00Z"
+}
+```
+**エラー**:
+- 400: バリデーション失敗
+- 409: 既に他グループ所属
+
+#### 8.1.2 `GET /api/family/groups/me`
+**説明**: 自分が所属する家族グループを取得。
+**認証**: 必須
+**レスポンス 200**:
+```json
+{
+  "group": { /* family_group */ },
+  "my_role": "owner",
+  "members_count": 4,
+  "pending_invites_count": 1
+}
+```
+**レスポンス 404**: 所属グループなし
+
+#### 8.1.3 `PATCH /api/family/groups/{id}`
+**説明**: グループ情報更新 (オーナーのみ)
+**リクエスト**:
+```json
+{
+  "name": "新しい家族名",
+  "description": "...",
+  "settings": { ... }
+}
+```
+
+#### 8.1.4 `DELETE /api/family/groups/{id}`
+**説明**: グループ解散 (オーナーのみ、再認証必須)
+**リクエスト**:
+```json
+{
+  "password": "..."
+}
+```
+
+#### 8.1.5 `POST /api/family/groups/{id}/transfer-owner`
+**説明**: オーナー譲渡
+**リクエスト**:
+```json
+{
+  "new_owner_member_id": "uuid",
+  "password": "..."
+}
+```
+
+### 8.2 メンバー操作
+
+#### 8.2.1 `GET /api/family/members`
+**クエリ**: `?group_id={uuid}`
+**レスポンス**: メンバー一覧 (`is_active = true` のみ)
+
+#### 8.2.2 `POST /api/family/members`
+**説明**: メンバー追加 (子供メンバー or 直接追加)
+```json
+{
+  "name": "長男",
+  "relation": "child",
+  "birth_date": "2016-04-15",
+  "gender": "male",
+  "allergies": ["卵"],
+  "role": "child",
+  "user_id": null
+}
+```
+
+#### 8.2.3 `PATCH /api/family/members/{id}`
+**説明**: メンバー情報更新
+
+#### 8.2.4 `DELETE /api/family/members/{id}`
+**説明**: メンバー除名
+
+#### 8.2.5 `POST /api/family/members/leave`
+**説明**: 自分が脱退
+
+#### 8.2.6 `POST /api/family/members/{id}/link-account`
+**説明**: 子供メンバーにアカウントを紐付ける
+
+### 8.3 招待
+
+#### 8.3.1 `POST /api/family/invites`
+**リクエスト**:
+```json
+{
+  "email": "spouse@example.com",
+  "role": "admin",
+  "nickname": "ダーリン"
+}
+```
+**レスポンス 201**:
+```json
+{
+  "id": "uuid",
+  "token": "abc123...",
+  "invite_url": "https://homegohan-app.vercel.app/invite/family/abc123...",
+  "expires_at": "..."
+}
+```
+
+#### 8.3.2 `GET /api/family/invites/{token}`
+**説明**: 招待トークン情報取得 (受諾画面用)
+**認証**: 不要 (token で identification)
+
+#### 8.3.3 `POST /api/family/invites/{token}/accept`
+**説明**: 招待受諾
+**認証**: 必須
+
+#### 8.3.4 `DELETE /api/family/invites/{id}`
+**説明**: 招待取消 (オーナー or 作成者)
+
+### 8.4 共有献立
+
+#### 8.4.1 `POST /api/family/shared-menus`
+**説明**: 共有献立を AI 生成
+```json
+{
+  "start_date": "2026-05-12",
+  "end_date": "2026-05-18",
+  "constraints": {
+    "use_fridge_first": true,
+    "respect_all_allergies": true,
+    "max_cooking_time_min": 30
+  }
+}
+```
+
+#### 8.4.2 `GET /api/family/shared-menus`
+**クエリ**: `?date_from=...&date_to=...`
+
+#### 8.4.3 `PATCH /api/family/shared-menus/{id}`
+
+#### 8.4.4 `DELETE /api/family/shared-menus/{id}`
+
+### 8.5 共有買い物リスト
+
+#### 8.5.1 `GET /api/family/shopping-list`
+
+#### 8.5.2 `POST /api/family/shopping-list/items`
+**説明**: 手動で買い物アイテム追加
+
+#### 8.5.3 `PATCH /api/family/shopping-list/items/{id}`
+**説明**: チェック / 担当者変更
+
+#### 8.5.4 `POST /api/family/shopping-list/regenerate`
+**説明**: 共有献立から再生成
+
+### 8.6 通知設定
+
+#### 8.6.1 `GET /api/family/notification-preferences`
+
+#### 8.6.2 `PUT /api/family/notification-preferences`
+
+### 8.7 アクティビティログ
+
+#### 8.7.1 `GET /api/family/activity`
+**クエリ**: `?limit=20&before={timestamp}`
+
+---
+
+## 9. UI 画面仕様
+
+### 9.1 Web 画面
+
+#### 9.1.1 `/family` (家族トップ)
+- ログイン中ユーザーの家族グループ一覧 (現状 1 グループのみ)
+- 未所属の場合は「家族グループを作成」or 「招待を確認」ボタン
+- 所属中の場合: グループ名、メンバーアバター一覧、ロール、最近のアクティビティ
+
+#### 9.1.2 `/family/create`
+- グループ名・説明・アイコン入力フォーム
+- プラン選択 (無料 / 有料)
+- 「作成」ボタン → 完了後 `/family/{id}` にリダイレクト
+
+#### 9.1.3 `/family/{id}` (グループ詳細)
+- グループ情報 (オーナーのみ編集ボタン表示)
+- メンバー一覧 (アバター + 名前 + ロール)
+- 「招待」「メンバー追加」「設定」ボタン (権限による表示制御)
+- タブ: メンバー / 共有献立 / 買い物リスト / アクティビティ / 設定
+
+#### 9.1.4 `/family/{id}/members/{memberId}` (メンバー詳細)
+- メンバーの基本情報
+- 食事制約・健康状態
+- 今週の食事記録 (公開設定 ON の場合)
+- 栄養トレンド (グラフ)
+- 編集ボタン (権限あり)
+
+#### 9.1.5 `/family/{id}/invites`
+- 保留中の招待一覧
+- 招待作成フォーム
+- リンクコピー機能
+- 取消ボタン
+
+#### 9.1.6 `/invite/family/{token}` (受諾画面、認証不要 → 認証必須)
+- グループ名、招待者、ロール表示
+- ログイン or 新規登録
+- 「参加する」ボタン
+- 既に他グループ所属の場合は警告
+
+#### 9.1.7 `/family/{id}/shared-menus`
+- 週間共有献立カレンダー
+- 「AI 生成」ボタン
+- 個別メンバーの servings 編集
+
+#### 9.1.8 `/family/{id}/shopping-list`
+- 買い物リスト (カテゴリ別)
+- チェックボックス、担当者割当
+- 手動追加フォーム
+
+### 9.2 Mobile App 画面
+
+#### 9.2.1 `app/family/index.tsx`
+- Web の `/family/{id}` 相当
+- ボトムシート式のメンバー追加
+
+#### 9.2.2 `app/family/invite-accept.tsx`
+- ディープリンク受諾画面
+- URL: `homegohan://invite/family/{token}`
+
+#### 9.2.3 `app/family/shopping-list.tsx`
+- リアルタイム同期 (Supabase Realtime)
+- スワイプでチェック / アンチェック
+
+---
+
+## 10. エラー / バリデーション
+
+### 10.1 サーバーサイドバリデーション
+
+| 項目 | 制約 |
+|------|------|
+| グループ名 | 1-100 文字、HTML タグ不可 |
+| 説明 | 0-500 文字 |
+| メンバー名 | 1-50 文字 |
+| Email (招待) | RFC 5322 準拠 |
+| 生年月日 | 過去 120 年以内 |
+| 身長 | 0 < x ≤ 300 cm |
+| 体重 | 0 < x ≤ 500 kg |
+| アレルギー | 各 50 文字以内、最大 30 個 |
+| 招待トークン | 32 byte hex |
+| 招待期限 | 7 日 |
+
+### 10.2 エラーコード一覧
+
+| コード | 意味 |
+|--------|------|
+| `FAMILY_GROUP_NOT_FOUND` | グループが存在しない |
+| `FAMILY_GROUP_FULL` | メンバー数上限到達 |
+| `FAMILY_USER_ALREADY_IN_GROUP` | 既に他グループ所属 |
+| `FAMILY_INVITE_EXPIRED` | 招待期限切れ |
+| `FAMILY_INVITE_USED` | 既に受諾済 |
+| `FAMILY_INVITE_CANCELLED` | キャンセル済 |
+| `FAMILY_PERMISSION_DENIED` | 権限不足 |
+| `FAMILY_OWNER_CANNOT_LEAVE` | オーナーは脱退不可 |
+| `FAMILY_NEED_ADMIN_FOR_TRANSFER` | 譲渡先管理者なし |
+
+---
+
+## 11. 段階的実装計画
+
+### Phase 1: MVP (4 週間)
+
+**ゴール**: 基本的な家族グループ作成・メンバー追加・招待が Web + Mobile で動く
+
+- ✅ DB マイグレーション (新テーブル群)
+- ✅ API: グループ CRUD、メンバー CRUD、招待
+- ✅ Web `/family` ページ群
+- ✅ Mobile `/family` 画面群
+- ✅ 招待 Email (Resend 経由)
+- ✅ 受諾フロー (Web + Mobile ディープリンク)
+- ✅ 通知 (招待・参加・脱退)
+
+### Phase 2: 共有機能 (3 週間)
+
+- ✅ 共有献立 API + UI
+- ✅ メンバー間食事記録閲覧
+- ✅ プライバシー設定 (公開・非公開)
+- ✅ 共有買い物リスト + Realtime 同期
+
+### Phase 3: 高度機能 (4 週間)
+
+- ✅ 食材按分 (servings allocation)
+- ✅ 子供メンバーアカウント発行 → 紐付け
+- ✅ 家族プラン課金 (Stripe 連携)
+- ✅ オーナー譲渡
+- ✅ 監査ログ (`family_activity_log`)
+
+### Phase 4: 拡張機能 (将来)
+
+- 1 ユーザー複数グループ所属
+- グループ間連合 (親戚グループ)
+- 共同決済 / 家計簿
+- グループチャット
+
+---
+
+## 12. テスト計画
+
+### 12.1 単体テスト
+- API ルートの input validation
+- 権限チェック (各ロール × 各操作)
+- トークン生成・検証ロジック
+
+### 12.2 統合テスト
+- 招待 → 受諾 → メンバー追加の一連フロー
+- グループ解散時の CASCADE 動作
+- 共有献立生成 + 個別 servings 反映
+
+### 12.3 E2E テスト (Playwright + Maestro)
+- `tests/e2e/family/` 配下に以下追加:
+  - `family-01-create-group.spec.ts`
+  - `family-02-invite-accept.spec.ts`
+  - `family-03-add-child-member.spec.ts`
+  - `family-04-leave-group.spec.ts`
+  - `family-05-transfer-owner.spec.ts`
+
+### 12.4 セキュリティテスト
+- 他グループのデータ参照不可 (RLS)
+- 招待トークンの brute force 耐性
+- メンバー除名の権限境界
+
+### 12.5 パフォーマンステスト
+- 20 人グループでの一覧表示
+- 招待 100 件の bulk 操作
+- 買い物リスト Realtime 同期の遅延
+
+---
+
+## 13. リリース基準
+
+### 13.1 機能基準
+- [ ] Phase 1 全機能が E2E テストでパス
+- [ ] 主要 5 ペルソナで手動シナリオテスト完了
+- [ ] エラーメッセージ全件が日本語化済
+
+### 13.2 品質基準
+- [ ] Vercel Lighthouse スコア 90 以上
+- [ ] Mobile App: TestFlight ベータで 5 件以上のクラッシュなし
+- [ ] API レスポンス p95 < 500ms
+
+### 13.3 ドキュメント基準
+- [ ] ユーザー向けヘルプ記事公開
+- [ ] FAQ 10 項目以上
+- [ ] 招待メール文面のレビュー完了
+
+### 13.4 法務基準
+- [ ] プライバシーポリシー更新 (家族間データ共有について明記)
+- [ ] 利用規約更新
+
+---
+
+## 14. 付録
+
+### 14.1 招待メールテンプレート
+
+```
+件名: 【ほめゴハン】「{group_name}」から家族グループに招待されました
+
+{inviter_name} さんから、ほめゴハンの家族グループに招待されました。
+
+家族グループ: {group_name}
+招待ロール: {role}
+有効期限: {expires_at_jst} まで
+
+下記リンクから参加してください:
+{invite_url}
+
+すでにほめゴハンをご利用中の方はログイン後に参加できます。
+未登録の方はこちらから新規登録してください: {signup_url}
+
+ご質問は support@homegohan.com までお気軽にどうぞ。
+
+---
+ほめゴハン運営チーム
+```
+
+### 14.2 通知ペイロード仕様
+
+```typescript
+type FamilyNotificationPayload =
+  | {
+      type: 'family.invite.received';
+      group_name: string;
+      inviter_name: string;
+      role: string;
+      invite_url: string;
+    }
+  | {
+      type: 'family.invite.accepted';
+      group_name: string;
+      member_name: string;
+    }
+  | {
+      type: 'family.member.removed';
+      group_name: string;
+      reason?: string;
+    }
+  // ... 他全種別
+```
+
+### 14.3 関連ドキュメント
+
+- `docs/requirements/02-organization-management.md`: 組織管理 (法人版の家族管理に相当)
+- `docs/requirements/03-operator-admin.md`: 運営者管理 (家族グループの統計・モデレーション)
+- `docs/architecture/auth-flow.md`: 認証フロー (Supabase Auth + RLS)
+- `docs/api/family.openapi.yaml`: API 仕様 (OpenAPI 形式、本書の正式版)
+
+### 14.4 オープン課題
+
+1. 家族プランの料金体系: Stripe での実装は別 Phase
+2. 子供アカウント発行時の親同意取得 (法的検討必要)
+3. グループ間の食事記録移管 (脱退時に一部だけ持っていく等)
+4. 多言語対応の翻訳費用
+5. 共有買い物リストの履歴管理 (削除済アイテムの監査)
+
+### 14.5 用語の使い分け (混乱防止)
+
+- 「家族」 = 一般用語
+- 「家族グループ」 = システム用語、`family_groups` テーブル
+- 「メンバー」 = `family_members` テーブルレコード
+- 「ユーザー」 = `auth.users` テーブルレコード (アカウント保持者)
+
+---
+
+**END OF FAMILY MANAGEMENT REQUIREMENTS DOCUMENT**
+
+次のドキュメント: `02-organization-management.md` (組織管理 / 法人契約)

--- a/docs/requirements/02-organization-management.md
+++ b/docs/requirements/02-organization-management.md
@@ -1,0 +1,1155 @@
+# 組織管理機能 要件定義書
+
+**ドキュメントバージョン**: 1.0
+**最終更新**: 2026-05-06
+**作成者**: Opus (Claude)
+**ステータス**: ドラフト (レビュー待ち)
+**関連ドキュメント**: `01-family-management.md`, `03-operator-admin.md`
+
+---
+
+## 1. エグゼクティブサマリー
+
+### 1.1 背景と目的
+
+ほめゴハンを **法人 (企業 / 健保 / 自治体 / 教育機関)** に提供する事業 (B2B) のための管理機能。社員・組合員・職員に「健康増進ベネフィット」として配布し、会社が健康スコア・食事改善状況をモニタリングする。
+
+組織管理機能は、法人契約者 (org_admin) が:
+- 組織内のメンバーを招待・管理
+- 部署単位で集計・チャレンジを運営
+- ヘルススコアの可視化 (個人プライバシー保護下)
+- 補助金 (健康経営優良法人取得支援等) のレポート作成
+
+を行うための SaaS 管理画面である。
+
+### 1.2 想定する顧客セグメント
+
+| セグメント | 規模 | 主な用途 |
+|------------|------|---------|
+| **健康保険組合** | 1,000〜100,000 加入者 | 加入者の生活習慣病予防 |
+| **大企業 (健康経営)** | 500〜10,000 従業員 | 健康経営優良法人取得 + ESG |
+| **中小企業** | 30〜500 従業員 | 福利厚生強化、離職率低減 |
+| **官公庁・教育機関** | 100〜5,000 職員 | 健康経営、生活習慣指導 |
+| **介護・看護施設** | 50〜500 職員 | 夜勤者の食事管理 |
+| **スポーツチーム** | 20〜200 選手 | パフォーマンス向上 |
+
+### 1.3 ビジネスモデル
+
+#### 1.3.1 課金体系
+| プラン | 月額 (1 ユーザー) | 機能 |
+|--------|------------------|------|
+| **Org Starter** | 480 円 | 基本機能 + 月次レポート |
+| **Org Standard** | 980 円 | + 部署別集計、チャレンジ |
+| **Org Pro** | 1,980 円 | + AI 個別アドバイス、産業医連携 |
+| **Org Enterprise** | 要相談 | + SSO (SAML)、API、SLA、専任カスタマーサポート |
+
+#### 1.3.2 契約フロー
+1. 法人問い合わせ (`/contact?type=org`)
+2. 営業対応 → デモ → 見積もり
+3. 契約締結 (オンライン or 紙)
+4. 運営側で `organizations` レコード作成 + 主担当者を `org_admin` ロール付与
+5. 主担当者がメンバー招待
+
+### 1.4 現状実装サマリ
+
+| 領域 | 状態 |
+|------|------|
+| `organizations` テーブル | ✅ |
+| `organization_invites`, `organization_challenges` 等 | ✅ |
+| `/org/dashboard`, `/org/members` 等 UI | ✅ |
+| `/api/org/*` API | ✅ (基本機能) |
+| 招待受諾フロー (`/invite/{token}`) | **未実装** |
+| 招待メール自動送信 | **未実装** |
+| メンバー除名 API | **未実装** |
+| CSV 一括インポート | **未実装** |
+| 部署と user_profiles の正規化 | **未整理** (現状 text 直参照) |
+| 請求 / プラン管理 UI | **未実装** |
+| チャレンジ参加・進捗 API | **未実装** |
+| 月次レポート PDF 出力 | **未実装** |
+| 産業医連携 (DB アクセス権限分離) | **未実装** |
+| SSO (SAML) | **未実装** |
+
+### 1.5 スコープ
+
+#### 含む
+- 組織レコード CRUD (運営側 + org_admin の自組織編集)
+- メンバー招待 (Email、CSV 一括)、受諾フロー、除名
+- 部署管理 (階層、メンバー割当)
+- ロール (org_admin / org_manager / org_member / org_viewer / org_industrial_doctor)
+- ヘルスダッシュボード (組織全体・部署別)
+- チャレンジ機能 (作成・参加・進捗・報酬)
+- 月次レポート PDF
+- お知らせ (組織内アナウンス)
+- プラン契約・課金 (Stripe 連携)
+- SSO (SAML、Phase 3)
+
+#### 含まない
+- 個人ユーザーの食事記録の生データ閲覧 (プライバシー保護のため、運営含めても匿名化集計のみ)
+- 給与・人事システム連携 (将来検討)
+- 専用モバイル App (Web 完結、メンバーは個人 App 利用)
+- ホワイトラベル化 (Phase 4)
+
+---
+
+## 2. 用語定義
+
+| 用語 | 定義 |
+|------|------|
+| **組織 (Organization)** | 法人契約の単位。1 法人 = 1 組織 (グループ会社は別組織) |
+| **組織管理者 (org_admin)** | 組織のオーナー権限 (請求・プラン変更・除名等) |
+| **組織マネージャー (org_manager)** | メンバー追加・編集・チャレンジ運営権限 |
+| **一般メンバー (org_member)** | 自分のデータ管理 + 組織内ランキング閲覧 |
+| **閲覧者 (org_viewer)** | 部署集計の閲覧のみ (人事担当者向け) |
+| **産業医 (org_industrial_doctor)** | 個別ユーザーの健康状態を閲覧可能 (同意取得後) |
+| **部署 (Department)** | 組織内の階層構造単位。部署 → 課 → チームの 3 階層対応 |
+| **チャレンジ (Challenge)** | 組織内で実施される健康増進企画 (例: 1 ヶ月で朝食を毎日食べる) |
+| **健康スコア** | 食事バランス + 運動 + 睡眠から算出される総合スコア (0-100) |
+| **匿名化集計** | 個人を特定できない形での集計値 (例: 部署平均、最低でも 10 名以上の集計) |
+| **同意** | 個別ユーザーが組織への詳細データ提供に同意 (オプトイン) |
+
+---
+
+## 3. ペルソナ
+
+### 3.1 ペルソナ A: 佐藤 健一 (45 歳、人事部長、従業員 800 名の製造業)
+
+**プロフィール**
+- 役職: 人事部長
+- 担当: 健康経営優良法人 (Bright500) 取得プロジェクト
+- 課題: 健保データはあるが「予防」にも投資したい。アプリ配布で食生活改善を可視化したい
+
+**主要ニーズ**
+- 全社員 800 名にアプリ展開、参加率 60% 以上
+- 部署別の健康スコアで管理職に施策案内
+- 月次レポートを役員報告に使用
+- 個人プライバシーは厳守 (匿名化集計のみ閲覧)
+- 健保連携でデータ二重管理を避ける
+
+**主要ジャーニー**
+1. ほめゴハンの法人問い合わせフォームから連絡
+2. 営業デモ → 1 ヶ月パイロット (50 名) 提案
+3. 契約締結 → 運営から `org_admin` 付与
+4. CSV で 50 名の Email 一括招待
+5. 1 ヶ月後にダッシュボードで「平均健康スコア +12 点」を確認
+6. 経営会議でデモ → 全社 800 名展開を決定
+
+### 3.2 ペルソナ B: 山口 真理子 (32 歳、健保保健師、加入者 5,000 名)
+
+**プロフィール**
+- 職業: 健保組合保健師
+- 担当: 特定保健指導 + 健康増進プログラム
+- 課題: 紙ベースの保健指導から脱却したい。リアルタイムで生活習慣を把握したい
+
+**主要ニーズ**
+- 加入者 5,000 名に展開、参加率 40% 以上
+- 高リスク者を自動で抽出 (BMI 高、塩分過多 等)
+- 産業医・保健師が個別に詳細データ閲覧 (同意済の人のみ)
+- HbA1c や血圧と連携 (将来)
+
+**主要ジャーニー**
+1. 健保契約締結 → `org_admin` ロール
+2. 加入者全員に招待メール送信 (1 度に 5,000 通)
+3. 同意者のみ詳細プロファイル取得
+4. ダッシュボードで「塩分摂取量 月平均 12g 以上」のメンバー 80 名を抽出
+5. 個別保健指導の対象として抽出データを利用
+
+### 3.3 ペルソナ C: 田村 浩二 (38 歳、IT スタートアップ CTO、社員 80 名)
+
+**プロフィール**
+- 職業: スタートアップ CTO
+- 課題: 社員の健康のため福利厚生を充実させたい。コストは低めに抑えたい
+
+**主要ニーズ**
+- 80 名分の月額利用料を抑えつつ機能は使いたい
+- 社内 Slack に通知連携 (チャレンジ達成等)
+- API で勤怠データと統合 (オプション)
+- 退職者の自動除名 (HR システムと連携)
+
+**主要ジャーニー**
+1. スタートアッププラン申し込み (Org Starter)
+2. 社員 80 名に招待 → 65 名が参加 (81%)
+3. 月次の社内チャレンジ「朝食を毎日食べよう」
+4. 達成者は社内ポイントと連動
+5. Slack に「今月の健康スコア No.1: ○○さん」自動投稿
+
+### 3.4 ペルソナ D: 中村 太郎 (52 歳、役所 健康増進課、職員 1,200 名)
+
+**プロフィール**
+- 職業: 自治体職員
+- 課題: 住民健康増進事業の効果を「数字」で示せていない
+
+**主要ニーズ**
+- 役所職員 → 住民へ展開する 2 段階モデル
+- 報告書を国に提出 (匿名化必須)
+- 高齢者向け簡易 UI
+
+**主要ジャーニー**
+1. 自治体契約 (Org Pro)
+2. 第 1 期: 役所職員 1,200 名で試験運用
+3. 第 2 期: 住民 50,000 名へ展開 (年金生活者多数)
+4. 国の健康日本 21 報告書に活用
+
+---
+
+## 4. ユースケース
+
+### 4.1 UC-ORG-01: 組織契約・初期セットアップ
+
+**フロー**:
+1. 法人が `/contact?type=org` で問い合わせ
+2. 営業が対応 → 契約 (オフライン)
+3. 運営 (super_admin) が `/admin/organizations/create` で組織レコード作成
+   - 名前、業種、従業員数、プラン、契約期間
+   - 主担当者の Email + 一時パスワード
+4. 主担当者にウェルカムメール送信
+5. 主担当者がログイン → `org_admin` ロール確認 → `/org/dashboard` 表示
+
+### 4.2 UC-ORG-02: メンバー招待 (Email)
+
+**フロー**:
+1. org_admin が `/org/invites` → 「招待」
+2. Email、ロール (org_admin / org_manager / org_member / org_viewer)、部署 (任意) を入力
+3. 「招待を送る」 → API `POST /api/org/invites`
+4. 招待メール自動送信 (Resend)
+5. 受信者が `/invite/{token}` で受諾
+6. 既存ユーザーならログイン、未登録なら新規登録
+7. `user_profiles.organization_id` が設定 + 部署紐付け
+
+### 4.3 UC-ORG-03: メンバー一括招待 (CSV)
+
+**フロー**:
+1. org_admin が `/org/invites/bulk` → CSV アップロード
+2. CSV 形式:
+```csv
+email,role,department,nickname,employee_id
+tanaka@example.com,org_member,営業部,田中太郎,EMP001
+yamada@example.com,org_manager,営業部,山田花子,EMP002
+```
+3. プレビュー画面で件数・エラー確認
+4. 「送信」 → 1 件ずつ非同期で招待作成 + Email 送信
+5. 進捗画面で「85/100 件完了」表示
+6. 完了後、エラー件 (Email 形式不正等) を CSV 出力
+
+### 4.4 UC-ORG-04: メンバー除名
+
+**フロー**:
+1. `/org/members` で対象ユーザー → 「除名」
+2. 確認モーダル: 「○○さんを組織から除名します。データはどうしますか?」
+   - 「個人アカウントとして残す」(デフォルト): `organization_id = null`
+   - 「アカウントごと削除」: 退職者向け、Supabase Auth から削除
+3. 確定 → API `DELETE /api/org/members/{id}`
+4. 監査ログに記録
+
+### 4.5 UC-ORG-05: 部署管理
+
+**フロー**:
+1. `/org/departments` で階層ツリー表示
+2. 新規部署: 「+ 部署を追加」 → 名前、親部署、マネージャー指定
+3. メンバー割当: 部署詳細 → 「メンバーを追加」 → ドラッグドロップ or 一覧から選択
+4. 部署変更: メンバー詳細 → 「所属部署変更」
+
+### 4.6 UC-ORG-06: チャレンジ作成・運営
+
+**フロー**:
+1. `/org/challenges` → 「新規チャレンジ」
+2. テンプレート選択 (朝食率 / 野菜スコア / 自炊率 / 歩数 / 減量 / カスタム)
+3. 詳細入力:
+   - タイトル: 「みんなで朝食習慣チャレンジ」
+   - 期間: 2026-06-01 〜 2026-06-30
+   - 対象: 全社 / 部署別 / 個別選択
+   - 目標値: 朝食率 80% 以上
+   - 報酬: 「達成者には 1,000 ポイント」
+4. 「公開」 → 対象メンバーに通知
+5. 期間中: ダッシュボードで進捗・参加率モニタ
+6. 期間終了後: 達成者リストを CSV 出力 (人事に提出)
+
+### 4.7 UC-ORG-07: ダッシュボード・レポート
+
+**フロー** (org_admin):
+1. `/org/dashboard` を開く
+2. KPI カード: 参加率、平均健康スコア、朝食率、深夜食率、活動率
+3. トレンドグラフ: 月次推移
+4. 部署別ヒートマップ: スコア低い部署を赤表示
+5. 「月次レポートを PDF で出力」 → 役員報告用 PDF 生成
+
+### 4.8 UC-ORG-08: メンバー視点 (org_member)
+
+**フロー**:
+1. メンバーが個人アプリにログイン
+2. 通常の食事管理 + 組織関連 UI:
+   - 「会社のチャレンジ」タブ
+   - 「部署内ランキング」 (匿名 or ニックネーム)
+   - 「会社のお知らせ」
+3. プライバシー設定: 「会社にデータを共有する範囲」
+   - 匿名化集計のみ (デフォルト)
+   - 部署マネージャーまで個別データ
+   - 産業医まで詳細データ
+
+### 4.9 UC-ORG-09: 産業医による個別データ閲覧 (同意済の人のみ)
+
+**フロー**:
+1. メンバーがプライバシー設定で「産業医にデータ提供を同意」
+2. 産業医 (org_industrial_doctor ロール) が `/org/health/{userId}` で詳細閲覧
+3. 食事記録、栄養トレンド、健康スコア、健診結果 (連携している場合)
+4. 産業医メモを記録 (`org_health_notes` テーブル)
+
+### 4.10 UC-ORG-10: 退職者の自動除名 (HR システム連携)
+
+**フロー** (Org Pro 以上):
+1. HR システムから退職者リストを Webhook で送信
+2. ほめゴハン側が自動的に該当者を除名
+3. データは個人アカウントとして残る
+4. メンバーには「○○組織から除名されました」通知
+
+---
+
+## 5. 機能要件
+
+### 5.1 F-ORG-001: 組織レコード管理
+
+#### 5.1.1 属性
+- `id`, `name`, `industry` (業種)、`employee_count`、`plan`
+- `subscription_status` (active / suspended / cancelled / trialing)
+- `subscription_expires_at`, `billing_email`
+- `logo_url`, `primary_color` (カラーカスタマイズ Pro 以上)
+- `settings` JSONB (各種設定)
+
+#### 5.1.2 操作
+- 作成: 運営側 (`super_admin`) のみ
+- 編集 (基本情報): `org_admin`
+- 編集 (プラン変更): `org_admin` (再認証必須)
+- 削除: 運営側のみ (契約終了時)
+- 一時停止: 運営側 (未払い等)
+
+### 5.2 F-ORG-002: メンバー管理
+
+#### 5.2.1 メンバー追加方法
+1. **個別招待 (Email)**: 1 件ずつ、招待リンク発行
+2. **CSV 一括招待**: 100 件ずつバッチ処理
+3. **直接作成**: org_admin が Email + パスワード設定で直接アカウント作成 (Admin API 経由)
+4. **SSO (Phase 3)**: SAML 経由で自動プロビジョニング
+
+#### 5.2.2 メンバー属性
+- ユーザー基本情報 (`user_profiles`)
+- 組織紐付け: `organization_id`
+- 部署紐付け: `department_id` (新規追加、現在の `department` text を移行)
+- 社員番号: `employee_id` (組織内ユニーク)
+- 入社日: `joined_at`
+- ロール: `org_member`, `org_manager`, `org_admin`, `org_viewer`, `org_industrial_doctor`
+- 在籍状況: `is_active_in_org`
+
+### 5.3 F-ORG-003: ロール・権限
+
+#### 5.3.1 ロール定義
+
+| ロール | 説明 | 主な権限 |
+|--------|------|---------|
+| **org_admin** | 組織管理者 | 全権限 (請求・プラン変更含む) |
+| **org_manager** | マネージャー | メンバー管理、チャレンジ運営、部署管理 |
+| **org_member** | 一般メンバー | 自分のデータ + 組織内ランキング閲覧 |
+| **org_viewer** | 閲覧者 | 集計のみ (HR 担当者用) |
+| **org_industrial_doctor** | 産業医 | 同意済メンバーの個別健康データ |
+
+#### 5.3.2 権限マトリクス
+
+| 操作 | org_admin | org_manager | org_member | org_viewer | org_industrial_doctor |
+|------|-----------|-------------|------------|------------|----------------------|
+| 組織情報編集 | ✅ | ❌ | ❌ | ❌ | ❌ |
+| プラン変更 / 請求 | ✅ | ❌ | ❌ | ❌ | ❌ |
+| メンバー招待 | ✅ | ✅ | ❌ | ❌ | ❌ |
+| メンバー除名 | ✅ | ✅ | ❌ | ❌ | ❌ |
+| ロール変更 | ✅ | ❌ | ❌ | ❌ | ❌ |
+| 部署管理 | ✅ | ✅ | ❌ | ❌ | ❌ |
+| チャレンジ作成 | ✅ | ✅ | ❌ | ❌ | ❌ |
+| チャレンジ参加 | ✅ | ✅ | ✅ | ❌ | ❌ |
+| ダッシュボード (集計) | ✅ | ✅ | △ (自部署のみ) | ✅ | ✅ |
+| 個別ユーザーデータ | ❌ | ❌ | ❌ | ❌ | ✅ (同意者のみ) |
+| 月次レポート PDF | ✅ | ✅ | ❌ | ✅ | ❌ |
+
+### 5.4 F-ORG-004: 招待機能
+
+#### 5.4.1 個別招待
+- Email、ロール、部署、ニックネーム、社員番号 (任意)
+- 招待 URL: `/invite/{token}`
+- 期限: 14 日
+- メール文面: 組織ロゴ + カスタムメッセージ (org_admin が事前設定)
+
+#### 5.4.2 CSV 一括招待
+- 上限: 1 回 1,000 件、月 5,000 件
+- フォーマット:
+```csv
+email,role,department,nickname,employee_id,joined_at
+```
+- バリデーション:
+  - Email 形式
+  - role が許可リスト内
+  - department が存在 (or 自動作成オプション)
+  - employee_id が組織内ユニーク
+- 進捗: 非同期処理、リアルタイム進捗表示
+- 結果: エラー件は CSV ダウンロード可
+
+#### 5.4.3 受諾フロー (Phase 1 最重要)
+- `/invite/{token}` ページ作成 (現状未実装)
+- 既存ユーザーならログイン → 紐付け
+- 未登録なら新規登録 (Email は招待 Email で自動入力、変更不可)
+- 受諾後 `user_profiles.organization_id` 設定
+- 同時に `organization_invites.accepted_at`, `accepted_by` 更新
+
+### 5.5 F-ORG-005: 部署管理
+
+#### 5.5.1 階層構造
+- 最大 3 階層 (例: 「営業本部 > 関東支社 > 営業 1 課」)
+- ツリー UI でドラッグ&ドロップ並べ替え
+
+#### 5.5.2 部署属性
+- `id`, `organization_id`, `parent_id` (self FK), `name`, `display_order`
+- `manager_id` (部署マネージャー)
+- メンバー数 (集計値、リアルタイム計算 or キャッシュ)
+
+#### 5.5.3 メンバー割当
+- 1 メンバー = 1 部署 (兼務は将来対応)
+- `user_profiles.department_id` (新規追加)
+- 移籍: 部署変更時に変更履歴 (`department_history`) を記録 (Pro 以上)
+
+### 5.6 F-ORG-006: チャレンジ機能
+
+#### 5.6.1 チャレンジ種類
+
+| 種別 | 目標 | 計測 |
+|------|------|------|
+| 朝食率 | 朝食実施率 80% 以上 | 朝食記録/期間日数 |
+| 野菜スコア | 野菜スコア 70 点以上 | 期間平均野菜スコア |
+| 自炊率 | 自炊率 60% 以上 | 自炊記録/全食事 |
+| 歩数 | 1 日平均 8,000 歩 | 歩数連携 (HealthKit 等) |
+| 減量 | 期間中 -2kg | 体重記録の差分 |
+| カスタム | 自由設定 | 手動評価 |
+
+#### 5.6.2 チャレンジライフサイクル
+1. `draft` (下書き)
+2. `active` (公開中、参加受付)
+3. `completed` (期間終了、達成判定済)
+4. `cancelled` (中止)
+
+#### 5.6.3 参加・進捗
+- 対象メンバーは自動参加 or オプトイン
+- 進捗計算は日次バッチ (深夜) or リアルタイム (Pro)
+- ダッシュボード: 達成率、Top 10、未達者数
+
+#### 5.6.4 報酬
+- 報酬テキスト (例: 「達成者には Amazon ギフト 1,000 円」)
+- 達成者リスト CSV 出力
+- 自動配布は将来対応 (Stripe Coupon / Slack 連携 等)
+
+### 5.7 F-ORG-007: ダッシュボード・レポート
+
+#### 5.7.1 リアルタイムダッシュボード (`/org/dashboard`)
+- KPI カード:
+  - 参加メンバー数 / 全メンバー数 (参加率)
+  - 平均健康スコア
+  - 朝食率、深夜食率、自炊率
+  - チャレンジ達成率
+- グラフ:
+  - 月次トレンド (折れ線)
+  - 部署別ヒートマップ (赤=低、緑=高)
+  - 年代別比較
+- アラート: スコアが急低下した部署をハイライト
+
+#### 5.7.2 月次レポート PDF
+- ロゴ入り PDF (Pro 以上)
+- セクション:
+  - 表紙 (組織名 + 期間)
+  - エグゼクティブサマリ (1 ページ)
+  - KPI 詳細 (3-5 ページ)
+  - 部署別比較 (1-2 ページ)
+  - チャレンジ結果 (1 ページ)
+  - 改善提案 (AI 生成、Pro)
+- 出力: PDF / Excel / Google Slides 形式選択可
+
+#### 5.7.3 健康経営優良法人レポート (Phase 2)
+- 経済産業省提出フォーマット対応
+- データを所定の様式に自動マッピング
+- 取得支援: ほめゴハンの取り組みを項目別に紐付け
+
+### 5.8 F-ORG-008: 通知・お知らせ
+
+#### 5.8.1 組織内お知らせ
+- org_admin が組織全員に告知
+- タイトル + 本文 (Markdown)
+- 配信: アプリ内通知 + Email (任意)
+- 既読管理: `organization_announcement_reads`
+
+#### 5.8.2 自動通知
+| 種別 | 配信先 | 経路 |
+|------|--------|------|
+| 招待を受け取った | 受信者 | Email + Push |
+| 組織から除名された | 除名対象 | Email + Push |
+| チャレンジが開始 | 対象メンバー | Push |
+| チャレンジ達成 | 達成者 | Push + アプリ内ポップアップ |
+| 月次レポート完成 | org_admin | Email |
+| 健康スコア低下警告 | org_admin (匿名集計) | アプリ内 |
+
+### 5.9 F-ORG-009: 課金・契約管理
+
+#### 5.9.1 プラン
+- Org Starter / Standard / Pro / Enterprise (前述)
+- 月額 / 年額 (年額は 10% 割引)
+- 最低契約期間: 1 ヶ月 (Enterprise は 1 年)
+
+#### 5.9.2 Stripe 連携
+- カード決済 / 銀行振込 (Enterprise)
+- 請求書発行 (PDF メール送付 + ASC ダッシュボード DL)
+- 自動更新 / キャンセル
+- 未払い時: 7 日後に組織を `suspended` 状態へ (機能制限)
+
+#### 5.9.3 ライセンス管理
+- プランごとのメンバー上限
+- 上限超過時: 招待不可 + アラート
+- メンバー追加で従量課金 (オプション)
+
+### 5.10 F-ORG-010: 産業医・保健師連携
+
+#### 5.10.1 ロール
+- `org_industrial_doctor`: 産業医
+- `org_health_nurse`: 保健師 (将来)
+
+#### 5.10.2 アクセス制御
+- 同意済メンバー (`user_profiles.consent_org_health_data = true`) のみ詳細閲覧
+- 閲覧履歴を `org_health_access_logs` に記録
+- 産業医メモ: `org_health_notes` (本人非公開、産業医のみ)
+
+#### 5.10.3 連携機能
+- 健診結果 PDF アップロード (将来)
+- HbA1c / 血圧などの数値入力
+- 個別保健指導の予約管理
+
+---
+
+## 6. 非機能要件
+
+### 6.1 パフォーマンス
+
+| 指標 | 目標 |
+|------|------|
+| ダッシュボード初回読み込み | < 1.5s |
+| メンバー一覧 (1,000 名) | < 2s (ページング) |
+| CSV 一括招待 (1,000 件) | バックグラウンド < 60s |
+| 月次レポート PDF 生成 | < 30s |
+| ダッシュボード KPI 更新間隔 | 5 分 (キャッシュ) |
+
+### 6.2 拡張性
+
+- 1 組織あたり最大メンバー: 100,000 名 (健保組合想定)
+- 同時アクセス: 1,000 ユーザー (大企業想定)
+- 部署数: 1 組織 1,000 まで
+
+### 6.3 セキュリティ
+
+- メンバー招待トークン: 32 byte hex + HMAC 署名
+- RLS ポリシー: 自組織のデータのみアクセス
+- 監査ログ: 全 admin 操作を `org_audit_logs` に記録
+- IP 制限 (Enterprise): IP allowlist 設定
+- 2FA 必須化 (Enterprise オプション)
+
+### 6.4 プライバシー
+
+- **匿名化集計の最低人数**: 10 名以上 (10 名未満の部署は集計対象外、または「その他」と統合)
+- **個別データアクセス**: 産業医・保健師のみ、かつ本人同意必須
+- **データ保持期間**: 退職後 6 ヶ月でデフォルト匿名化、本人申請で 30 日後削除可
+- GDPR 対応 (EU 拠点企業向け、Phase 3)
+
+### 6.5 法務・コンプライアンス
+
+- 個人情報保護法準拠
+- 健康保険法 (健保組合契約時)
+- 企業の労働安全衛生法
+- 健康経営優良法人取得要件をデータ提供で支援
+
+### 6.6 SLA (Pro / Enterprise)
+
+| 指標 | Pro | Enterprise |
+|------|-----|-----------|
+| 稼働率 | 99.5% | 99.9% |
+| サポート応答 | 営業日 1 営業日 | 24/7、初動 1 時間 |
+| バックアップ | 日次 | 1 時間ごと |
+| RTO | 4 時間 | 1 時間 |
+| RPO | 24 時間 | 1 時間 |
+
+---
+
+## 7. データモデル
+
+### 7.1 既存テーブル (拡張)
+
+#### 7.1.1 `organizations`
+```sql
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS billing_email VARCHAR(255);
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS primary_color VARCHAR(7);  -- '#FF6B6B'
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS member_limit INT NOT NULL DEFAULT 30;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS sso_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS sso_metadata_url TEXT;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS contract_started_at TIMESTAMPTZ;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS contract_ended_at TIMESTAMPTZ;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS suspended_at TIMESTAMPTZ;
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS suspended_reason TEXT;
+```
+
+#### 7.1.2 `user_profiles` (department 正規化)
+```sql
+ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS department_id UUID REFERENCES departments(id) ON DELETE SET NULL;
+ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS employee_id VARCHAR(50);
+ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS joined_org_at DATE;
+ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS is_active_in_org BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS consent_org_health_data BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS consent_org_data_at TIMESTAMPTZ;
+
+CREATE UNIQUE INDEX idx_user_profiles_org_emp ON user_profiles(organization_id, employee_id) WHERE employee_id IS NOT NULL;
+
+-- 旧 department text → department_id への移行 (バックフィル)
+-- 一度限りのスクリプトで実行
+```
+
+#### 7.1.3 `departments` (拡張)
+```sql
+ALTER TABLE departments ADD COLUMN IF NOT EXISTS member_count_cache INT NOT NULL DEFAULT 0;
+ALTER TABLE departments ADD COLUMN IF NOT EXISTS member_count_updated_at TIMESTAMPTZ;
+```
+
+### 7.2 新規テーブル
+
+#### 7.2.1 `organization_audit_logs`
+```sql
+CREATE TABLE organization_audit_logs (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  actor_id        UUID NOT NULL REFERENCES auth.users(id),
+  action_type     VARCHAR(50) NOT NULL,  -- 'invite_sent', 'member_removed', 'role_changed', 'plan_changed', etc.
+  target_id       UUID,
+  target_type     VARCHAR(30),  -- 'user', 'department', 'challenge', 'organization'
+  details         JSONB DEFAULT '{}',
+  ip_address      INET,
+  user_agent      TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_org_audit_org ON organization_audit_logs(organization_id, created_at DESC);
+CREATE INDEX idx_org_audit_actor ON organization_audit_logs(actor_id, created_at DESC);
+```
+
+#### 7.2.2 `organization_announcements`
+```sql
+CREATE TABLE organization_announcements (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  title           VARCHAR(200) NOT NULL,
+  body            TEXT NOT NULL,  -- Markdown
+  send_email      BOOLEAN NOT NULL DEFAULT FALSE,
+  target_dept_id  UUID REFERENCES departments(id),  -- null = 組織全体
+  scheduled_at    TIMESTAMPTZ,
+  published_at    TIMESTAMPTZ,
+  created_by      UUID NOT NULL REFERENCES auth.users(id),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE organization_announcement_reads (
+  announcement_id UUID NOT NULL REFERENCES organization_announcements(id) ON DELETE CASCADE,
+  user_id         UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  read_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (announcement_id, user_id)
+);
+```
+
+#### 7.2.3 `org_health_access_logs`
+```sql
+CREATE TABLE org_health_access_logs (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  doctor_id       UUID NOT NULL REFERENCES auth.users(id),
+  patient_id      UUID NOT NULL REFERENCES auth.users(id),
+  access_type     VARCHAR(30) NOT NULL,  -- 'view_meals', 'view_health_score', 'add_note', 'view_history'
+  details         JSONB DEFAULT '{}',
+  accessed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_org_health_access_doctor ON org_health_access_logs(doctor_id, accessed_at DESC);
+CREATE INDEX idx_org_health_access_patient ON org_health_access_logs(patient_id, accessed_at DESC);
+```
+
+#### 7.2.4 `org_health_notes`
+```sql
+CREATE TABLE org_health_notes (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  patient_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  doctor_id       UUID NOT NULL REFERENCES auth.users(id),
+  note            TEXT NOT NULL,
+  category        VARCHAR(50),  -- 'consultation', 'guidance', 'follow_up'
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_org_health_notes_patient ON org_health_notes(patient_id, created_at DESC);
+```
+
+#### 7.2.5 `org_subscriptions`
+```sql
+CREATE TABLE org_subscriptions (
+  id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id         UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  plan                    VARCHAR(50) NOT NULL,
+  billing_cycle           VARCHAR(20) NOT NULL CHECK (billing_cycle IN ('monthly', 'yearly')),
+  amount_jpy              INT NOT NULL,
+  currency                VARCHAR(3) NOT NULL DEFAULT 'JPY',
+  starts_at               TIMESTAMPTZ NOT NULL,
+  ends_at                 TIMESTAMPTZ NOT NULL,
+  auto_renew              BOOLEAN NOT NULL DEFAULT TRUE,
+  stripe_subscription_id  VARCHAR(255),
+  status                  VARCHAR(30) NOT NULL DEFAULT 'active',
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE org_invoices (
+  id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id         UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  subscription_id         UUID REFERENCES org_subscriptions(id),
+  amount_jpy              INT NOT NULL,
+  tax_jpy                 INT NOT NULL DEFAULT 0,
+  status                  VARCHAR(30) NOT NULL,  -- 'draft', 'sent', 'paid', 'overdue', 'cancelled'
+  invoice_number          VARCHAR(50) NOT NULL UNIQUE,
+  due_date                DATE NOT NULL,
+  paid_at                 TIMESTAMPTZ,
+  pdf_url                 TEXT,
+  stripe_invoice_id       VARCHAR(255),
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+#### 7.2.6 `department_history`
+```sql
+CREATE TABLE department_history (
+  id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                 UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  organization_id         UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  from_department_id      UUID REFERENCES departments(id),
+  to_department_id        UUID REFERENCES departments(id),
+  changed_by              UUID REFERENCES auth.users(id),
+  changed_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  reason                  TEXT
+);
+
+CREATE INDEX idx_dept_history_user ON department_history(user_id, changed_at DESC);
+```
+
+---
+
+## 8. API 仕様
+
+### 8.1 組織情報
+
+#### 8.1.1 `GET /api/org/me`
+**説明**: 自分が所属する組織情報 + ロール
+**レスポンス**:
+```json
+{
+  "organization": { /* organizations row */ },
+  "my_roles": ["org_admin"],
+  "member_count": 80,
+  "department": { /* departments row */ }
+}
+```
+
+#### 8.1.2 `PATCH /api/org/me`
+**説明**: 組織情報更新 (org_admin のみ)
+
+#### 8.1.3 `GET /api/org/{id}` (super_admin / org_admin)
+**説明**: 組織詳細
+
+### 8.2 メンバー管理
+
+#### 8.2.1 `GET /api/org/members`
+**クエリ**:
+- `q`: 検索 (名前 / Email / 社員番号)
+- `department_id`: 部署フィルタ
+- `role`: ロールフィルタ
+- `is_active`: 在籍中のみ
+- `limit`, `offset`
+
+#### 8.2.2 `POST /api/org/members`
+**説明**: 直接アカウント作成 (Admin API 経由)
+
+#### 8.2.3 `PATCH /api/org/members/{userId}`
+**説明**: メンバー情報更新 (部署変更・ロール変更等)
+
+#### 8.2.4 `DELETE /api/org/members/{userId}`
+**説明**: メンバー除名
+
+#### 8.2.5 `POST /api/org/members/bulk-import`
+**説明**: CSV 一括招待
+**リクエスト**: `multipart/form-data` with CSV file
+**レスポンス**: 処理 ID (非同期処理開始)
+
+#### 8.2.6 `GET /api/org/members/bulk-import/{importId}`
+**説明**: 進捗・結果確認
+
+### 8.3 部署管理
+
+#### 8.3.1 `GET /api/org/departments`
+**説明**: 階層ツリー取得
+
+#### 8.3.2 `POST /api/org/departments`
+**リクエスト**:
+```json
+{
+  "name": "営業 1 課",
+  "parent_id": "uuid",
+  "manager_id": "uuid",
+  "display_order": 1
+}
+```
+
+#### 8.3.3 `PATCH /api/org/departments/{id}`
+
+#### 8.3.4 `DELETE /api/org/departments/{id}`
+**注**: 配下のメンバー・サブ部署がある場合は 409、移動先指定が必要
+
+#### 8.3.5 `POST /api/org/departments/{id}/move-members`
+**説明**: 一括メンバー移動
+
+### 8.4 招待
+
+#### 8.4.1 `GET /api/org/invites`
+**説明**: 招待一覧 (pending / accepted / expired / cancelled でフィルタ)
+
+#### 8.4.2 `POST /api/org/invites`
+**説明**: 個別招待
+
+#### 8.4.3 `POST /api/org/invites/bulk`
+**説明**: 一括招待
+
+#### 8.4.4 `DELETE /api/org/invites/{id}`
+**説明**: 招待取消
+
+#### 8.4.5 `POST /api/org/invites/{id}/resend`
+**説明**: 再送
+
+#### 8.4.6 `GET /api/invite/{token}`
+**説明**: 招待トークン検証 (受諾画面用、認証不要)
+**レスポンス**:
+```json
+{
+  "organization": { "name": "株式会社ABC" },
+  "role": "org_member",
+  "department": { "name": "営業部" },
+  "expires_at": "2026-05-20T12:00:00Z"
+}
+```
+
+#### 8.4.7 `POST /api/invite/{token}/accept`
+**説明**: 招待受諾 (認証必須)
+
+### 8.5 チャレンジ
+
+#### 8.5.1 `GET /api/org/challenges`
+#### 8.5.2 `POST /api/org/challenges`
+#### 8.5.3 `PATCH /api/org/challenges/{id}` (status 変更含む)
+#### 8.5.4 `DELETE /api/org/challenges/{id}`
+#### 8.5.5 `POST /api/org/challenges/{id}/join`
+#### 8.5.6 `GET /api/org/challenges/{id}/participants`
+#### 8.5.7 `GET /api/org/challenges/{id}/results` (達成者リスト CSV)
+
+### 8.6 ダッシュボード・統計
+
+#### 8.6.1 `GET /api/org/stats`
+**クエリ**: `?period=7d|30d|90d|1y&department_id=...`
+**レスポンス**: KPI 統計
+
+#### 8.6.2 `GET /api/org/stats/trends`
+**説明**: 時系列推移
+
+#### 8.6.3 `GET /api/org/stats/heatmap`
+**説明**: 部署別ヒートマップ
+
+#### 8.6.4 `POST /api/org/reports/monthly`
+**説明**: 月次レポート PDF 生成
+**レスポンス**: `{ "report_id": "uuid", "status": "generating" }`
+
+#### 8.6.5 `GET /api/org/reports/{id}`
+**説明**: レポートダウンロード
+
+### 8.7 お知らせ
+
+#### 8.7.1 `GET /api/org/announcements`
+#### 8.7.2 `POST /api/org/announcements`
+#### 8.7.3 `PATCH /api/org/announcements/{id}`
+#### 8.7.4 `DELETE /api/org/announcements/{id}`
+#### 8.7.5 `POST /api/org/announcements/{id}/mark-read`
+
+### 8.8 産業医
+
+#### 8.8.1 `GET /api/org/health/patients`
+**説明**: 同意済メンバー一覧 (org_industrial_doctor のみ)
+
+#### 8.8.2 `GET /api/org/health/patients/{userId}`
+**説明**: 患者個別データ
+
+#### 8.8.3 `POST /api/org/health/patients/{userId}/notes`
+**説明**: 産業医メモ追加
+
+### 8.9 課金・契約
+
+#### 8.9.1 `GET /api/org/subscription`
+#### 8.9.2 `POST /api/org/subscription/upgrade`
+#### 8.9.3 `POST /api/org/subscription/cancel`
+#### 8.9.4 `GET /api/org/invoices`
+#### 8.9.5 `GET /api/org/invoices/{id}/pdf`
+
+### 8.10 監査ログ
+
+#### 8.10.1 `GET /api/org/audit-logs`
+**クエリ**: `?action_type=...&actor_id=...&limit=50&offset=0`
+
+---
+
+## 9. UI 画面仕様
+
+### 9.1 `/org/dashboard`
+- KPI カード × 5 (参加率・健康スコア・朝食率・自炊率・チャレンジ達成率)
+- 月次トレンドグラフ (折れ線、3 ヶ月分)
+- 部署別ヒートマップ
+- 「月次レポートを生成」ボタン
+- 最近のアクティビティ (新規参加、チャレンジ達成等)
+
+### 9.2 `/org/members`
+- 一覧テーブル (名前 + Email + 部署 + ロール + 在籍状況 + 健康スコア)
+- 検索バー、フィルタ (部署 / ロール / 在籍状況)
+- 「メンバー追加」「CSV インポート」ボタン
+- 行アクション: 編集 / ロール変更 / 部署変更 / 除名
+- 1 行クリックでメンバー詳細
+
+### 9.3 `/org/members/{id}`
+- メンバー基本情報
+- 健康スコアトレンド (集計のみ、個別データは産業医のみ)
+- 部署変更履歴 (Pro)
+- アクティビティログ (招待受諾・最終ログイン等)
+
+### 9.4 `/org/invites`
+- タブ: Pending / Accepted / Expired / Cancelled
+- 招待リスト (Email + ロール + 部署 + 期限 + 状態)
+- 「招待」「CSV インポート」ボタン
+- 行アクション: リンクコピー / 再送 / 取消
+
+### 9.5 `/org/invites/bulk`
+- CSV ファイルアップロード
+- プレビュー (件数、エラー件)
+- 「送信」ボタン → 進捗バー
+- 完了後、エラー件 CSV ダウンロード
+
+### 9.6 `/invite/{token}` (受諾画面、最重要)
+- 組織ロゴ + 組織名
+- 招待者、ロール、部署表示
+- 期限表示
+- 「ログインして参加」「新規登録して参加」ボタン
+- 認証後 → 確認画面 → 「参加する」 → ダッシュボードへ
+
+### 9.7 `/org/departments`
+- 階層ツリー UI (左ペイン)
+- 選択部署の詳細 (右ペイン): 名前、マネージャー、メンバー、サブ部署
+- ドラッグ&ドロップで階層変更
+- 「部署追加」「部署削除」「メンバー追加」ボタン
+
+### 9.8 `/org/challenges`
+- アクティブ・終了済タブ
+- カード一覧 (タイトル、期間、参加者数、達成率)
+- 「新規チャレンジ」ボタン → 作成ウィザード (テンプレ選択 → 詳細入力 → プレビュー → 公開)
+
+### 9.9 `/org/challenges/{id}`
+- チャレンジ詳細
+- 進捗グラフ (日次/週次)
+- 参加者リスト (達成者バッジ)
+- 「達成者 CSV ダウンロード」「中止」「複製して再開催」ボタン
+
+### 9.10 `/org/announcements`
+- お知らせリスト
+- 「新規」 → エディタ画面 (Markdown プレビュー)
+- 配信対象選択 (組織全体 / 部署別)
+- 既読率 (送信後)
+
+### 9.11 `/org/settings`
+- 組織情報 (ロゴ、業種、住所、連絡先)
+- カスタムカラー (Pro)
+- 通知設定
+- SSO 設定 (Enterprise)
+- 「プラン変更」「契約解除」リンク
+
+### 9.12 `/org/billing`
+- 現在のプラン
+- 次回請求日 + 金額
+- 過去の請求書一覧 (PDF DL)
+- 支払方法 (カード変更)
+
+### 9.13 `/org/audit-logs`
+- 監査ログ一覧
+- フィルタ (アクション種別 / 担当者 / 日付)
+- 詳細展開で詳細 JSON 表示
+
+### 9.14 産業医画面 (`/org/health/*`)
+- `/org/health/patients`: 同意済メンバー一覧
+- `/org/health/patients/{id}`: 個別ダッシュボード (食事 / 栄養 / スコア)
+- 「メモ追加」「保健指導記録」ボタン
+
+### 9.15 メンバー視点 (`/org/me`)
+- 自分が所属する組織情報
+- 部署内ランキング (匿名)
+- 進行中のチャレンジ
+- お知らせ一覧
+
+---
+
+## 10. エラー / バリデーション
+
+### 10.1 バリデーション
+
+| 項目 | 制約 |
+|------|------|
+| 組織名 | 1-100 文字 |
+| 業種 | enum (IT / 製造 / 小売 / etc.) |
+| 従業員数 | 1-1,000,000 |
+| Email (招待) | RFC 5322 |
+| 社員番号 | 1-50 文字、組織内ユニーク |
+| 部署名 | 1-100 文字 |
+| 部署階層 | 最大 3 |
+| チャレンジ期間 | 1-180 日 |
+
+### 10.2 主要エラーコード
+
+| コード | 意味 |
+|--------|------|
+| `ORG_MEMBER_LIMIT_EXCEEDED` | プランのメンバー数上限超過 |
+| `ORG_INVITE_DOMAIN_NOT_ALLOWED` | 招待 Email ドメインが許可リスト外 |
+| `ORG_USER_ALREADY_IN_ORG` | 既に他組織所属 |
+| `ORG_DEPARTMENT_HAS_MEMBERS` | 部署にメンバーが残っている |
+| `ORG_SUBSCRIPTION_SUSPENDED` | 契約一時停止中 |
+| `ORG_PERMISSION_DENIED` | 権限不足 |
+| `ORG_PLAN_FEATURE_REQUIRED` | 上位プランが必要 |
+
+---
+
+## 11. 段階的実装計画
+
+### Phase 1: 招待受諾フロー完成 (1 週間)
+- `/invite/{token}` 受諾画面
+- API: `GET /api/invite/{token}`, `POST /api/invite/{token}/accept`
+- 招待メール自動送信 (Resend)
+- メンバー除名 API + UI
+
+### Phase 2: CSV 一括 + 部署正規化 (2 週間)
+- CSV 一括招待 API + UI
+- `user_profiles.department_id` への移行
+- 部署変更履歴
+
+### Phase 3: ダッシュボード強化 (3 週間)
+- 月次レポート PDF 生成
+- 部署別ヒートマップ
+- アラート機能
+
+### Phase 4: チャレンジ機能 (3 週間)
+- 進捗計算 (日次バッチ)
+- 自動通知
+- 達成者管理
+
+### Phase 5: 課金・契約 (4 週間)
+- Stripe 連携
+- 請求書 PDF
+- プラン変更フロー
+
+### Phase 6: 産業医・SSO・SLA (6 週間)
+- 産業医ロール + アクセス制御
+- 同意フロー
+- SAML SSO (Enterprise)
+- 監査ログ強化
+
+---
+
+## 12. テスト計画
+
+- 各 API の権限テスト
+- 招待受諾の各種ケース
+- CSV import のバリデーション
+- 1,000 名規模の負荷テスト
+- セキュリティテスト (他組織データへのアクセス試行)
+- E2E (Playwright):
+  - `org/01-create-organization.spec.ts`
+  - `org/02-invite-and-accept.spec.ts`
+  - `org/03-bulk-import.spec.ts`
+  - `org/04-challenge-create-join.spec.ts`
+  - `org/05-monthly-report.spec.ts`
+
+---
+
+## 13. リリース基準
+
+- [ ] Phase 1-3 全機能 E2E パス
+- [ ] パイロット組織 3 社で 4 週間運用
+- [ ] サポートマニュアル整備
+- [ ] 営業向けセールスシート
+- [ ] 利用規約・プライバシーポリシー法務確認
+- [ ] Stripe 本番接続テスト
+
+---
+
+## 14. 付録
+
+### 14.1 招待メールテンプレート
+
+```
+件名: 【ほめゴハン】{org_name} から組織に招待されました
+
+{inviter_name} さんから、ほめゴハンの組織「{org_name}」に招待されました。
+
+ロール: {role_label}
+部署: {department}
+有効期限: {expires_at_jst} まで
+
+下記リンクから参加してください:
+{invite_url}
+
+このサービスは {org_name} 様が福利厚生として提供しています。
+ご利用にあたっての注意事項は別途 {org_terms_url} をご確認ください。
+
+ご質問は {support_email} までお気軽にどうぞ。
+
+---
+ほめゴハン運営チーム
+```
+
+### 14.2 CSV 一括招待フォーマット
+
+```csv
+email,role,department,nickname,employee_id,joined_org_at
+yamada.taro@example.com,org_member,営業部,山田太郎,E001,2024-04-01
+sato.hanako@example.com,org_manager,開発部,佐藤花子,E002,2023-04-01
+```
+
+### 14.3 月次レポート PDF サンプル構成
+
+1. 表紙: 組織ロゴ + 期間
+2. エグゼクティブサマリ: 主要 KPI ハイライト
+3. 参加状況: 招待数、参加率、アクティブ率
+4. 健康スコア推移: 月次トレンド
+5. 部署別比較: ヒートマップ + ランキング
+6. チャレンジ結果: 開催チャレンジと達成率
+7. 改善提案 (AI、Pro): 部署・年代別の傾向分析
+8. 付録: 利用規約変更点・お知らせ
+
+### 14.4 関連ドキュメント
+
+- `01-family-management.md`
+- `03-operator-admin.md`
+- `docs/architecture/multi-tenancy.md` (組織テナント分離設計)
+- `docs/security/rls-policies.md`
+
+---
+
+**END OF ORGANIZATION MANAGEMENT REQUIREMENTS DOCUMENT**
+
+次のドキュメント: `03-operator-admin.md` (運営者管理)

--- a/docs/requirements/03-operator-admin.md
+++ b/docs/requirements/03-operator-admin.md
@@ -1,0 +1,1332 @@
+# ほめゴハン運営者管理 要件定義書
+
+**ドキュメントバージョン**: 1.0
+**最終更新**: 2026-05-06
+**作成者**: Opus (Claude)
+**ステータス**: ドラフト (レビュー待ち)
+**関連ドキュメント**: `01-family-management.md`, `02-organization-management.md`
+
+---
+
+## 1. エグゼクティブサマリー
+
+### 1.1 背景と目的
+
+ほめゴハンの運営事業者 (= 開発・運営会社) が、サービス全体を管理・モニタリング・最適化するための **内部向け管理コンソール**。本書のスコープは「運営者向け」であり、エンドユーザーや法人契約管理者は対象外 (それぞれ別ドキュメント)。
+
+具体的には:
+- ユーザー管理 (検索・BAN・サポート)
+- 組織契約管理 (営業フロー・契約管理)
+- コンテンツモデレーション (不適切食事・レシピ・AI出力)
+- システム運用 (LLM 使用量・機能フラグ・DB 統計)
+- 売上・MRR 分析
+- 監査・コンプライアンス
+- カスタマーサポート (問い合わせ対応・チケット管理)
+- インフラ運用 (Edge Function 状況・Vercel 監視)
+
+### 1.2 想定する利用者
+
+| ロール | 役職例 | 主な業務 |
+|--------|--------|---------|
+| **super_admin** | CTO / プロダクトオーナー | 全権限、システム設定、ロール付与 |
+| **admin** | 運営マネージャー | 日常運営、モデレーション、組織管理 |
+| **support** | カスタマーサポート | 問い合わせ対応、ユーザー BAN 提案 |
+| **sales** | 営業担当 (新ロール) | 法人契約フロー、見込み客管理 |
+| **finance** | 経理 (新ロール) | 請求・支払・売上管理 |
+| **content_moderator** | モデレーター (新ロール) | 不適切コンテンツの審査 |
+
+### 1.3 ビジネス価値
+
+- **運営効率化**: 1 人で 10,000 ユーザーを管理可能にする
+- **品質維持**: モデレーション体制でコンテンツ品質確保
+- **コスト最適化**: LLM 使用量・インフラコストの可視化と削減
+- **コンプライアンス**: 監査ログでガバナンス対応
+- **スケーラビリティ**: 100 万ユーザー規模でも運用可能な設計
+
+### 1.4 現状実装サマリ
+
+| 領域 | 状態 |
+|------|------|
+| `/admin` 基本画面 (ユーザー管理 / モデレーション / 監査) | ✅ |
+| `/super-admin` 画面 (LLM 統計 / 機能フラグ / DB 統計) | ✅ |
+| `/support` 画面 (問い合わせ管理 / ユーザー詳細) | ✅ |
+| ロール体系 (user / support / org_admin / admin / super_admin) | ✅ |
+| 監査ログ (`admin_audit_logs`) | ✅ (一部のみ) |
+| 売上 / MRR ダッシュボード | **未実装** |
+| サポートチケット (返信スレッド) | **未実装** |
+| Push / Email 通知送信 | **未実装** |
+| A/B テスト・セグメント | **未実装** |
+| インフラ監視ダッシュボード | **未実装** |
+| 不正検知 (BOT / 不正利用) | **未実装** |
+| データエクスポート (BigQuery 連携 等) | **未実装** |
+| sales / finance / content_moderator ロール | **未実装** |
+
+### 1.5 スコープ
+
+#### 含む
+- 既存 `/admin` `/super-admin` `/support` の機能完成
+- 売上・MRR ダッシュボード
+- サポートチケット (返信スレッド)
+- 通知配信 (Push / Email)
+- 不正検知・BAN 自動化
+- インフラ監視 (Vercel / Supabase / LLM API 統合)
+- 営業向け CRM 軽量機能 (見込み客 / 契約進捗)
+- 経理向け売上管理
+- A/B テスト基盤
+- 監査ログ完全網羅
+
+#### 含まない
+- 高度な BI ツール (Looker / Tableau 連携、別途検討)
+- 自動運用 (Auto-scaling 設定、Vercel が担当)
+- 法務管理 (契約書管理、別 SaaS 利用前提)
+- 給与計算 (運営側従業員管理は別 HR システム)
+
+---
+
+## 2. 用語定義
+
+| 用語 | 定義 |
+|------|------|
+| **運営者 (Operator)** | ほめゴハンの開発・運営会社のスタッフ。super_admin / admin / support / sales / finance / content_moderator のロールを持つ |
+| **管理コンソール** | `/admin`, `/super-admin`, `/support` を含む運営者向け Web UI 全体 |
+| **アクション (Action)** | 運営者が行う操作 (ユーザー BAN / プラン変更 / 機能フラグ更新 等) |
+| **監査ログ** | 全アクションを永続記録する不可逆ログ |
+| **モデレーション** | 不適切コンテンツ (食事写真・レシピ・AI 出力) の審査と対処 |
+| **チケット** | ユーザーからの問い合わせをスレッド形式で管理する単位 |
+| **MRR (Monthly Recurring Revenue)** | 月次経常収益。法人プラン契約から算出 |
+| **コホート** | 特定期間に登録したユーザー群 (例: 2026-04 登録者) |
+| **機能フラグ** | コードで if 分岐する条件で機能を ON/OFF (`feature_flags`) |
+| **LLM コスト** | OpenAI / xAI / Gemini への支払い API 料金 |
+| **不正利用 (Abuse)** | スパム投稿・大量登録・規約違反等 |
+| **クォータ** | 各ユーザーの API 利用上限 (LLM 呼び出し回数等) |
+
+---
+
+## 3. ペルソナ
+
+### 3.1 ペルソナ A: 田中 大輔 (38 歳、CTO、super_admin)
+
+**プロフィール**
+- 役職: CTO 兼開発責任者
+- 業務: プロダクト全体の開発・運営・経営判断
+- IT リテラシー: 最高
+- 課題: 1 日中の運営オペレーションでコードを書く時間が無い
+
+**主要ニーズ**
+- LLM コストが急増した日に即座に原因特定 (どのユーザー / どの機能)
+- 機能フラグで A/B テストを迅速に展開・撤回
+- 売上 / MRR / 解約率を毎日ダッシュボードでチェック
+- セキュリティインシデント発生時に admin 全員に即通知
+- DB スキーマ変更前のデータ確認・バックアップ確認
+
+**主要ジャーニー**
+1. 朝、`/super-admin` ダッシュボードを開く → 昨日の KPI チェック
+2. 「LLM コスト 前日比 +30%」アラート → 原因調査画面 → 異常ユーザー特定
+3. 該当ユーザーをクォータ制限へ
+4. 機能フラグ「new_meal_ai_v2」を 5% から 25% へ拡大
+5. 監査ログを確認 → 全 admin の昨日の操作を一覧
+
+### 3.2 ペルソナ B: 山田 由香 (32 歳、運営マネージャー、admin)
+
+**プロフィール**
+- 役職: カスタマーオペレーション・マネージャー
+- 業務: 日常運営、ユーザーサポート統括、モデレーション統括
+- IT リテラシー: 中-高
+
+**主要ニーズ**
+- 毎日 30 件のモデレーション (不適切食事・レシピ) を効率的に処理
+- ユーザー BAN を判断 (規約違反度合いに応じて)
+- カスタマーサポートのチケット進捗管理
+- 月末に支援組織の請求書発行確認
+
+**主要ジャーニー**
+1. 朝、`/admin/moderation` でフラグ一覧
+2. 1 件ずつ確認 (画像 + 投稿者履歴) → OK / 削除 / BAN を判断
+3. `/admin/inquiries` で未対応チケット 5 件 → support チームに割当
+4. 月次組織レポートを役員に共有
+
+### 3.3 ペルソナ C: 佐藤 健 (28 歳、カスタマーサポート、support)
+
+**プロフィール**
+- 役職: カスタマーサポート担当
+- 業務: ユーザー問い合わせ対応 (1 日 50 件)
+- IT リテラシー: 中
+
+**主要ニーズ**
+- ユーザー検索で即座にユーザー詳細表示
+- 過去問い合わせ履歴を確認しつつ返信
+- 食事記録の不具合 (画像認識失敗) の原因確認
+- BAN は提案するが実行は admin 待ち
+
+**主要ジャーニー**
+1. 朝、新規問い合わせ 20 件をチェック
+2. 「画像認識が動かない」ユーザーの詳細画面 → 食事記録一覧
+3. 該当画像を確認 → 解析ログを参照 → 「Gemini API timeout」を確認
+4. ユーザーに「再撮影をお試しください」回答
+5. 解決後にチケット close
+
+### 3.4 ペルソナ D: 鈴木 雄一 (40 歳、営業マネージャー、sales)
+
+**プロフィール**
+- 役職: 法人営業
+- 業務: B2B 営業 (健保・大企業)
+- IT リテラシー: 中
+
+**主要ニーズ**
+- 見込み客リスト管理 (Salesforce 風)
+- 商談進捗 (アプローチ → デモ → 提案 → 契約)
+- パイロット運用の効果データを営業資料として出力
+- 契約後はカスタマーサクセスに引き継ぎ
+
+**主要ジャーニー**
+1. `/admin/sales/leads` で見込み客一覧
+2. 商談予定の企業に訪問前準備 (過去メール + パイロットデータ)
+3. 契約締結 → ステージを「契約済」に変更 → 自動で経理に通知
+4. パイロット組織の効果データを PDF 出力 → 提案資料に活用
+
+### 3.5 ペルソナ E: 田中 美穂 (35 歳、経理担当、finance)
+
+**プロフィール**
+- 役職: 経理・財務
+- 業務: 売上計上、請求書発行、未払い管理
+- IT リテラシー: 中
+
+**主要ニーズ**
+- 月末に全組織の請求書を一括生成
+- 未払い組織の自動アラート
+- 売上推移を MRR / ARR / 解約率で把握
+- Stripe 売上データと内部 DB を照合
+
+**主要ジャーニー**
+1. 月末日に `/admin/finance/invoices` → 「全組織分一括生成」
+2. PDF 確認 → 1 件問題あり (プラン変更途中) → 個別調整
+3. Stripe 連携 → 自動送信
+4. 翌月初に未払い 3 件 → 督促メール送信
+
+---
+
+## 4. ユースケース
+
+### 4.1 UC-OP-01: ユーザー検索と詳細表示
+
+**フロー**:
+1. `/admin/users` を開く
+2. 検索 (Email / 名前 / ユーザー ID / 電話番号)
+3. 検索結果から 1 件選択 → 詳細画面
+4. 表示内容:
+   - 基本情報 (Email、登録日、最終ログイン、プラン)
+   - ロール一覧
+   - 食事記録統計 (件数、最終記録日、画像認識成功率)
+   - AI セッション数
+   - 問い合わせ履歴
+   - 管理ノート
+   - BAN 履歴
+   - 監査ログ (このユーザーに対するアクション)
+
+### 4.2 UC-OP-02: ユーザー BAN
+
+**フロー**:
+1. ユーザー詳細画面 → 「BAN」ボタン
+2. 確認モーダル:
+   - 理由 (規約違反 / スパム / 不正利用 / その他)
+   - BAN 種別 (一時 / 永久)
+   - 期間 (一時 BAN の場合: 1 日 / 7 日 / 30 日)
+   - 通知メッセージ (ユーザーに送る理由説明、編集可)
+3. 確定 → API `POST /api/admin/users/{id}/ban`
+4. 監査ログ記録 + ユーザーに Email 通知
+5. ユーザーログイン時に「アカウントが BAN されています」表示
+
+### 4.3 UC-OP-03: モデレーション処理 (食事画像)
+
+**フロー**:
+1. `/admin/moderation` の「食事フラグ」タブ
+2. フラグ一覧 (フラグタイプ / 投稿者 / 画像 / 報告者 / 報告日)
+3. 1 件選択 → 詳細表示 (画像 + 投稿コメント + 投稿者過去履歴)
+4. 判断:
+   - **承認 (false positive)**: フラグ解除、投稿継続
+   - **削除のみ**: 画像削除、投稿者には警告通知
+   - **削除 + 一時 BAN**: 規約違反度に応じて BAN
+   - **削除 + 永久 BAN**: 重大違反時
+5. 解決理由を入力 → 確定
+6. 監査ログ記録 + 報告者に「処理完了」通知
+
+### 4.4 UC-OP-04: AI コンテンツモデレーション
+
+**フロー**:
+1. `/admin/moderation/ai-content` を開く
+2. AI が生成した不適切コンテンツのフラグ一覧
+3. 例: AI Advisor が誤った医療アドバイスをした、AI 献立に毒性のある食材が混入
+4. レビュー → プロンプト修正、ブロックリスト追加、 system prompt 更新
+5. 修正後に該当ユーザーに「お詫びと正しい情報」通知
+
+### 4.5 UC-OP-05: 機能フラグ管理
+
+**フロー**:
+1. `/super-admin/feature-flags` を開く
+2. 機能フラグ一覧 (`new_meal_ai_v2`, `family_groups_enabled`, `experimental_chat_streaming` 等)
+3. 各フラグ:
+   - 説明
+   - 有効化対象 (全ユーザー / 割合 / 特定ユーザー / 特定組織)
+   - 現在の有効率
+4. 編集 → 「5% から 25% へ拡大」
+5. 確定 → API `PUT /api/super-admin/feature-flags`
+6. 監査ログ記録、即座に反映
+7. メトリクス監視 (有効化後のエラー率上昇等を自動検知)
+
+### 4.6 UC-OP-06: LLM 使用量分析
+
+**フロー**:
+1. `/super-admin/llm-usage` を開く
+2. 期間選択 (今日 / 7 日 / 30 日 / カスタム)
+3. ダッシュボード:
+   - 総コスト (USD / JPY)
+   - モデル別内訳 (Gemini Flash Lite / Gemini Image / xAI Grok / OpenAI / Claude)
+   - 機能別内訳 (analyze-meal / classify-photo / ai-consultation / generate-week-menu 等)
+   - ユーザー別 Top 50 (異常検知用)
+   - 時系列推移 (時間別)
+4. 異常検知:
+   - 1 ユーザーが 1 日 1,000 リクエスト超 → アラート
+   - モデル別コストが前日比 +50% → アラート
+5. クォータ設定:
+   - フリープランは 1 日 50 回まで
+   - プレミアムは 1 日 500 回
+   - 法人は組織単位で設定
+
+### 4.7 UC-OP-07: 売上ダッシュボード
+
+**フロー**:
+1. `/admin/finance/dashboard` を開く
+2. KPI カード:
+   - 今月の売上 (リアルタイム集計)
+   - MRR (Monthly Recurring Revenue)
+   - ARR (Annual Recurring Revenue)
+   - 解約率 (Churn Rate)
+   - LTV (Customer Lifetime Value)
+   - CAC (Customer Acquisition Cost)
+3. グラフ:
+   - 月次売上推移
+   - プラン別内訳 (個人 vs 法人)
+   - コホート分析 (登録月別の継続率)
+4. 法人契約一覧:
+   - 契約中 / 契約準備中 / 解約済
+   - 各組織の契約金額 + 次回更新日
+
+### 4.8 UC-OP-08: サポートチケット
+
+**フロー**:
+1. `/support/tickets` でチケット一覧
+2. ステータス: Open / In Progress / Resolved / Closed
+3. 1 件選択 → スレッド表示
+4. メッセージ送信 (テンプレート選択可)
+5. 内部メモ (ユーザーには見えない、support 同士)
+6. ユーザー詳細画面と連動 (チケット内で「ユーザーの食事記録を見る」リンク)
+7. 解決後 → 「Resolved」 → ユーザーに Email 自動送信
+8. 担当者割り当て (チケットを「自分」「○○さん」に)
+
+### 4.9 UC-OP-09: 通知配信
+
+**フロー**:
+1. `/admin/notifications/campaigns` で通知キャンペーン管理
+2. 「新規キャンペーン」 → ターゲット指定:
+   - 全ユーザー
+   - フィルタ (プラン / 登録月 / 最終ログイン日 / 食事記録なし期間 等)
+   - CSV アップロードで個別指定
+3. メッセージ作成:
+   - Push 通知 (タイトル + 本文 + ディープリンク)
+   - Email (件名 + HTML 本文)
+   - アプリ内通知
+4. プレビュー → A/B テスト設定 (任意)
+5. 配信予約 (即時 / スケジュール)
+6. 配信後: 開封率、クリック率、コンバージョン率を計測
+
+### 4.10 UC-OP-10: 不正検知・自動 BAN
+
+**フロー**:
+1. ルール作成: `/super-admin/abuse-rules`
+2. 例:
+   - 「24 時間で 1,000 食事記録 → 一時 BAN (BOT 疑い)」
+   - 「同じ画像を 100 回投稿 → 削除 + 警告」
+   - 「1 IP から 10 アカウント登録 → 全 BAN」
+3. 自動実行: バッチジョブ (5 分毎)
+4. 検知時:
+   - admin に通知
+   - 自動 BAN (設定によりレベル分け)
+5. 手動レビュー UI: `/admin/abuse/queue`
+
+### 4.11 UC-OP-11: インフラ監視
+
+**フロー**:
+1. `/super-admin/infra` で統合ダッシュボード
+2. 表示内容:
+   - Vercel 関数の実行時間 (p50 / p95 / p99)
+   - Vercel エラー率
+   - Supabase Edge Function ステータス
+   - Supabase DB 接続数 / クエリ時間
+   - LLM API レスポンス時間
+   - キャッシュヒット率
+3. アラート: しきい値超過で Slack / Email
+4. インシデント記録: 過去のインシデントと対応履歴
+
+### 4.12 UC-OP-12: 監査ログ閲覧
+
+**フロー**:
+1. `/admin/audit-logs` で全ログ
+2. フィルタ:
+   - アクション種別 (BAN / role_change / setting_change 等)
+   - 担当者 (admin)
+   - 対象 (ユーザー / 組織)
+   - 期間
+3. 詳細展開: JSON で詳細表示
+4. CSV エクスポート (法務対応)
+
+### 4.13 UC-OP-13: ロール付与・剥奪
+
+**フロー**:
+1. `/super-admin/admins` で全管理者一覧
+2. 「ロール変更」ボタン → モーダル
+3. 付与可能ロール:
+   - super_admin (super_admin のみ付与可)
+   - admin (admin / super_admin)
+   - support, sales, finance, content_moderator (admin / super_admin)
+4. パスワード再認証必須
+5. 監査ログ + 対象者に Email 通知
+
+### 4.14 UC-OP-14: 営業 / CRM 機能
+
+**フロー** (sales):
+1. `/admin/sales/leads` で見込み客リスト
+2. 「新規」 → 企業情報入力 (会社名、業種、従業員数、担当者、電話、メール)
+3. ステージ管理: アプローチ → 商談 → 提案 → 契約
+4. 商談メモ (時系列)
+5. 提案書 PDF 自動生成 (パイロット効果データを反映)
+6. 契約締結 → 組織レコード作成 (運営作業)
+
+### 4.15 UC-OP-15: A/B テスト
+
+**フロー**:
+1. `/super-admin/experiments` で実験管理
+2. 「新規実験」:
+   - 名前: `new_chat_ui_2026_05`
+   - 仮説: 新 UI でメッセージ送信率 +20%
+   - バリアント: A (現行) / B (新)
+   - 配分: 50/50
+   - 期間: 14 日
+   - 主要メトリクス: メッセージ送信数 / 滞在時間
+3. 実行中: 統計的有意性をリアルタイム計算
+4. 結果分析: 
+   - p 値、信頼区間
+   - サブグループ別 (年代 / プラン)
+5. 採用 / 却下を決定
+
+---
+
+## 5. 機能要件
+
+### 5.1 F-OP-001: ユーザー管理
+
+#### 5.1.1 検索
+- 検索対象: Email / 名前 / ユーザー ID / 社員番号 / 電話番号
+- 全文検索 (Postgres tsvector)
+- フィルタ: プラン / ロール / 登録月 / 最終ログイン日 / 在籍状況 / BAN 状態
+- ソート: 登録日 / 最終ログイン日 / 食事記録数 / プラン
+
+#### 5.1.2 ユーザー詳細
+- 基本情報セクション
+- 食事記録統計
+- AI 利用統計
+- 健康スコアトレンド
+- 問い合わせ履歴
+- 管理ノート
+- 監査ログ
+- 関連組織 / 家族グループ
+- BAN 履歴
+
+#### 5.1.3 BAN 機能
+- 一時 BAN (期間指定) / 永久 BAN
+- 理由カテゴリ + 自由記述
+- 自動 unBAN (期間切れ)
+- BAN 中はログイン拒否、Push 通知配信停止
+- BAN 解除も可
+
+### 5.2 F-OP-002: モデレーション
+
+#### 5.2.1 種類
+- **食事フラグ** (`moderation_flags`): 不適切な食事画像
+- **レシピフラグ** (`recipe_flags`): 不適切なレシピ
+- **AI コンテンツフラグ** (`ai_content_logs`): AI が生成した問題コンテンツ
+- **コメントフラグ** (将来): 食事コメント
+
+#### 5.2.2 処理アクション
+- 承認 (false positive)
+- コンテンツ削除のみ
+- 削除 + 警告
+- 削除 + 一時 BAN
+- 削除 + 永久 BAN
+- エスカレーション (super_admin へ)
+
+#### 5.2.3 統計
+- フラグ件数推移
+- 解決時間 (中央値)
+- フラグ種別の比率
+- 担当者別処理件数
+
+#### 5.2.4 自動モデレーション
+- 画像 NSFW 検出 (Gemini モデレーション API)
+- テキスト hate speech 検出
+- 自動フラグ → 人間レビューへ
+
+### 5.3 F-OP-003: 監査ログ
+
+#### 5.3.1 記録対象
+**全ての admin 操作を記録**:
+- ユーザー BAN / unBAN
+- ロール変更
+- 組織作成 / 削除 / プラン変更
+- 機能フラグ更新
+- システム設定変更
+- お知らせ作成 / 削除
+- モデレーション解決
+- データエクスポート
+- 通知キャンペーン送信
+- 不正検知ルール変更
+
+#### 5.3.2 記録項目
+- `id`, `actor_id`, `action_type`, `target_id`, `target_type`
+- `details` JSON (前後の値)
+- `ip_address`, `user_agent`, `created_at`
+- `severity`: info / warn / critical
+
+#### 5.3.3 不可逆性
+- 監査ログは UPDATE / DELETE 不可 (RLS で禁止)
+- super_admin でも変更不可
+- データ保持期間: 7 年 (法務要件)
+- アーカイブ: 1 年経過後はコールドストレージへ
+
+### 5.4 F-OP-004: 機能フラグ
+
+#### 5.4.1 構造
+```json
+{
+  "key": "new_meal_ai_v2",
+  "description": "新しい食事 AI V2",
+  "enabled": true,
+  "rollout_strategy": {
+    "type": "percentage",  // 'all', 'percentage', 'user_ids', 'organization_ids', 'roles'
+    "value": 25
+  },
+  "constraints": {
+    "min_user_age_days": 7,  // 登録 7 日以上
+    "exclude_plans": ["free"]
+  },
+  "created_at": "...",
+  "updated_at": "..."
+}
+```
+
+#### 5.4.2 評価ロジック
+- API リクエスト時に `is_enabled(flag_key, user)` を呼ぶ
+- ハッシュベースで安定的にユーザーを A/B 分け
+- メトリクス自動記録 (有効ユーザー数 / 効果)
+
+#### 5.4.3 緊急停止
+- 1 クリックで全ロールバック
+- インシデント発生時に即座に無効化
+
+### 5.5 F-OP-005: LLM コスト管理
+
+#### 5.5.1 計測単位
+- リクエスト毎: ユーザー / 機能 / モデル / トークン数 / コスト USD
+- 集計: 日次 / 週次 / 月次
+
+#### 5.5.2 ダッシュボード
+- 総コスト (USD / JPY)
+- モデル別内訳: Gemini Flash Lite / Gemini Image / xAI Grok / OpenAI / Claude
+- 機能別内訳:
+  - `analyze-meal-photo`
+  - `classify-photo`
+  - `analyze-fridge`
+  - `analyze-health-checkup`
+  - `analyze-weight-scale`
+  - `ai-consultation` (ストリーミング、トークン多)
+  - `generate-week-menu`
+  - `generate-day-menu`
+  - `generate-single-meal`
+  - `image/generate` (献立画像生成)
+- ユーザー別 Top 50: 異常使用検知
+- 時系列推移: 時間 / 日別
+
+#### 5.5.3 クォータ
+| プラン | 1 日上限 | 1 ヶ月上限 |
+|--------|---------|----------|
+| Free | 50 リクエスト | 1,000 リクエスト |
+| Pro | 500 リクエスト | 10,000 リクエスト |
+| Premium | 2,000 リクエスト | 50,000 リクエスト |
+| 法人 | 組織単位で設定 | 組織単位で設定 |
+
+#### 5.5.4 異常検知
+- 1 ユーザーが 1 日 5,000 リクエスト超 → アラート + 一時クォータ削減
+- モデル別前日比 +50% → アラート
+- 特定機能のコスト急増 → アラート
+
+### 5.6 F-OP-006: 売上・MRR ダッシュボード
+
+#### 5.6.1 KPI
+- 今月の売上 (リアルタイム)
+- 確定済売上 / 予測売上
+- MRR / ARR
+- 新規 MRR / 拡張 MRR / 縮小 MRR / 解約 MRR (Net New MRR)
+- 解約率 (logo churn / revenue churn)
+- LTV / CAC / LTV/CAC ratio
+- 平均契約金額 (ACV)
+
+#### 5.6.2 プラン別内訳
+- 個人プラン (Free / Pro / Premium)
+- 法人プラン (Org Starter / Standard / Pro / Enterprise)
+- 各プランのアクティブユーザー / 売上
+
+#### 5.6.3 コホート分析
+- 登録月別の継続率 (1 / 3 / 6 / 12 ヶ月)
+- 課金転換率 (Free → Paid)
+- 月次売上のコホート分解
+
+#### 5.6.4 法人契約管理
+- 契約中組織一覧 (契約金額 / 次回更新日 / 担当営業)
+- 解約予兆検知 (アクティブ率低下、ログイン頻度低下)
+- 契約更新リマインダー (30 / 14 / 7 日前)
+
+### 5.7 F-OP-007: サポートチケット
+
+#### 5.7.1 チケット属性
+- ID, ステータス (Open / In Progress / Pending / Resolved / Closed)
+- 優先度 (Low / Medium / High / Urgent)
+- カテゴリ (アカウント / 課金 / 機能 / 不具合 / その他)
+- 担当者
+- ユーザー (関連)
+- 作成日時 / 解決日時
+
+#### 5.7.2 スレッド
+- ユーザー → サポート、サポート → ユーザーのメッセージ交換
+- 添付ファイル (画像、PDF)
+- 内部メモ (サポート同士、ユーザー非公開)
+- ステータス変更履歴
+- テンプレート (よくある回答を保存)
+
+#### 5.7.3 SLA
+- 初動応答: 営業日 24 時間以内
+- 解決目標: 優先度別 (High: 48 時間 / Medium: 7 日 / Low: 30 日)
+- アラート: SLA 超過時に担当者・マネージャーに通知
+
+#### 5.7.4 統計
+- 未対応件数
+- 平均解決時間
+- カテゴリ別件数
+- 担当者別 KPI (件数 / 解決時間)
+
+### 5.8 F-OP-008: 通知配信
+
+#### 5.8.1 種類
+- **キャンペーン通知**: マーケティング・お知らせ (`/admin/notifications/campaigns`)
+- **トランザクション通知**: 自動配信 (登録完了 / 課金完了 / BAN / 招待 等)
+- **緊急通知**: インシデント発生時 (admin 全員に Slack + Email)
+
+#### 5.8.2 配信チャネル
+- Push 通知 (APNs / FCM)
+- Email (Resend)
+- アプリ内通知
+- SMS (将来、コスト次第)
+
+#### 5.8.3 ターゲット指定
+- 全ユーザー
+- フィルタ:
+  - プラン
+  - 登録月
+  - 最終ログイン日
+  - 食事記録なし期間
+  - 健康スコア
+  - 居住地 (将来)
+- CSV アップロード
+- セグメント保存・再利用
+
+#### 5.8.4 A/B テスト
+- メッセージ A / B / C を分割配信
+- 開封率 / クリック率 / コンバージョン率
+- 統計的有意性
+
+#### 5.8.5 配信スケジュール
+- 即時
+- 予約 (日時指定)
+- ユーザータイムゾーン考慮 (将来)
+
+### 5.9 F-OP-009: 不正検知
+
+#### 5.9.1 検知ルール
+- 大量登録 (同 IP から 10 分で 10 アカウント)
+- BOT 疑い (24 時間で 1,000 食事記録)
+- 同一画像連投 (1 ユーザーが同じ画像を 50 回)
+- API スパム (1 分間に 1,000 リクエスト)
+- スクリーンスクレイピング検知
+
+#### 5.9.2 自動アクション
+- 警告 (1 段階目): ユーザーに警告通知
+- レート制限 (2 段階目): API 呼び出し制限
+- 一時 BAN (3 段階目): 24 時間 BAN
+- 永久 BAN (4 段階目): admin レビュー後
+
+#### 5.9.3 手動レビューキュー
+- 自動検知の偽陽性確認
+- BAN 解除リクエスト処理
+- 異議申立フロー
+
+### 5.10 F-OP-010: インフラ監視
+
+#### 5.10.1 監視対象
+- Vercel: 関数実行時間、エラー率、デプロイ状況
+- Supabase: DB クエリ時間、Edge Function ステータス、ストレージ使用量、Auth ステータス
+- LLM API: レスポンス時間 (p50/p95/p99)、エラー率、コスト
+- Vercel-Analytics: ページビュー、Core Web Vitals
+- カスタム metrics: 食事認識成功率、献立生成成功率
+
+#### 5.10.2 アラート
+- しきい値超過で Slack #incident チャンネル + Email
+- PagerDuty 連携 (将来)
+- 自動エスカレーション (5 分未対応で次の担当者)
+
+#### 5.10.3 インシデント管理
+- インシデント記録 (発生時刻、影響範囲、対応者、復旧時刻)
+- ポストモーテム作成
+- 再発防止策追跡
+
+### 5.11 F-OP-011: 営業 (CRM)
+
+#### 5.11.1 リード管理
+- 見込み客リスト
+- スコアリング (確度高/中/低)
+- ステージ: アプローチ / 商談 / 提案 / 交渉 / 契約 / 失注
+
+#### 5.11.2 商談記録
+- 時系列メモ
+- 添付資料 (提案書 / 議事録)
+- 次のアクション (リマインダー)
+
+#### 5.11.3 提案書生成
+- パイロット効果データ自動取得
+- テンプレート差し込み
+- PDF / PowerPoint 出力
+
+### 5.12 F-OP-012: 経理 (Finance)
+
+#### 5.12.1 請求書発行
+- 月末一括生成
+- 個別調整 (プラン変更途中、日割り)
+- PDF + Stripe 連携
+
+#### 5.12.2 未払い管理
+- アラート (期限切れ 7/14/30 日)
+- 督促メール (テンプレート)
+- 一時停止フラグ
+
+#### 5.12.3 売上計上
+- 月次売上計上 (Stripe データと内部 DB 照合)
+- 会計ソフト連携 (freee / マネーフォワード)
+
+### 5.13 F-OP-013: A/B テスト基盤
+
+#### 5.13.1 実験設計
+- 仮説、メトリクス、期間、配分
+- バリアント (A / B / C…)
+- ターゲット (全ユーザー / セグメント)
+
+#### 5.13.2 実行
+- ハッシュベース安定割当
+- メトリクス自動記録
+
+#### 5.13.3 統計分析
+- 平均値の差、p 値、信頼区間
+- ベイズ推定 (将来)
+- サブグループ別 (年代 / プラン)
+
+### 5.14 F-OP-014: データエクスポート
+
+#### 5.14.1 用途
+- 法務開示請求対応 (個人データ)
+- BI ツール連携 (BigQuery / Snowflake / Looker)
+- 機械学習データセット作成
+
+#### 5.14.2 形式
+- CSV / Parquet / JSON
+- 個人特定情報の自動マスキング
+
+---
+
+## 6. 非機能要件
+
+### 6.1 パフォーマンス
+- ユーザー検索 (100 万件) < 1s
+- ダッシュボード < 2s
+- 監査ログ閲覧 < 1.5s
+- レポート生成 < 30s
+
+### 6.2 セキュリティ
+- 全 admin に 2FA 必須 (Phase 2)
+- IP allowlist (Enterprise admin)
+- 全操作監査ログ
+- セッション 1 時間タイムアウト
+- ロール変更は再認証必須
+
+### 6.3 スケーラビリティ
+- 1,000 万ユーザー対応
+- 同時 admin: 50 名
+- 監査ログ: 1 億行 / 年
+
+### 6.4 可用性
+- 管理コンソール 99.9%
+- インシデント時に自動フェイルオーバー (将来)
+
+### 6.5 法務・コンプライアンス
+- 個人情報保護法
+- GDPR (EU 拠点企業利用時)
+- SOC 2 Type II (将来取得)
+- 監査ログ 7 年保持
+
+---
+
+## 7. データモデル
+
+### 7.1 既存テーブル拡張
+
+#### 7.1.1 `user_profiles.roles`
+```sql
+-- 新規ロール追加
+-- ロール: user / support / sales / finance / content_moderator / org_member / org_manager / org_admin / org_industrial_doctor / admin / super_admin
+```
+
+#### 7.1.2 `admin_audit_logs`
+```sql
+ALTER TABLE admin_audit_logs ADD COLUMN IF NOT EXISTS target_type VARCHAR(30);
+ALTER TABLE admin_audit_logs ADD COLUMN IF NOT EXISTS severity VARCHAR(20) NOT NULL DEFAULT 'info' CHECK (severity IN ('info', 'warn', 'critical'));
+
+-- 不可逆性: UPDATE/DELETE 禁止
+CREATE POLICY "audit_logs_immutable" ON admin_audit_logs FOR UPDATE USING (false);
+CREATE POLICY "audit_logs_immutable_delete" ON admin_audit_logs FOR DELETE USING (false);
+```
+
+### 7.2 新規テーブル
+
+#### 7.2.1 `support_tickets`
+```sql
+CREATE TABLE support_tickets (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES auth.users(id),
+  subject         VARCHAR(200) NOT NULL,
+  category        VARCHAR(50) NOT NULL,
+  priority        VARCHAR(20) NOT NULL DEFAULT 'medium' CHECK (priority IN ('low', 'medium', 'high', 'urgent')),
+  status          VARCHAR(20) NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'in_progress', 'pending', 'resolved', 'closed')),
+  assignee_id     UUID REFERENCES auth.users(id),
+  resolved_at     TIMESTAMPTZ,
+  closed_at       TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE support_ticket_messages (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  ticket_id       UUID NOT NULL REFERENCES support_tickets(id) ON DELETE CASCADE,
+  sender_id       UUID NOT NULL REFERENCES auth.users(id),
+  is_internal     BOOLEAN NOT NULL DEFAULT FALSE,
+  body            TEXT NOT NULL,
+  attachments     JSONB DEFAULT '[]',
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+#### 7.2.2 `notification_campaigns`
+```sql
+CREATE TABLE notification_campaigns (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name              VARCHAR(200) NOT NULL,
+  channel           VARCHAR(20) NOT NULL CHECK (channel IN ('push', 'email', 'in_app')),
+  target_filter     JSONB NOT NULL,  -- { plan: ['free'], min_age_days: 7, ... }
+  variants          JSONB NOT NULL,  -- [{ key: 'A', subject: '...', body: '...' }, ...]
+  scheduled_at      TIMESTAMPTZ,
+  status            VARCHAR(20) NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'scheduled', 'sending', 'sent', 'cancelled')),
+  total_recipients  INT,
+  sent_count        INT NOT NULL DEFAULT 0,
+  open_count        INT NOT NULL DEFAULT 0,
+  click_count       INT NOT NULL DEFAULT 0,
+  conversion_count  INT NOT NULL DEFAULT 0,
+  created_by        UUID NOT NULL REFERENCES auth.users(id),
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+#### 7.2.3 `abuse_rules`
+```sql
+CREATE TABLE abuse_rules (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name            VARCHAR(100) NOT NULL,
+  description     TEXT,
+  rule_type       VARCHAR(50) NOT NULL,  -- 'request_rate', 'content_repetition', 'multi_account', etc.
+  threshold       JSONB NOT NULL,
+  action_type     VARCHAR(30) NOT NULL,  -- 'warning', 'rate_limit', 'temp_ban', 'perm_ban', 'manual_review'
+  action_config   JSONB DEFAULT '{}',
+  is_active       BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by      UUID NOT NULL REFERENCES auth.users(id),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE abuse_detections (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  rule_id         UUID NOT NULL REFERENCES abuse_rules(id),
+  user_id         UUID NOT NULL REFERENCES auth.users(id),
+  detected_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  details         JSONB NOT NULL,
+  action_taken    VARCHAR(30),
+  reviewed_by     UUID REFERENCES auth.users(id),
+  review_status   VARCHAR(20),  -- 'auto', 'confirmed', 'false_positive', 'escalated'
+  reviewed_at     TIMESTAMPTZ
+);
+```
+
+#### 7.2.4 `experiments` (A/B テスト)
+```sql
+CREATE TABLE experiments (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  key             VARCHAR(100) NOT NULL UNIQUE,
+  hypothesis      TEXT,
+  variants        JSONB NOT NULL,  -- [{ key: 'control', weight: 50 }, { key: 'variant_a', weight: 50 }]
+  primary_metric  VARCHAR(100),
+  start_date      DATE,
+  end_date        DATE,
+  status          VARCHAR(20) NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'running', 'completed', 'cancelled')),
+  result          JSONB,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE experiment_assignments (
+  experiment_id   UUID NOT NULL REFERENCES experiments(id),
+  user_id         UUID NOT NULL REFERENCES auth.users(id),
+  variant_key     VARCHAR(50) NOT NULL,
+  assigned_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (experiment_id, user_id)
+);
+```
+
+#### 7.2.5 `sales_leads`
+```sql
+CREATE TABLE sales_leads (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_name    VARCHAR(200) NOT NULL,
+  industry        VARCHAR(100),
+  employee_count  INT,
+  contact_name    VARCHAR(100),
+  contact_email   VARCHAR(255),
+  contact_phone   VARCHAR(50),
+  source          VARCHAR(50),  -- 'website', 'referral', 'event', 'cold_call'
+  stage           VARCHAR(30) NOT NULL DEFAULT 'approach',  -- 'approach', 'meeting', 'proposal', 'negotiation', 'won', 'lost'
+  assigned_to     UUID REFERENCES auth.users(id),
+  estimated_acv   INT,  -- Annual Contract Value
+  notes           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE sales_lead_activities (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  lead_id         UUID NOT NULL REFERENCES sales_leads(id) ON DELETE CASCADE,
+  actor_id        UUID NOT NULL REFERENCES auth.users(id),
+  activity_type   VARCHAR(30) NOT NULL,  -- 'call', 'email', 'meeting', 'note', 'stage_change'
+  details         JSONB NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+#### 7.2.6 `infra_metrics`
+```sql
+CREATE TABLE infra_metrics (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  metric_name     VARCHAR(100) NOT NULL,
+  source          VARCHAR(50) NOT NULL,  -- 'vercel', 'supabase', 'gemini', 'xai', 'openai', 'custom'
+  value           NUMERIC NOT NULL,
+  unit            VARCHAR(20),
+  tags            JSONB DEFAULT '{}',
+  recorded_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_infra_metrics_recent ON infra_metrics(metric_name, recorded_at DESC);
+
+CREATE TABLE infra_alerts (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  metric_name     VARCHAR(100) NOT NULL,
+  threshold       NUMERIC NOT NULL,
+  comparison      VARCHAR(10) NOT NULL CHECK (comparison IN ('>', '>=', '<', '<=', '=')),
+  triggered_at    TIMESTAMPTZ NOT NULL,
+  resolved_at     TIMESTAMPTZ,
+  details         JSONB,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+---
+
+## 8. API 仕様
+
+### 8.1 ユーザー管理
+- `GET /api/admin/users` (検索・フィルタ・ソート)
+- `GET /api/admin/users/{id}` (詳細)
+- `PATCH /api/admin/users/{id}` (基本情報更新)
+- `POST /api/admin/users/{id}/ban`
+- `POST /api/admin/users/{id}/unban`
+- `PUT /api/admin/users/{id}/roles`
+- `GET /api/admin/users/{id}/audit-logs`
+- `POST /api/admin/users/{id}/notes`
+
+### 8.2 モデレーション
+- `GET /api/admin/moderation/{type}` (food / recipe / ai_content)
+- `PUT /api/admin/moderation/{type}/{id}` (解決)
+- `POST /api/admin/moderation/auto-rules`
+
+### 8.3 監査ログ
+- `GET /api/admin/audit-logs`
+- `POST /api/admin/audit-logs/export`
+
+### 8.4 機能フラグ
+- `GET /api/super-admin/feature-flags`
+- `PUT /api/super-admin/feature-flags/{key}`
+- `POST /api/super-admin/feature-flags`
+- `DELETE /api/super-admin/feature-flags/{key}`
+
+### 8.5 LLM 使用量
+- `GET /api/super-admin/llm-usage` (フィルタ・期間指定)
+- `GET /api/super-admin/llm-usage/users/{id}`
+- `POST /api/super-admin/llm-usage/quota-update`
+
+### 8.6 売上 / 経理
+- `GET /api/admin/finance/dashboard`
+- `GET /api/admin/finance/mrr`
+- `GET /api/admin/finance/cohorts`
+- `POST /api/admin/finance/invoices/generate`
+- `GET /api/admin/finance/invoices`
+- `POST /api/admin/finance/invoices/{id}/resend`
+
+### 8.7 サポート
+- `GET /api/support/tickets`
+- `POST /api/support/tickets`
+- `GET /api/support/tickets/{id}`
+- `POST /api/support/tickets/{id}/messages`
+- `PATCH /api/support/tickets/{id}` (ステータス・担当者)
+
+### 8.8 通知配信
+- `GET /api/admin/notifications/campaigns`
+- `POST /api/admin/notifications/campaigns`
+- `POST /api/admin/notifications/campaigns/{id}/send`
+- `GET /api/admin/notifications/campaigns/{id}/stats`
+
+### 8.9 不正検知
+- `GET /api/super-admin/abuse/rules`
+- `POST /api/super-admin/abuse/rules`
+- `PATCH /api/super-admin/abuse/rules/{id}`
+- `GET /api/super-admin/abuse/detections`
+- `POST /api/super-admin/abuse/detections/{id}/review`
+
+### 8.10 インフラ監視
+- `GET /api/super-admin/infra/dashboard`
+- `GET /api/super-admin/infra/metrics`
+- `GET /api/super-admin/infra/alerts`
+- `POST /api/super-admin/infra/alerts/{id}/acknowledge`
+
+### 8.11 営業
+- `GET /api/admin/sales/leads`
+- `POST /api/admin/sales/leads`
+- `PATCH /api/admin/sales/leads/{id}`
+- `POST /api/admin/sales/leads/{id}/activities`
+- `POST /api/admin/sales/leads/{id}/proposal-pdf`
+
+### 8.12 A/B テスト
+- `GET /api/super-admin/experiments`
+- `POST /api/super-admin/experiments`
+- `PATCH /api/super-admin/experiments/{id}`
+- `GET /api/super-admin/experiments/{id}/results`
+
+### 8.13 データエクスポート
+- `POST /api/super-admin/exports`
+- `GET /api/super-admin/exports/{id}` (ステータス確認)
+- `GET /api/super-admin/exports/{id}/download`
+
+---
+
+## 9. UI 画面仕様
+
+### 9.1 `/admin` 既存拡張
+
+#### 9.1.1 `/admin` (ダッシュボード)
+- KPI カード: 全ユーザー / アクティブユーザー / 食事記録 / AI セッション / 未対応チケット数
+- グラフ: 月次推移
+- 直近のアクティビティ (監査ログ最新 10 件)
+
+#### 9.1.2 `/admin/users` 拡張
+- 高度な検索 (全文検索・複数条件)
+- BAN ボタン強化 (理由・期間)
+- 一括操作 (CSV ダウンロード、一括 BAN)
+
+#### 9.1.3 `/admin/moderation` 拡張
+- 自動モデレーションルール管理
+- 統計ダッシュボード
+- エスカレーション機能
+
+#### 9.1.4 `/admin/audit-logs` 拡張
+- 高度フィルタ
+- CSV エクスポート
+
+### 9.2 新規画面
+
+#### 9.2.1 `/admin/finance/dashboard` (新規)
+- MRR / ARR / 解約率
+- コホート分析
+- 法人契約一覧
+
+#### 9.2.2 `/admin/finance/invoices` (新規)
+- 請求書一覧
+- 一括生成
+- 個別 PDF 表示
+
+#### 9.2.3 `/admin/sales/leads` (新規)
+- 見込み客リスト
+- ステージ管理
+- 商談記録
+
+#### 9.2.4 `/admin/sales/leads/{id}` (新規)
+- リード詳細
+- 活動履歴
+- 提案書生成ボタン
+
+#### 9.2.5 `/admin/notifications/campaigns` (新規)
+- キャンペーン一覧
+- 新規作成ウィザード
+- 送信統計
+
+#### 9.2.6 `/support/tickets` (拡張)
+- チケット一覧 (フィルタ豊富化)
+- 担当者割当・SLA 表示
+
+#### 9.2.7 `/support/tickets/{id}` (新規)
+- スレッドビュー
+- 内部メモ
+- ユーザー詳細リンク
+
+### 9.3 `/super-admin` 既存拡張
+
+#### 9.3.1 `/super-admin` (ダッシュボード) 強化
+- システム健全性ステータス
+- LLM コストアラート
+- 過去 24 時間の重要イベント
+
+#### 9.3.2 `/super-admin/llm-usage` 強化
+- ユーザー別 Top N
+- 異常検知アラート
+- クォータ設定
+
+#### 9.3.3 `/super-admin/feature-flags` 強化
+- ロールアウト戦略 UI
+- メトリクス連携
+
+### 9.4 新規画面 (super-admin)
+
+#### 9.4.1 `/super-admin/infra` (新規)
+- 統合監視ダッシュボード
+- アラート履歴
+
+#### 9.4.2 `/super-admin/abuse` (新規)
+- ルール管理
+- 検知キュー
+
+#### 9.4.3 `/super-admin/experiments` (新規)
+- 実験管理
+- 統計分析
+
+#### 9.4.4 `/super-admin/exports` (新規)
+- データエクスポート要求
+- ダウンロード
+
+---
+
+## 10. エラーハンドリング・バリデーション
+
+### 10.1 共通エラーパターン
+- 401: 未認証
+- 403: 権限不足 (ロール / 範囲)
+- 404: リソース未存在
+- 409: 競合 (同時編集等)
+- 422: バリデーション失敗
+- 429: レート制限
+- 500: サーバーエラー
+- 503: サービス停止 (メンテナンス)
+
+### 10.2 主要エラーコード
+| コード | 意味 |
+|--------|------|
+| `OP_PERMISSION_DENIED` | ロール不足 |
+| `OP_TARGET_PROTECTED` | super_admin 等 保護ユーザーへの操作不可 |
+| `OP_AUDIT_LOG_IMMUTABLE` | 監査ログ書き換え不可 |
+| `OP_FEATURE_FLAG_IN_USE` | 削除しようとしたフラグが利用中 |
+| `OP_QUOTA_EXCEEDED` | LLM クォータ超過 |
+| `OP_RE_AUTH_REQUIRED` | 再認証必須 |
+
+---
+
+## 11. 段階的実装計画
+
+### Phase 1: 既存機能の完成 (3 週間)
+- 監査ログ網羅 (現在記録されてない操作も記録)
+- ユーザー BAN 強化
+- モデレーション統計強化
+
+### Phase 2: サポートチケット (2 週間)
+- `support_tickets` + `support_ticket_messages`
+- スレッド UI
+- SLA / アラート
+
+### Phase 3: 通知配信 (3 週間)
+- Push 基盤 (APNs/FCM 統合)
+- Email 基盤 (Resend)
+- キャンペーン UI
+
+### Phase 4: 売上・MRR (3 週間)
+- Stripe 連携完了
+- ダッシュボード
+- コホート分析
+
+### Phase 5: 不正検知 (2 週間)
+- ルールエンジン
+- 自動 BAN
+- 手動レビュー UI
+
+### Phase 6: 営業・経理ロール (2 週間)
+- 新ロール追加
+- 営業 CRM 機能
+- 経理請求書管理
+
+### Phase 7: A/B テスト基盤 (2 週間)
+- 実験エンジン
+- 統計分析
+
+### Phase 8: インフラ監視 (3 週間)
+- メトリクス収集
+- 統合ダッシュボード
+- アラート
+
+### Phase 9: 拡張機能 (継続)
+- データエクスポート
+- BigQuery 連携
+- 高度な BI
+
+---
+
+## 12. テスト計画
+
+### 12.1 単体・統合
+- 各 API の権限テスト
+- 監査ログ記録の網羅性テスト
+- 機能フラグ評価ロジック
+
+### 12.2 E2E (Playwright)
+- `op/01-user-search.spec.ts`
+- `op/02-user-ban.spec.ts`
+- `op/03-moderation-resolve.spec.ts`
+- `op/04-feature-flag-toggle.spec.ts`
+- `op/05-llm-usage-dashboard.spec.ts`
+- `op/06-support-ticket-thread.spec.ts`
+- `op/07-mrr-dashboard.spec.ts`
+- `op/08-notification-campaign.spec.ts`
+
+### 12.3 セキュリティ
+- 権限境界テスト (各ロール × 各操作)
+- SQL injection 攻撃耐性
+- 監査ログ改ざん試行
+
+### 12.4 負荷テスト
+- 監査ログ 1 億行で検索時間
+- 通知 100 万件配信
+- ダッシュボード同時アクセス 100 admin
+
+---
+
+## 13. リリース基準
+
+- [ ] Phase 1 完了 + 監査ログ網羅性 100%
+- [ ] 全主要 API のレート制限実装
+- [ ] super_admin の 2FA 必須化
+- [ ] サポートマニュアル完備
+- [ ] インシデント対応プレイブック
+- [ ] バックアップ・リストア手順
+
+---
+
+## 14. 付録
+
+### 14.1 ロール体系図 (詳細)
+
+```
+super_admin
+  ├ admin
+  │   ├ support
+  │   ├ sales (新)
+  │   ├ finance (新)
+  │   └ content_moderator (新)
+  ├ org_admin
+  │   ├ org_manager
+  │   ├ org_industrial_doctor (新)
+  │   ├ org_member
+  │   └ org_viewer
+  └ user
+```
+
+### 14.2 通知テンプレート例
+
+```
+件名: 【ほめゴハン】ご利用上の重要なお知らせ
+
+{user_name} 様
+
+ご利用中のアカウントについて、以下のお知らせがあります。
+
+{notification_body}
+
+ご質問・ご不明な点がございましたら、サポートまでお気軽にどうぞ。
+support@homegohan.com
+
+---
+ほめゴハン運営チーム
+```
+
+### 14.3 関連ドキュメント
+
+- `01-family-management.md`
+- `02-organization-management.md`
+- `docs/security/rbac.md` (ロールベースアクセス制御詳細)
+- `docs/operations/incident-response.md`
+- `docs/finance/billing.md`
+- `docs/marketing/notification-strategy.md`
+
+### 14.4 オープン課題
+
+1. **2FA 実装**: TOTP / Email OTP / SMS のうちどれか (Phase 2)
+2. **Stripe vs 自社請求**: 法人プランは銀行振込多め、Stripe との併用検討
+3. **GDPR 対応**: EU 拠点企業向け、Phase 3 で本格対応
+4. **データ保持期間**: 退会後の食事記録は何ヶ月保持? (現在 6 ヶ月、要法務確認)
+5. **AI モデレーション精度**: Gemini モデレーション API の偽陽性率
+6. **インシデント対応 SLA**: 内部目標 (P0: 30 分以内、P1: 2 時間)
+7. **オンコール体制**: 24/7 vs 営業時間のみ (人員次第)
+
+### 14.5 用語の使い分け
+
+- 「運営者 / Operator」: ほめゴハン会社の従業員
+- 「管理者 / admin」: 管理コンソール ロール名
+- 「管理コンソール」: `/admin` `/super-admin` `/support` を含む UI 全体
+- 「管理画面」: 個別の画面 (例: ユーザー管理画面)
+
+---
+
+**END OF OPERATOR ADMIN REQUIREMENTS DOCUMENT**
+
+3 本完成。次は実装計画 PR の起案。


### PR DESCRIPTION
## 概要

ほめゴハンの 3 系統管理機能の要件定義書を Opus 直接起草。

| 系統 | ファイル | 行数 |
|------|---------|------|
| 家族管理 | docs/requirements/01-family-management.md | 1194 |
| 組織管理 | docs/requirements/02-organization-management.md | 1155 |
| 運営者管理 | docs/requirements/03-operator-admin.md | 1332 |
| **合計** | | **3681 行** |

## 各ドキュメントの構成

1. エグゼクティブサマリ
2. 用語定義
3. ペルソナ (3-5 人)
4. ユースケース (10-15 件)
5. 機能要件 (主要 7-14 機能)
6. 非機能要件 (パフォーマンス・セキュリティ・スケーラビリティ等)
7. データモデル (新規テーブル + 既存拡張)
8. API 仕様 (各 endpoint)
9. UI 画面仕様 (各画面)
10. エラー / バリデーション
11. 段階的実装計画 (Phase 1-9)
12. テスト計画 (Playwright spec 含む)
13. リリース基準
14. 付録 (テンプレート / 関連 docs / オープン課題)

## 重要ポイント

- 既存実装を尊重しつつ、致命的不足 (招待受諾フロー / 売上ダッシュボード / サポートチケット 等) を補完
- 3 系統の権限・招待・通知が **相互に絡む** ことを意識
- 法務・コンプライアンス・SLA を非機能要件に明記
- 段階的実装計画で MVP → 拡張 を整理

## 次のステップ

1. ユーザーレビュー
2. 修正反映
3. 各 Phase の **実装計画書** (PR 単位の詳細設計) を起草
4. 並列 implementer で実装フェーズ