### PR TITLE
feat(family/09): Phase 1-A — handson_tour DB Migration + RPC 2 本

### DIFF
--- a/supabase/migrations/20260508093813_handson_tour.sql
+++ b/supabase/migrations/20260508093813_handson_tour.sql
@@ -1,0 +1,174 @@
+-- =====================================================
+-- Migration: handson_tour
+-- Source: docs/design/operator/01-data-model.md §3.26
+-- Phase: family/09 Phase 1-A
+-- Idempotent: yes (IF NOT EXISTS / ON CONFLICT)
+-- =====================================================
+
+BEGIN;
+
+-- =========================================
+-- §3.26.1 user_profiles 拡張 (handson_tour 状態)
+-- =========================================
+
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS handson_tour_completed_at TIMESTAMPTZ NULL,
+  ADD COLUMN IF NOT EXISTS handson_tour_skipped_at   TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN user_profiles.handson_tour_completed_at IS
+  '初回ハンズオンチュートリアル完了日時 (family/09)。NULL = 未完走';
+COMMENT ON COLUMN user_profiles.handson_tour_skipped_at IS
+  '初回ハンズオンチュートリアル明示スキップ or auto-skip 日時 (family/09)';
+
+-- 部分インデックス: 表示判定 (should_show) 高速化、pending な user_id だけ index に乗る
+CREATE INDEX IF NOT EXISTS idx_user_profiles_handson_tour_pending
+  ON user_profiles (user_id)
+  WHERE handson_tour_completed_at IS NULL AND handson_tour_skipped_at IS NULL;
+
+
+-- =========================================
+-- §3.26.2 meal_logs 拡張 (sandbox 識別子)
+-- =========================================
+
+ALTER TABLE meal_logs
+  ADD COLUMN IF NOT EXISTS is_sandbox BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN meal_logs.is_sandbox IS
+  'true = ハンズオンチュートリアル中の sandbox 投入 (family/09)';
+
+-- 通常 UI のクエリ高速化(WHERE is_sandbox=false で index pruning)
+CREATE INDEX IF NOT EXISTS idx_meal_logs_user_non_sandbox
+  ON meal_logs (user_id, eaten_at DESC)
+  WHERE is_sandbox = false;
+
+-- 部分 UNIQUE: ハンズオン中の二重 INSERT 防止 (user_id, is_sandbox=true) は 1 行のみ
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_user_sandbox_meal
+  ON meal_logs (user_id)
+  WHERE is_sandbox = true;
+
+
+-- =========================================
+-- §3.26.3 weekly_menus 拡張 (sandbox 識別子)
+-- =========================================
+
+ALTER TABLE weekly_menus
+  ADD COLUMN IF NOT EXISTS is_sandbox BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN weekly_menus.is_sandbox IS
+  'true = ハンズオンチュートリアル中の sandbox 投入 (family/09)';
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_user_sandbox_menu
+  ON weekly_menus (user_id)
+  WHERE is_sandbox = true;
+
+
+-- =========================================
+-- §3.26.4 badges seed (tutorial_complete)
+-- =========================================
+
+INSERT INTO badges (code, name, description, condition_json)
+VALUES (
+  'tutorial_complete',
+  '使い方マスター',
+  'はじめての使い方ガイドを最後まで完走',
+  '{"type":"event","event":"handson_tour_completed"}'::jsonb
+)
+ON CONFLICT (code) DO NOTHING;
+
+
+-- =========================================
+-- §3.26.5 RPC: user_has_non_sandbox_activity
+-- =========================================
+
+CREATE OR REPLACE FUNCTION user_has_non_sandbox_activity(p_user_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1 FROM meal_logs WHERE user_id = p_user_id AND is_sandbox = false LIMIT 1
+  ) OR EXISTS (
+    SELECT 1 FROM weekly_menus WHERE user_id = p_user_id AND is_sandbox = false LIMIT 1
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION user_has_non_sandbox_activity IS
+  'family/09 condition C 判定: ユーザーが既に non-sandbox の食事記録 or 献立を持つか';
+
+REVOKE EXECUTE ON FUNCTION user_has_non_sandbox_activity(uuid) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION user_has_non_sandbox_activity(uuid) TO service_role;
+
+
+-- =========================================
+-- §3.26.6 RPC: complete_handson_tour (atomic 卒業処理)
+-- =========================================
+
+CREATE OR REPLACE FUNCTION complete_handson_tour(p_user_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_existing_completed_at timestamptz;
+  v_completed_at timestamptz;
+  v_was_already boolean;
+  v_badge_id uuid;
+  v_badge_name text;
+  v_badge_icon_url text;
+  v_badge_obtained_at timestamptz;
+BEGIN
+  -- UPDATE 前に既存値を取得 (already_completed 判定のため)
+  -- now() はトランザクション開始時刻で固定なので、COALESCE 後の RETURNING と完全一致して
+  -- 判定が壊れる。先に SELECT NULL チェックすることで防ぐ。
+  SELECT handson_tour_completed_at INTO v_existing_completed_at
+  FROM user_profiles WHERE user_id = p_user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'profile_not_found';
+  END IF;
+
+  v_was_already := (v_existing_completed_at IS NOT NULL);
+
+  UPDATE user_profiles
+  SET handson_tour_completed_at = COALESCE(handson_tour_completed_at, now())
+  WHERE user_id = p_user_id
+  RETURNING handson_tour_completed_at INTO v_completed_at;
+
+  SELECT id, name, icon_url INTO v_badge_id, v_badge_name, v_badge_icon_url
+  FROM badges WHERE code = 'tutorial_complete';
+
+  IF v_badge_id IS NULL THEN
+    RAISE EXCEPTION 'badge_not_found';
+  END IF;
+
+  INSERT INTO user_badges (user_id, badge_id, obtained_at)
+  VALUES (p_user_id, v_badge_id, now())
+  ON CONFLICT (user_id, badge_id) DO NOTHING;
+
+  SELECT obtained_at INTO v_badge_obtained_at
+  FROM user_badges WHERE user_id = p_user_id AND badge_id = v_badge_id;
+
+  RETURN jsonb_build_object(
+    'completed_at', v_completed_at,
+    'badge_awarded', jsonb_build_object(
+      'code', 'tutorial_complete',
+      'name', v_badge_name,
+      'obtained_at', v_badge_obtained_at,
+      'icon_url', v_badge_icon_url
+    ),
+    'already_completed', v_was_already
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION complete_handson_tour IS
+  'family/09 卒業処理: profile UPDATE + tutorial_complete バッジ INSERT を atomic に実行';
+
+REVOKE EXECUTE ON FUNCTION complete_handson_tour(uuid) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION complete_handson_tour(uuid) TO service_role;
+
+COMMIT;


### PR DESCRIPTION
## 概要

`docs/design/operator/01-data-model.md §3.26` を canonical として、family/09 ハンズオンチュートリアル Phase 1-A の DB Migration を実装した。

**含む DDL:**
- ALTER 3 表: `user_profiles` (2 列追加) / `meal_logs` (1 列追加) / `weekly_menus` (1 列追加)
- INDEX 4 件: `idx_user_profiles_handson_tour_pending` / `idx_meal_logs_user_non_sandbox` / `uniq_user_sandbox_meal` / `uniq_user_sandbox_menu`
- SEED 1 件: `badges.tutorial_complete`
- RPC 2 本: `user_has_non_sandbox_activity(uuid)` / `complete_handson_tour(uuid)`

すべての DDL は `IF NOT EXISTS` / `ON CONFLICT DO NOTHING` / `CREATE OR REPLACE FUNCTION` で冪等化済。

RPC 2 本は `REVOKE EXECUTE FROM anon, authenticated` + `GRANT EXECUTE TO service_role` で service_role のみ実行可能。

## ローカル Supabase 動作確認

Docker が未起動のためローカル Supabase も未起動。`supabase db reset` による apply 検証は別途実施が必要。

## Definition of Done

- [x] supabase/migrations/ に新ファイル 1 件追加
- [x] BEGIN/COMMIT で囲まれている
- [x] すべての DDL が冪等(IF NOT EXISTS / ON CONFLICT)
- [x] RPC 2 本が REVOKE/GRANT で service_role のみ実行可能
- [x] `tutorial_complete` バッジが seed されている
- [ ] ローカル Supabase が立っていれば `supabase db reset` で apply 成功 — ローカル Supabase 未起動のため apply 検証は別途実施