### PR TITLE
feat(family/09): /api/menu-plans/add に planner バッジ付与を追加

### DIFF
--- a/src/app/api/menu-plans/add/route.ts
+++ b/src/app/api/menu-plans/add/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { awardBadge } from '@/lib/badges/awardBadge';
 
 const ADMIN_ROLES = ['admin', 'super_admin', 'org_admin', 'org_industrial_doctor'] as const;
 
@@ -86,7 +87,24 @@ export async function POST(request: Request) {
       );
     }
 
-    return NextResponse.json({ success: true, menuId: newMenu.id });
+    // バッジ付与(副次処理: 失敗しても主処理は成功)
+    let badgeAwarded: { code: string; name: string | null; obtained_at: string | null; icon_url: string | null } | null = null;
+    try {
+      const badgeResult = await awardBadge(supabase, user.id, 'planner');
+      if (badgeResult.awarded) {
+        console.info('planner badge awarded', { userId: user.id });
+        badgeAwarded = {
+          code: 'planner',
+          name: badgeResult.name,
+          obtained_at: badgeResult.obtained_at,
+          icon_url: badgeResult.icon_url,
+        };
+      }
+    } catch (badgeErr) {
+      console.error('planner badge award failed (non-fatal):', badgeErr);
+    }
+
+    return NextResponse.json({ success: true, menuId: newMenu.id, badge_awarded: badgeAwarded });
   } catch (err: unknown) {
     console.error('menu-plans/add error:', err);
     return NextResponse.json(

--- a/src/lib/badges/awardBadge.ts
+++ b/src/lib/badges/awardBadge.ts
@@ -1,0 +1,83 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface AwardBadgeResult {
+  awarded: boolean;
+  badge_id: string | null;
+  obtained_at: string | null;
+  name: string | null;
+  icon_url: string | null;
+}
+
+/**
+ * 指定バッジをユーザーに付与する汎用ヘルパー。
+ *
+ * - badges テーブルから code でバッジを検索する
+ * - user_badges に INSERT (ON CONFLICT DO NOTHING 相当の動作)
+ * - 失敗しても呼び出し元の主処理は影響を受けない想定
+ *   (呼び出し元が try-catch で囲んで console.error のみにすること)
+ */
+export async function awardBadge(
+  supabase: SupabaseClient,
+  userId: string,
+  badgeCode: string,
+): Promise<AwardBadgeResult> {
+  // 1. バッジマスター取得
+  const { data: badge, error: badgeError } = await supabase
+    .from('badges')
+    .select('id, name, icon_url')
+    .eq('code', badgeCode)
+    .single();
+
+  if (badgeError || !badge) {
+    return { awarded: false, badge_id: null, obtained_at: null, name: null, icon_url: null };
+  }
+
+  // 2. 既に獲得済みか確認
+  const { data: existing } = await supabase
+    .from('user_badges')
+    .select('obtained_at')
+    .eq('user_id', userId)
+    .eq('badge_id', badge.id)
+    .single();
+
+  if (existing) {
+    // 既獲得 — 重複付与しない
+    return {
+      awarded: false,
+      badge_id: badge.id,
+      obtained_at: existing.obtained_at,
+      name: badge.name,
+      icon_url: badge.icon_url ?? null,
+    };
+  }
+
+  // 3. INSERT (PK 制約で冪等)
+  const now = new Date().toISOString();
+  const { error: insertError } = await supabase.from('user_badges').insert({
+    user_id: userId,
+    badge_id: badge.id,
+    obtained_at: now,
+  });
+
+  if (insertError) {
+    // ON CONFLICT 相当: PK 重複(code 23505)は付与済みとみなす
+    if (insertError.code === '23505') {
+      return {
+        awarded: false,
+        badge_id: badge.id,
+        obtained_at: null,
+        name: badge.name,
+        icon_url: badge.icon_url ?? null,
+      };
+    }
+    throw insertError;
+  }
+
+  return {
+    awarded: true,
+    badge_id: badge.id,
+    obtained_at: now,
+    name: badge.name,
+    icon_url: badge.icon_url ?? null,
+  };
+}


### PR DESCRIPTION
## 概要

P1-B-API (#805) で作成された `/api/menu-plans/add` に、`planner` バッジ付与ロジックを追加する。

## 変更内容

- **新規**: `src/lib/badges/awardBadge.ts` — 汎用バッジ付与 helper
  - `badges` テーブルから `code` で検索 → `user_badges` に INSERT (PK 制約で冪等)
  - 戻り値: `{ awarded: boolean; badge_id; obtained_at; name; icon_url }`
  - `first_bite` / `planner` / 将来バッジでも流用可能
- **改修**: `src/app/api/menu-plans/add/route.ts`
  - `weekly_menus` INSERT 後に `awardBadge(supabase, user.id, 'planner')` を呼び出し
  - バッジ付与失敗は `console.error` のみ、主処理の成否に影響しない
  - レスポンスに `badge_awarded` フィールドを追加 (`null` or `{ code, name, obtained_at, icon_url }`)
  - sandbox 行でもバッジ付与する (設計書 §3 準拠)

## バッジ seed 状況

- `docs/seed_badges.sql` に `first_bite` / `planner` が定義済み
- `supabase/migrations/` には seed SQL が含まれていない
- DB に投入されているかは実環境依存。未投入の場合は `badges` テーブルへの SELECT が `null` を返し、`awardBadge` が `{ awarded: false }` を返すだけで副作用なし

## DOD チェックリスト

- [x] menu-plans/add で planner バッジ INSERT
- [x] 共通 helper (`awardBadge`) を新規作成
- [x] レスポンスに `badge_awarded` フィールド追加
- [x] `npx tsc --noEmit` 型エラーなし
- [x] `npx next build` 通過
- [x] 既存 `/api/meal-plans/add-from-photo` の挙動を壊さない (未改修)

## フォローアップ推奨

- `first_bite` / `planner` バッジが本番 DB に未投入の場合は `docs/seed_badges.sql` を migration に昇格する Issue が必要