### PR TITLE
feat(family/09): Phase 3-B — Mobile 既存画面 sandbox 対応(V4GenerateModal/BadgesPage/meals-new/settings)

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -365,6 +365,22 @@ export default function SettingsTab() {
           </View>
         </View>
 
+        {/* ── ガイド ── */}
+        <View>
+          <Text style={styles.sectionLabel}>ガイド</Text>
+          <View style={styles.sectionCard}>
+            <SettingRow
+              icon="🎓"
+              iconBg="#EFF6FF"
+              title="使い方ガイドをもう一度見る"
+              subtitle="ハンズオンチュートリアルを再表示"
+              testID="settings-restart-handson-tour"
+              onPress={() => router.push("/handson-tour?force=1")}
+              last
+            />
+          </View>
+        </View>
+
         {/* ── サポートと法的情報 ── */}
         <View>
           <Text style={styles.sectionLabel}>サポートと法的情報</Text>

--- a/apps/mobile/app/badges/index.tsx
+++ b/apps/mobile/app/badges/index.tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
-import { useEffect, useState } from "react";
-import { ScrollView, Text, View } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import { useEffect, useRef, useState } from "react";
+import { Animated, ScrollView, Text, View } from "react-native";
 
 import { Card, EmptyState, LoadingState, PageHeader } from "../../src/components/ui";
 import { getApi } from "../../src/lib/api";
@@ -15,7 +16,86 @@ type Badge = {
   obtainedAt: string | null;
 };
 
+// Highlight border + background animation for tutorial mode (§1.2 Q10)
+function HighlightedBadgeCard({ badge, isHighlighted }: { badge: Badge; isHighlighted: boolean }) {
+  const borderAnim = useRef(new Animated.Value(0)).current;
+  const bgAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (!isHighlighted) return;
+    // Pulse the highlight on mount
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(borderAnim, { toValue: 1, duration: 600, useNativeDriver: false }),
+        Animated.timing(borderAnim, { toValue: 0.4, duration: 600, useNativeDriver: false }),
+      ]),
+    ).start();
+    Animated.timing(bgAnim, { toValue: 1, duration: 400, useNativeDriver: false }).start();
+  }, [isHighlighted, borderAnim, bgAnim]);
+
+  const borderWidth = isHighlighted
+    ? borderAnim.interpolate({ inputRange: [0, 1], outputRange: [2, 4] })
+    : 1;
+  const borderColor = isHighlighted ? colors.accent : colors.border;
+  const backgroundColor = isHighlighted
+    ? bgAnim.interpolate({ inputRange: [0, 1], outputRange: [colors.card, colors.accentLight] })
+    : colors.card;
+
+  return (
+    <Animated.View
+      testID={`badge-card-${badge.code}`}
+      style={{
+        borderWidth,
+        borderColor,
+        borderRadius: 16,
+        backgroundColor,
+        overflow: "hidden",
+      }}
+    >
+      {/* legacy testID compatibility: inner View with the old testID pattern */}
+      <View testID={`badges-badge-${badge.code}`}>
+        <Card variant={badge.earned ? "success" : "default"}>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}>
+            <View
+              style={{
+                width: 40,
+                height: 40,
+                borderRadius: 20,
+                backgroundColor: badge.earned ? colors.successLight : colors.bg,
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Ionicons
+                name={badge.earned ? "checkmark-circle" : "ellipse-outline"}
+                size={24}
+                color={badge.earned ? colors.success : colors.textMuted}
+              />
+            </View>
+            <View style={{ flex: 1, gap: 2 }}>
+              <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>{badge.name}</Text>
+              <Text style={{ fontSize: 13, color: colors.textLight }}>{badge.description}</Text>
+              {badge.obtainedAt ? (
+                <Text style={{ fontSize: 12, color: colors.textMuted }}>獲得: {badge.obtainedAt}</Text>
+              ) : null}
+            </View>
+            {isHighlighted && (
+              <View style={{ alignItems: "center" }}>
+                <Ionicons name="star" size={18} color={colors.accent} />
+              </View>
+            )}
+          </View>
+        </Card>
+      </View>
+    </Animated.View>
+  );
+}
+
 export default function BadgesPage() {
+  const params = useLocalSearchParams<{ "tutorial-mode"?: string; highlight?: string }>();
+  const tutorialMode = params["tutorial-mode"] === "1";
+  const highlightCode = params["highlight"] ?? null;
+
   const [badges, setBadges] = useState<Badge[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -45,17 +125,20 @@ export default function BadgesPage() {
 
   return (
     <View testID="badges-screen" style={{ flex: 1, backgroundColor: colors.bg }}>
-      <PageHeader
-        title="バッジ"
-        right={
-          <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.xs }}>
-            <Ionicons name="trophy" size={20} color={colors.accent} />
-            <Text testID="badges-earned-count" style={{ fontSize: 13, fontWeight: "700", color: colors.textMuted }}>
-              {earnedCount}/{badges.length}
-            </Text>
-          </View>
-        }
-      />
+      {/* tutorialMode 時はヘッダー非表示 (Spotlight 連動のため) */}
+      {!tutorialMode && (
+        <PageHeader
+          title="バッジ"
+          right={
+            <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.xs }}>
+              <Ionicons name="trophy" size={20} color={colors.accent} />
+              <Text testID="badges-earned-count" style={{ fontSize: 13, fontWeight: "700", color: colors.textMuted }}>
+                {earnedCount}/{badges.length}
+              </Text>
+            </View>
+          }
+        />
+      )}
       <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.md }}>
 
       {isLoading ? (
@@ -76,37 +159,11 @@ export default function BadgesPage() {
       ) : (
         <View style={{ gap: spacing.sm }}>
           {badges.map((b) => (
-            <Card
-              testID={`badges-badge-${b.code}`}
+            <HighlightedBadgeCard
               key={b.id}
-              variant={b.earned ? "success" : "default"}
-            >
-              <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}>
-                <View
-                  style={{
-                    width: 40,
-                    height: 40,
-                    borderRadius: 20,
-                    backgroundColor: b.earned ? colors.successLight : colors.bg,
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  <Ionicons
-                    name={b.earned ? "checkmark-circle" : "ellipse-outline"}
-                    size={24}
-                    color={b.earned ? colors.success : colors.textMuted}
-                  />
-                </View>
-                <View style={{ flex: 1, gap: 2 }}>
-                  <Text style={{ fontSize: 15, fontWeight: "700", color: colors.text }}>{b.name}</Text>
-                  <Text style={{ fontSize: 13, color: colors.textLight }}>{b.description}</Text>
-                  {b.obtainedAt ? (
-                    <Text style={{ fontSize: 12, color: colors.textMuted }}>獲得: {b.obtainedAt}</Text>
-                  ) : null}
-                </View>
-              </View>
-            </Card>
+              badge={b}
+              isHighlighted={tutorialMode && highlightCode === b.code}
+            />
           ))}
         </View>
       )}

--- a/apps/mobile/app/meals/new.tsx
+++ b/apps/mobile/app/meals/new.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import * as ImageManipulator from "expo-image-manipulator";
 import * as ImagePicker from "expo-image-picker";
-import { router } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Alert, Image, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -10,6 +10,7 @@ import { Button, Card } from "../../src/components/ui";
 import { colors, spacing, radius } from "../../src/theme";
 import { supabase } from "../../src/lib/supabase";
 import { getApi } from "../../src/lib/api";
+import { MOCK_PHOTO_RESPONSE } from "@homegohan/handson-tour-shared";
 
 // Inlined from lib/meal-image to avoid importing server-side code
 interface MealImageDish { name?: string | null; image_url?: string | null; image_source?: string | null; image_status?: string | null; image_generated_at?: string | null; [key: string]: any; }
@@ -184,9 +185,14 @@ const CATEGORY_EMOJI: Record<string, string> = {
   "野菜": "🥬", "肉類": "🥩", "魚介類": "🐟", "乳製品": "🧀", "果物": "🍎", "調味料": "🧂",
 };
 
+// ─── Sandbox asset ───────────────────────────────────
+const SANDBOX_SAMPLE_IMAGE = require("../../assets/handson-tour/sample-meal.jpg");
+
 // ─── Component ───────────────────────────────────────
 export default function MealNewPage() {
   const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{ source?: string; sandbox?: string }>();
+  const isSandboxMode = params.source === "handson_tour" && params.sandbox === "true";
 
   // Step & mode
   const [step, setStep] = useState<Step>("mode-select");
@@ -623,6 +629,23 @@ export default function MealNewPage() {
     } finally { setIsSaving(false); }
   }
 
+  // ─── Sandbox save ──────────────────────────────────
+  async function saveSandboxMeal() {
+    setIsSaving(true);
+    try {
+      const api = getApi();
+      await api.post("/api/meal-plans/add-from-photo", {
+        ...MOCK_PHOTO_RESPONSE,
+        sandbox: true,
+        source: "handson_tour",
+      });
+      router.back();
+    } catch {
+      // sandbox errors are non-fatal — navigate back anyway
+      router.back();
+    } finally { setIsSaving(false); }
+  }
+
   // ─── Header title ──────────────────────────────────
   const headerTitle = useMemo(() => {
     switch (step) {
@@ -647,6 +670,100 @@ export default function MealNewPage() {
     else if (step === "manual") { setStep("mode-select"); resetAll(); }
     else { setStep("mode-select"); resetAll(); }
   };
+
+  // ─── Render: sandbox early return ─────────────────
+  if (isSandboxMode) {
+    return (
+      <View testID="meal-new-screen-sandbox" style={{ flex: 1, backgroundColor: colors.bg }}>
+        {/* Sandbox header */}
+        <View style={{
+          flexDirection: "row", alignItems: "center", gap: spacing.md,
+          paddingTop: insets.top + 8, paddingBottom: spacing.sm, paddingHorizontal: spacing.lg,
+          backgroundColor: colors.card, borderBottomWidth: 1, borderBottomColor: colors.border,
+        }}>
+          <Pressable onPress={() => router.back()} hitSlop={12}>
+            <Ionicons name="close" size={22} color={colors.textLight} />
+          </Pressable>
+          <View style={{ flex: 1, flexDirection: "row", alignItems: "center", gap: spacing.sm, justifyContent: "center" }}>
+            <Ionicons name="camera" size={18} color={colors.accent} />
+            <Text style={{ fontSize: 16, fontWeight: "600", color: colors.text }}>食事を記録</Text>
+          </View>
+          <View style={{ width: 22 }} />
+        </View>
+
+        <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
+          {/* Sample image */}
+          <Image
+            source={SANDBOX_SAMPLE_IMAGE}
+            style={{ width: "100%", height: 220, borderRadius: 12 }}
+            resizeMode="cover"
+          />
+
+          {/* Mock result card */}
+          <Card>
+            <View style={{ gap: spacing.sm }}>
+              <Text style={{ fontSize: 17, fontWeight: "700", color: colors.text }}>
+                {MOCK_PHOTO_RESPONSE.dishName}
+              </Text>
+              <View style={{ flexDirection: "row", gap: spacing.md, flexWrap: "wrap" }}>
+                <Text style={{ fontSize: 13, color: colors.textLight }}>
+                  {MOCK_PHOTO_RESPONSE.calories} kcal
+                </Text>
+                <Text style={{ fontSize: 13, color: colors.textLight }}>
+                  たんぱく質 {MOCK_PHOTO_RESPONSE.protein_g}g
+                </Text>
+                <Text style={{ fontSize: 13, color: colors.textLight }}>
+                  脂質 {MOCK_PHOTO_RESPONSE.fat_g}g
+                </Text>
+                <Text style={{ fontSize: 13, color: colors.textLight }}>
+                  炭水化物 {MOCK_PHOTO_RESPONSE.carbs_g}g
+                </Text>
+              </View>
+              <Text style={{ fontSize: 12, color: colors.textMuted }}>
+                ※ チュートリアル用のサンプル解析結果です
+              </Text>
+            </View>
+          </Card>
+
+          {/* Detected items */}
+          <View style={{ gap: spacing.xs }}>
+            {MOCK_PHOTO_RESPONSE.detected_items.map((item) => (
+              <View key={item.name} style={{ flexDirection: "row", justifyContent: "space-between", paddingVertical: 4 }}>
+                <Text style={{ fontSize: 14, color: colors.text }}>{item.name}</Text>
+                <Text style={{ fontSize: 13, color: colors.textMuted }}>{item.portion_g}g</Text>
+              </View>
+            ))}
+          </View>
+
+          {/* Save button */}
+          <Pressable
+            testID="meal-sandbox-save-btn"
+            onPress={saveSandboxMeal}
+            disabled={isSaving}
+            style={({ pressed }) => ({
+              paddingVertical: spacing.lg,
+              borderRadius: 12,
+              backgroundColor: colors.accent,
+              alignItems: "center",
+              justifyContent: "center",
+              flexDirection: "row",
+              gap: spacing.sm,
+              opacity: isSaving ? 0.7 : pressed ? 0.9 : 1,
+            })}
+          >
+            {isSaving ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <Ionicons name="checkmark-circle" size={20} color="#fff" />
+            )}
+            <Text style={{ fontSize: 16, fontWeight: "700", color: "#fff" }}>
+              {isSaving ? "保存中..." : "この食事を記録する"}
+            </Text>
+          </Pressable>
+        </ScrollView>
+      </View>
+    );
+  }
 
   // ─── Render ────────────────────────────────────────
   return (

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@expo-google-fonts/noto-sans-jp": "^0.4.3",
     "@homegohan/core": "*",
+    "@homegohan/handson-tour-shared": "*",
     "@homegohan/shared": "*",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-community/slider": "4.5.5",

--- a/apps/mobile/src/components/menu/V4GenerateModal.tsx
+++ b/apps/mobile/src/components/menu/V4GenerateModal.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -29,6 +29,8 @@ import {
   validateSlotCount,
   type MealDay,
 } from "../../../../../lib/slot-builder";
+import { MOCK_MENU_RESPONSE } from "@homegohan/handson-tour-shared";
+import { getApi } from "../../lib/api";
 import { colors, radius, shadows, spacing } from "../../theme";
 
 // ============================================================
@@ -45,7 +47,32 @@ export interface V4GenerateParams {
   ultimateMode: false;
 }
 
-interface Props {
+// ── Sandbox props (discriminated union) ──────────────────────
+export interface V4GenerateModalSandboxProps {
+  mode: "sandbox";
+  visible: boolean;
+  onClose: () => void;
+  initialFlags?: {
+    useFridgeFirst?: boolean;
+    quickMeals?: boolean;
+    japaneseStyle?: boolean;
+    healthy?: boolean;
+  };
+  prefilled?: typeof MOCK_MENU_RESPONSE;
+  loadingDurationMs?: number;
+  apiOptions?: { source: "handson_tour"; sandbox: true };
+  onSandboxComplete?: (result: typeof MOCK_MENU_RESPONSE) => void;
+  // Normal-mode props not needed in sandbox — provide dummies for type compat
+  mealPlanDays?: DayRow[];
+  weekStartDate?: string;
+  weekEndDate?: string;
+  isGenerating?: boolean;
+  onGenerate?: (params: V4GenerateParams) => Promise<void>;
+}
+
+// ── Normal props ─────────────────────────────────────────────
+export interface V4GenerateModalNormalProps {
+  mode?: "normal" | undefined;
   visible: boolean;
   onClose: () => void;
   onGenerate: (params: V4GenerateParams) => Promise<void>;
@@ -54,6 +81,8 @@ interface Props {
   weekEndDate: string;
   isGenerating: boolean;
 }
+
+export type V4GenerateModalProps = V4GenerateModalSandboxProps | V4GenerateModalNormalProps;
 
 // DayRow は weekly/index.tsx と同じ型構造に対応
 interface DayRow {
@@ -142,7 +171,190 @@ const C = {
 // Component
 // ============================================================
 
-export function V4GenerateModal({
+export function V4GenerateModal(props: V4GenerateModalProps) {
+  // ── Sandbox mode ────────────────────────────────────────────
+  if (props.mode === "sandbox") {
+    return <V4GenerateModalSandbox {...props} />;
+  }
+
+  // ── Normal mode ─────────────────────────────────────────────
+  return <V4GenerateModalNormal {...props} />;
+}
+
+// ============================================================
+// Sandbox implementation
+// ============================================================
+function V4GenerateModalSandbox({
+  visible,
+  onClose,
+  prefilled = MOCK_MENU_RESPONSE,
+  loadingDurationMs = 2000,
+  apiOptions = { source: "handson_tour", sandbox: true },
+  onSandboxComplete,
+}: V4GenerateModalSandboxProps) {
+  const [isSandboxLoading, setIsSandboxLoading] = useState(false);
+  const [sandboxDone, setSandboxDone] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reset when modal opens
+  useEffect(() => {
+    if (visible) {
+      setSandboxDone(false);
+      setIsSandboxLoading(false);
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [visible]);
+
+  const handleSandboxGenerate = async () => {
+    if (isSandboxLoading || sandboxDone) return;
+    setIsSandboxLoading(true);
+    timerRef.current = setTimeout(async () => {
+      try {
+        const api = getApi();
+        await api.post("/api/menu-plans/add", {
+          ...prefilled,
+          ...apiOptions,
+        });
+      } catch {
+        // sandbox errors are ignored — mock flow must complete
+      }
+      setSandboxDone(true);
+      setIsSandboxLoading(false);
+      onSandboxComplete?.(prefilled);
+    }, loadingDurationMs);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+      testID="v4-modal-sandbox"
+    >
+      <KeyboardAvoidingView
+        style={{ flex: 1, backgroundColor: C.bg }}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        {/* Header */}
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingHorizontal: spacing.lg,
+            paddingVertical: spacing.md,
+            borderBottomWidth: 1,
+            borderBottomColor: C.border,
+            backgroundColor: C.card,
+          }}
+        >
+          <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+            <Ionicons name="sparkles" size={20} color={C.accent} />
+            <Text style={{ fontSize: 17, fontWeight: "700", color: C.text }}>
+              AI献立アシスタント
+            </Text>
+          </View>
+          <Pressable
+            onPress={onClose}
+            hitSlop={8}
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 16,
+              backgroundColor: C.bg,
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Ionicons name="close" size={18} color={C.textLight} />
+          </Pressable>
+        </View>
+
+        {/* Sandbox content */}
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}
+        >
+          {/* Preview card */}
+          <View
+            style={{
+              padding: spacing.lg,
+              borderRadius: radius.xl,
+              backgroundColor: C.accentLight,
+              borderWidth: 1,
+              borderColor: C.accent,
+              gap: spacing.sm,
+            }}
+          >
+            <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
+              <Ionicons name="restaurant" size={18} color={C.accent} />
+              <Text style={{ fontSize: 15, fontWeight: "700", color: C.text }}>
+                {prefilled.dish_name}
+              </Text>
+            </View>
+            <Text style={{ fontSize: 13, color: C.textLight }}>
+              {prefilled.calories} kcal · 調理時間 {prefilled.cooking_time_minutes} 分 · {prefilled.servings} 人分
+            </Text>
+            <Text style={{ fontSize: 12, color: C.textMuted }}>
+              ※ チュートリアル用のサンプル献立です
+            </Text>
+          </View>
+
+          {sandboxDone ? (
+            <View style={{ alignItems: "center", gap: spacing.md, paddingVertical: spacing.xl }}>
+              <Ionicons name="checkmark-circle" size={48} color={C.success} />
+              <Text style={{ fontSize: 16, fontWeight: "700", color: C.success }}>
+                献立を追加しました！
+              </Text>
+            </View>
+          ) : (
+            <Pressable
+              testID="v4-sandbox-submit-btn"
+              onPress={handleSandboxGenerate}
+              disabled={isSandboxLoading}
+              style={({ pressed }) => ({
+                paddingVertical: spacing.lg,
+                borderRadius: radius.xl,
+                backgroundColor: isSandboxLoading ? C.purple : C.accent,
+                alignItems: "center",
+                justifyContent: "center",
+                flexDirection: "row",
+                gap: spacing.sm,
+                opacity: isSandboxLoading ? 0.85 : pressed ? 0.9 : 1,
+              })}
+            >
+              {isSandboxLoading ? (
+                <>
+                  <ActivityIndicator size="small" color="#fff" />
+                  <Text style={{ fontSize: 16, fontWeight: "700", color: "#fff" }}>
+                    献立を作成中...
+                  </Text>
+                </>
+              ) : (
+                <>
+                  <Ionicons name="sparkles" size={18} color="#fff" />
+                  <Text style={{ fontSize: 16, fontWeight: "700", color: "#fff" }}>
+                    この献立を追加する
+                  </Text>
+                </>
+              )}
+            </Pressable>
+          )}
+
+          <View style={{ height: spacing.xl }} />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+// ============================================================
+// Normal implementation (original logic, extracted)
+// ============================================================
+function V4GenerateModalNormal({
   visible,
   onClose,
   onGenerate,
@@ -150,7 +362,7 @@ export function V4GenerateModal({
   weekStartDate,
   weekEndDate,
   isGenerating,
-}: Props) {
+}: V4GenerateModalNormalProps) {
   const todayStr = useMemo(() => getTodayStr(), []);
 
   const [selectedMode, setSelectedMode] = useState<GenerateMode | null>(null);

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "strict": true,
     "paths": {
+      "@homegohan/handson-tour-shared": ["../../packages/handson-tour-shared/src/index.ts"],
+      "@homegohan/handson-tour-shared/*": ["../../packages/handson-tour-shared/src/*"],
       "@homegohan/shared": ["../../packages/shared/src/index.ts"],
       "@homegohan/shared/*": ["../../packages/shared/src/*"]
     }


### PR DESCRIPTION
## Summary

- **V4GenerateModal** に `mode='sandbox'` discriminated union を追加。sandbox 時は `MOCK_MENU_RESPONSE` を prefilled として表示し、固定 2000ms loading 後に `getApi()` 経由で `POST /api/menu-plans/add` を呼ぶ。既存 normal モードは挙動変更なし。
- **BadgesPage** に `?tutorial-mode=1&highlight=<code>` クエリ対応を追加。tutorial モード時はヘッダー非表示。`Animated.View` で枠線太化 (2→4px pulse) + 背景 fade (accentLight) のハイライト演出を実装。既存 `badges-badge-${code}` testID を互換維持しつつ `badge-card-${code}` を追加。
- **MealNewPage** に `?source=handson_tour&sandbox=true` 動線を追加。固定写真 (`assets/handson-tour/sample-meal.jpg`) と `MOCK_PHOTO_RESPONSE` の解析結果を表示、保存時 `sandbox=true` フラグ付きで API 呼び出し。
- **settings.tsx** に「使い方ガイドをもう一度見る」行を追加 (`testID=settings-restart-handson-tour`、`router.push('/handson-tour?force=1')`)。
- **アセット**: `apps/mobile/assets/handson-tour/sample-meal.jpg` を `tests/e2e/fixtures/karaage.jpg` から追加。
- `@homegohan/handson-tour-shared` を mobile の `package.json` と `tsconfig.json` に追加。

## 変更ファイル

| ファイル | 種別 |
|---|---|
| `apps/mobile/src/components/menu/V4GenerateModal.tsx` | 改修 |
| `apps/mobile/app/badges/index.tsx` | 改修 |
| `apps/mobile/app/meals/new.tsx` | 改修 |
| `apps/mobile/app/(tabs)/settings.tsx` | 改修 |
| `apps/mobile/assets/handson-tour/sample-meal.jpg` | 新規アセット |
| `apps/mobile/package.json` | 依存追加 |
| `apps/mobile/tsconfig.json` | path エイリアス追加 |

## PR DOD チェック

- [x] 既存ファイル改修 4 + アセット 1
- [x] discriminated union で型分岐 (`V4GenerateModalSandboxProps | V4GenerateModalNormalProps`)
- [x] BadgesPage Mobile 版にハイライト演出追加 (`Animated.View` 枠線 + 背景 fade)
- [x] settings に「使い方ガイドをもう一度見る」追加 (`testID=settings-restart-handson-tour`)
- [x] `npx tsc --noEmit` で型エラーなし (apps/mobile 担当ファイル、既存エラーは pre-existing)
- [x] 既存 testID 互換維持 (`badges-badge-${code}` 残しつつ `badge-card-${code}` 追加)
- [x] `npm ci` でエラーなし

## Test plan

- [ ] V4GenerateModal を `mode="sandbox"` で呼び出し、MOCK_MENU_RESPONSE のプレビューが表示されることを確認
- [ ] 「この献立を追加する」タップ後 2000ms loading → onSandboxComplete 呼び出しを確認
- [ ] `/badges?tutorial-mode=1&highlight=<code>` でバッジカードがハイライトされることを確認
- [ ] `/meals/new?source=handson_tour&sandbox=true` でサンプル画像と MOCK_PHOTO_RESPONSE が表示されることを確認
- [ ] settings 画面に「使い方ガイドをもう一度見る」が表示され、タップで `/handson-tour?force=1` に遷移することを確認
- [ ] (Maestro E2E は Phase 5 担当)