### PR TITLE
feat(family/09): Phase 2-B — Mobile UI コア(Tour ルーティング + Coachmark + Confetti)

### DIFF
--- a/apps/mobile/app/handson-tour/_layout.tsx
+++ b/apps/mobile/app/handson-tour/_layout.tsx
@@ -1,0 +1,76 @@
+// handson-tour/_layout.tsx
+// Canonical: docs/design/family/09-onboarding-handson-tour/16-files-structure.md §1.3 §1.3.3
+// TourProvider でラップ + 認証ガード + status 確認
+
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+
+import { useAuth } from '../../src/providers/AuthProvider';
+import { TourProvider } from '../../src/contexts/TourContext';
+import { getApi } from '../../src/lib/api';
+
+export default function HandsonTourLayout() {
+  const { session, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const params = useLocalSearchParams<{ force?: string }>();
+  const entrySource: 'auto' | 'settings_force' =
+    params.force === '1' ? 'settings_force' : 'auto';
+
+  const [statusChecked, setStatusChecked] = useState(false);
+  const [statusLoading, setStatusLoading] = useState(true);
+
+  useEffect(() => {
+    if (authLoading) return;
+
+    // 未認証ならサインイン画面へ
+    if (!session) {
+      router.replace('/(auth)/sign-in' as never);
+      return;
+    }
+
+    // ツアー表示 status を確認
+    const checkStatus = async () => {
+      try {
+        const api = getApi();
+        const res = await api.get<{ should_show: boolean }>('/api/handson-tour/status');
+        const shouldShow = res.should_show;
+
+        // force=1 のときは should_show に関わらず表示
+        if (!shouldShow && entrySource !== 'settings_force') {
+          router.replace('/home' as never);
+          return;
+        }
+      } catch {
+        // API エラー → ツアーを表示 (フォールバック)
+      } finally {
+        setStatusLoading(false);
+        setStatusChecked(true);
+      }
+    };
+
+    void checkStatus();
+  }, [authLoading, session, entrySource]);
+
+  if (authLoading || statusLoading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" color="#2563EB" />
+      </View>
+    );
+  }
+
+  if (!statusChecked) return null;
+
+  return (
+    <TourProvider initialEntrySource={entrySource}>
+      <Stack screenOptions={{ headerShown: false, animation: 'fade' }}>
+        <Stack.Screen name="index" />
+        <Stack.Screen name="photo" />
+        <Stack.Screen name="menu" />
+        <Stack.Screen name="badges" />
+        <Stack.Screen name="graduate" />
+      </Stack>
+    </TourProvider>
+  );
+}

--- a/apps/mobile/app/handson-tour/badges.tsx
+++ b/apps/mobile/app/handson-tour/badges.tsx
@@ -1,0 +1,210 @@
+// handson-tour/badges.tsx — Step 3 バッジ確認 (ハンズオン専用)
+// Canonical: docs/design/family/09-onboarding-handson-tour/05-step3-badges.md
+// 注意: apps/mobile/app/badges/index.tsx (通常バッジ画面、P3-B 改修) とは別ファイル
+
+import { useRouter } from 'expo-router';
+import React, { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import {
+  HANDSON_TOUR_CONSTANTS,
+  HANDSON_TOUR_I18N_JA,
+  HANDSON_TOUR_ROUTES,
+  STEP3_SUB_STEP_TO_TARGET,
+  personalize,
+} from '@homegohan/handson-tour-shared';
+import type { SubStepOfStep3 } from '@homegohan/handson-tour-shared';
+
+import { useProfile } from '../../src/providers/ProfileProvider';
+import { TourOverlay } from '../../src/handson-tour/TourOverlay';
+import { getApi } from '../../src/lib/api';
+
+const i18n = HANDSON_TOUR_I18N_JA.tour;
+
+function safeNickname(raw: string | null | undefined): string {
+  if (!raw) return 'あなた';
+  const trimmed = raw.trim();
+  if (!trimmed) return 'あなた';
+  if (trimmed.length > 30) return `${trimmed.slice(0, 30)}…`;
+  return trimmed;
+}
+
+export default function HandsonTourBadges() {
+  const router = useRouter();
+  const { profile } = useProfile();
+  const nickname = safeNickname(profile?.nickname);
+
+  const [subStep, setSubStep] = useState<SubStepOfStep3>('3.0');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const advanceSubStep = (next: SubStepOfStep3) => {
+    setSubStep(next);
+  };
+
+  // バッジ情報の取得
+  useEffect(() => {
+    const fetchBadges = async () => {
+      try {
+        await getApi().get('/api/badges');
+        // first_bite と planner が獲得済みであることを期待
+        setIsLoading(false);
+        advanceSubStep('3.1');
+      } catch {
+        setError(true);
+        setIsLoading(false);
+      }
+    };
+
+    void fetchBadges();
+  }, []);
+
+  // サブステップ自動進行
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    if (subStep === '3.1') {
+      timer = setTimeout(
+        () => advanceSubStep('3.2'),
+        HANDSON_TOUR_CONSTANTS.STEP3_INTRO_AUTO_MS
+      );
+    }
+
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [subStep]);
+
+  const handleSkip = () => {
+    router.replace('/home' as never);
+  };
+
+  const handleNext = () => {
+    switch (subStep) {
+      case '3.2':
+        advanceSubStep('3.3');
+        break;
+      case '3.3':
+        advanceSubStep('3.4');
+        break;
+      case '3.4':
+        router.push(HANDSON_TOUR_ROUTES.step4 as never);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const getBubble = (): {
+    title?: string;
+    body: string;
+    position: 'top' | 'bottom' | 'left' | 'right' | 'auto';
+  } => {
+    switch (subStep) {
+      case '3.0':
+        return {
+          body: i18n.step3.loading_text,
+          position: 'auto',
+        };
+      case '3.1':
+        return {
+          title: personalize(i18n.step3.intro_title, { nickname }),
+          body: i18n.step3.intro_title,
+          position: 'auto',
+        };
+      case '3.2':
+        return {
+          title: i18n.step3.first_bite_title,
+          body: i18n.step3.first_bite_bubble,
+          position: 'bottom',
+        };
+      case '3.3':
+        return {
+          title: i18n.step3.planner_title,
+          body: i18n.step3.planner_bubble,
+          position: 'bottom',
+        };
+      case '3.4':
+        return {
+          title: i18n.step3.tutorial_complete_title,
+          body: i18n.step3.tutorial_complete_bubble,
+          position: 'bottom',
+        };
+      default:
+        return { body: '', position: 'auto' };
+    }
+  };
+
+  const isManualStep = ['3.2', '3.3', '3.4'].includes(subStep);
+
+  if (isLoading) {
+    return (
+      <View style={styles.loadingContainer} testID="tour-step-3-loading">
+        <ActivityIndicator size="large" color="#2563EB" />
+        <Text style={styles.loadingText}>{i18n.step3.loading_text}</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.loadingContainer}>
+        <Text style={styles.errorText}>{i18n.step3.error_title}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1 }} testID="tour-step-3">
+      {/* P3-B が BadgesPage に tutorial-mode サポートを追加する。現在はプレースホルダー */}
+      <View style={{ flex: 1, backgroundColor: '#F9FAFB' }} />
+
+      <TourOverlay
+        targetTestId={STEP3_SUB_STEP_TO_TARGET[subStep] as string | null}
+        targetTestIds={
+          Array.isArray(STEP3_SUB_STEP_TO_TARGET[subStep])
+            ? (STEP3_SUB_STEP_TO_TARGET[subStep] as string[])
+            : undefined
+        }
+        bubble={getBubble()}
+        progress={{ current: 4, total: 5 }}
+        primaryAction={
+          isManualStep
+            ? {
+                label: i18n.step3.next_button,
+                onPress: handleNext,
+              }
+            : undefined
+        }
+        showSkip={false}
+        onSkip={handleSkip}
+        accessibilityLabel={personalize(i18n.step3.a11y_title, { nickname })}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+    gap: 16,
+  },
+  loadingText: {
+    fontSize: 15,
+    color: '#6B7280',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#EF4444',
+    textAlign: 'center',
+    paddingHorizontal: 32,
+  },
+});

