### PR TITLE
fix(layout): タブバー余白の Platform 分岐と iPad サイドバー二重表示を修正

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Tabs, Redirect, router } from "expo-router";
-import { ActivityIndicator, View } from "react-native";
+import { ActivityIndicator, Platform, View } from "react-native";
 
 import { colors } from "../../src/theme";
 import { useAuth } from "../../src/providers/AuthProvider";
@@ -38,8 +38,8 @@ export default function TabsLayout() {
           tabBarStyle: {
             backgroundColor: colors.card,
             borderTopColor: colors.border,
-            height: 88,
-            paddingBottom: 30,
+            height: Platform.OS === 'ios' ? 88 : 64,
+            paddingBottom: Platform.OS === 'ios' ? 30 : 8,
             paddingTop: 8,
           },
           tabBarActiveTintColor: colors.accent,

--- a/src/app/(main)/MainLayout.tsx
+++ b/src/app/(main)/MainLayout.tsx
@@ -178,7 +178,7 @@ export default function MainLayout({
       <NativeAppTabRouter />
       
       {/* デスクトップ用サイドバー (Hidden on Mobile) */}
-      <aside className="hidden lg:flex flex-col w-64 fixed inset-y-0 left-0 bg-white border-r border-gray-100 z-50 shadow-sm">
+      <aside className={`${initialIsNativeApp ? 'hidden' : 'hidden lg:flex'} flex-col w-64 fixed inset-y-0 left-0 bg-white border-r border-gray-100 z-50 shadow-sm`}>
         <div className="p-8">
           <Link href="/home" className="flex items-center gap-3 group">
              <div className="w-8 h-8 rounded-lg bg-accent flex items-center justify-center text-white font-bold shadow-md group-hover:shadow-lg transition-shadow">H</div>


### PR DESCRIPTION
## Summary

- **Android タブバー余白ズレ**: `apps/mobile/app/(tabs)/_layout.tsx` の `tabBarStyle` で `height` と `paddingBottom` が iOS 固定値になっていたため、Android では不要な余白が発生していた。`Platform.OS` による分岐 (`ios`: height=88/paddingBottom=30、`android`: height=64/paddingBottom=8) に変更し、`Platform` を import 追加
- **iPad サイドバー二重表示**: `src/app/(main)/MainLayout.tsx` の `aside` が `hidden lg:flex` で横幅 1024px 超では常に表示されていた。`initialIsNativeApp` が true のとき `hidden` (常に非表示) に切り替え、ネイティブアプリの iPad でサイドバーとネイティブタブバーが二重表示される問題を解消

## Test plan

- [ ] Android 実機 / エミュレーターでタブバーの高さが適切 (64px 相当) になっていることを確認
- [ ] iOS 実機 / シミュレーターでタブバーの高さが従来通り (88px) であることを確認
- [ ] iPad (横向き, 1024px 超) で Web アプリを開いたとき、非 nativeApp モードでサイドバーが表示されることを確認
- [ ] iPad 上のネイティブアプリ (`?native=true` または Cookie で `isNativeApp=true`) でサイドバーが非表示になることを確認
- [ ] デスクトップ Web (1024px 超) で非 nativeApp 時にサイドバーが引き続き表示されることを確認