### PR TITLE
chore(ios): TestFlight 暗号化輸出規制ダイアログをスキップする設定を追加

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -30,7 +30,10 @@
         "NSPhotoLibraryAddUsageDescription": "解析結果の保存のために写真ライブラリへ追加する場合があります。"
       },
       "icon": "./assets/icon-ios.png",
-      "runtimeVersion": "1.0.0"
+      "runtimeVersion": "1.0.0",
+      "config": {
+        "usesNonExemptEncryption": false
+      }
     },
     "android": {
       "package": "com.homegohan.app",


### PR DESCRIPTION
## Summary

- `apps/mobile/app.json` の `ios` オブジェクトに `config.usesNonExemptEncryption: false` を追加
- Expo がビルド時に `Info.plist` へ `ITSAppUsesNonExemptEncryption=NO` を自動展開する
- TestFlight / App Store 提出時の「コンプライアンス情報を書き出す」ダイアログを毎回スキップできるようになる

## 背景

このアプリは独自の暗号化ライブラリを一切使用しておらず、ネットワーク通信は Supabase への HTTPS (OS 標準 TLS) のみ。輸出規制上 exempt に該当するため、`ITSAppUsesNonExemptEncryption=NO` の明示設定が正しい対応。

## Test plan

- [ ] `python3 -c "import json; json.load(open('apps/mobile/app.json'))"` で JSON パース確認 → OK
- [ ] `tsc --noEmit` で型チェック → エラーなし
- [ ] 次回 EAS Build 後、TestFlight アップロード時にコンプライアンスダイアログが出ないことを確認