--- a/apps/mobile/app/handson-tour/graduate.tsx
+++ b/apps/mobile/app/handson-tour/graduate.tsx
@@ -1,0 +1,344 @@
+// handson-tour/graduate.tsx — Step 4 卒業
+// Canonical: docs/design/family/09-onboarding-handson-tour/06-step4-graduation.md
+
+import { useRouter } from 'expo-router';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+
+import {
+  HANDSON_TOUR_CONSTANTS,
+  HANDSON_TOUR_I18N_JA,
+  personalize,
+} from '@homegohan/handson-tour-shared';
+
+import { useProfile } from '../../src/providers/ProfileProvider';
+import { Confetti } from '../../src/handson-tour/Confetti';
+import { getApi } from '../../src/lib/api';
+
+const i18n = HANDSON_TOUR_I18N_JA.tour;
+
+type CompleteResponse = {
+  completed_at: string;
+  badge_awarded: {
+    code: string;
+    name: string;
+    obtained_at: string;
+    icon_url: string | null;
+  };
+  already_completed: boolean;
+};
+
+function safeNickname(raw: string | null | undefined): string {
+  if (!raw) return 'あなた';
+  const trimmed = raw.trim();
+  if (!trimmed) return 'あなた';
+  if (trimmed.length > 30) return `${trimmed.slice(0, 30)}…`;
+  return trimmed;
+}
+
+export default function HandsonTourGraduate() {
+  const router = useRouter();
+  const { profile } = useProfile();
+  const nickname = safeNickname(profile?.nickname);
+
+  const [subStep, setSubStep] = useState<'4.0' | '4.1' | '4.2' | '4.3'>('4.0');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [homeButtonEnabled, setHomeButtonEnabled] = useState(false);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+  const [completeData, setCompleteData] = useState<CompleteResponse | null>(null);
+
+  // アニメーション
+  const badgeScale = useSharedValue(0.5);
+  const contentOpacity = useSharedValue(0);
+  const badgeAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: badgeScale.value }],
+  }));
+  const contentAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: contentOpacity.value,
+  }));
+
+  // POST /api/handson-tour/complete (マウント直後 100ms 後)
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      try {
+        const res = await getApi().post<CompleteResponse>('/api/handson-tour/complete', {});
+        setCompleteData(res);
+        setIsLoading(false);
+        setSubStep('4.1');
+        startGraduateAnimation();
+      } catch {
+        setError(true);
+        setIsLoading(false);
+      }
+    }, HANDSON_TOUR_CONSTANTS.STEP4_SAVING_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  const startGraduateAnimation = () => {
+    // 🎓 スプリングアニメーション
+    badgeScale.value = withSpring(1, { damping: 10, stiffness: 100 });
+
+    // コンテンツ fade in
+    contentOpacity.value = withTiming(1, { duration: 600, easing: Easing.out(Easing.ease) });
+
+    // 5 秒後にホームボタン活性化
+    const enableTimer = setTimeout(() => {
+      setHomeButtonEnabled(true);
+      setSubStep('4.2');
+    }, HANDSON_TOUR_CONSTANTS.STEP4_BUTTON_ACTIVATION_MS);
+
+    return () => clearTimeout(enableTimer);
+  };
+
+  // 画面タップでアニメーションスキップ
+  const handleScreenTap = () => {
+    if (subStep === '4.1') {
+      setHomeButtonEnabled(true);
+      setSubStep('4.2');
+    }
+  };
+
+  const handleGoHome = async () => {
+    if (!homeButtonEnabled || isTransitioning) return;
+    setIsTransitioning(true);
+    setSubStep('4.3');
+    router.replace('/home' as never);
+  };
+
+  if (isLoading) {
+    return (
+      <View style={styles.loadingContainer} testID="tour-step-4-saving">
+        <ActivityIndicator size="large" color="#2563EB" />
+        <Text style={styles.loadingText}>{i18n.step4.saving_text}</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.loadingContainer}>
+        <Text style={styles.errorTitle}>{i18n.step4.error_title}</Text>
+        <Text style={styles.errorSubtitle}>{i18n.step4.error_subtitle}</Text>
+        <Pressable
+          onPress={() => {
+            setError(false);
+            setIsLoading(true);
+            // リトライ
+            getApi()
+              .post<CompleteResponse>('/api/handson-tour/complete', {})
+              .then((res) => {
+                setCompleteData(res);
+                setIsLoading(false);
+                setSubStep('4.1');
+                startGraduateAnimation();
+              })
+              .catch(() => {
+                setIsLoading(false);
+                setError(true);
+              });
+          }}
+          style={styles.retryButton}
+          accessibilityRole="button"
+          accessibilityLabel="もう一度"
+        >
+          <Text style={styles.retryButtonText}>{i18n.step4.retry_button}</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <Pressable
+      style={{ flex: 1 }}
+      onPress={handleScreenTap}
+      testID="tour-step-4-graduate"
+      accessible={false}
+    >
+      <View style={styles.container}>
+        {/* 紙吹雪 */}
+        <Confetti visible={subStep === '4.1' || subStep === '4.2'} />
+
+        <SafeAreaView style={styles.content}>
+          {/* 🎓 アイコン */}
+          <Animated.View style={[styles.badgeContainer, badgeAnimatedStyle]}>
+            <Text style={styles.badgeIcon}>🎓</Text>
+          </Animated.View>
+
+          <Animated.View style={[styles.textContainer, contentAnimatedStyle]}>
+            {/* タイトル */}
+            <Text
+              style={styles.title}
+              accessibilityRole="header"
+              accessibilityLiveRegion="assertive"
+            >
+              {i18n.step4.title}
+            </Text>
+
+            {/* サブタイトル */}
+            <Text style={styles.subtitle}>
+              {personalize(i18n.step4.subtitle, { nickname })}
+            </Text>
+
+            {/* バッジカード */}
+            <View style={styles.badgeCard}>
+              <Text style={styles.badgeCardIcon}>
+                {completeData?.badge_awarded?.icon_url ? '🏆' : '🎓'}
+              </Text>
+              <Text style={styles.badgeLabel}>{i18n.step4.badge_label}</Text>
+            </View>
+
+            {/* ホームへボタン */}
+            <Pressable
+              testID="tour-step-4-go-home"
+              onPress={handleGoHome}
+              disabled={!homeButtonEnabled || isTransitioning}
+              accessibilityRole="button"
+              accessibilityLabel="ホーム画面へ進む"
+              style={[
+                styles.homeButton,
+                (!homeButtonEnabled || isTransitioning) && styles.homeButtonDisabled,
+              ]}
+            >
+              <Text style={styles.homeButtonText}>{i18n.step4.home_button}</Text>
+            </Pressable>
+          </Animated.View>
+        </SafeAreaView>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+    gap: 16,
+  },
+  loadingText: {
+    fontSize: 15,
+    color: '#6B7280',
+  },
+  errorTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#EF4444',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  errorSubtitle: {
+    fontSize: 14,
+    color: '#6B7280',
+    textAlign: 'center',
+    paddingHorizontal: 32,
+    marginBottom: 24,
+  },
+  retryButton: {
+    backgroundColor: '#2563EB',
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+  },
+  retryButtonText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  badgeContainer: {
+    width: 80,
+    height: 80,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  badgeIcon: {
+    fontSize: 64,
+  },
+  textContainer: {
+    alignItems: 'center',
+    width: '100%',
+  },
+  title: {
+    fontSize: 26,
+    fontWeight: '700',
+    color: '#111827',
+    textAlign: 'center',
+    marginBottom: 12,
+    maxWidth: 320,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#6B7280',
+    textAlign: 'center',
+    lineHeight: 24,
+    marginBottom: 32,
+    maxWidth: 280,
+  },
+  badgeCard: {
+    backgroundColor: '#EFF6FF',
+    borderRadius: 12,
+    paddingVertical: 20,
+    paddingHorizontal: 32,
+    alignItems: 'center',
+    marginBottom: 40,
+    maxWidth: 240,
+    width: '100%',
+    minHeight: 120,
+    justifyContent: 'center',
+  },
+  badgeCardIcon: {
+    fontSize: 52,
+    marginBottom: 8,
+  },
+  badgeLabel: {
+    fontSize: 14,
+    color: '#2563EB',
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  homeButton: {
+    backgroundColor: '#2563EB',
+    borderRadius: 12,
+    paddingVertical: 16,
+    width: '80%',
+    maxWidth: 320,
+    alignItems: 'center',
+    minHeight: 56,
+    justifyContent: 'center',
+  },
+  homeButtonDisabled: {
+    opacity: 0.4,
+  },
+  homeButtonText: {
+    color: '#FFFFFF',
+    fontSize: 17,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/app/handson-tour/index.tsx
+++ b/apps/mobile/app/handson-tour/index.tsx
@@ -1,0 +1,248 @@
+// handson-tour/index.tsx — Step 0 ウェルカム画面
+// Canonical: docs/design/family/09-onboarding-handson-tour/02-step0-welcome.md
+
+import { useRouter } from 'expo-router';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  AccessibilityInfo,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+import {
+  HANDSON_TOUR_I18N_JA,
+  HANDSON_TOUR_ROUTES,
+  personalize,
+} from '@homegohan/handson-tour-shared';
+import { useProfile } from '../../src/providers/ProfileProvider';
+import { TourProgress } from '../../src/handson-tour/TourProgress';
+import { useReducedMotion } from '../../src/handson-tour/useReducedMotion';
+import { getApi } from '../../src/lib/api';
+
+const i18n = HANDSON_TOUR_I18N_JA.tour;
+
+function safeNickname(raw: string | null | undefined): string {
+  if (!raw) return 'あなた';
+  const trimmed = raw.trim();
+  if (!trimmed) return 'あなた';
+  if (trimmed.length > 30) return `${trimmed.slice(0, 30)}…`;
+  return trimmed;
+}
+
+export default function HandsonTourWelcome() {
+  const router = useRouter();
+  const { profile } = useProfile();
+  const reducedMotion = useReducedMotion();
+  const nickname = safeNickname(profile?.nickname);
+
+  const [isTransitioning, setIsTransitioning] = useState(false);
+  const mountTimeRef = useRef(Date.now());
+
+  // Entrance アニメーション
+  const opacity = useSharedValue(0);
+  const scale = useSharedValue(reducedMotion ? 1 : 0.95);
+
+  useEffect(() => {
+    const duration = reducedMotion ? 100 : 300;
+    opacity.value = withTiming(1, { duration, easing: Easing.out(Easing.ease) });
+    if (!reducedMotion) {
+      scale.value = withTiming(1, { duration, easing: Easing.out(Easing.ease) });
+    }
+  }, []);
+
+  // VoiceOver アナウンス
+  useEffect(() => {
+    const msg = personalize(i18n.step0.a11y_title, { nickname });
+    AccessibilityInfo.announceForAccessibility(
+      `${msg}。${i18n.step0.subtitle}`
+    );
+  }, [nickname]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ scale: scale.value }],
+  }));
+
+  const handleStart = () => {
+    if (isTransitioning) return;
+    setIsTransitioning(true);
+    router.push(HANDSON_TOUR_ROUTES.step1 as never);
+  };
+
+  const handleSkip = async () => {
+    if (isTransitioning) return;
+    setIsTransitioning(true);
+
+    try {
+      await getApi().post('/api/handson-tour/skip', {
+        step: 0,
+        reason: 'user_action',
+      });
+    } catch {
+      // エラー無視、遷移は継続
+    }
+
+    router.replace('/home' as never);
+  };
+
+  return (
+    <View
+      style={styles.backdrop}
+      testID="tour-step-0"
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+      accessibilityLabel={personalize(i18n.step0.a11y_title, { nickname })}
+    >
+      <Animated.View style={[styles.modal, animatedStyle]}>
+        <SafeAreaView style={styles.safeArea}>
+          {/* アプリアイコン (装飾) */}
+          <View
+            style={styles.iconContainer}
+            accessible={false}
+            importantForAccessibility="no-hide-descendants"
+          >
+            <Text style={styles.appIcon}>🏠</Text>
+          </View>
+
+          {/* タイトル */}
+          <Text
+            testID="tour-step-0-title"
+            accessibilityRole="header"
+            style={styles.title}
+          >
+            {personalize(i18n.step0.title, { nickname })}
+          </Text>
+
+          {/* サブタイトル */}
+          <Text testID="tour-step-0-subtitle" style={styles.subtitle}>
+            {i18n.step0.subtitle}
+          </Text>
+
+          {/* 進捗ドット */}
+          <View style={styles.progressContainer}>
+            <TourProgress current={1} total={5} />
+          </View>
+
+          {/* はじめるボタン */}
+          <Pressable
+            testID="tour-step-0-start"
+            onPress={handleStart}
+            disabled={isTransitioning}
+            accessibilityRole="button"
+            accessibilityLabel="ハンズオンを はじめる"
+            accessibilityHint={i18n.step0.a11y_start_hint}
+            style={[styles.primaryButton, isTransitioning && styles.buttonDisabled]}
+          >
+            <Text style={styles.primaryButtonText}>{i18n.step0.start_button}</Text>
+          </Pressable>
+
+          {/* あとでボタン */}
+          <Pressable
+            testID="tour-step-0-skip"
+            onPress={handleSkip}
+            disabled={isTransitioning}
+            accessibilityRole="button"
+            accessibilityLabel="チュートリアルを終了する"
+            accessibilityHint={i18n.step0.a11y_later_hint}
+            style={styles.laterButton}
+          >
+            <Text style={styles.laterButtonText}>{i18n.step0.later_button}</Text>
+          </Pressable>
+        </SafeAreaView>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modal: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    width: '100%',
+    maxWidth: 480,
+    flex: 1,
+  },
+  safeArea: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    paddingVertical: 32,
+  },
+  iconContainer: {
+    width: 96,
+    height: 96,
+    borderRadius: 24,
+    backgroundColor: '#EFF6FF',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 32,
+  },
+  appIcon: {
+    fontSize: 48,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#111827',
+    textAlign: 'center',
+    marginBottom: 16,
+    maxWidth: 320,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#6B7280',
+    textAlign: 'center',
+    lineHeight: 24,
+    marginBottom: 40,
+    maxWidth: 280,
+  },
+  progressContainer: {
+    marginBottom: 40,
+  },
+  primaryButton: {
+    backgroundColor: '#2563EB',
+    borderRadius: 12,
+    paddingVertical: 16,
+    width: '80%',
+    maxWidth: 320,
+    alignItems: 'center',
+    marginBottom: 16,
+    minHeight: 56,
+    justifyContent: 'center',
+  },
+  primaryButtonText: {
+    color: '#FFFFFF',
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  laterButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    minHeight: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  laterButtonText: {
+    color: '#6B7280',
+    fontSize: 15,
+  },
+});

