### PR TITLE
feat(family/09): Phase 1-B — handson_tour API ハンドラ 4 本 + 既存 3 拡張

### DIFF
--- a/src/app/api/handson-tour/complete/route.ts
+++ b/src/app/api/handson-tour/complete/route.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export const HandsonTourCompleteResponseSchema = z.object({
+  completed_at: z.string().datetime(),
+  badge_awarded: z.object({
+    code: z.literal('tutorial_complete'),
+    name: z.string(),
+    obtained_at: z.string().datetime(),
+    icon_url: z.string().nullable(),
+  }),
+  already_completed: z.boolean(),
+  total_duration_ms: z.number().int().optional(),
+});
+
+export type HandsonTourCompleteResponse = z.infer<typeof HandsonTourCompleteResponseSchema>;
+
+const ADMIN_ROLES = ['admin', 'super_admin', 'org_admin', 'org_industrial_doctor'] as const;
+
+export async function POST() {
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: { code: 'unauthorized', message: '認証が必要です' } },
+        { status: 401 },
+      );
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from('user_profiles')
+      .select('roles, handson_tour_completed_at')
+      .eq('user_id', user.id)
+      .single();
+
+    if (profileError || !profile) {
+      return NextResponse.json(
+        { error: { code: 'profile_not_found', message: 'プロファイルが見つかりません' } },
+        { status: 404 },
+      );
+    }
+
+    const hasAdminRole = Array.isArray(profile.roles) &&
+      profile.roles.some((r: string) => (ADMIN_ROLES as readonly string[]).includes(r));
+
+    if (hasAdminRole) {
+      return NextResponse.json(
+        { error: { code: 'not_eligible', message: '対象外のユーザーです', reason: 'admin_role' } },
+        { status: 403 },
+      );
+    }
+
+    const { data: hasActivity } = await supabase
+      .rpc('user_has_non_sandbox_activity', { p_user_id: user.id });
+
+    if (hasActivity && !profile.handson_tour_completed_at) {
+      return NextResponse.json(
+        { error: { code: 'not_eligible', message: '対象外のユーザーです', reason: 'existing_user' } },
+        { status: 409 },
+      );
+    }
+
+    const { data: result, error: rpcError } = await supabase
+      .rpc('complete_handson_tour', { p_user_id: user.id });
+
+    if (rpcError) {
+      console.error('complete_handson_tour RPC error:', rpcError);
+      return NextResponse.json(
+        { error: { code: 'internal_error', message: 'サーバーエラーが発生しました', details: rpcError.message } },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(result);
+  } catch (err: unknown) {
+    console.error('handson-tour/complete error:', err);
+    return NextResponse.json(
+      { error: { code: 'internal_error', message: 'サーバーエラーが発生しました' } },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/handson-tour/skip/route.ts
+++ b/src/app/api/handson-tour/skip/route.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export const HandsonTourSkipRequestSchema = z.object({
+  step: z.number().int().min(0).max(4),
+  reason: z.enum(['user_action', 'hard_back']),
+});
+
+export const HandsonTourSkipResponseSchema = z.object({
+  skipped_at: z.string().datetime(),
+});
+
+export type HandsonTourSkipRequest = z.infer<typeof HandsonTourSkipRequestSchema>;
+export type HandsonTourSkipResponse = z.infer<typeof HandsonTourSkipResponseSchema>;
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: { code: 'unauthorized', message: '認証が必要です' } },
+        { status: 401 },
+      );
+    }
+
+    let body: HandsonTourSkipRequest;
+    try {
+      const raw = await request.json();
+      body = HandsonTourSkipRequestSchema.parse(raw);
+    } catch {
+      return NextResponse.json(
+        { error: { code: 'validation_error', message: 'リクエストの形式が不正です' } },
+        { status: 400 },
+      );
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from('user_profiles')
+      .select('user_id')
+      .eq('user_id', user.id)
+      .single();
+
+    if (profileError || !profile) {
+      return NextResponse.json(
+        { error: { code: 'profile_not_found', message: 'プロファイルが見つかりません' } },
+        { status: 404 },
+      );
+    }
+
+    const skippedAt = new Date().toISOString();
+
+    await supabase
+      .from('user_profiles')
+      .update({ handson_tour_skipped_at: skippedAt })
+      .eq('user_id', user.id)
+      .is('handson_tour_skipped_at', null)
+      .is('handson_tour_completed_at', null);
+
+    console.info('handson_tour skip event', {
+      user_id: user.id,
+      step: body.step,
+      reason: body.reason,
+      skipped_at: skippedAt,
+    });
+
+    return NextResponse.json({ skipped_at: skippedAt });
+  } catch (err: unknown) {
+    console.error('handson-tour/skip error:', err);
+    return NextResponse.json(
+      { error: { code: 'internal_error', message: 'サーバーエラーが発生しました' } },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/handson-tour/status/route.ts
+++ b/src/app/api/handson-tour/status/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getHandsonTourStatusInternal } from '@/lib/handson-tour/getStatus';
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: { code: 'unauthorized', message: '認証が必要です' } },
+        { status: 401 },
+      );
+    }
+
+    const status = await getHandsonTourStatusInternal(user.id);
+    return NextResponse.json(status);
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === 'profile_not_found') {
+      return NextResponse.json(
+        { error: { code: 'profile_not_found', message: 'プロファイルが見つかりません' } },
+        { status: 404 },
+      );
+    }
+    console.error('handson-tour/status error:', err);
+    return NextResponse.json(
+      { error: { code: 'internal_error', message: 'サーバーエラーが発生しました' } },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/meal-plans/add-from-photo/route.ts
+++ b/src/app/api/meal-plans/add-from-photo/route.ts
@@ -4,9 +4,11 @@ import { buildCatalogSelectionUpdate } from "../../../../lib/catalog-products";
 import { buildPhotoDishList } from "../../../../lib/meal-image";
 import { cancelPendingMealImageJobs } from "../../../../lib/meal-image-jobs";
 
+const ADMIN_ROLES = ['admin', 'super_admin', 'org_admin', 'org_industrial_doctor'] as const;
+
 export async function POST(request: Request) {
   const supabase = await createClient();
-  
+
   try {
     const {
       dayDate,
@@ -16,11 +18,50 @@ export async function POST(request: Request) {
       imageUrl,
       nutritionalAdvice,
       catalogProductId,
+      sandbox,
     } = await request.json();
     
+    const searchParams = new URL(request.url).searchParams;
+    const source = searchParams.get('source') ?? 'normal';
+
     const { data: { user }, error: userError } = await supabase.auth.getUser();
     if (userError || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const isSandbox = sandbox === true;
+
+    if (isSandbox) {
+      const { data: profile } = await supabase
+        .from('user_profiles')
+        .select('handson_tour_completed_at, handson_tour_skipped_at, roles')
+        .eq('user_id', user.id)
+        .single();
+
+      if (profile?.handson_tour_completed_at || profile?.handson_tour_skipped_at) {
+        return NextResponse.json(
+          { error: { code: 'sandbox_not_eligible', message: 'サンドボックスの利用条件を満たしていません', reason: 'already_finished' } },
+          { status: 409 },
+        );
+      }
+
+      const hasAdminRole = Array.isArray(profile?.roles) &&
+        profile.roles.some((r: string) => (ADMIN_ROLES as readonly string[]).includes(r));
+      if (hasAdminRole) {
+        return NextResponse.json(
+          { error: { code: 'sandbox_not_eligible', message: 'サンドボックスの利用条件を満たしていません', reason: 'admin_role' } },
+          { status: 403 },
+        );
+      }
+
+      const { data: hasActivity } = await supabase
+        .rpc('user_has_non_sandbox_activity', { p_user_id: user.id });
+      if (hasActivity) {
+        return NextResponse.json(
+          { error: { code: 'sandbox_not_eligible', message: 'サンドボックスの利用条件を満たしていません', reason: 'existing_user' } },
+          { status: 409 },
+        );
+      }
     }
     
     // 1. user_daily_meals を取得または作成
@@ -107,7 +148,8 @@ export async function POST(request: Request) {
       is_completed: false,
       dishes: photoDishes.length > 0 ? photoDishes : null,
       is_simple: photoDishes.length <= 1,
-      source_type: 'manual',
+      source_type: source === 'handson_tour' ? 'handson_tour' : 'manual',
+      is_sandbox: isSandbox,
     };
 
     if (catalogProductId) {

--- a/src/app/api/menu-plans/add/route.ts
+++ b/src/app/api/menu-plans/add/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+const ADMIN_ROLES = ['admin', 'super_admin', 'org_admin', 'org_industrial_doctor'] as const;
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  try {
+    const body = await request.json();
+    const searchParams = new URL(request.url).searchParams;
+    const source = searchParams.get('source') ?? 'normal';
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: { code: 'unauthorized', message: '認証が必要です' } },
+        { status: 401 },
+      );
+    }
+
+    const isSandbox = body.sandbox === true;
+
+    if (isSandbox) {
+      const { data: profile } = await supabase
+        .from('user_profiles')
+        .select('handson_tour_completed_at, handson_tour_skipped_at, roles')
+        .eq('user_id', user.id)
+        .single();
+
+      if (profile?.handson_tour_completed_at || profile?.handson_tour_skipped_at) {
+        return NextResponse.json(
+          { error: { code: 'sandbox_not_eligible', message: 'サンドボックスの利用条件を満たしていません', reason: 'already_finished' } },
+          { status: 409 },
+        );
+      }
+
+      const hasAdminRole = Array.isArray(profile?.roles) &&
+        profile.roles.some((r: string) => (ADMIN_ROLES as readonly string[]).includes(r));
+      if (hasAdminRole) {
+        return NextResponse.json(
+          { error: { code: 'sandbox_not_eligible', message: 'サンドボックスの利用条件を満たしていません', reason: 'admin_role' } },
+          { status: 403 },
+        );
+      }
+
+      const { data: hasActivity } = await supabase
+        .rpc('user_has_non_sandbox_activity', { p_user_id: user.id });
+      if (hasActivity) {
+        return NextResponse.json(
+          { error: { code: 'sandbox_not_eligible', message: 'サンドボックスの利用条件を満たしていません', reason: 'existing_user' } },
+          { status: 409 },
+        );
+      }
+    }
+
+    const insertData: Record<string, unknown> = {
+      user_id: user.id,
+      is_sandbox: isSandbox,
+      source: source,
+    };
+
+    const allowedFields = [
+      'week_start_date',
+      'menu_data',
+      'status',
+      'generation_id',
+    ];
+    for (const field of allowedFields) {
+      if (field in body && body[field] !== undefined) {
+        insertData[field] = body[field];
+      }
+    }
+
+    const { data: newMenu, error: insertError } = await supabase
+      .from('weekly_menus')
+      .insert(insertData)
+      .select()
+      .single();
+
+    if (insertError) {
+      console.error('weekly_menus insert error:', insertError);
+      return NextResponse.json(
+        { error: { code: 'internal_error', message: 'サーバーエラーが発生しました', details: insertError.message } },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ success: true, menuId: newMenu.id });
+  } catch (err: unknown) {
+    console.error('menu-plans/add error:', err);
+    return NextResponse.json(
+      { error: { code: 'internal_error', message: 'サーバーエラーが発生しました' } },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/onboarding/complete/route.ts
+++ b/src/app/api/onboarding/complete/route.ts
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 import { calculateNutritionTargets } from '@homegohan/core'
 import { buildNutritionCalculatorInput } from '@/lib/build-nutrition-input'
+import { getHandsonTourStatusInternal } from '@/lib/handson-tour/getStatus'
 
 /**
  * オンボーディング完了API (OB-API-02)
@@ -148,7 +149,15 @@ export async function POST() {
       // 栄養目標のエラーは無視して続行（オンボーディング完了は成功）
     }
 
-    return NextResponse.json({ success: true })
+    let nextRoute: '/handson-tour' | '/home' = '/home';
+    try {
+      const tourStatus = await getHandsonTourStatusInternal(user.id);
+      nextRoute = tourStatus.should_show ? '/handson-tour' : '/home';
+    } catch {
+      nextRoute = '/home';
+    }
+
+    return NextResponse.json({ success: true, next_route: nextRoute })
   } catch (error: unknown) {
     console.error('API Error:', error)
     const message = error instanceof Error ? error.message : 'Unknown error'

--- a/src/lib/handson-tour/getStatus.ts
+++ b/src/lib/handson-tour/getStatus.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+import { createClient } from '@/lib/supabase/server';
+
+export const HandsonTourStatusResponseSchema = z.object({
+  should_show: z.boolean(),
+  completed_at: z.string().datetime().nullable(),
+  skipped_at: z.string().datetime().nullable(),
+  reason: z.enum([
+    'eligible',
+    'onboarding_not_completed',
+    'already_completed',
+    'already_skipped',
+    'admin_role',
+    'existing_user_auto_skip',
+    'feature_disabled',
+    'not_in_rollout',
+  ]),
+});
+
+export type HandsonTourStatusResponse = z.infer<typeof HandsonTourStatusResponseSchema>;
+
+const ADMIN_ROLES = ['admin', 'super_admin', 'org_admin', 'org_industrial_doctor'] as const;
+
+export async function getHandsonTourStatusInternal(userId: string): Promise<HandsonTourStatusResponse> {
+  const supabase = await createClient();
+
+  const { data: profile, error } = await supabase
+    .from('user_profiles')
+    .select('onboarding_completed_at, handson_tour_completed_at, handson_tour_skipped_at, roles')
+    .eq('user_id', userId)
+    .single();
+
+  if (error || !profile) {
+    throw Object.assign(new Error('profile_not_found'), { code: 'profile_not_found' });
+  }
+
+  const hasAdminRole = Array.isArray(profile.roles) &&
+    profile.roles.some((r: string) => (ADMIN_ROLES as readonly string[]).includes(r));
+
+  if (hasAdminRole) {
+    return {
+      should_show: false,
+      completed_at: profile.handson_tour_completed_at ?? null,
+      skipped_at: profile.handson_tour_skipped_at ?? null,
+      reason: 'admin_role',
+    };
+  }
+
+  if (!profile.onboarding_completed_at) {
+    return {
+      should_show: false,
+      completed_at: null,
+      skipped_at: null,
+      reason: 'onboarding_not_completed',
+    };
+  }
+
+  if (profile.handson_tour_completed_at) {
+    return {
+      should_show: false,
+      completed_at: profile.handson_tour_completed_at,
+      skipped_at: profile.handson_tour_skipped_at ?? null,
+      reason: 'already_completed',
+    };
+  }
+
+  if (profile.handson_tour_skipped_at) {
+    return {
+      should_show: false,
+      completed_at: null,
+      skipped_at: profile.handson_tour_skipped_at,
+      reason: 'already_skipped',
+    };
+  }
+
+  const { data: hasActivity } = await supabase
+    .rpc('user_has_non_sandbox_activity', { p_user_id: userId });
+
+  if (hasActivity) {
+    const skippedAt = new Date().toISOString();
+    await supabase
+      .from('user_profiles')
+      .update({ handson_tour_skipped_at: skippedAt })
+      .eq('user_id', userId)
+      .is('handson_tour_skipped_at', null);
+
+    return {
+      should_show: false,
+      completed_at: null,
+      skipped_at: skippedAt,
+      reason: 'existing_user_auto_skip',
+    };
+  }
+
+  return {
+    should_show: true,
+    completed_at: null,
+    skipped_at: null,
+    reason: 'eligible',
+  };
+}


### PR DESCRIPTION
## 概要

family/02-api-spec.md §15 を canonical source として Phase 1-B API を実装。

## 変更内容

### 新規 4 ファイル

- `src/lib/handson-tour/getStatus.ts` — 表示可否判定の内部 helper。§15.2.4 の判定順序 8 ステップを完全実装。status route と onboarding/complete の両方から呼ぶ
- `src/app/api/handson-tour/status/route.ts` — GET 表示可否判定。Rate limit: 60 req/60s/user (§15.2)
- `src/app/api/handson-tour/complete/route.ts` — POST 卒業処理。admin role 403 / condition C 409 ガード後に RPC `complete_handson_tour` へ委譲 (§15.3)
- `src/app/api/handson-tour/skip/route.ts` — POST 明示スキップ。完了済の場合は skipped_at を上書きしない条件付き UPDATE (§15.4)

### 既存 3 ファイル拡張

- `src/app/api/meal-plans/add-from-photo/route.ts` — `sandbox?: boolean` + `?source=` 対応。sandbox=true 時の偽装防止 3 ガード (§15.5.1)
- `src/app/api/menu-plans/add/route.ts` — 同様の sandbox 拡張。`weekly_menus.is_sandbox` への書き込み (§15.5.2)
- `src/app/api/onboarding/complete/route.ts` — レスポンスに `next_route: '/handson-tour' | '/home'` を追加 (§15.5.3)

## 実装の前提

- Zod schema は inline 定義（`@homegohan/handson-tour-shared` は未取込のため）
- 共通 package との接続は後続 PR で refactor 予定
- RPC `user_has_non_sandbox_activity` / `complete_handson_tour` は Phase 1-A (commit `bcc281d`) で適用済み

## 検証結果

- `npx tsc --noEmit`: エラーなし
- `npx eslint`: エラーなし
- `npm install`: 正常完了