### PR TITLE
feat(family/09): Phase 4-A — PostHog SDK 注入(Web + Mobile)+ Cookie 同意連携

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -13,6 +13,7 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 
 import { registerAndSaveExpoPushToken } from "../src/lib/pushNotifications";
 import { AuthProvider, useAuth } from "../src/providers/AuthProvider";
+import { PostHogProvider } from "../src/providers/PostHogProvider";
 import { ProfileProvider } from "../src/providers/ProfileProvider";
 
 // E2E テスト中に LogBox の自動ポップアップがタップを横取りして失敗するため抑制する
@@ -63,22 +64,24 @@ export default function RootLayout() {
 
   return (
     <SafeAreaProvider>
-      <AuthProvider>
-        <ProfileProvider>
-          <PushTokenRegistrar />
-          <Stack screenOptions={{ headerShown: false }}>
-            <Stack.Screen name="index" />
-            <Stack.Screen name="(public)" />
-            <Stack.Screen name="(auth)" />
-            <Stack.Screen name="(tabs)" />
-            <Stack.Screen name="(org)" />
-            <Stack.Screen name="(admin)" />
-            <Stack.Screen name="(support)" />
-            <Stack.Screen name="(super-admin)" />
-            <Stack.Screen name="meals/new" options={{ presentation: "modal" }} />
-          </Stack>
-        </ProfileProvider>
-      </AuthProvider>
+      <PostHogProvider>
+        <AuthProvider>
+          <ProfileProvider>
+            <PushTokenRegistrar />
+            <Stack screenOptions={{ headerShown: false }}>
+              <Stack.Screen name="index" />
+              <Stack.Screen name="(public)" />
+              <Stack.Screen name="(auth)" />
+              <Stack.Screen name="(tabs)" />
+              <Stack.Screen name="(org)" />
+              <Stack.Screen name="(admin)" />
+              <Stack.Screen name="(support)" />
+              <Stack.Screen name="(super-admin)" />
+              <Stack.Screen name="meals/new" options={{ presentation: "modal" }} />
+            </Stack>
+          </ProfileProvider>
+        </AuthProvider>
+      </PostHogProvider>
     </SafeAreaProvider>
   );
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -45,6 +45,7 @@
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
     "react-native-url-polyfill": "^2.0.0",
+    "posthog-react-native": "^3.3.10",
     "react-native-web": "^0.20.0",
     "react-native-webview": "13.13.5",
     "zod": "^4.1.13"

--- a/apps/mobile/src/lib/posthog.ts
+++ b/apps/mobile/src/lib/posthog.ts
@@ -1,0 +1,109 @@
+// PostHog Mobile (React Native) SDK 初期化
+// Canonical: docs/design/operator/07-audit-monitoring.md §15.1, §15.7, §15.9
+
+import PostHog from 'posthog-react-native';
+
+// PostHogEventProperties は posthog-core からのもの
+// named export が公開されていないため互換型をローカル定義
+export type PostHogEventProperties = Record<string, string | number | boolean | null | undefined>;
+
+// PII フィルタキー (operator/07 §15.7)
+const FORBIDDEN_KEYS = [
+  'nickname', 'email', 'phone', 'address',
+  'weight_kg', 'height_cm', 'age', 'gender',
+  'allergies', 'dietary_preferences', 'nutrition_goal',
+  'password', 'jwt', 'token',
+] as const;
+
+/**
+ * PII キーをプロパティから除去する (operator/07 §15.7)
+ */
+function sanitizeProps(props: PostHogEventProperties): PostHogEventProperties {
+  const filtered: PostHogEventProperties = { ...props };
+  for (const key of FORBIDDEN_KEYS) {
+    if ((key as string) in filtered) {
+      delete filtered[key as string];
+    }
+  }
+  return filtered;
+}
+
+let _posthog: PostHog | null = null;
+
+/**
+ * PostHog Mobile SDK インスタンスを返す。
+ * 未初期化の場合は null を返す (graceful degradation)。
+ */
+export function getPostHogClient(): PostHog | null {
+  return _posthog;
+}
+
+/**
+ * PostHog Mobile SDK を非同期初期化する。
+ * - EXPO_PUBLIC_POSTHOG_KEY が未設定の場合はスキップ
+ * - production 環境のみ init (graceful degradation)
+ */
+export async function initPostHogMobile(): Promise<PostHog | null> {
+  const key = process.env['EXPO_PUBLIC_POSTHOG_KEY'];
+  const host = process.env['EXPO_PUBLIC_POSTHOG_HOST'] ?? 'https://us.i.posthog.com';
+
+  // 環境変数未設定はスキップ (graceful degradation)
+  if (!key) {
+    return null;
+  }
+
+  if (_posthog) {
+    return _posthog;
+  }
+
+  try {
+    const client = new PostHog(key, { host });
+    // ready() で非同期初期化の完了を待つ
+    await client.ready();
+    _posthog = client;
+    return _posthog;
+  } catch {
+    // init 失敗時はアプリをクラッシュさせない
+    return null;
+  }
+}
+
+/**
+ * PII フィルタを適用した上でイベントを capture する
+ */
+export function captureEvent(
+  eventName: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  props: Record<string, any>,
+): void {
+  if (!_posthog) return;
+  try {
+    // sanitizeProps の戻り値を SDK が期待する型にキャスト
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _posthog.capture(eventName, sanitizeProps(props as PostHogEventProperties) as any);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * PostHog Mobile のキャプチャを停止する
+ */
+export async function optOutPostHogMobile(): Promise<void> {
+  try {
+    await _posthog?.optOut();
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * PostHog Mobile のキャプチャを再開する
+ */
+export async function optInPostHogMobile(): Promise<void> {
+  try {
+    await _posthog?.optIn();
+  } catch {
+    // ignore
+  }
+}

--- a/apps/mobile/src/providers/PostHogProvider.tsx
+++ b/apps/mobile/src/providers/PostHogProvider.tsx
@@ -1,0 +1,78 @@
+// PostHog Mobile Provider
+// Canonical: docs/design/operator/07-audit-monitoring.md §15.1, §15.5, §15.9
+
+import React, { useEffect } from "react";
+import { setAnalyticsAdapter } from "@homegohan/handson-tour-shared";
+import { supabase } from "../lib/supabase";
+import {
+  initPostHogMobile,
+  getPostHogClient,
+  captureEvent,
+} from "../lib/posthog";
+
+/**
+ * PostHog Mobile Provider
+ * - apps/mobile/app/_layout.tsx の AuthProvider と並列で配置する
+ * - PostHog を非同期初期化し、AnalyticsAdapter を共通 package に注入する
+ * - 認証ユーザー取得後に identify を呼ぶ (PII は含めない, operator/07 §15.5)
+ */
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    let isMounted = true;
+
+    (async () => {
+      // PostHog 初期化 (EXPO_PUBLIC_POSTHOG_KEY 未設定時はスキップ)
+      const client = await initPostHogMobile();
+      if (!isMounted || !client) return;
+
+      // AnalyticsAdapter を共通 package に注入
+      setAnalyticsAdapter({
+        capture: (eventName, payload) => {
+          // captureEvent 内で PII フィルタ + graceful degradation
+          captureEvent(eventName, payload as Record<string, string | number | boolean | null>);
+        },
+      });
+
+      // 認証ユーザーの identify (PII 不可, operator/07 §15.5)
+      const { data: authData } = await supabase.auth.getUser();
+      if (!isMounted || !authData.user) return;
+
+      const userId = authData.user.id;
+
+      // profile から非 PII 属性を取得
+      const { data: profile } = await supabase
+        .from('user_profiles')
+        .select('created_at, plan_key_cached')
+        .eq('id', userId)
+        .single();
+
+      try {
+        client.identify(userId, {
+          signup_at: profile?.created_at ?? null,
+          platform: 'ios',
+          plan_key_cached: profile?.plan_key_cached ?? null,
+        });
+      } catch {
+        // ignore
+      }
+    })();
+
+    // 認証状態変化を監視: サインアウト時に reset
+    const { data: sub } = supabase.auth.onAuthStateChange((event) => {
+      if (event === 'SIGNED_OUT') {
+        try {
+          getPostHogClient()?.reset();
+        } catch {
+          // ignore
+        }
+      }
+    });
+
+    return () => {
+      isMounted = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  return <>{children}</>;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "lucide-react": "^0.554.0",
         "next": "14.2.35",
         "openai": "^6.9.1",
+        "posthog-js": "^1.257.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -76,6 +77,7 @@
         "expo-updates": "~0.28.18",
         "expo-web-browser": "~15.0.0",
         "lucide-react-native": "^1.14.0",
+        "posthog-react-native": "^3.3.10",
         "react": "19.0.0",
         "react-native": "0.79.6",
         "react-native-reanimated": "^3.17.5",
@@ -97,6 +99,60 @@
         "react-test-renderer": "^19.0.0",
         "resolve-from": "^5.0.0",
         "typescript": "~5.8.3"
+      }
+    },
+    "apps/mobile/node_modules/posthog-react-native": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/posthog-react-native/-/posthog-react-native-3.16.1.tgz",
+      "integrity": "sha512-qrsQC552nY9emZbv2HmnPfckS1waFf5kG1LLGF1noUhgXWzNfLfwK20FIypjRR50O+j/vCFIzQBmoy4Sv/U2RA==",
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": ">=1.0.0",
+        "@react-navigation/native": ">= 5.0.0",
+        "expo-application": ">= 4.0.0",
+        "expo-device": ">= 4.0.0",
+        "expo-file-system": ">= 13.0.0",
+        "expo-localization": ">= 11.0.0",
+        "posthog-react-native-session-replay": ">= 1.0.0",
+        "react-native-device-info": ">= 10.0.0",
+        "react-native-localize": ">= 3.0.0",
+        "react-native-navigation": ">= 6.0.0",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-svg": ">= 15.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        },
+        "@react-navigation/native": {
+          "optional": true
+        },
+        "expo-application": {
+          "optional": true
+        },
+        "expo-device": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "posthog-react-native-session-replay": {
+          "optional": true
+        },
+        "react-native-device-info": {
+          "optional": true
+        },
+        "react-native-localize": {
+          "optional": true
+        },
+        "react-native-navigation": {
+          "optional": true
+        },
+        "react-native-safe-area-context": {
+          "optional": true
+        }
       }
     },
     "apps/mobile/node_modules/react": {
@@ -4248,6 +4304,252 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.127.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
@@ -4283,6 +4585,21 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.28.4",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.28.4.tgz",
+      "integrity": "sha512-wmtUYHYqA3zIAKDKvYWRNWAQsWOIBwxV08e+bWzVy0wQQzpaS/LzzRupXWRMRrLOk+1x3JKFxbqA3n0QGvpqsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.372.10"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.372.10",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.10.tgz",
+      "integrity": "sha512-KuT3vLu3LSFsNWCwasS4gqjH/ysAyIUcB/aJSmKyNhDd/85hAznHRz1eSSl0sMvtsDTYiQIq0I0ybduVbrpPew==",
+      "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -6025,6 +6342,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -8317,6 +8641,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
@@ -9124,6 +9459,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -10846,6 +11190,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -17673,6 +18023,37 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/posthog-js": {
+      "version": "1.372.10",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.10.tgz",
+      "integrity": "sha512-ZQslIenDM8UpwKhmeeEnJ+t2nXr8mOIjCG+Ej3DCJnTBk9NX9Sr5RMuwHeGG8UJitwvtGOADyiY7DignOXaZwg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.28.4",
+        "@posthog/types": "1.372.10",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -17866,6 +18247,12 @@
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/query-string": {
       "version": "7.1.3",
@@ -21206,6 +21593,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lucide-react": "^0.554.0",
     "next": "14.2.35",
     "openai": "^6.9.1",
+    "posthog-js": "^1.257.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Noto_Sans_JP, Noto_Serif_JP } from "next/font/google";
+import { PostHogProvider } from "@/components/PostHogProvider";
 import "./globals.css";
 
 const notoSans = Noto_Sans_JP({ 
@@ -130,7 +131,9 @@ export default function RootLayout({
         />
       </head>
       <body className="font-sans antialiased">
-        {children}
+        <PostHogProvider>
+          {children}
+        </PostHogProvider>
       </body>
     </html>
   );

--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+// PostHog Web Provider
+// Canonical: docs/design/operator/07-audit-monitoring.md §15.1, §15.5, §15.9
+// Cookie 同意連携: docs/design/cross/08-legal-compliance.md §13
+
+import { useEffect } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { posthog, initPostHog, getAnalyticsConsent, ANALYTICS_CONSENT_KEY } from "@/lib/posthog";
+import { setAnalyticsAdapter } from "@homegohan/handson-tour-shared";
+
+/**
+ * PostHog Web Provider
+ * - root layout (src/app/layout.tsx) の body 内でラップする
+ * - Cookie 同意確認済みの場合のみ PostHog init を呼ぶ
+ * - 認証ユーザー取得後に identify を呼ぶ (PII は含めない)
+ * - setAnalyticsAdapter で共通 package に PostHog を接続する
+ */
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    // Cookie 同意確認 (localStorage 代替)
+    const hasConsent = getAnalyticsConsent();
+    if (!hasConsent) {
+      return;
+    }
+
+    // PostHog init (production + 同意あり)
+    initPostHog();
+
+    // AnalyticsAdapter を共通 package に注入
+    setAnalyticsAdapter({
+      capture: (eventName, payload) => {
+        try {
+          posthog.capture(eventName, payload as Record<string, unknown>);
+        } catch {
+          // ignore — analytics failure should not break app
+        }
+      },
+    });
+
+    // 認証ユーザーの identify (PII 不可、operator/07 §15.5)
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data }) => {
+      if (!data.user) return;
+
+      const userId = data.user.id;
+
+      // profile から非 PII 属性を取得
+      supabase
+        .from('user_profiles')
+        .select('created_at, plan_key_cached')
+        .eq('id', userId)
+        .single()
+        .then(({ data: profile }) => {
+          try {
+            posthog.identify(userId, {
+              signup_at: profile?.created_at ?? null,
+              platform: 'web',
+              plan_key_cached: profile?.plan_key_cached ?? null,
+            });
+          } catch {
+            // ignore
+          }
+        });
+    });
+
+    // Cookie 同意変更を監視 (storage event)
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === ANALYTICS_CONSENT_KEY) {
+        if (e.newValue === 'false' || e.newValue === null) {
+          try {
+            posthog.opt_out_capturing();
+          } catch {
+            // ignore
+          }
+        } else if (e.newValue === 'true') {
+          try {
+            posthog.opt_in_capturing();
+          } catch {
+            // ignore
+          }
+        }
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+    };
+  }, []);
+
+  return <>{children}</>;
+}

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -1,0 +1,106 @@
+// PostHog Web SDK 初期化
+// Canonical: docs/design/operator/07-audit-monitoring.md §15.1, §15.7, §15.9
+// Cookie 同意連携: docs/design/cross/08-legal-compliance.md §13
+
+import posthog from 'posthog-js';
+
+export { posthog };
+
+// PII フィルタキー (operator/07 §15.7)
+const FORBIDDEN_KEYS = [
+  'nickname', 'email', 'phone', 'address',
+  'weight_kg', 'height_cm', 'age', 'gender',
+  'allergies', 'dietary_preferences', 'nutrition_goal',
+  'password', 'jwt', 'token',
+] as const;
+
+/**
+ * localStorage キー: Cookie 同意 (計測) の opt-in 状態
+ * 本来は cookie_consents テーブルから取得するが、
+ * v1 では localStorage で代替 (cross/08 §13)
+ */
+export const ANALYTICS_CONSENT_KEY = 'cookie_consent_analytics';
+
+/**
+ * 計測 Cookie への同意状態を確認する
+ */
+export function getAnalyticsConsent(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return localStorage.getItem(ANALYTICS_CONSENT_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * PostHog を初期化する。
+ * - NODE_ENV が production かつ NEXT_PUBLIC_POSTHOG_KEY が設定済みの場合のみ init
+ * - Cookie 同意なしの場合は init を呼ばない (cross/08 §13)
+ */
+export function initPostHog(): void {
+  const key = process.env['NEXT_PUBLIC_POSTHOG_KEY'];
+  const host = process.env['NEXT_PUBLIC_POSTHOG_HOST'] ?? 'https://us.i.posthog.com';
+
+  // 環境変数未設定 or 開発環境はスキップ (graceful degradation)
+  if (!key || process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
+  if (posthog.__loaded) {
+    return;
+  }
+
+  posthog.init(key, {
+    api_host: host,
+    person_profiles: 'identified_only',
+    autocapture: false,
+    capture_pageview: false,
+    persistence: 'localStorage',
+    sanitize_properties: (props) => {
+      for (const forbiddenKey of FORBIDDEN_KEYS) {
+        if (forbiddenKey in props) {
+          delete props[forbiddenKey as string];
+        }
+      }
+      return props;
+    },
+  });
+}
+
+/**
+ * 同意取消し時に呼ぶ: PostHog のキャプチャを停止する
+ */
+export function optOutPostHog(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (posthog.__loaded) {
+      posthog.opt_out_capturing();
+    }
+  } catch {
+    // ignore
+  }
+  try {
+    localStorage.setItem(ANALYTICS_CONSENT_KEY, 'false');
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * 同意時に呼ぶ: PostHog のキャプチャを再開する
+ */
+export function optInPostHog(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(ANALYTICS_CONSENT_KEY, 'true');
+  } catch {
+    // ignore
+  }
+  // init 済みの場合は opt_in_capturing
+  if (posthog.__loaded) {
+    posthog.opt_in_capturing();
+  } else {
+    initPostHog();
+  }
+}


### PR DESCRIPTION
## Summary

- **Web**: `src/lib/posthog.ts` + `src/components/PostHogProvider.tsx` 新規作成。`posthog-js` 初期化・PII フィルタ・Cookie 同意連携（localStorage `cookie_consent_analytics` で代替）・`setAnalyticsAdapter` 注入・認証ユーザー identify を実装
- **Mobile**: `apps/mobile/src/lib/posthog.ts` + `apps/mobile/src/providers/PostHogProvider.tsx` 新規作成。`posthog-react-native` の `new PostHog() + ready()` による非同期初期化・PII フィルタ・`setAnalyticsAdapter` 注入・identify を実装
- **root layout**: Web `src/app/layout.tsx`・Mobile `apps/mobile/app/_layout.tsx` に各 PostHogProvider を追加
- **deps**: `posthog-js ^1.257.0`（Web）・`posthog-react-native ^3.3.10`（Mobile）追加

## PostHog init を呼ぶ条件

| 条件 | Web | Mobile |
|---|---|---|
| `NEXT_PUBLIC_POSTHOG_KEY` (Web) / `EXPO_PUBLIC_POSTHOG_KEY` (Mobile) が設定済み | 必須 | 必須 |
| `NODE_ENV === 'production'` | 必須 | 不問（key なければスキップ） |
| Cookie 同意 (`localStorage.cookie_consent_analytics === 'true'`) | 必須 | 不問（Mobile は Cookie 同意不要） |

いずれかが欠けた場合は init をスキップ（graceful degradation）。

## DOD チェックリスト

- [x] Web `src/lib/posthog.ts` + `src/components/PostHogProvider.tsx` 新規
- [x] Mobile `apps/mobile/src/lib/posthog.ts` + `PostHogProvider.tsx` 新規
- [x] root layout に Provider 追加（Web + Mobile）
- [x] `setAnalyticsAdapter` で共通 package に PostHog 接続
- [x] PII フィルタ実装（FORBIDDEN_KEYS 14 種）
- [x] Cookie 同意連携（localStorage 代替、opt-out 経路あり）
- [x] `npx tsc --noEmit` 型エラーなし（posthog 関連）
- [x] `npx next build` — posthog 関連エラーなし（既存の handson-tour route.ts エラーは本 PR 対象外）
- [x] `package.json` に posthog-js / posthog-react-native 追加