--- a/apps/mobile/app/handson-tour/menu.tsx
+++ b/apps/mobile/app/handson-tour/menu.tsx
@@ -1,0 +1,196 @@
+// handson-tour/menu.tsx — Step 2 AI による献立追加
+// Canonical: docs/design/family/09-onboarding-handson-tour/04-step2-menu.md
+
+import { useRouter } from 'expo-router';
+import React, { useEffect, useState } from 'react';
+import { View } from 'react-native';
+
+import {
+  HANDSON_TOUR_CONSTANTS,
+  HANDSON_TOUR_I18N_JA,
+  HANDSON_TOUR_ROUTES,
+  MOCK_MENU_RESPONSE,
+  STEP2_SUB_STEP_TO_TARGET,
+  personalize,
+} from '@homegohan/handson-tour-shared';
+import type { SubStepOfStep2 } from '@homegohan/handson-tour-shared';
+
+import { useProfile } from '../../src/providers/ProfileProvider';
+import { TourSandboxWrapper } from '../../src/handson-tour/TourSandboxWrapper';
+
+const i18n = HANDSON_TOUR_I18N_JA.tour;
+
+function safeNickname(raw: string | null | undefined): string {
+  if (!raw) return 'あなた';
+  const trimmed = raw.trim();
+  if (!trimmed) return 'あなた';
+  if (trimmed.length > 30) return `${trimmed.slice(0, 30)}…`;
+  return trimmed;
+}
+
+export default function HandsonTourMenu() {
+  const router = useRouter();
+  const { profile } = useProfile();
+  const nickname = safeNickname(profile?.nickname);
+
+  const [subStep, setSubStep] = useState<SubStepOfStep2>('2.1');
+
+  const advanceSubStep = (next: SubStepOfStep2) => {
+    setSubStep(next);
+  };
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    switch (subStep) {
+      case '2.1':
+        timer = setTimeout(
+          () => advanceSubStep('2.2'),
+          HANDSON_TOUR_CONSTANTS.STEP2_INTRO_AUTO_MS
+        );
+        break;
+      case '2.5':
+        timer = setTimeout(
+          () => advanceSubStep('2.6'),
+          HANDSON_TOUR_CONSTANTS.STEP2_LOADING_DURATION_MS
+        );
+        break;
+      case '2.9':
+        // Step 3 へ遷移
+        router.push(HANDSON_TOUR_ROUTES.step3 as never);
+        break;
+      default:
+        break;
+    }
+
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [subStep]);
+
+  const handleSkip = () => {
+    router.replace('/home' as never);
+  };
+
+  const handleSandboxComplete = () => {
+    advanceSubStep('2.8');
+    setTimeout(() => advanceSubStep('2.9'), 500);
+  };
+
+  const getBubble = (): {
+    title?: string;
+    body: string;
+    position: 'top' | 'bottom' | 'left' | 'right' | 'auto';
+  } => {
+    switch (subStep) {
+      case '2.1':
+        return {
+          title: i18n.step2.intro_title,
+          body: i18n.step2.intro_hint,
+          position: 'auto',
+        };
+      case '2.2':
+        return {
+          body: i18n.step2.flags_bubble,
+          position: 'bottom',
+        };
+      case '2.3':
+        return {
+          body: i18n.step2.note_bubble,
+          position: 'top',
+        };
+      case '2.4':
+        return {
+          body: i18n.step2.generate_bubble,
+          position: 'top',
+        };
+      case '2.5':
+        return {
+          body: i18n.step2.generate_bubble,
+          position: 'auto',
+        };
+      case '2.6':
+        return {
+          title: personalize(i18n.step2.result_title, { nickname }),
+          body: i18n.step2.result_bubble_no_exclude,
+          position: 'bottom',
+        };
+      case '2.7':
+        return {
+          body: i18n.step2.add_bubble,
+          position: 'top',
+        };
+      case '2.8':
+      case '2.9':
+        return {
+          body: i18n.step2.add_bubble,
+          position: 'auto',
+        };
+      default:
+        return { body: '', position: 'auto' };
+    }
+  };
+
+  const isAutoStep = ['2.1', '2.5', '2.8', '2.9'].includes(subStep);
+
+  const getPrimaryAction = () => {
+    if (isAutoStep) return undefined;
+    switch (subStep) {
+      case '2.2':
+        return {
+          label: i18n.step2.next_button,
+          onPress: () => advanceSubStep('2.3'),
+        };
+      case '2.3':
+        return {
+          label: i18n.step2.next_button,
+          onPress: () => advanceSubStep('2.4'),
+        };
+      case '2.4':
+        return {
+          label: i18n.step2.generate_button,
+          onPress: () => advanceSubStep('2.5'),
+        };
+      case '2.6':
+        return {
+          label: i18n.step2.next_button,
+          onPress: () => advanceSubStep('2.7'),
+        };
+      case '2.7':
+        return {
+          label: i18n.step2.add_button,
+          onPress: () => handleSandboxComplete(),
+        };
+      default:
+        return undefined;
+    }
+  };
+
+  return (
+    <View style={{ flex: 1 }} testID="tour-step-2">
+      <TourSandboxWrapper
+        subStep={subStep}
+        subStepToTarget={STEP2_SUB_STEP_TO_TARGET}
+        overlay={{
+          bubble: getBubble(),
+          progress: { current: 3, total: 5 },
+          primaryAction: getPrimaryAction(),
+          showSkip: false,
+          onSkip: handleSkip,
+          accessibilityLabel: i18n.step2.a11y_title,
+        }}
+        childProps={{
+          mode: 'sandbox',
+          initialFlags: { no_cook: true },
+          prefilled: MOCK_MENU_RESPONSE,
+          loadingDurationMs: HANDSON_TOUR_CONSTANTS.STEP2_LOADING_DURATION_MS,
+          apiOptions: { source: 'handson_tour', sandbox: true },
+        }}
+        onSandboxComplete={handleSandboxComplete}
+      >
+        {/* P3-B が V4GenerateModal に mode='sandbox' サポートを追加する。現在はプレースホルダー */}
+        <View style={{ flex: 1 }} />
+      </TourSandboxWrapper>
+    </View>
+  );
+}

