### PR TITLE
fix(family/09): route.ts の schema export 削除でビルドエラー解消

### DIFF
--- a/src/app/api/handson-tour/complete/route.ts
+++ b/src/app/api/handson-tour/complete/route.ts
@@ -1,20 +1,5 @@
-import { z } from 'zod';
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-
-export const HandsonTourCompleteResponseSchema = z.object({
-  completed_at: z.string().datetime(),
-  badge_awarded: z.object({
-    code: z.literal('tutorial_complete'),
-    name: z.string(),
-    obtained_at: z.string().datetime(),
-    icon_url: z.string().nullable(),
-  }),
-  already_completed: z.boolean(),
-  total_duration_ms: z.number().int().optional(),
-});
-
-export type HandsonTourCompleteResponse = z.infer<typeof HandsonTourCompleteResponseSchema>;
 
 const ADMIN_ROLES = ['admin', 'super_admin', 'org_admin', 'org_industrial_doctor'] as const;
 

--- a/src/app/api/handson-tour/skip/route.ts
+++ b/src/app/api/handson-tour/skip/route.ts
@@ -1,18 +1,9 @@
-import { z } from 'zod';
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-
-export const HandsonTourSkipRequestSchema = z.object({
-  step: z.number().int().min(0).max(4),
-  reason: z.enum(['user_action', 'hard_back']),
-});
-
-export const HandsonTourSkipResponseSchema = z.object({
-  skipped_at: z.string().datetime(),
-});
-
-export type HandsonTourSkipRequest = z.infer<typeof HandsonTourSkipRequestSchema>;
-export type HandsonTourSkipResponse = z.infer<typeof HandsonTourSkipResponseSchema>;
+import {
+  HandsonTourSkipRequestSchema,
+  type HandsonTourSkipRequest,
+} from '@/lib/handson-tour/schemas';
 
 export async function POST(request: Request) {
   try {

--- a/src/lib/handson-tour/schemas.ts
+++ b/src/lib/handson-tour/schemas.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+export const HandsonTourStatusResponseSchema = z.object({
+  should_show: z.boolean(),
+  completed_at: z.string().datetime().nullable(),
+  skipped_at: z.string().datetime().nullable(),
+  reason: z.enum([
+    'eligible',
+    'onboarding_not_completed',
+    'already_completed',
+    'already_skipped',
+    'admin_role',
+    'existing_user_auto_skip',
+    'feature_disabled',
+    'not_in_rollout',
+  ]),
+});
+export type HandsonTourStatusResponse = z.infer<typeof HandsonTourStatusResponseSchema>;
+
+export const HandsonTourCompleteResponseSchema = z.object({
+  completed_at: z.string().datetime(),
+  badge_awarded: z.object({
+    code: z.literal('tutorial_complete'),
+    name: z.string(),
+    obtained_at: z.string().datetime(),
+    icon_url: z.string().nullable(),
+  }),
+  already_completed: z.boolean(),
+  total_duration_ms: z.number().int().optional(),
+});
+export type HandsonTourCompleteResponse = z.infer<typeof HandsonTourCompleteResponseSchema>;
+
+export const HandsonTourSkipRequestSchema = z.object({
+  step: z.number().int().min(0).max(4),
+  reason: z.enum(['user_action', 'hard_back']),
+});
+export type HandsonTourSkipRequest = z.infer<typeof HandsonTourSkipRequestSchema>;
+
+export const HandsonTourSkipResponseSchema = z.object({
+  skipped_at: z.string().datetime(),
+});
+export type HandsonTourSkipResponse = z.infer<typeof HandsonTourSkipResponseSchema>;


### PR DESCRIPTION
## Summary

Vercel デプロイで PR #805(P1-B-API)由来のビルドエラーが発生していたのを hot fix。

```
src/app/api/handson-tour/complete/route.ts
Type error: Route "src/app/api/handson-tour/complete/route.ts" does not match the required types of a Next.js Route.
  "HandsonTourCompleteResponseSchema" is not a valid Route export field.
```

Next.js 14 App Router の route.ts は HTTP method handler(GET/POST 等)と予約済み config 以外の export を許可しない。設計書 family/02 §15 では schema を route.ts inline 定義としていたが、Next.js 制約上 lib 切り出しが正解。

## 変更

- 新規 `src/lib/handson-tour/schemas.ts`: Status / Complete / Skip の Request / Response Zod schema と TypeScript 型を集約 export
- `src/app/api/handson-tour/skip/route.ts`: schema/type 定義を削除、schemas.ts から import
- `src/app/api/handson-tour/complete/route.ts`: 同上(中で schema を直接 import していなかったので import なし、ただし他から import するルートを確保)

## 検証

- `npx tsc --noEmit` で本 PR 関連エラー 0
- 既存 import 元(あるなら)は schemas.ts 経由に switch するパス変更のみ

## Follow-up

- 設計書 family/02 §15.2.3 / §15.3.3 / §15.4.2 / §15.4.3 と family/09 §09 の「schema は route.ts に inline」記述を「schemas.ts に集約 → route.ts は import」に修正(別 PR で)

## Test plan

- [x] tsc --noEmit がエラーなし
- [ ] Vercel ビルドが通る(マージ後確認)