### PR TITLE
feat(family/09): Mobile 接続 — Tour プレースホルダー → 実 sandbox + registerTourTarget ref 登録

### DIFF
--- a/apps/mobile/app/badges/index.tsx
+++ b/apps/mobile/app/badges/index.tsx
@@ -6,6 +6,7 @@ import { Animated, ScrollView, Text, View } from "react-native";
 import { Card, EmptyState, LoadingState, PageHeader } from "../../src/components/ui";
 import { getApi } from "../../src/lib/api";
 import { colors, spacing } from "../../src/theme";
+import { registerTourTarget, unregisterTourTarget } from "../../src/handson-tour/useTourOverlayLogic";
 
 type Badge = {
   id: string;
@@ -17,9 +18,10 @@ type Badge = {
 };
 
 // Highlight border + background animation for tutorial mode (§1.2 Q10)
-function HighlightedBadgeCard({ badge, isHighlighted }: { badge: Badge; isHighlighted: boolean }) {
+function HighlightedBadgeCard({ badge, isHighlighted, inTutorialMode }: { badge: Badge; isHighlighted: boolean; inTutorialMode: boolean }) {
   const borderAnim = useRef(new Animated.Value(0)).current;
   const bgAnim = useRef(new Animated.Value(0)).current;
+  const viewRef = useRef<View>(null);
 
   useEffect(() => {
     if (!isHighlighted) return;
@@ -33,6 +35,18 @@ function HighlightedBadgeCard({ badge, isHighlighted }: { badge: Badge; isHighli
     Animated.timing(bgAnim, { toValue: 1, duration: 400, useNativeDriver: false }).start();
   }, [isHighlighted, borderAnim, bgAnim]);
 
+  // Tour Spotlight target ref 登録 (tutorial-mode=1 のときのみ)
+  useEffect(() => {
+    if (!inTutorialMode) return;
+    const testId = `badge-card-${badge.code}`;
+    if (viewRef.current) {
+      registerTourTarget(testId, viewRef.current);
+    }
+    return () => {
+      unregisterTourTarget(testId);
+    };
+  }, [inTutorialMode, badge.code]);
+
   const borderWidth = isHighlighted
     ? borderAnim.interpolate({ inputRange: [0, 1], outputRange: [2, 4] })
     : 1;
@@ -43,6 +57,7 @@ function HighlightedBadgeCard({ badge, isHighlighted }: { badge: Badge; isHighli
 
   return (
     <Animated.View
+      ref={viewRef as any}
       testID={`badge-card-${badge.code}`}
       style={{
         borderWidth,
@@ -163,6 +178,7 @@ export default function BadgesPage() {
               key={b.id}
               badge={b}
               isHighlighted={tutorialMode && highlightCode === b.code}
+              inTutorialMode={tutorialMode}
             />
           ))}
         </View>

--- a/apps/mobile/app/handson-tour/menu.tsx
+++ b/apps/mobile/app/handson-tour/menu.tsx
@@ -1,9 +1,12 @@
 // handson-tour/menu.tsx — Step 2 AI による献立追加
 // Canonical: docs/design/family/09-onboarding-handson-tour/04-step2-menu.md
+//
+// V4GenerateModal は React Native <Modal> を使うため、TourOverlay も別の <Modal> で
+// ラップして V4GenerateModal の上に重ねる必要がある (TourSandboxWrapper は非使用)。
 
 import { useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
-import { View } from 'react-native';
+import { Modal, View } from 'react-native';
 
 import {
   HANDSON_TOUR_CONSTANTS,
@@ -15,8 +18,9 @@ import {
 } from '@homegohan/handson-tour-shared';
 import type { SubStepOfStep2 } from '@homegohan/handson-tour-shared';
 
+import { V4GenerateModal } from '../../src/components/menu/V4GenerateModal';
+import { TourOverlay } from '../../src/handson-tour/TourOverlay';
 import { useProfile } from '../../src/providers/ProfileProvider';
-import { TourSandboxWrapper } from '../../src/handson-tour/TourSandboxWrapper';
 
 const i18n = HANDSON_TOUR_I18N_JA.tour;
 
@@ -166,31 +170,44 @@ export default function HandsonTourMenu() {
     }
   };
 
+  const target = STEP2_SUB_STEP_TO_TARGET[subStep];
+  const targetTestId = typeof target === 'string' ? target : null;
+  const targetTestIds = Array.isArray(target) ? target : undefined;
+
   return (
     <View style={{ flex: 1 }} testID="tour-step-2">
-      <TourSandboxWrapper
-        subStep={subStep}
-        subStepToTarget={STEP2_SUB_STEP_TO_TARGET}
-        overlay={{
-          bubble: getBubble(),
-          progress: { current: 3, total: 5 },
-          primaryAction: getPrimaryAction(),
-          showSkip: false,
-          onSkip: handleSkip,
-          accessibilityLabel: i18n.step2.a11y_title,
+      {/* V4GenerateModal は内部で React Native <Modal> を使うため常時表示 */}
+      <V4GenerateModal
+        mode="sandbox"
+        visible={true}
+        onClose={() => {
+          // Tour 中は onClose を無効化 (TourOverlay のスキップで制御)
         }}
-        childProps={{
-          mode: 'sandbox',
-          initialFlags: { no_cook: true },
-          prefilled: MOCK_MENU_RESPONSE,
-          loadingDurationMs: HANDSON_TOUR_CONSTANTS.STEP2_LOADING_DURATION_MS,
-          apiOptions: { source: 'handson_tour', sandbox: true },
-        }}
+        prefilled={MOCK_MENU_RESPONSE}
+        loadingDurationMs={HANDSON_TOUR_CONSTANTS.STEP2_LOADING_DURATION_MS}
+        apiOptions={{ source: 'handson_tour', sandbox: true }}
         onSandboxComplete={handleSandboxComplete}
+      />
+
+      {/* TourOverlay を別 Modal でラップして V4GenerateModal の上に重ねる */}
+      <Modal
+        visible={true}
+        transparent
+        animationType="none"
+        statusBarTranslucent
+        onRequestClose={handleSkip}
       >
-        {/* P3-B が V4GenerateModal に mode='sandbox' サポートを追加する。現在はプレースホルダー */}
-        <View style={{ flex: 1 }} />
-      </TourSandboxWrapper>
+        <TourOverlay
+          targetTestId={targetTestId}
+          targetTestIds={targetTestIds}
+          bubble={getBubble()}
+          progress={{ current: 3, total: 5 }}
+          primaryAction={getPrimaryAction()}
+          showSkip={false}
+          onSkip={handleSkip}
+          accessibilityLabel={i18n.step2.a11y_title}
+        />
+      </Modal>
     </View>
   );
 }

--- a/apps/mobile/app/handson-tour/photo.tsx
+++ b/apps/mobile/app/handson-tour/photo.tsx
@@ -3,7 +3,15 @@
 
 import { useRouter } from 'expo-router';
 import React, { useEffect, useRef, useState } from 'react';
-import { View } from 'react-native';
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
   HANDSON_TOUR_CONSTANTS,
@@ -15,8 +23,165 @@ import {
 } from '@homegohan/handson-tour-shared';
 import type { SubStepOfStep1 } from '@homegohan/handson-tour-shared';
 
+import { Card } from '../../src/components/ui';
+import { getApi } from '../../src/lib/api';
+import { colors, radius, spacing } from '../../src/theme';
 import { useProfile } from '../../src/providers/ProfileProvider';
 import { TourSandboxWrapper } from '../../src/handson-tour/TourSandboxWrapper';
+import { registerTourTarget, unregisterTourTarget } from '../../src/handson-tour/useTourOverlayLogic';
+
+const SANDBOX_SAMPLE_IMAGE = require('../../assets/handson-tour/sample-meal.jpg');
+
+// ─── Sandbox content component ────────────────────────────────
+// Accepts mode / onSandboxComplete injected by TourSandboxWrapper.cloneElement
+interface MealSandboxEmbedProps {
+  mode?: 'sandbox';
+  onSandboxComplete?: (result: unknown) => void;
+  prefilled?: typeof MOCK_PHOTO_RESPONSE;
+  apiOptions?: { source: 'handson_tour'; sandbox: true };
+}
+
+function MealSandboxEmbed({ onSandboxComplete, prefilled = MOCK_PHOTO_RESPONSE, apiOptions = { source: 'handson_tour', sandbox: true } }: MealSandboxEmbedProps) {
+  const insets = useSafeAreaInsets();
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Spotlight target refs
+  const cameraButtonRef = useRef<View>(null);
+  const resultDishNameRef = useRef<View>(null);
+  const resultCaloriesRef = useRef<View>(null);
+  const saveButtonRef = useRef<View>(null);
+
+  useEffect(() => {
+    // Register tour targets after mount
+    const ids = [
+      ['meal-camera-button', cameraButtonRef],
+      ['meal-result-dish-name', resultDishNameRef],
+      ['meal-result-calories', resultCaloriesRef],
+      ['meal-save-button', saveButtonRef],
+    ] as const;
+
+    for (const [id, ref] of ids) {
+      if (ref.current) registerTourTarget(id, ref.current);
+    }
+
+    return () => {
+      for (const [id] of ids) {
+        unregisterTourTarget(id);
+      }
+    };
+  }, []);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const api = getApi();
+      await api.post('/api/meal-plans/add-from-photo', {
+        ...prefilled,
+        sandbox: apiOptions.sandbox,
+        source: apiOptions.source,
+      });
+      onSandboxComplete?.(prefilled);
+    } catch {
+      // sandbox errors are non-fatal — complete anyway
+      onSandboxComplete?.(prefilled);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <View testID="meal-new-screen-sandbox" style={{ flex: 1, backgroundColor: colors.bg }}>
+      {/* Header */}
+      <View style={{
+        flexDirection: 'row', alignItems: 'center', gap: spacing.md,
+        paddingTop: insets.top + 8, paddingBottom: spacing.sm, paddingHorizontal: spacing.lg,
+        backgroundColor: colors.card, borderBottomWidth: 1, borderBottomColor: colors.border,
+      }}>
+        <View style={{ width: 22 }} />
+        <View style={{ flex: 1, alignItems: 'center' }}>
+          <Text style={{ fontSize: 16, fontWeight: '600', color: colors.text }}>食事を記録</Text>
+        </View>
+        <View style={{ width: 22 }} />
+      </View>
+
+      <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
+        {/* Sample image — Spotlight target for sub-step 1.2 */}
+        <View ref={cameraButtonRef} testID="meal-camera-button">
+          <Image
+            source={SANDBOX_SAMPLE_IMAGE}
+            style={{ width: '100%', height: 220, borderRadius: radius.lg ?? 12 }}
+            resizeMode="cover"
+          />
+        </View>
+
+        {/* Mock result card — Spotlight targets for sub-step 1.5 */}
+        <Card>
+          <View style={{ gap: spacing.sm }}>
+            <View ref={resultDishNameRef} testID="meal-result-dish-name">
+              <Text style={{ fontSize: 17, fontWeight: '700', color: colors.text }}>
+                {prefilled.dishName}
+              </Text>
+            </View>
+            <View style={{ flexDirection: 'row', gap: spacing.md, flexWrap: 'wrap' }}>
+              <View ref={resultCaloriesRef} testID="meal-result-calories">
+                <Text style={{ fontSize: 13, color: colors.textLight }}>
+                  {prefilled.calories} kcal
+                </Text>
+              </View>
+              <Text style={{ fontSize: 13, color: colors.textLight }}>
+                たんぱく質 {prefilled.protein_g}g
+              </Text>
+              <Text style={{ fontSize: 13, color: colors.textLight }}>
+                脂質 {prefilled.fat_g}g
+              </Text>
+              <Text style={{ fontSize: 13, color: colors.textLight }}>
+                炭水化物 {prefilled.carbs_g}g
+              </Text>
+            </View>
+            <Text style={{ fontSize: 12, color: colors.textMuted }}>
+              ※ チュートリアル用のサンプル解析結果です
+            </Text>
+          </View>
+        </Card>
+
+        {/* Detected items */}
+        <View style={{ gap: spacing.xs }}>
+          {prefilled.detected_items.map((item) => (
+            <View key={item.name} style={{ flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 4 }}>
+              <Text style={{ fontSize: 14, color: colors.text }}>{item.name}</Text>
+              <Text style={{ fontSize: 13, color: colors.textMuted }}>{item.portion_g}g</Text>
+            </View>
+          ))}
+        </View>
+
+        {/* Save button — Spotlight target for sub-step 1.6 */}
+        <View ref={saveButtonRef} testID="meal-save-button">
+          <Pressable
+            onPress={handleSave}
+            disabled={isSaving}
+            style={({ pressed }) => ({
+              paddingVertical: spacing.lg,
+              borderRadius: 12,
+              backgroundColor: colors.accent,
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexDirection: 'row',
+              gap: spacing.sm,
+              opacity: isSaving ? 0.7 : pressed ? 0.9 : 1,
+            })}
+          >
+            {isSaving ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : null}
+            <Text style={{ fontSize: 16, fontWeight: '700', color: '#fff' }}>
+              {isSaving ? '保存中...' : 'この食事を記録する'}
+            </Text>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
 
 const i18n = HANDSON_TOUR_I18N_JA.tour;
 
@@ -179,8 +344,7 @@ export default function HandsonTourPhoto() {
         }}
         onSandboxComplete={handleSandboxComplete}
       >
-        {/* P3-B が MealNewScreen に mode='sandbox' サポートを追加する。現在はプレースホルダー */}
-        <View style={{ flex: 1 }} />
+        <MealSandboxEmbed />
       </TourSandboxWrapper>
     </View>
   );

--- a/apps/mobile/app/meals/new.tsx
+++ b/apps/mobile/app/meals/new.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from "@expo/vector-icons";
 import * as ImageManipulator from "expo-image-manipulator";
 import * as ImagePicker from "expo-image-picker";
 import { router, useLocalSearchParams } from "expo-router";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ActivityIndicator, Alert, Image, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -11,6 +11,7 @@ import { colors, spacing, radius } from "../../src/theme";
 import { supabase } from "../../src/lib/supabase";
 import { getApi } from "../../src/lib/api";
 import { MOCK_PHOTO_RESPONSE } from "@homegohan/handson-tour-shared";
+import { registerTourTarget, unregisterTourTarget } from "../../src/handson-tour/useTourOverlayLogic";
 
 // Inlined from lib/meal-image to avoid importing server-side code
 interface MealImageDish { name?: string | null; image_url?: string | null; image_source?: string | null; image_status?: string | null; image_generated_at?: string | null; [key: string]: any; }
@@ -193,6 +194,28 @@ export default function MealNewPage() {
   const insets = useSafeAreaInsets();
   const params = useLocalSearchParams<{ source?: string; sandbox?: string }>();
   const isSandboxMode = params.source === "handson_tour" && params.sandbox === "true";
+
+  // Sandbox Tour Spotlight target refs
+  const cameraButtonRef = useRef<View>(null);
+  const resultDishNameRef = useRef<View>(null);
+  const resultCaloriesRef = useRef<View>(null);
+  const saveButtonRef = useRef<View>(null);
+
+  // Tour target 登録 (sandbox モード時のみ)
+  useEffect(() => {
+    if (!isSandboxMode) return;
+    if (cameraButtonRef.current) registerTourTarget("meal-camera-button", cameraButtonRef.current);
+    if (resultDishNameRef.current) registerTourTarget("meal-result-dish-name", resultDishNameRef.current);
+    if (resultCaloriesRef.current) registerTourTarget("meal-result-calories", resultCaloriesRef.current);
+    if (saveButtonRef.current) registerTourTarget("meal-save-button", saveButtonRef.current);
+    return () => {
+      unregisterTourTarget("meal-camera-button");
+      unregisterTourTarget("meal-result-dish-name");
+      unregisterTourTarget("meal-result-calories");
+      unregisterTourTarget("meal-save-button");
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSandboxMode]);
 
   // Step & mode
   const [step, setStep] = useState<Step>("mode-select");
@@ -692,21 +715,23 @@ export default function MealNewPage() {
         </View>
 
         <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
-          {/* Sample image */}
-          <Image
-            source={SANDBOX_SAMPLE_IMAGE}
-            style={{ width: "100%", height: 220, borderRadius: 12 }}
-            resizeMode="cover"
-          />
+          {/* Sample image — testID: meal-camera-button (Step 1 sub-step 1.2 Spotlight target) */}
+          <View ref={cameraButtonRef} testID="meal-camera-button">
+            <Image
+              source={SANDBOX_SAMPLE_IMAGE}
+              style={{ width: "100%", height: 220, borderRadius: 12 }}
+              resizeMode="cover"
+            />
+          </View>
 
-          {/* Mock result card */}
+          {/* Mock result card — testIDs for sub-steps 1.5 Spotlight targets */}
           <Card>
             <View style={{ gap: spacing.sm }}>
-              <Text style={{ fontSize: 17, fontWeight: "700", color: colors.text }}>
+              <Text ref={resultDishNameRef as any} testID="meal-result-dish-name" style={{ fontSize: 17, fontWeight: "700", color: colors.text }}>
                 {MOCK_PHOTO_RESPONSE.dishName}
               </Text>
               <View style={{ flexDirection: "row", gap: spacing.md, flexWrap: "wrap" }}>
-                <Text style={{ fontSize: 13, color: colors.textLight }}>
+                <Text ref={resultCaloriesRef as any} testID="meal-result-calories" style={{ fontSize: 13, color: colors.textLight }}>
                   {MOCK_PHOTO_RESPONSE.calories} kcal
                 </Text>
                 <Text style={{ fontSize: 13, color: colors.textLight }}>
@@ -735,9 +760,10 @@ export default function MealNewPage() {
             ))}
           </View>
 
-          {/* Save button */}
+          {/* Save button — testID: meal-save-button (Step 1 sub-step 1.6 Spotlight target) */}
           <Pressable
-            testID="meal-sandbox-save-btn"
+            ref={saveButtonRef as any}
+            testID="meal-save-button"
             onPress={saveSandboxMeal}
             disabled={isSaving}
             style={({ pressed }) => ({


### PR DESCRIPTION
## Summary

- `apps/mobile/app/handson-tour/photo.tsx`: `TourSandboxWrapper` の子要素プレースホルダー `<View />` を `MealSandboxEmbed` コンポーネントに差し替え。`meal-camera-button` / `meal-result-dish-name` / `meal-result-calories` / `meal-save-button` に `useRef<View>` を付与し `registerTourTarget` で Spotlight target を登録。
- `apps/mobile/app/handson-tour/menu.tsx`: `V4GenerateModal` (mode="sandbox") が React Native `<Modal>` を使うため `TourSandboxWrapper` を廃止し、`V4GenerateModal` と `TourOverlay` を別々の `<Modal>` でレンダリングして正しい Z オーダーを確保。
- `apps/mobile/app/badges/index.tsx`: `tutorial-mode=1` のとき `HighlightedBadgeCard` の `Animated.View` に ref を付与し `registerTourTarget("badge-card-{code}", ref)` を呼ぶ。unmount 時に `unregisterTourTarget` でクリーンアップ。
- `apps/mobile/app/meals/new.tsx`: sandbox モード時に `meal-camera-button` / `meal-result-dish-name` / `meal-result-calories` / `meal-save-button` の各 View に ref を付与し `registerTourTarget` で登録。Spotlight target testID も追加。

## DOD チェックリスト

- [x] photo.tsx と menu.tsx のプレースホルダー差し替え完了
- [x] 既存 Mobile 画面 (badges, meals/new) で registerTourTarget 接続完了
- [x] `npx tsc --noEmit` 実行: 修正ファイルに型エラーなし (残存エラーは P2-B/P3-B の pre-existing: react-native-reanimated 型宣言なし等)
- [x] `npm install` エラーなし
- [x] 既存挙動を壊さない (tutorialMode=false / isSandboxMode=false 時は変更なし)

## 技術的メモ

**menu.tsx の Modal 二重構造について**: `V4GenerateModal` の sandbox 実装は内部で RN `<Modal>` を使う。`TourSandboxWrapper` の `TourOverlay` は `StyleSheet.absoluteFill` で実装されているため、`<Modal>` の後ろに隠れてしまう。回避策として `TourOverlay` を独立した `<Modal transparent>` でラップし、React Native の Modal スタッキング順序 (後のモーダルが上) を利用して TourOverlay が V4GenerateModal の上に表示されるようにした。

**registerTourTarget タイミング**: `useEffect(() => {...}, [])` で mount 後に実行。React Native では ref は render commit 後に populated されるため、effect 実行時には必ず ref.current が非 null になる。