--- a/apps/mobile/app/handson-tour/photo.tsx
+++ b/apps/mobile/app/handson-tour/photo.tsx
@@ -1,0 +1,187 @@
+// handson-tour/photo.tsx — Step 1 写真からの食事追加
+// Canonical: docs/design/family/09-onboarding-handson-tour/03-step1-photo.md
+
+import { useRouter } from 'expo-router';
+import React, { useEffect, useRef, useState } from 'react';
+import { View } from 'react-native';
+
+import {
+  HANDSON_TOUR_CONSTANTS,
+  HANDSON_TOUR_I18N_JA,
+  HANDSON_TOUR_ROUTES,
+  MOCK_PHOTO_RESPONSE,
+  STEP1_SUB_STEP_TO_TARGET,
+  personalize,
+} from '@homegohan/handson-tour-shared';
+import type { SubStepOfStep1 } from '@homegohan/handson-tour-shared';
+
+import { useProfile } from '../../src/providers/ProfileProvider';
+import { TourSandboxWrapper } from '../../src/handson-tour/TourSandboxWrapper';
+
+const i18n = HANDSON_TOUR_I18N_JA.tour;
+
+function safeNickname(raw: string | null | undefined): string {
+  if (!raw) return 'あなた';
+  const trimmed = raw.trim();
+  if (!trimmed) return 'あなた';
+  if (trimmed.length > 30) return `${trimmed.slice(0, 30)}…`;
+  return trimmed;
+}
+
+export default function HandsonTourPhoto() {
+  const router = useRouter();
+  const { profile } = useProfile();
+  const nickname = safeNickname(profile?.nickname);
+  const targetKcal = 1900; // フォールバック値、実際はプロフィールから取得
+  const percent = Math.round((MOCK_PHOTO_RESPONSE.calories / targetKcal) * 100);
+
+  const [subStep, setSubStep] = useState<SubStepOfStep1>('1.1');
+  const mountTimeRef = useRef(Date.now());
+
+  const advanceSubStep = (next: SubStepOfStep1) => {
+    setSubStep(next);
+  };
+
+  // サブステップ自動進行テーブル
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    switch (subStep) {
+      case '1.1':
+        timer = setTimeout(
+          () => advanceSubStep('1.2'),
+          HANDSON_TOUR_CONSTANTS.STEP1_INTRO_AUTO_MS
+        );
+        break;
+      case '1.2':
+        timer = setTimeout(
+          () => advanceSubStep('1.3'),
+          HANDSON_TOUR_CONSTANTS.STEP1_CAMERA_AUTO_MS
+        );
+        break;
+      case '1.3':
+        timer = setTimeout(
+          () => advanceSubStep('1.4'),
+          HANDSON_TOUR_CONSTANTS.STEP1_ANALYZING_DURATION_MS
+        );
+        break;
+      case '1.4':
+        timer = setTimeout(
+          () => advanceSubStep('1.5'),
+          HANDSON_TOUR_CONSTANTS.STEP1_RESULT_TO_SPOTLIGHT_MS
+        );
+        break;
+      default:
+        break;
+    }
+
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [subStep]);
+
+  const handleSandboxComplete = async () => {
+    // Step 2 へ遷移
+    router.push(HANDSON_TOUR_ROUTES.step2 as never);
+  };
+
+  const handleSkip = async () => {
+    router.replace('/home' as never);
+  };
+
+  // サブステップに応じた bubble 設定
+  const getBubble = (): {
+    title?: string;
+    body: string;
+    position: 'top' | 'bottom' | 'left' | 'right' | 'auto';
+  } => {
+    switch (subStep) {
+      case '1.1':
+        return {
+          title: i18n.step1.intro_title,
+          body: i18n.step1.intro_hint,
+          position: 'auto',
+        };
+      case '1.2':
+        return {
+          body: i18n.step1.camera_bubble,
+          position: 'top',
+        };
+      case '1.3':
+        return {
+          body: i18n.step1.camera_bubble,
+          position: 'auto',
+        };
+      case '1.4':
+        return {
+          body: i18n.step1.camera_bubble,
+          position: 'auto',
+        };
+      case '1.5':
+        return {
+          title: i18n.step1.result_title,
+          body: personalize(i18n.step1.result_bubble_with_target, {
+            nickname,
+            target_kcal: targetKcal,
+            percent,
+          }),
+          position: 'bottom',
+        };
+      case '1.6':
+        return {
+          body: i18n.step1.save_bubble,
+          position: 'top',
+        };
+      case '1.7':
+        return {
+          body: i18n.step1.save_bubble,
+          position: 'auto',
+        };
+      default:
+        return { body: '', position: 'auto' };
+    }
+  };
+
+  const isAutoStep = ['1.1', '1.2', '1.3', '1.4', '1.7'].includes(subStep);
+
+  const primaryAction = !isAutoStep
+    ? {
+        label: subStep === '1.6' ? i18n.step1.save_button : i18n.step1.next_button,
+        onPress: () => {
+          if (subStep === '1.5') advanceSubStep('1.6');
+          else if (subStep === '1.6') {
+            advanceSubStep('1.7');
+            // 保存 API は sandbox モードで既存コンポーネントが呼ぶ
+            setTimeout(() => handleSandboxComplete(), 1000);
+          }
+        },
+      }
+    : undefined;
+
+  return (
+    <View style={{ flex: 1 }} testID="tour-step-1">
+      <TourSandboxWrapper
+        subStep={subStep}
+        subStepToTarget={STEP1_SUB_STEP_TO_TARGET}
+        overlay={{
+          bubble: getBubble(),
+          progress: { current: 2, total: 5 },
+          primaryAction,
+          showSkip: false,
+          onSkip: handleSkip,
+          accessibilityLabel: i18n.step1.a11y_title,
+        }}
+        childProps={{
+          mode: 'sandbox',
+          initialStep: 'result',
+          prefilled: MOCK_PHOTO_RESPONSE,
+          apiOptions: { source: 'handson_tour', sandbox: true },
+        }}
+        onSandboxComplete={handleSandboxComplete}
+      >
+        {/* P3-B が MealNewScreen に mode='sandbox' サポートを追加する。現在はプレースホルダー */}
+        <View style={{ flex: 1 }} />
+      </TourSandboxWrapper>
+    </View>
+  );
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -15,8 +15,10 @@
   "dependencies": {
     "@expo-google-fonts/noto-sans-jp": "^0.4.3",
     "@homegohan/core": "*",
+    "@homegohan/handson-tour-shared": "*",
     "@homegohan/shared": "*",
     "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-masked-view/masked-view": "^0.3.2",
     "@react-native-community/slider": "4.5.5",
     "@supabase/supabase-js": "^2.78.0",
     "expo": "~53.0.0",
@@ -38,6 +40,7 @@
     "lucide-react-native": "^1.14.0",
     "react": "19.0.0",
     "react-native": "0.79.6",
+    "react-native-reanimated": "^3.17.5",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",

--- a/apps/mobile/src/contexts/TourContext.tsx
+++ b/apps/mobile/src/contexts/TourContext.tsx
@@ -1,0 +1,91 @@
+// TourContext — Mobile 版
+// Canonical: docs/design/family/09-onboarding-handson-tour/16-files-structure.md §1.3
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import type { TourState } from '@homegohan/handson-tour-shared';
+
+type TourContextValue = {
+  /** 現在のツアー state */
+  tourState: TourState;
+  /** Step を進める */
+  advanceStep: () => void;
+  /** ツアーをスキップ */
+  skipTour: () => void;
+  /** analytics 用 dwell 時間を記録 */
+  recordStepDwell: (step: number, ms: number) => void;
+  /** entrySource をセット */
+  setEntrySource: (source: 'auto' | 'settings_force') => void;
+};
+
+const TourContext = createContext<TourContextValue | null>(null);
+
+interface TourProviderProps {
+  children: React.ReactNode;
+  initialEntrySource?: 'auto' | 'settings_force';
+}
+
+export function TourProvider({ children, initialEntrySource = 'auto' }: TourProviderProps) {
+  const [tourState, setTourState] = useState<TourState>({
+    currentStep: 0,
+    tourStartTimestamp: Date.now(),
+    entrySource: initialEntrySource,
+    stepDwellMs: {},
+    forceMode: initialEntrySource === 'settings_force',
+  });
+
+  const advanceStep = useCallback(() => {
+    setTourState((prev) => ({
+      ...prev,
+      currentStep: Math.min(prev.currentStep + 1, 5) as TourState['currentStep'],
+    }));
+  }, []);
+
+  const skipTour = useCallback(() => {
+    setTourState((prev) => ({
+      ...prev,
+      currentStep: 5,
+    }));
+  }, []);
+
+  const recordStepDwell = useCallback((step: number, ms: number) => {
+    setTourState((prev) => ({
+      ...prev,
+      stepDwellMs: { ...prev.stepDwellMs, [step]: ms },
+    }));
+  }, []);
+
+  const setEntrySource = useCallback((source: 'auto' | 'settings_force') => {
+    setTourState((prev) => ({
+      ...prev,
+      entrySource: source,
+      forceMode: source === 'settings_force',
+    }));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      tourState,
+      advanceStep,
+      skipTour,
+      recordStepDwell,
+      setEntrySource,
+    }),
+    [tourState, advanceStep, skipTour, recordStepDwell, setEntrySource]
+  );
+
+  return <TourContext.Provider value={value}>{children}</TourContext.Provider>;
+}
+
+export function useTourContext(): TourContextValue {
+  const ctx = useContext(TourContext);
+  if (!ctx) throw new Error('useTourContext must be used within <TourProvider>');
+  return ctx;
+}

--- a/apps/mobile/src/handson-tour/Confetti.tsx
+++ b/apps/mobile/src/handson-tour/Confetti.tsx
@@ -1,0 +1,226 @@
+// Confetti — Step 4 紙吹雪 (Reanimated v3 自前実装)
+// Canonical: docs/design/family/09-onboarding-handson-tour/06-step4-graduation.md §3.3
+// react-confetti は React DOM 専用のため独自実装
+// CONFETTI_PARTICLE_COUNT=300, CONFETTI_DURATION_MS=3000
+
+import React, { useEffect, useMemo } from 'react';
+import { Dimensions, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { HANDSON_TOUR_CONSTANTS } from '@homegohan/handson-tour-shared';
+
+import { useReducedMotion } from './useReducedMotion';
+
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+
+// Primary カラーパレット + アクセントカラー (紙吹雪用)
+const CONFETTI_COLORS = [
+  '#2563EB', // blue-600
+  '#10B981', // emerald-500
+  '#F59E0B', // amber-500
+  '#EF4444', // red-500
+  '#8B5CF6', // violet-500
+  '#EC4899', // pink-500
+  '#06B6D4', // cyan-500
+  '#F97316', // orange-500
+];
+
+type ParticleData = {
+  id: number;
+  x: number;
+  startY: number;
+  color: string;
+  size: number;
+  rotationSpeed: number;
+  fallSpeed: number;
+  delay: number;
+  shape: 'rect' | 'circle' | 'ribbon';
+};
+
+function seededRandom(seed: number): number {
+  const x = Math.sin(seed + 1) * 10000;
+  return x - Math.floor(x);
+}
+
+function generateParticles(count: number): ParticleData[] {
+  return Array.from({ length: count }, (_, i) => {
+    const r1 = seededRandom(i * 7 + 1);
+    const r2 = seededRandom(i * 7 + 2);
+    const r3 = seededRandom(i * 7 + 3);
+    const r4 = seededRandom(i * 7 + 4);
+    const r5 = seededRandom(i * 7 + 5);
+    const r6 = seededRandom(i * 7 + 6);
+
+    const shapes: ParticleData['shape'][] = ['rect', 'circle', 'ribbon'];
+    const shape = shapes[Math.floor(r6 * shapes.length)]!;
+
+    return {
+      id: i,
+      x: r1 * SCREEN_WIDTH,
+      startY: -20 - r2 * 80, // 画面上部からスタート
+      color: CONFETTI_COLORS[Math.floor(r3 * CONFETTI_COLORS.length)]!,
+      size: 6 + r4 * 8, // 6-14px
+      rotationSpeed: 200 + r5 * 600, // 200-800ms で 1 回転
+      fallSpeed: (HANDSON_TOUR_CONSTANTS.CONFETTI_DURATION_MS / 1000) * 0.7 + r6 * 1.5, // 2.1-3.6s で落下
+      delay: r1 * (HANDSON_TOUR_CONSTANTS.CONFETTI_DURATION_MS * 0.3), // 最大 900ms の遅延
+      shape,
+    };
+  });
+}
+
+function ConfettiParticle({ particle }: { particle: ParticleData }) {
+  const translateY = useSharedValue(particle.startY);
+  const translateX = useSharedValue(particle.x);
+  const opacity = useSharedValue(1);
+  const rotate = useSharedValue(0);
+
+  useEffect(() => {
+    const duration = particle.fallSpeed * 1000;
+    const delay = particle.delay;
+
+    // 落下アニメーション
+    translateY.value = withDelay(
+      delay,
+      withTiming(SCREEN_HEIGHT + 20, {
+        duration,
+        easing: Easing.linear,
+      })
+    );
+
+    // 横揺れ (sin 波形っぽく)
+    translateX.value = withDelay(
+      delay,
+      withSequence(
+        withTiming(particle.x + 30, { duration: duration / 3, easing: Easing.inOut(Easing.ease) }),
+        withTiming(particle.x - 20, { duration: duration / 3, easing: Easing.inOut(Easing.ease) }),
+        withTiming(particle.x + 10, { duration: duration / 3, easing: Easing.inOut(Easing.ease) })
+      )
+    );
+
+    // 回転
+    rotate.value = withDelay(
+      delay,
+      withTiming(360 * 3, {
+        duration,
+        easing: Easing.linear,
+      })
+    );
+
+    // フェードアウト (落下の終盤)
+    opacity.value = withDelay(
+      delay + duration * 0.7,
+      withTiming(0, {
+        duration: duration * 0.3,
+        easing: Easing.out(Easing.ease),
+      })
+    );
+  }, []);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translateX.value },
+      { translateY: translateY.value },
+      { rotate: `${rotate.value}deg` },
+    ],
+    opacity: opacity.value,
+  }));
+
+  const { size, color, shape } = particle;
+
+  const shapeStyle = (() => {
+    switch (shape) {
+      case 'circle':
+        return {
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          backgroundColor: color,
+        };
+      case 'ribbon':
+        return {
+          width: size * 0.3,
+          height: size * 2,
+          borderRadius: 2,
+          backgroundColor: color,
+        };
+      case 'rect':
+      default:
+        return {
+          width: size,
+          height: size * 0.6,
+          borderRadius: 2,
+          backgroundColor: color,
+        };
+    }
+  })();
+
+  return (
+    <Animated.View
+      style={[
+        styles.particle,
+        { left: 0, top: 0 },
+        animatedStyle,
+      ]}
+      accessible={false}
+      importantForAccessibility="no"
+    >
+      <View style={shapeStyle} />
+    </Animated.View>
+  );
+}
+
+interface ConfettiProps {
+  /** 紙吹雪を表示するか */
+  visible: boolean;
+  /** 動きを強制的に減らす (テスト用) */
+  forceReducedMotion?: boolean;
+}
+
+export function Confetti({ visible, forceReducedMotion }: ConfettiProps) {
+  const reducedMotion = useReducedMotion(forceReducedMotion);
+
+  const particles = useMemo(
+    () => generateParticles(HANDSON_TOUR_CONSTANTS.CONFETTI_PARTICLE_COUNT),
+    []
+  );
+
+  if (!visible) return null;
+
+  // prefers-reduced-motion 時は静的アイコン表示
+  if (reducedMotion) {
+    return (
+      <View style={styles.reducedMotionContainer} accessible={false}>
+        <Text style={styles.reducedMotionIcon}>🎓</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none" accessible={false}>
+      {particles.map((particle) => (
+        <ConfettiParticle key={particle.id} particle={particle} />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  particle: {
+    position: 'absolute',
+  },
+  reducedMotionContainer: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  reducedMotionIcon: {
+    fontSize: 64,
+  },
+});

--- a/apps/mobile/src/handson-tour/TourBubble.tsx
+++ b/apps/mobile/src/handson-tour/TourBubble.tsx
@@ -1,0 +1,311 @@
+// TourBubble — Mobile 版 吹き出しコンポーネント
+// Canonical: docs/design/family/09-onboarding-handson-tour/07-components.md §3
+
+import React from 'react';
+import {
+  ActivityIndicator,
+  Dimensions,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import type { TargetRect, TourBubbleProps } from '@homegohan/handson-tour-shared';
+
+const BUBBLE_DEFAULT_MAX_WIDTH = 280;
+const BUBBLE_ARROW_SIZE = 8;
+const SCREEN_PADDING = 16;
+
+type BubbleActualPosition = 'top' | 'bottom' | 'left' | 'right' | 'center';
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function calculateBubblePosition(
+  target: TargetRect | null,
+  preferredPosition: 'top' | 'bottom' | 'left' | 'right' | 'auto',
+  bubbleWidth: number,
+  bubbleEstimatedHeight: number,
+  offset: number
+): { x: number; y: number; actualPosition: BubbleActualPosition } {
+  const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
+
+  if (!target) {
+    return {
+      x: (screenWidth - bubbleWidth) / 2,
+      y: (screenHeight - bubbleEstimatedHeight) / 2,
+      actualPosition: 'center',
+    };
+  }
+
+  let resolvedPosition: 'top' | 'bottom' | 'left' | 'right' = 'bottom';
+
+  if (preferredPosition === 'auto') {
+    const spaceBelow = screenHeight - (target.y + target.height);
+    const spaceAbove = target.y;
+    if (spaceBelow >= bubbleEstimatedHeight + offset + SCREEN_PADDING) {
+      resolvedPosition = 'bottom';
+    } else if (spaceAbove >= bubbleEstimatedHeight + offset + SCREEN_PADDING) {
+      resolvedPosition = 'top';
+    } else {
+      resolvedPosition = 'bottom';
+    }
+  } else {
+    resolvedPosition = preferredPosition;
+  }
+
+  switch (resolvedPosition) {
+    case 'top':
+      return {
+        x: clamp(
+          target.x + target.width / 2 - bubbleWidth / 2,
+          SCREEN_PADDING,
+          screenWidth - bubbleWidth - SCREEN_PADDING
+        ),
+        y: target.y - bubbleEstimatedHeight - offset,
+        actualPosition: 'top',
+      };
+    case 'bottom':
+      return {
+        x: clamp(
+          target.x + target.width / 2 - bubbleWidth / 2,
+          SCREEN_PADDING,
+          screenWidth - bubbleWidth - SCREEN_PADDING
+        ),
+        y: target.y + target.height + offset,
+        actualPosition: 'bottom',
+      };
+    case 'left':
+      return {
+        x: target.x - bubbleWidth - offset,
+        y: clamp(
+          target.y + target.height / 2 - bubbleEstimatedHeight / 2,
+          SCREEN_PADDING,
+          screenHeight - bubbleEstimatedHeight - SCREEN_PADDING
+        ),
+        actualPosition: 'left',
+      };
+    case 'right':
+      return {
+        x: target.x + target.width + offset,
+        y: clamp(
+          target.y + target.height / 2 - bubbleEstimatedHeight / 2,
+          SCREEN_PADDING,
+          screenHeight - bubbleEstimatedHeight - SCREEN_PADDING
+        ),
+        actualPosition: 'right',
+      };
+    default:
+      return {
+        x: clamp(
+          target.x + target.width / 2 - bubbleWidth / 2,
+          SCREEN_PADDING,
+          screenWidth - bubbleWidth - SCREEN_PADDING
+        ),
+        y: target.y + target.height + offset,
+        actualPosition: 'bottom',
+      };
+  }
+}
+
+function Arrow({ actualPosition }: { actualPosition: BubbleActualPosition }) {
+  if (actualPosition === 'center') return null;
+
+  const arrowStyle = (() => {
+    switch (actualPosition) {
+      case 'bottom':
+        // 吹き出しが target の下 → 矢印は上向き (吹き出しトップ)
+        return {
+          top: -BUBBLE_ARROW_SIZE,
+          left: '50%' as const,
+          marginLeft: -BUBBLE_ARROW_SIZE,
+          borderLeftWidth: BUBBLE_ARROW_SIZE,
+          borderRightWidth: BUBBLE_ARROW_SIZE,
+          borderBottomWidth: BUBBLE_ARROW_SIZE,
+          borderLeftColor: 'transparent',
+          borderRightColor: 'transparent',
+          borderBottomColor: '#FFFFFF',
+        };
+      case 'top':
+        // 吹き出しが target の上 → 矢印は下向き (吹き出しボトム)
+        return {
+          bottom: -BUBBLE_ARROW_SIZE,
+          left: '50%' as const,
+          marginLeft: -BUBBLE_ARROW_SIZE,
+          borderLeftWidth: BUBBLE_ARROW_SIZE,
+          borderRightWidth: BUBBLE_ARROW_SIZE,
+          borderTopWidth: BUBBLE_ARROW_SIZE,
+          borderLeftColor: 'transparent',
+          borderRightColor: 'transparent',
+          borderTopColor: '#FFFFFF',
+        };
+      case 'right':
+        return {
+          left: -BUBBLE_ARROW_SIZE,
+          top: '50%' as const,
+          marginTop: -BUBBLE_ARROW_SIZE,
+          borderTopWidth: BUBBLE_ARROW_SIZE,
+          borderBottomWidth: BUBBLE_ARROW_SIZE,
+          borderRightWidth: BUBBLE_ARROW_SIZE,
+          borderTopColor: 'transparent',
+          borderBottomColor: 'transparent',
+          borderRightColor: '#FFFFFF',
+        };
+      case 'left':
+        return {
+          right: -BUBBLE_ARROW_SIZE,
+          top: '50%' as const,
+          marginTop: -BUBBLE_ARROW_SIZE,
+          borderTopWidth: BUBBLE_ARROW_SIZE,
+          borderBottomWidth: BUBBLE_ARROW_SIZE,
+          borderLeftWidth: BUBBLE_ARROW_SIZE,
+          borderTopColor: 'transparent',
+          borderBottomColor: 'transparent',
+          borderLeftColor: '#FFFFFF',
+        };
+      default:
+        return {};
+    }
+  })();
+
+  return <View style={[styles.arrow, arrowStyle]} />;
+}
+
+export function TourBubble(props: TourBubbleProps) {
+  const { target, bubble, position, primaryAction, progress, offset } = props;
+  const maxWidth = bubble.maxWidth ?? BUBBLE_DEFAULT_MAX_WIDTH;
+
+  // 高さは内容によって変わるが、概算で計算する
+  const estimatedHeight = 120;
+
+  const pos = calculateBubblePosition(target, position, maxWidth, estimatedHeight, offset);
+
+  return (
+    <View
+      testID="tour-bubble"
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+      style={[
+        styles.bubble,
+        {
+          position: 'absolute',
+          left: pos.x,
+          top: pos.y,
+          maxWidth,
+        },
+      ]}
+    >
+      <Arrow actualPosition={pos.actualPosition} />
+
+      {/* 進捗ドット (bubble 内) */}
+      {progress && (
+        <View style={styles.progressContainer}>
+          {Array.from({ length: progress.total }).map((_, i) => (
+            <View
+              key={i}
+              accessible={false}
+              style={[
+                styles.progressDot,
+                i + 1 <= progress.current ? styles.progressDotActive : styles.progressDotInactive,
+              ]}
+            />
+          ))}
+        </View>
+      )}
+
+      {/* タイトル */}
+      {bubble.title && (
+        <Text testID="tour-bubble-title" style={styles.title}>
+          {bubble.title}
+        </Text>
+      )}
+
+      {/* 本文 */}
+      <Text testID="tour-bubble-body" style={styles.body}>
+        {bubble.body}
+      </Text>
+
+      {/* primary action */}
+      {primaryAction && (
+        <Pressable
+          testID="tour-next-button"
+          onPress={primaryAction.onPress}
+          disabled={primaryAction.disabled}
+          accessibilityRole="button"
+          accessibilityLabel={primaryAction.label}
+          style={[styles.button, primaryAction.disabled && styles.buttonDisabled]}
+        >
+          {primaryAction.showSpinner ? (
+            <ActivityIndicator size="small" color="#FFFFFF" />
+          ) : (
+            <Text style={styles.buttonText}>{primaryAction.label}</Text>
+          )}
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bubble: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.12,
+    shadowRadius: 16,
+    elevation: 8,
+  },
+  arrow: {
+    position: 'absolute',
+    width: 0,
+    height: 0,
+  },
+  progressContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginBottom: 8,
+    gap: 8,
+  },
+  progressDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  progressDotActive: {
+    backgroundColor: '#2563EB',
+  },
+  progressDotInactive: {
+    backgroundColor: '#D1D5DB',
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#111827',
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 14,
+    color: '#374151',
+    lineHeight: 20,
+    marginBottom: 12,
+  },
+  button: {
+    backgroundColor: '#2563EB',
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    alignItems: 'center',
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/src/handson-tour/TourOverlay.tsx
+++ b/apps/mobile/src/handson-tour/TourOverlay.tsx
@@ -1,0 +1,192 @@
+// TourOverlay — Mobile 版
+// Canonical: docs/design/family/09-onboarding-handson-tour/07-components.md §2.5
+// MaskedView + Reanimated v3 で実装
+
+import MaskedView from '@react-native-masked-view/masked-view';
+import React, { useCallback, useEffect } from 'react';
+import { BackHandler, Pressable, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+import type { TourOverlayProps } from '@homegohan/handson-tour-shared';
+import { HANDSON_TOUR_CONSTANTS } from '@homegohan/handson-tour-shared';
+
+import { TourBubble } from './TourBubble';
+import { useTourOverlayLogic } from './useTourOverlayLogic';
+import { useReducedMotion } from './useReducedMotion';
+
+export function TourOverlay(props: TourOverlayProps) {
+  const {
+    targetTestId,
+    targetTestIds,
+    bubble,
+    primaryAction,
+    autoAdvanceMs,
+    onAutoAdvance,
+    autoAdvanceTappable,
+    showSkip,
+    onSkip,
+    progress,
+    dimOpacity = 0.6,
+    spotlightPadding = 8,
+    bubbleOffset = 12,
+    accessibilityLabel = '使い方ガイド',
+    forceReducedMotion,
+    scrollRecalcIntervalMs,
+    spotlightClickBehavior = 'block',
+  } = props;
+
+  const reducedMotion = useReducedMotion(forceReducedMotion);
+
+  const { targetRect } = useTourOverlayLogic({
+    targetTestId,
+    targetTestIds,
+    autoAdvanceMs,
+    onAutoAdvance,
+    scrollRecalcIntervalMs,
+  });
+
+  // Fade in アニメーション
+  const opacity = useSharedValue(0);
+
+  useEffect(() => {
+    const duration = reducedMotion
+      ? 0
+      : HANDSON_TOUR_CONSTANTS.OVERLAY_FADE_IN_MS;
+    opacity.value = withTiming(1, { duration });
+  }, []);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  // Android ハードバック対応
+  const handleSkip = useCallback(() => {
+    if (onSkip) onSkip();
+  }, [onSkip]);
+
+  useEffect(() => {
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (onSkip) {
+        onSkip();
+        return true;
+      }
+      return false;
+    });
+    return () => sub.remove();
+  }, [onSkip]);
+
+  // Spotlight の外タップ処理
+  const handleOutsideTap = useCallback(() => {
+    if (autoAdvanceTappable && onAutoAdvance) {
+      onAutoAdvance();
+    }
+  }, [autoAdvanceTappable, onAutoAdvance]);
+
+  // Mask element 構築
+  const maskElement = (
+    <View style={StyleSheet.absoluteFill}>
+      {/* ベース: 黒 (マスクされる領域 = dim) */}
+      <View style={[StyleSheet.absoluteFill, { backgroundColor: 'black' }]} />
+      {/* 穴: 透明 (Spotlight = 見える領域) */}
+      {targetRect && (
+        <View
+          style={{
+            position: 'absolute',
+            left: targetRect.x - spotlightPadding,
+            top: targetRect.y - spotlightPadding,
+            width: targetRect.width + spotlightPadding * 2,
+            height: targetRect.height + spotlightPadding * 2,
+            backgroundColor: 'transparent',
+            borderRadius: 12,
+          }}
+        />
+      )}
+    </View>
+  );
+
+  return (
+    <Animated.View
+      style={[StyleSheet.absoluteFill, animatedStyle, styles.container]}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+      testID="tour-overlay"
+    >
+      {/* Spotlight マスクで穴抜き背景 */}
+      <MaskedView
+        style={StyleSheet.absoluteFill}
+        maskElement={maskElement}
+      >
+        <Pressable
+          style={[StyleSheet.absoluteFill]}
+          onPress={spotlightClickBehavior === 'block' ? undefined : handleOutsideTap}
+          accessible={false}
+        >
+          <View
+            style={[
+              StyleSheet.absoluteFill,
+              { backgroundColor: `rgba(0,0,0,${dimOpacity})` },
+            ]}
+          />
+        </Pressable>
+      </MaskedView>
+
+      {/* Spotlight 外タップ (autoAdvanceTappable 時) */}
+      {spotlightClickBehavior === 'forward' && (
+        <Pressable
+          style={StyleSheet.absoluteFill}
+          onPress={handleOutsideTap}
+          accessible={false}
+        />
+      )}
+
+      {/* 吹き出し */}
+      <TourBubble
+        target={targetRect}
+        bubble={bubble}
+        position={bubble.position}
+        primaryAction={primaryAction}
+        progress={progress}
+        offset={bubbleOffset}
+      />
+
+      {/* スキップボタン */}
+      {showSkip && (
+        <Pressable
+          testID="tour-skip-button"
+          onPress={handleSkip}
+          style={styles.skipButton}
+          accessibilityRole="button"
+          accessibilityLabel="チュートリアルを終了する"
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+        >
+          <Text style={styles.skipText}>あとで</Text>
+        </Pressable>
+      )}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    zIndex: 999,
+  },
+  skipButton: {
+    position: 'absolute',
+    top: 50,
+    right: 16,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    minHeight: 44,
+    justifyContent: 'center',
+  },
+  skipText: {
+    color: 'rgba(255,255,255,0.85)',
+    fontSize: 15,
+    fontWeight: '500',
+  },
+});

--- a/apps/mobile/src/handson-tour/TourProgress.tsx
+++ b/apps/mobile/src/handson-tour/TourProgress.tsx
@@ -1,0 +1,61 @@
+// TourProgress — Mobile 版 進捗ドット
+// Canonical: docs/design/family/09-onboarding-handson-tour/07-components.md §4
+
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import type { TourProgressProps } from '@homegohan/handson-tour-shared';
+
+const DEFAULT_ACTIVE_COLOR = '#2563EB';
+const DEFAULT_INACTIVE_COLOR = '#D1D5DB';
+
+export function TourProgress(props: TourProgressProps) {
+  const {
+    current,
+    total,
+    size = 8,
+    spacing = 8,
+    activeColor = DEFAULT_ACTIVE_COLOR,
+    inactiveColor = DEFAULT_INACTIVE_COLOR,
+  } = props;
+
+  return (
+    <View
+      testID="tour-progress-dots"
+      accessibilityRole="progressbar"
+      accessibilityValue={{
+        min: 1,
+        max: total,
+        now: current,
+        text: `ステップ ${current} / ${total}`,
+      }}
+      style={styles.container}
+    >
+      {Array.from({ length: total }).map((_, i) => (
+        <View
+          key={i}
+          accessible={false}
+          importantForAccessibility="no"
+          style={[
+            {
+              width: size,
+              height: size,
+              borderRadius: size / 2,
+              backgroundColor: i + 1 <= current ? activeColor : inactiveColor,
+              marginHorizontal: spacing / 2,
+            },
+          ]}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginVertical: 4,
+  },
+});

--- a/apps/mobile/src/handson-tour/TourSandboxWrapper.tsx
+++ b/apps/mobile/src/handson-tour/TourSandboxWrapper.tsx
@@ -1,0 +1,40 @@
+// TourSandboxWrapper — Mobile 版 HOC
+// Canonical: docs/design/family/09-onboarding-handson-tour/07-components.md §5
+
+import React from 'react';
+import { View } from 'react-native';
+
+import type { TourSandboxWrapperProps } from '@homegohan/handson-tour-shared';
+
+import { TourOverlay } from './TourOverlay';
+
+type TourSandboxWrapperPropsWithChildren<T> = TourSandboxWrapperProps<T> & {
+  children: React.ReactElement;
+};
+
+export function TourSandboxWrapper<T>(props: TourSandboxWrapperPropsWithChildren<T>) {
+  const { childProps, subStep, overlay, subStepToTarget, onSandboxComplete, children } = props;
+
+  const target = subStepToTarget[subStep];
+  const targetTestId = typeof target === 'string' ? target : null;
+  const targetTestIds = Array.isArray(target) ? target : undefined;
+
+  // children に mode='sandbox' + onSandboxComplete を注入
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sandboxChild = React.cloneElement(children as React.ReactElement<any>, {
+    ...(childProps as object),
+    mode: 'sandbox',
+    onSandboxComplete,
+  });
+
+  return (
+    <View style={{ flex: 1 }}>
+      {sandboxChild}
+      <TourOverlay
+        {...overlay}
+        targetTestId={targetTestId}
+        targetTestIds={targetTestIds}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/src/handson-tour/index.ts
+++ b/apps/mobile/src/handson-tour/index.ts
@@ -1,0 +1,10 @@
+// barrel export — Mobile Handson Tour コンポーネント
+// Canonical: docs/design/family/09-onboarding-handson-tour/16-files-structure.md §1.3
+
+export { TourOverlay } from './TourOverlay';
+export { TourBubble } from './TourBubble';
+export { TourProgress } from './TourProgress';
+export { TourSandboxWrapper } from './TourSandboxWrapper';
+export { Confetti } from './Confetti';
+export { useTourOverlayLogic, registerTourTarget, unregisterTourTarget } from './useTourOverlayLogic';
+export { useReducedMotion } from './useReducedMotion';

--- a/apps/mobile/src/handson-tour/useReducedMotion.ts
+++ b/apps/mobile/src/handson-tour/useReducedMotion.ts
@@ -1,0 +1,37 @@
+// Mobile 版 useReducedMotion
+// Canonical: docs/design/family/09-onboarding-handson-tour/07-components.md §10 (web/mobile 差分)
+// docs/design/family/09-onboarding-handson-tour/02-step0-welcome.md §5.6
+
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+/**
+ * AccessibilityInfo.isReduceMotionEnabled() を使って
+ * システムの「動きを減らす」設定を購読する。
+ */
+export function useReducedMotion(forceReducedMotion?: boolean): boolean {
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    if (forceReducedMotion) {
+      setReduceMotion(true);
+      return;
+    }
+
+    // 初期値を取得
+    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion).catch(() => {
+      // エラーの場合は false のまま
+    });
+
+    // 変更を購読
+    const sub = AccessibilityInfo.addEventListener('reduceMotionChanged', (isEnabled) => {
+      setReduceMotion(isEnabled);
+    });
+
+    return () => {
+      sub.remove();
+    };
+  }, [forceReducedMotion]);
+
+  return reduceMotion;
+}

--- a/apps/mobile/src/handson-tour/useTourOverlayLogic.ts
+++ b/apps/mobile/src/handson-tour/useTourOverlayLogic.ts
@@ -1,0 +1,170 @@
+// Mobile 版 useTourOverlayLogic
+// Canonical: docs/design/family/09-onboarding-handson-tour/07-components.md §2.3 §7.3
+// measureInWindow + 100ms ポーリング + onLayout 連動
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { findNodeHandle, UIManager } from 'react-native';
+
+import type { TargetRect, TourOverlayProps } from '@homegohan/handson-tour-shared';
+
+type UseTourOverlayLogicResult = {
+  targetRect: TargetRect | null;
+  isVisible: boolean;
+};
+
+function mergeRects(rects: TargetRect[]): TargetRect {
+  const minX = Math.min(...rects.map((r) => r.x));
+  const minY = Math.min(...rects.map((r) => r.y));
+  const maxX = Math.max(...rects.map((r) => r.x + r.width));
+  const maxY = Math.max(...rects.map((r) => r.y + r.height));
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+/**
+ * testID からネイティブの measureInWindow で矩形を取得する。
+ * 100ms 間隔でポーリングし、targetTestId 変更時に再計算する。
+ */
+export function useTourOverlayLogic(
+  props: Pick<
+    TourOverlayProps,
+    | 'targetTestId'
+    | 'targetTestIds'
+    | 'autoAdvanceMs'
+    | 'onAutoAdvance'
+    | 'scrollRecalcIntervalMs'
+  >
+): UseTourOverlayLogicResult {
+  const { targetTestId, targetTestIds, autoAdvanceMs, onAutoAdvance, scrollRecalcIntervalMs } =
+    props;
+
+  const [targetRect, setTargetRect] = useState<TargetRect | null>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  const autoAdvanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scrollRecalcTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  /**
+   * testID で指定された要素の矩形を measureInWindow で取得する。
+   * 見つからない場合は null を返す。
+   */
+  const measureSingleElement = useCallback((testId: string): TargetRect | null => {
+    // RN での testID 検索: __getDefaultDisplayName__ 等がないため
+    // React Native の findNodeHandle / UIManager.measure を利用する
+    // ただし testID から ref なしに要素を取得するには
+    // @testing-library 的アプローチが必要なため、ここでは
+    // グローバル登録された ref を使うパターンを採用する。
+    const ref = tourTargetRefRegistry.get(testId);
+    if (!ref) return null;
+
+    return new Promise<TargetRect | null>((resolve) => {
+      const handle = findNodeHandle(ref);
+      if (!handle) {
+        resolve(null);
+        return;
+      }
+      UIManager.measure(handle, (_x, _y, width, height, pageX, pageY) => {
+        if (width === 0 && height === 0) {
+          resolve(null);
+          return;
+        }
+        resolve({ x: pageX, y: pageY, width, height });
+      });
+    }) as unknown as TargetRect | null;
+  }, []);
+
+  const measureTarget = useCallback(() => {
+    const ids = targetTestIds ?? (targetTestId ? [targetTestId] : null);
+    if (!ids || ids.length === 0) {
+      setTargetRect(null);
+      return;
+    }
+
+    // 同期的に取得できる場合のフォールバック
+    const results: TargetRect[] = [];
+    let pending = ids.length;
+
+    ids.forEach((id) => {
+      const ref = tourTargetRefRegistry.get(id);
+      if (!ref) {
+        pending--;
+        if (pending === 0 && results.length > 0) {
+          setTargetRect(results.length === 1 ? results[0]! : mergeRects(results));
+        } else if (pending === 0) {
+          setTargetRect(null);
+        }
+        return;
+      }
+
+      const handle = findNodeHandle(ref);
+      if (!handle) {
+        pending--;
+        if (pending === 0 && results.length > 0) {
+          setTargetRect(results.length === 1 ? results[0]! : mergeRects(results));
+        } else if (pending === 0) {
+          setTargetRect(null);
+        }
+        return;
+      }
+
+      UIManager.measure(handle, (_x, _y, width, height, pageX, pageY) => {
+        if (width > 0 || height > 0) {
+          results.push({ x: pageX, y: pageY, width, height });
+        }
+        pending--;
+        if (pending === 0) {
+          if (results.length > 0) {
+            setTargetRect(results.length === 1 ? results[0]! : mergeRects(results));
+          } else {
+            setTargetRect(null);
+          }
+        }
+      });
+    });
+  }, [targetTestId, targetTestIds]);
+
+  useEffect(() => {
+    // Entrance アニメーション開始
+    setIsVisible(true);
+
+    // target 計測
+    measureTarget();
+
+    // Auto-advance タイマー
+    if (autoAdvanceMs !== undefined && onAutoAdvance) {
+      autoAdvanceTimerRef.current = setTimeout(() => {
+        onAutoAdvance();
+      }, autoAdvanceMs);
+    }
+
+    // Scroll 監視 (100ms 間隔)
+    const interval = scrollRecalcIntervalMs ?? 100;
+    scrollRecalcTimerRef.current = setInterval(() => {
+      measureTarget();
+    }, interval);
+
+    return () => {
+      if (autoAdvanceTimerRef.current) clearTimeout(autoAdvanceTimerRef.current);
+      if (scrollRecalcTimerRef.current) clearInterval(scrollRecalcTimerRef.current);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetTestId, targetTestIds?.join(',')]);
+
+  return { targetRect, isVisible };
+}
+
+// ============================================================
+// グローバル ref レジストリ
+// TourTarget コンポーネントがここに ref を登録することで
+// useTourOverlayLogic が testID から要素を取得できるようにする。
+// ============================================================
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tourTargetRefRegistry = new Map<string, any>();
+
+export function registerTourTarget(testId: string, ref: unknown): void {
+  tourTargetRefRegistry.set(testId, ref);
+}
+
+export function unregisterTourTarget(testId: string): void {
+  tourTargetRefRegistry.delete(testId);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,11 @@
       "dependencies": {
         "@expo-google-fonts/noto-sans-jp": "^0.4.3",
         "@homegohan/core": "*",
+        "@homegohan/handson-tour-shared": "*",
         "@homegohan/shared": "*",
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-native-community/slider": "4.5.5",
+        "@react-native-masked-view/masked-view": "^0.3.2",
         "@supabase/supabase-js": "^2.78.0",
         "expo": "~53.0.0",
         "expo-constants": "~17.1.8",
@@ -76,6 +78,7 @@
         "lucide-react-native": "^1.14.0",
         "react": "19.0.0",
         "react-native": "0.79.6",
+        "react-native-reanimated": "^3.17.5",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
         "react-native-svg": "15.11.2",
@@ -1520,6 +1523,21 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
@@ -2849,6 +2867,10 @@
     },
     "node_modules/@homegohan/core": {
       "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@homegohan/handson-tour-shared": {
+      "resolved": "packages/handson-tour-shared",
       "link": true
     },
     "node_modules/@homegohan/shared": {
@@ -4376,6 +4398,16 @@
       "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.5.tgz",
       "integrity": "sha512-x2N415pg4ZxIltArOKczPwn7JEYh+1OxQ4+hTnafomnMsqs65HZuEWcX+Ch8c5r8V83DiunuQUf5hWGWlw8hQQ==",
       "license": "MIT"
+    },
+    "node_modules/@react-native-masked-view/masked-view": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.3.2.tgz",
+      "integrity": "sha512-XwuQoW7/GEgWRMovOQtX3A4PrXhyaZm0lVUiY8qJDvdngjLms9Cpdck6SmGAUNqQwcj2EadHC1HwL0bEyoa/SQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16",
+        "react-native": ">=0.57"
+      }
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.79.6",
@@ -18119,6 +18151,41 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-reanimated": {
+      "version": "3.19.5",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.19.5.tgz",
+      "integrity": "sha512-bd4AwIkBAaY4BjrgpSoKjEaRG/tXD756F5nGuiH5IMBSKN8tRdUEA8hWZCyIo/R6/kha/tVSoCqodVUACh7ZWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "invariant": "^2.2.4",
+        "react-native-is-edge-to-edge": "1.1.7"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/react-native-is-edge-to-edge": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
+      "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-safe-area-context": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz",
@@ -21631,6 +21698,13 @@
     "packages/core": {
       "name": "@homegohan/core",
       "version": "0.2.0",
+      "peerDependencies": {
+        "zod": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "packages/handson-tour-shared": {
+      "name": "@homegohan/handson-tour-shared",
+      "version": "0.1.0",
       "peerDependencies": {
         "zod": "^3.0.0 || ^4.0.0"
       }


### PR DESCRIPTION
## Summary

- `apps/mobile/app/handson-tour/` 配下に Expo Router ページ 6 本新規作成 (_layout / Step0-4)
- `apps/mobile/src/handson-tour/` 配下に TourOverlay / TourBubble / TourProgress / TourSandboxWrapper / Confetti / useTourOverlayLogic / useReducedMotion / index.ts 新規作成
- `apps/mobile/src/contexts/TourContext.tsx` 新規作成
- `@homegohan/handson-tour-shared` から types / mocks / i18n / personalize / constants / analytics / url-routes / steps を import
- npm 依存追加: `@homegohan/handson-tour-shared`(workspace), `@react-native-masked-view/masked-view`, `react-native-reanimated`

## 実装詳細

### TourOverlay (Mobile)
- `@react-native-masked-view/masked-view` で穴抜き Spotlight
- `react-native-reanimated` v3 で fade アニメーション (200ms)
- `accessibilityRole="alert"` / `accessibilityLiveRegion="polite"` 対応
- Android `BackHandler` でハードバック時に skip API 発火

### Confetti (Step 4)
- `react-confetti` は React DOM 専用のため Reanimated v3 で 300 パーティクル自前実装
- `prefers-reduced-motion` 時は静的 🎓 アイコン表示

### TourBubble
- 吹き出し自動配置 (top/bottom/left/right/auto)
- 画面端クリップ防止 (clamp)

### 各 Step ページ
- Step 0: 認証確認 + status API + TourProvider 初期化
- Step 1-2: TourSandboxWrapper で既存コンポーネントをサンドボックスマウント (P3-B が sandbox props 対応予定)
- Step 3: BadgesPage を tutorial-mode でラップ (P3-B 改修予定)
- Step 4: POST /api/handson-tour/complete + Confetti + ホームへ遷移

## 制約遵守

- P3-B 担当ファイル (`V4GenerateModal.tsx`, `badges/index.tsx`, `meals/new.tsx`, `settings.tsx`) には一切触れていない
- P1-B-API 担当の `src/app/api/**` には一切触れていない

## Test plan

- [ ] `npm install` エラーなし
- [ ] `npx tsc --noEmit` で本タスク起因の型エラーなし (既存エラーは mainブランチ由来)
- [ ] `apps/mobile/app/handson-tour/` 配下 6 ファイル作成確認
- [ ] `apps/mobile/src/handson-tour/` 配下 8 ファイル作成確認
- [ ] `apps/mobile/src/contexts/TourContext.tsx` 作成確認
- [ ] `@react-native-masked-view/masked-view` が package.json に追加されている
- [ ] `react-native-reanimated` が package.json に追加されている
- [ ] EAS Build 前にローカル確認必須

🤖 Generated with [Claude Code](https://claude.com/claude-code)