### PR TITLE
feat(operator): B — super_admin プラン管理 UI + API(plans / feature-packages / coupons)

### DIFF
--- a/src/app/(super-admin)/coupons/[id]/page.tsx
+++ b/src/app/(super-admin)/coupons/[id]/page.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+/**
+ * /super-admin/coupons/[id] — クーポン詳細・編集
+ * operator/03-ui-spec.md §14 / operator/04-plan-management.md §4.1 準拠
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+
+type Coupon = {
+  id: string;
+  code: string;
+  display_name: string | null;
+  discount_type: 'fixed' | 'percentage';
+  discount_value: number;
+  applicable_to: string;
+  applicable_plans: string[];
+  valid_from: string;
+  valid_until: string;
+  max_uses: number | null;
+  uses_count: number;
+  per_user_limit: number;
+  duration_months: number | null;
+  gross_margin_preview_jpy: number | null;
+  status: string;
+  created_by: string;
+  created_at: string;
+};
+
+type Redemption = {
+  id: string;
+  user_id: string | null;
+  organization_id: string | null;
+  subscription_target: string;
+  discount_amount_jpy: number;
+  redeemed_at: string;
+  ended_at: string | null;
+};
+
+const STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  active: { label: '有効', color: 'bg-green-100 text-green-700' },
+  paused: { label: '停止中', color: 'bg-yellow-100 text-yellow-700' },
+  expired: { label: '期限切れ', color: 'bg-slate-100 text-slate-500' },
+};
+
+export default function CouponDetailPage() {
+  const params = useParams();
+  const couponId = params.id as string;
+
+  const [coupon, setCoupon] = useState<Coupon | null>(null);
+  const [redemptions, setRedemptions] = useState<Redemption[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [activeTab, setActiveTab] = useState<'detail' | 'redemptions'>('detail');
+
+  const [displayName, setDisplayName] = useState('');
+  const [validUntil, setValidUntil] = useState('');
+  const [maxUses, setMaxUses] = useState('');
+
+  const fetchCoupon = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/super-admin/coupons/${couponId}`);
+      const data = await res.json() as { data?: Coupon; error?: { message: string } };
+      if (!res.ok) {
+        setError(data.error?.message ?? '取得に失敗しました');
+        return;
+      }
+      setCoupon(data.data!);
+      setDisplayName(data.data!.display_name ?? '');
+      setValidUntil(data.data!.valid_until.slice(0, 10));
+      setMaxUses(data.data!.max_uses != null ? String(data.data!.max_uses) : '');
+    } catch {
+      setError('ネットワークエラー');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [couponId]);
+
+  const fetchRedemptions = useCallback(async () => {
+    if (!coupon) return;
+    try {
+      const res = await fetch(`/api/super-admin/coupons/${coupon.code}/redemptions`);
+      const data = await res.json() as { data?: Redemption[] };
+      if (data.data) setRedemptions(data.data);
+    } catch {
+      // non-critical
+    }
+  }, [coupon]);
+
+  useEffect(() => {
+    fetchCoupon();
+  }, [fetchCoupon]);
+
+  useEffect(() => {
+    if (activeTab === 'redemptions') fetchRedemptions();
+  }, [activeTab, fetchRedemptions]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setSaveError('');
+    setSaveSuccess(false);
+    try {
+      const res = await fetch(`/api/super-admin/coupons/${couponId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          display_name: displayName || null,
+          valid_until: new Date(validUntil).toISOString(),
+          max_uses: maxUses ? Number(maxUses) : null,
+        }),
+      });
+      const data = await res.json() as { data?: Coupon; error?: { message: string } };
+      if (!res.ok) {
+        setSaveError(data.error?.message ?? '保存に失敗しました');
+        return;
+      }
+      setCoupon(data.data!);
+      setSaveSuccess(true);
+    } catch {
+      setSaveError('ネットワークエラー');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleStatusChange = async (newStatus: 'active' | 'paused') => {
+    const label = newStatus === 'paused' ? '停止' : '再開';
+    if (!confirm(`このクーポンを${label}しますか？`)) return;
+    try {
+      const res = await fetch(`/api/super-admin/coupons/${couponId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (res.ok) fetchCoupon();
+    } catch {
+      alert('ステータス変更に失敗しました');
+    }
+  };
+
+  if (isLoading) {
+    return <div className="flex items-center justify-center h-48 text-slate-400">読み込み中...</div>;
+  }
+
+  if (error || !coupon) {
+    return (
+      <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+        {error || 'クーポンが見つかりません'}
+      </div>
+    );
+  }
+
+  const statusInfo = STATUS_LABELS[coupon.status] ?? { label: coupon.status, color: 'bg-slate-100 text-slate-500' };
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Link href="/super-admin/coupons" className="text-slate-400 hover:text-slate-600 text-sm">
+            ← 一覧
+          </Link>
+          <span className="text-slate-300">/</span>
+          <code className="font-mono font-bold text-slate-900">{coupon.code}</code>
+          <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${statusInfo.color}`}>
+            {statusInfo.label}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {coupon.status === 'active' && (
+            <button
+              onClick={() => handleStatusChange('paused')}
+              className="px-3 py-1.5 border border-yellow-300 text-yellow-600 rounded-lg text-xs font-medium hover:bg-yellow-50 transition-colors"
+            >
+              一時停止
+            </button>
+          )}
+          {coupon.status === 'paused' && (
+            <button
+              onClick={() => handleStatusChange('active')}
+              className="px-3 py-1.5 bg-green-500 text-white rounded-lg text-xs font-medium hover:bg-green-600 transition-colors"
+            >
+              再開する
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* タブ */}
+      <div className="flex gap-1 mb-6 border-b border-slate-200">
+        {(['detail', 'redemptions'] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+              activeTab === tab
+                ? 'border-orange-500 text-orange-600'
+                : 'border-transparent text-slate-500 hover:text-slate-700'
+            }`}
+          >
+            {tab === 'detail' ? '詳細' : `適用履歴 (${coupon.uses_count})`}
+          </button>
+        ))}
+      </div>
+
+      {/* 詳細タブ */}
+      {activeTab === 'detail' && (
+        <div className="bg-white rounded-xl border border-slate-200 p-6 space-y-5">
+          <div className="grid grid-cols-2 gap-4 pb-4 border-b border-slate-100">
+            <div>
+              <span className="text-xs text-slate-500">割引</span>
+              <p className="text-2xl font-bold text-slate-800">
+                {coupon.discount_type === 'percentage'
+                  ? `${coupon.discount_value}%`
+                  : `¥${coupon.discount_value.toLocaleString()} OFF`}
+              </p>
+            </div>
+            <div>
+              <span className="text-xs text-slate-500">利用数</span>
+              <p className="text-2xl font-bold text-slate-800">
+                {coupon.uses_count}
+                {coupon.max_uses != null && <span className="text-slate-400 text-base"> / {coupon.max_uses}</span>}
+              </p>
+            </div>
+            {coupon.gross_margin_preview_jpy != null && (
+              <div>
+                <span className="text-xs text-slate-500">実質粗利プレビュー</span>
+                <p className="text-lg font-semibold text-slate-700">
+                  ¥{coupon.gross_margin_preview_jpy.toLocaleString()}
+                </p>
+              </div>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">表示名</label>
+            <input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">有効期限</label>
+              <input
+                type="date"
+                value={validUntil}
+                onChange={(e) => setValidUntil(e.target.value)}
+                className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">最大利用回数</label>
+              <input
+                type="number"
+                value={maxUses}
+                onChange={(e) => setMaxUses(e.target.value)}
+                min={coupon.uses_count}
+                className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+                placeholder="無制限"
+              />
+            </div>
+          </div>
+
+          <div className="text-xs text-slate-400 grid grid-cols-2 gap-2">
+            <div>適用対象: {coupon.applicable_to}</div>
+            <div>1 ユーザー上限: {coupon.per_user_limit} 回</div>
+            <div>割引期間: {coupon.duration_months != null ? `${coupon.duration_months} ヶ月` : 'ずっと'}</div>
+            <div>作成日: {new Date(coupon.created_at).toLocaleDateString('ja-JP')}</div>
+          </div>
+
+          {saveError && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+              {saveError}
+            </div>
+          )}
+          {saveSuccess && (
+            <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg text-sm">
+              保存しました
+            </div>
+          )}
+
+          <div className="flex justify-end pt-2">
+            <button
+              onClick={handleSave}
+              disabled={isSaving}
+              className="px-5 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600 transition-colors disabled:opacity-50"
+            >
+              {isSaving ? '保存中...' : '保存する'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* 適用履歴タブ */}
+      {activeTab === 'redemptions' && (
+        <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 border-b border-slate-200">
+              <tr>
+                <th className="text-left px-4 py-3 font-medium text-slate-600">適用日</th>
+                <th className="text-left px-4 py-3 font-medium text-slate-600">対象</th>
+                <th className="text-right px-4 py-3 font-medium text-slate-600">割引額</th>
+                <th className="text-left px-4 py-3 font-medium text-slate-600">ステータス</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {redemptions.map((r) => (
+                <tr key={r.id} className="hover:bg-slate-50">
+                  <td className="px-4 py-3 text-slate-600">
+                    {new Date(r.redeemed_at).toLocaleDateString('ja-JP')}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600 text-xs">
+                    {r.subscription_target} / {r.user_id ? r.user_id.slice(0, 8) : r.organization_id?.slice(0, 8)}...
+                  </td>
+                  <td className="px-4 py-3 text-right font-medium text-slate-800">
+                    ¥{r.discount_amount_jpy.toLocaleString()}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                      r.ended_at ? 'bg-slate-100 text-slate-500' : 'bg-green-100 text-green-700'
+                    }`}>
+                      {r.ended_at ? '終了' : '有効'}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+              {redemptions.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-4 py-6 text-center text-slate-400">
+                    適用履歴がありません
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(super-admin)/coupons/new/page.tsx
+++ b/src/app/(super-admin)/coupons/new/page.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+/**
+ * /super-admin/coupons/new — クーポン新規作成
+ * operator/03-ui-spec.md §14 (「+ 新規クーポン」モーダル相当) /
+ * operator/04-plan-management.md §4.1 準拠
+ */
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+// Stripe 手数料: 3.6% + ¥40 (operator/04-plan-management.md §4.1 §15.12)
+function calcGrossMargin(priceJpy: number, discountPercent: number = 0): number {
+  const effective = priceJpy * (1 - discountPercent / 100);
+  const fee = effective * 0.036 + 40;
+  return Math.round(effective - fee);
+}
+
+export default function CouponNewPage() {
+  const router = useRouter();
+
+  const [code, setCode] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [discountType, setDiscountType] = useState<'fixed' | 'percentage'>('percentage');
+  const [discountValue, setDiscountValue] = useState('');
+  const [applicableTo, setApplicableTo] = useState<'all' | 'personal' | 'family' | 'org'>('all');
+  const [validFrom, setValidFrom] = useState(new Date().toISOString().slice(0, 10));
+  const [validUntil, setValidUntil] = useState('');
+  const [maxUses, setMaxUses] = useState('');
+  const [perUserLimit, setPerUserLimit] = useState('1');
+  const [durationMonths, setDurationMonths] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  // 粗利プレビュー (典型的な Pro 月額 ¥980 で計算)
+  const typicalPrice = 980;
+  const grossMarginPreview = discountType === 'percentage' && discountValue
+    ? calcGrossMargin(typicalPrice, Number(discountValue))
+    : null;
+
+  const handleGenerateCode = () => {
+    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    const code = Array.from({ length: 8 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+    setCode(code);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const res = await fetch('/api/super-admin/coupons', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code: code.toUpperCase(),
+          display_name: displayName || undefined,
+          discount_type: discountType,
+          discount_value: Number(discountValue),
+          applicable_to: applicableTo,
+          valid_from: new Date(validFrom).toISOString(),
+          valid_until: new Date(validUntil).toISOString(),
+          max_uses: maxUses ? Number(maxUses) : null,
+          per_user_limit: Number(perUserLimit),
+          duration_months: durationMonths ? Number(durationMonths) : null,
+          gross_margin_preview_jpy: grossMarginPreview,
+        }),
+      });
+
+      const data = await res.json() as { data?: { id: string }; error?: { message: string } };
+      if (!res.ok) {
+        setError(data.error?.message ?? '作成に失敗しました');
+        return;
+      }
+      router.push(`/super-admin/coupons/${data.data!.id}`);
+    } catch {
+      setError('ネットワークエラーが発生しました');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex items-center gap-3 mb-6">
+        <Link href="/super-admin/coupons" className="text-slate-400 hover:text-slate-600 text-sm">
+          ← 一覧に戻る
+        </Link>
+        <span className="text-slate-300">/</span>
+        <h1 className="text-xl font-bold text-slate-900">新規クーポン作成</h1>
+      </div>
+
+      <form onSubmit={handleSubmit} className="bg-white rounded-xl border border-slate-200 p-6 space-y-5">
+        {/* コード */}
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">クーポンコード *</label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={code}
+              onChange={(e) => setCode(e.target.value.toUpperCase())}
+              required
+              pattern="^[A-Z0-9_-]+$"
+              className="flex-1 border border-slate-200 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-orange-500"
+              placeholder="例: SUMMER2026"
+            />
+            <button
+              type="button"
+              onClick={handleGenerateCode}
+              className="px-3 py-2 border border-slate-200 text-slate-600 rounded-lg text-xs hover:bg-slate-50 transition-colors whitespace-nowrap"
+            >
+              自動生成
+            </button>
+          </div>
+        </div>
+
+        {/* 表示名 */}
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">表示名</label>
+          <input
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="例: 夏のスペシャルキャンペーン"
+          />
+        </div>
+
+        {/* 割引種別・値 */}
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-2">割引種別 *</label>
+          <div className="flex gap-4 mb-3">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                value="percentage"
+                checked={discountType === 'percentage'}
+                onChange={() => setDiscountType('percentage')}
+                className="accent-orange-500"
+              />
+              <span className="text-sm">パーセント (%)</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="radio"
+                value="fixed"
+                checked={discountType === 'fixed'}
+                onChange={() => setDiscountType('fixed')}
+                className="accent-orange-500"
+              />
+              <span className="text-sm">固定額 (円)</span>
+            </label>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              value={discountValue}
+              onChange={(e) => setDiscountValue(e.target.value)}
+              required
+              min="0.01"
+              max={discountType === 'percentage' ? '100' : undefined}
+              step="0.01"
+              className="w-32 border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              placeholder="20"
+            />
+            <span className="text-slate-500 text-sm">{discountType === 'percentage' ? '%' : '円'}</span>
+          </div>
+          {/* 粗利プレビュー (operator/04-plan-management.md §4.1) */}
+          {grossMarginPreview !== null && (
+            <div className="mt-2 bg-slate-50 border border-slate-200 rounded px-3 py-2 text-xs text-slate-600">
+              実質粗利プレビュー (Pro ¥980 基準): <strong>¥{grossMarginPreview.toLocaleString()}</strong>
+              <span className="text-slate-400 ml-2">(Stripe 手数料 3.6%+¥40 控除後)</span>
+            </div>
+          )}
+        </div>
+
+        {/* 適用対象 */}
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">適用対象</label>
+          <select
+            value={applicableTo}
+            onChange={(e) => setApplicableTo(e.target.value as typeof applicableTo)}
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+          >
+            <option value="all">全て</option>
+            <option value="personal">個人</option>
+            <option value="family">家族</option>
+            <option value="org">組織</option>
+          </select>
+        </div>
+
+        {/* 有効期限 */}
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">有効開始日 *</label>
+            <input
+              type="date"
+              value={validFrom}
+              onChange={(e) => setValidFrom(e.target.value)}
+              required
+              className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">有効終了日 *</label>
+            <input
+              type="date"
+              value={validUntil}
+              onChange={(e) => setValidUntil(e.target.value)}
+              required
+              min={validFrom}
+              className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+        </div>
+
+        {/* 利用上限 */}
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">最大利用回数</label>
+            <input
+              type="number"
+              value={maxUses}
+              onChange={(e) => setMaxUses(e.target.value)}
+              min="1"
+              className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              placeholder="無制限"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">ユーザー毎の上限</label>
+            <input
+              type="number"
+              value={perUserLimit}
+              onChange={(e) => setPerUserLimit(e.target.value)}
+              min="1"
+              required
+              className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            />
+          </div>
+        </div>
+
+        {/* 割引期間 */}
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">割引期間 (月)</label>
+          <input
+            type="number"
+            value={durationMonths}
+            onChange={(e) => setDurationMonths(e.target.value)}
+            min="1"
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="ずっと (空欄)"
+          />
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        <div className="flex gap-3 justify-end pt-2">
+          <Link
+            href="/super-admin/coupons"
+            className="px-4 py-2 border border-slate-200 text-slate-700 rounded-lg text-sm hover:bg-slate-50 transition-colors"
+          >
+            キャンセル
+          </Link>
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="px-6 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600 transition-colors disabled:opacity-50"
+          >
+            {isLoading ? '作成中...' : '作成する'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/coupons/page.tsx
+++ b/src/app/(super-admin)/coupons/page.tsx
@@ -1,0 +1,133 @@
+/**
+ * /super-admin/coupons — クーポン管理一覧
+ * operator/03-ui-spec.md §14 準拠
+ */
+
+import Link from 'next/link';
+import { createClient } from '@/lib/supabase/server';
+
+type Coupon = {
+  id: string;
+  code: string;
+  display_name: string | null;
+  discount_type: 'fixed' | 'percentage';
+  discount_value: number;
+  applicable_to: string;
+  valid_from: string;
+  valid_until: string;
+  uses_count: number;
+  max_uses: number | null;
+  status: string;
+};
+
+const STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  active: { label: '有効', color: 'bg-green-100 text-green-700' },
+  paused: { label: '停止中', color: 'bg-yellow-100 text-yellow-700' },
+  expired: { label: '期限切れ', color: 'bg-slate-100 text-slate-500' },
+};
+
+function formatDiscount(coupon: Coupon): string {
+  if (coupon.discount_type === 'percentage') return `${coupon.discount_value}%`;
+  return `¥${coupon.discount_value.toLocaleString()} OFF`;
+}
+
+export default async function CouponsPage() {
+  const supabase = createClient();
+
+  const { data: coupons, error } = await supabase
+    .from('coupons')
+    .select('id, code, display_name, discount_type, discount_value, applicable_to, valid_from, valid_until, uses_count, max_uses, status')
+    .order('created_at', { ascending: false });
+
+  return (
+    <div>
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">クーポン管理</h1>
+          <p className="text-sm text-slate-500 mt-1">割引コードの作成・管理</p>
+        </div>
+        <Link
+          href="/super-admin/coupons/new"
+          className="px-4 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600 transition-colors"
+        >
+          + 新規クーポン
+        </Link>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-4 text-sm">
+          データの取得に失敗しました: {error.message}
+        </div>
+      )}
+
+      {/* テーブル */}
+      <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 border-b border-slate-200">
+            <tr>
+              <th className="text-left px-4 py-3 font-medium text-slate-600">コード</th>
+              <th className="text-left px-4 py-3 font-medium text-slate-600">割引</th>
+              <th className="text-left px-4 py-3 font-medium text-slate-600">対象</th>
+              <th className="text-left px-4 py-3 font-medium text-slate-600">有効期限</th>
+              <th className="text-center px-4 py-3 font-medium text-slate-600">利用数</th>
+              <th className="text-center px-4 py-3 font-medium text-slate-600">ステータス</th>
+              <th className="text-center px-4 py-3 font-medium text-slate-600">操作</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {(coupons as Coupon[] ?? []).map((coupon) => {
+              const statusInfo = STATUS_LABELS[coupon.status] ?? { label: coupon.status, color: 'bg-slate-100 text-slate-500' };
+              const isExpired = new Date(coupon.valid_until) < new Date();
+              return (
+                <tr key={coupon.id} className="hover:bg-slate-50 transition-colors">
+                  <td className="px-4 py-3">
+                    <code className="font-mono text-xs bg-slate-100 px-2 py-0.5 rounded">{coupon.code}</code>
+                    {coupon.display_name && (
+                      <p className="text-xs text-slate-400 mt-0.5">{coupon.display_name}</p>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 font-medium text-slate-800">
+                    {formatDiscount(coupon)}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">{coupon.applicable_to}</td>
+                  <td className="px-4 py-3">
+                    <span className={isExpired ? 'text-red-500' : 'text-slate-600'}>
+                      {new Date(coupon.valid_until).toLocaleDateString('ja-JP')}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-center text-slate-700">
+                    {coupon.uses_count}
+                    {coupon.max_uses != null && (
+                      <span className="text-slate-400"> / {coupon.max_uses}</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${statusInfo.color}`}>
+                      {statusInfo.label}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <Link
+                      href={`/super-admin/coupons/${coupon.id}`}
+                      className="text-orange-500 hover:text-orange-600 font-medium text-xs"
+                    >
+                      詳細
+                    </Link>
+                  </td>
+                </tr>
+              );
+            })}
+            {(coupons ?? []).length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-4 py-8 text-center text-slate-400">
+                  クーポンがありません
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/feature-packages/[id]/page.tsx
+++ b/src/app/(super-admin)/feature-packages/[id]/page.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+/**
+ * /super-admin/feature-packages/[id] — 機能パッケージ詳細・編集
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+
+type FeaturePackage = {
+  id: string;
+  package_key: string;
+  display_name: string;
+  description: string | null;
+  feature_flags: string[];
+  display_order: number;
+  status: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export default function FeaturePackageDetailPage() {
+  const params = useParams();
+  const pkgId = params.id as string;
+
+  const [pkg, setPkg] = useState<FeaturePackage | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  // 編集フィールド
+  const [displayName, setDisplayName] = useState('');
+  const [description, setDescription] = useState('');
+  const [featureFlagsRaw, setFeatureFlagsRaw] = useState('');
+  const [displayOrder, setDisplayOrder] = useState(0);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  const fetchPkg = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/super-admin/feature-packages/${pkgId}`);
+      const data = await res.json() as { data?: FeaturePackage; error?: { message: string } };
+      if (!res.ok) {
+        setError(data.error?.message ?? '取得に失敗しました');
+        return;
+      }
+      setPkg(data.data!);
+      setDisplayName(data.data!.display_name);
+      setDescription(data.data!.description ?? '');
+      setFeatureFlagsRaw(data.data!.feature_flags.join('\n'));
+      setDisplayOrder(data.data!.display_order);
+    } catch {
+      setError('ネットワークエラー');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [pkgId]);
+
+  useEffect(() => {
+    fetchPkg();
+  }, [fetchPkg]);
+
+  const handleSave = async () => {
+    const flags = featureFlagsRaw.split(/[\n,]/).map((f) => f.trim()).filter(Boolean);
+    if (flags.length === 0) {
+      setSaveError('機能フラグを少なくとも1つ入力してください');
+      return;
+    }
+    setIsSaving(true);
+    setSaveError('');
+    setSaveSuccess(false);
+
+    try {
+      const res = await fetch(`/api/super-admin/feature-packages/${pkgId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          display_name: displayName,
+          description: description || null,
+          feature_flags: flags,
+          display_order: displayOrder,
+        }),
+      });
+      const data = await res.json() as { data?: FeaturePackage; error?: { message: string } };
+      if (!res.ok) {
+        setSaveError(data.error?.message ?? '保存に失敗しました');
+        return;
+      }
+      setPkg(data.data!);
+      setSaveSuccess(true);
+    } catch {
+      setSaveError('ネットワークエラー');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDeprecate = async () => {
+    if (!confirm('この機能パッケージを廃止しますか？')) return;
+    try {
+      const res = await fetch(`/api/super-admin/feature-packages/${pkgId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'deprecated' }),
+      });
+      if (res.ok) fetchPkg();
+    } catch {
+      alert('廃止処理に失敗しました');
+    }
+  };
+
+  if (isLoading) {
+    return <div className="flex items-center justify-center h-48 text-slate-400">読み込み中...</div>;
+  }
+
+  if (error || !pkg) {
+    return (
+      <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+        {error || '機能パッケージが見つかりません'}
+      </div>
+    );
+  }
+
+  const flags = featureFlagsRaw.split(/[\n,]/).map((f) => f.trim()).filter(Boolean);
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Link href="/super-admin/feature-packages" className="text-slate-400 hover:text-slate-600 text-sm">
+            ← 一覧
+          </Link>
+          <span className="text-slate-300">/</span>
+          <h1 className="text-xl font-bold text-slate-900">{pkg.display_name}</h1>
+          <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+            pkg.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-slate-100 text-slate-500'
+          }`}>
+            {pkg.status === 'active' ? '有効' : '廃止'}
+          </span>
+        </div>
+        {pkg.status === 'active' && (
+          <button
+            onClick={handleDeprecate}
+            className="px-3 py-1.5 border border-red-300 text-red-600 rounded-lg text-xs font-medium hover:bg-red-50 transition-colors"
+          >
+            廃止する
+          </button>
+        )}
+      </div>
+
+      <div className="bg-white rounded-xl border border-slate-200 p-6 space-y-5">
+        <div>
+          <label className="block text-xs font-medium text-slate-500 mb-1">package_key</label>
+          <code className="font-mono text-sm bg-slate-100 px-2 py-1 rounded">{pkg.package_key}</code>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">表示名 *</label>
+          <input
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">説明</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">機能フラグ</label>
+          <textarea
+            value={featureFlagsRaw}
+            onChange={(e) => setFeatureFlagsRaw(e.target.value)}
+            rows={5}
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-orange-500"
+          />
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {flags.map((flag) => (
+              <span key={flag} className="px-2 py-0.5 bg-blue-50 text-blue-700 text-xs rounded font-mono">
+                {flag}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">表示順</label>
+          <input
+            type="number"
+            value={displayOrder}
+            onChange={(e) => setDisplayOrder(Number(e.target.value))}
+            min="0"
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+          />
+        </div>
+
+        {saveError && (
+          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+            {saveError}
+          </div>
+        )}
+        {saveSuccess && (
+          <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg text-sm">
+            保存しました
+          </div>
+        )}
+
+        <div className="flex justify-end pt-2">
+          <button
+            onClick={handleSave}
+            disabled={isSaving}
+            className="px-5 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600 transition-colors disabled:opacity-50"
+          >
+            {isSaving ? '保存中...' : '保存する'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/feature-packages/new/page.tsx
+++ b/src/app/(super-admin)/feature-packages/new/page.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+/**
+ * /super-admin/feature-packages/new — 機能パッケージ新規作成
+ */
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+export default function FeaturePackageNewPage() {
+  const router = useRouter();
+  const [packageKey, setPackageKey] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [description, setDescription] = useState('');
+  const [featureFlagsRaw, setFeatureFlagsRaw] = useState('');
+  const [displayOrder, setDisplayOrder] = useState('0');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const flags = featureFlagsRaw
+      .split(/[\n,]/)
+      .map((f) => f.trim())
+      .filter(Boolean);
+
+    if (flags.length === 0) {
+      setError('機能フラグを少なくとも1つ入力してください');
+      return;
+    }
+
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const res = await fetch('/api/super-admin/feature-packages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          package_key: packageKey,
+          display_name: displayName,
+          description: description || undefined,
+          feature_flags: flags,
+          display_order: Number(displayOrder),
+        }),
+      });
+
+      const data = await res.json() as { data?: { id: string }; error?: { message: string } };
+      if (!res.ok) {
+        setError(data.error?.message ?? '作成に失敗しました');
+        return;
+      }
+      router.push(`/super-admin/feature-packages/${data.data!.id}`);
+    } catch {
+      setError('ネットワークエラーが発生しました');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex items-center gap-3 mb-6">
+        <Link href="/super-admin/feature-packages" className="text-slate-400 hover:text-slate-600 transition-colors text-sm">
+          ← 一覧に戻る
+        </Link>
+        <span className="text-slate-300">/</span>
+        <h1 className="text-xl font-bold text-slate-900">機能パッケージ新規作成</h1>
+      </div>
+
+      <form onSubmit={handleSubmit} className="bg-white rounded-xl border border-slate-200 p-6 space-y-5">
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">
+            package_key *
+            <span className="text-xs text-slate-400 ml-2">英小文字・数字・アンダースコアのみ</span>
+          </label>
+          <input
+            type="text"
+            value={packageKey}
+            onChange={(e) => setPackageKey(e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ''))}
+            required
+            pattern="^[a-z0-9_]+$"
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="例: ai_analysis"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">表示名 *</label>
+          <input
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            required
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="例: AI 解析"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">説明</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="パッケージの説明"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">
+            機能フラグ *
+            <span className="text-xs text-slate-400 ml-2">改行またはカンマ区切りで複数入力</span>
+          </label>
+          <textarea
+            value={featureFlagsRaw}
+            onChange={(e) => setFeatureFlagsRaw(e.target.value)}
+            required
+            rows={4}
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-orange-500"
+            placeholder="food_recognition&#10;ai_consultation&#10;ai_menu_generate"
+          />
+          {featureFlagsRaw && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {featureFlagsRaw.split(/[\n,]/).map((f) => f.trim()).filter(Boolean).map((flag) => (
+                <span key={flag} className="px-2 py-0.5 bg-blue-50 text-blue-700 text-xs rounded font-mono">
+                  {flag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">表示順</label>
+          <input
+            type="number"
+            value={displayOrder}
+            onChange={(e) => setDisplayOrder(e.target.value)}
+            min="0"
+            className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+          />
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        <div className="flex gap-3 justify-end pt-2">
+          <Link
+            href="/super-admin/feature-packages"
+            className="px-4 py-2 border border-slate-200 text-slate-700 rounded-lg text-sm hover:bg-slate-50 transition-colors"
+          >
+            キャンセル
+          </Link>
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="px-6 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600 transition-colors disabled:opacity-50"
+          >
+            {isLoading ? '作成中...' : '作成する'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/feature-packages/page.tsx
+++ b/src/app/(super-admin)/feature-packages/page.tsx
@@ -1,0 +1,86 @@
+/**
+ * /super-admin/feature-packages — 機能パッケージ一覧
+ * operator/01-data-model.md §3.3 準拠
+ */
+
+import Link from 'next/link';
+import { createClient } from '@/lib/supabase/server';
+
+export default async function FeaturePackagesPage() {
+  const supabase = createClient();
+
+  const { data: packages, error } = await supabase
+    .from('feature_packages')
+    .select('*')
+    .order('display_order', { ascending: true });
+
+  return (
+    <div>
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">機能パッケージ</h1>
+          <p className="text-sm text-slate-500 mt-1">feature_packages — プランに付与する機能フラグのバンドル</p>
+        </div>
+        <Link
+          href="/super-admin/feature-packages/new"
+          className="px-4 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600 transition-colors"
+        >
+          + 新規作成
+        </Link>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-4 text-sm">
+          データの取得に失敗しました: {error.message}
+        </div>
+      )}
+
+      <div className="grid gap-4">
+        {(packages ?? []).map((pkg) => (
+          <div key={pkg.id} className="bg-white rounded-xl border border-slate-200 p-5">
+            <div className="flex items-start justify-between">
+              <div className="flex-1">
+                <div className="flex items-center gap-3 mb-2">
+                  <code className="font-mono text-xs bg-slate-100 px-2 py-0.5 rounded">{pkg.package_key}</code>
+                  <h3 className="text-base font-semibold text-slate-800">{pkg.display_name}</h3>
+                  <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                    pkg.status === 'active'
+                      ? 'bg-green-100 text-green-700'
+                      : 'bg-slate-100 text-slate-500'
+                  }`}>
+                    {pkg.status === 'active' ? '有効' : '廃止'}
+                  </span>
+                </div>
+                {pkg.description && (
+                  <p className="text-sm text-slate-500 mb-3">{pkg.description}</p>
+                )}
+                <div className="flex flex-wrap gap-1.5">
+                  {((pkg.feature_flags as string[] | null) ?? []).map((flag: string) => (
+                    <span
+                      key={flag}
+                      className="px-2 py-0.5 bg-blue-50 text-blue-700 text-xs rounded font-mono"
+                    >
+                      {flag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <Link
+                href={`/super-admin/feature-packages/${pkg.id}`}
+                className="ml-4 text-orange-500 hover:text-orange-600 text-sm font-medium flex-shrink-0"
+              >
+                編集
+              </Link>
+            </div>
+          </div>
+        ))}
+        {(packages ?? []).length === 0 && (
+          <div className="bg-white rounded-xl border border-slate-200 px-4 py-8 text-center text-slate-400">
+            機能パッケージがありません
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/layout.tsx
+++ b/src/app/(super-admin)/layout.tsx
@@ -1,0 +1,103 @@
+/**
+ * (super-admin) route group layout
+ * super_admin ロールガード + サブナビ
+ * operator/03-ui-spec.md §3 (共通レイアウト) / §22 (super_admin ダッシュボード) 準拠
+ */
+
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { requireRole } from '@/lib/auth/helpers';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+
+const superAdminNavItems = [
+  { href: '/super-admin/plans', label: 'プラン管理', icon: '📋' },
+  { href: '/super-admin/feature-packages', label: '機能パッケージ', icon: '📦' },
+  { href: '/super-admin/coupons', label: 'クーポン', icon: '🎟' },
+];
+
+export default async function SuperAdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Server Component でロールガード
+  try {
+    await requireRole(['super_admin']);
+  } catch (err) {
+    if (err instanceof AuthError) {
+      redirect('/login?redirect=/super-admin/plans');
+    }
+    if (err instanceof ForbiddenError) {
+      redirect('/login?redirect=/super-admin/plans');
+    }
+    throw err;
+  }
+
+  return (
+    <div className="min-h-screen flex bg-slate-50">
+      {/* Sidebar */}
+      <aside className="w-60 bg-slate-900 text-white flex flex-col shadow-xl flex-shrink-0">
+        {/* Header */}
+        <div className="p-5 border-b border-slate-700">
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-lg bg-orange-500 flex items-center justify-center text-lg font-bold">
+              S
+            </div>
+            <div>
+              <p className="text-sm font-bold text-white">Super Admin</p>
+              <p className="text-xs text-slate-400">ほめゴハン 運営</p>
+            </div>
+          </div>
+        </div>
+
+        {/* 環境バッジ (operator/03-ui-spec.md §3.1 準拠) */}
+        {process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ? (
+          <div className="mx-4 mt-3 px-3 py-1 bg-red-600 text-white text-xs font-bold text-center rounded">
+            PROD
+          </div>
+        ) : process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' ? (
+          <div className="mx-4 mt-3 px-3 py-1 bg-blue-600 text-white text-xs font-bold text-center rounded">
+            PREVIEW
+          </div>
+        ) : (
+          <div className="mx-4 mt-3 px-3 py-1 bg-yellow-500 text-black text-xs font-bold text-center rounded">
+            LOCAL / STAGING
+          </div>
+        )}
+
+        {/* Navigation */}
+        <nav className="flex-1 p-4 space-y-1 mt-2">
+          <p className="text-xs text-slate-500 px-3 pb-1 uppercase tracking-wider">プラン管理</p>
+          {superAdminNavItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-slate-300 hover:text-white hover:bg-slate-700 transition-colors text-sm"
+            >
+              <span>{item.icon}</span>
+              <span>{item.label}</span>
+            </Link>
+          ))}
+        </nav>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-slate-700">
+          <Link
+            href="/home"
+            className="flex items-center gap-2 px-3 py-2 text-slate-400 hover:text-white text-sm rounded-lg hover:bg-slate-700 transition-colors"
+          >
+            <span>←</span>
+            <span>アプリに戻る</span>
+          </Link>
+        </div>
+      </aside>
+
+      {/* Main Content */}
+      <main className="flex-1 overflow-y-auto">
+        <div className="p-8 max-w-7xl mx-auto">
+          {children}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/plans/[id]/page.tsx
+++ b/src/app/(super-admin)/plans/[id]/page.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+/**
+ * /super-admin/plans/[id] — プラン詳細・編集
+ * operator/03-ui-spec.md §24 準拠
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+
+type Plan = {
+  id: string;
+  plan_key: string;
+  display_name: string;
+  plan_type: string;
+  description: string | null;
+  monthly_price_jpy: number | null;
+  yearly_price_jpy: number | null;
+  max_members: number | null;
+  stripe_product_id: string | null;
+  stripe_price_id: string | null;
+  status: string;
+  display_order: number;
+  trial_days: number;
+  feature_packages: string[];
+  price_history: PriceHistoryEntry[];
+};
+
+type PriceHistoryEntry = {
+  id: string;
+  old_monthly_price_jpy: number | null;
+  new_monthly_price_jpy: number | null;
+  reason: string | null;
+  applies_to: string;
+  changed_by: string;
+  created_at: string;
+};
+
+const STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  draft: { label: '下書き', color: 'bg-slate-100 text-slate-600' },
+  public: { label: '公開中', color: 'bg-green-100 text-green-700' },
+  private: { label: '非公開', color: 'bg-yellow-100 text-yellow-700' },
+  deprecated: { label: '廃止', color: 'bg-red-100 text-red-700' },
+};
+
+export default function PlanDetailPage() {
+  const params = useParams();
+  const planId = params.id as string;
+
+  const [plan, setPlan] = useState<Plan | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  // 編集フィールド
+  const [displayName, setDisplayName] = useState('');
+  const [description, setDescription] = useState('');
+  const [bannerUrl, setBannerUrl] = useState('');
+  const [displayOrder, setDisplayOrder] = useState(0);
+  const [activeTab, setActiveTab] = useState<'basic' | 'price' | 'history'>('basic');
+
+  const fetchPlan = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/super-admin/plans/${planId}`);
+      const data = await res.json() as { data?: Plan; error?: { message: string } };
+      if (!res.ok) {
+        setError(data.error?.message ?? 'プランの取得に失敗しました');
+        return;
+      }
+      setPlan(data.data!);
+      setDisplayName(data.data!.display_name);
+      setDescription(data.data!.description ?? '');
+      setBannerUrl('');
+      setDisplayOrder(data.data!.display_order);
+    } catch {
+      setError('ネットワークエラー');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [planId]);
+
+  useEffect(() => {
+    fetchPlan();
+  }, [fetchPlan]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setSaveError('');
+    setSaveSuccess(false);
+    try {
+      const res = await fetch(`/api/super-admin/plans/${planId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          display_name: displayName,
+          description: description || null,
+          banner_url: bannerUrl || null,
+          display_order: displayOrder,
+        }),
+      });
+      const data = await res.json() as { data?: Plan; error?: { message: string } };
+      if (!res.ok) {
+        setSaveError(data.error?.message ?? '保存に失敗しました');
+        return;
+      }
+      setSaveSuccess(true);
+      setPlan(data.data!);
+    } catch {
+      setSaveError('ネットワークエラー');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleStatusChange = async (newStatus: 'public' | 'private') => {
+    const confirm = window.confirm(
+      newStatus === 'public' ? 'このプランを公開しますか？' : 'このプランを非公開にしますか？'
+    );
+    if (!confirm) return;
+
+    try {
+      const res = await fetch(`/api/super-admin/plans/${planId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (res.ok) fetchPlan();
+    } catch {
+      alert('ステータス変更に失敗しました');
+    }
+  };
+
+  if (isLoading) {
+    return <div className="flex items-center justify-center h-48 text-slate-400">読み込み中...</div>;
+  }
+
+  if (error || !plan) {
+    return (
+      <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+        {error || 'プランが見つかりません'}
+      </div>
+    );
+  }
+
+  const statusInfo = STATUS_LABELS[plan.status] ?? { label: plan.status, color: 'bg-slate-100 text-slate-600' };
+  const isEditable = plan.status === 'draft' || plan.status === 'public' || plan.status === 'private';
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Link href="/super-admin/plans" className="text-slate-400 hover:text-slate-600 transition-colors text-sm">
+            ← 一覧
+          </Link>
+          <span className="text-slate-300">/</span>
+          <h1 className="text-xl font-bold text-slate-900">{plan.display_name}</h1>
+          <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${statusInfo.color}`}>
+            {statusInfo.label}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {plan.status === 'draft' && (
+            <button
+              onClick={() => handleStatusChange('public')}
+              className="px-3 py-1.5 bg-green-500 text-white rounded-lg text-xs font-medium hover:bg-green-600 transition-colors"
+            >
+              公開する
+            </button>
+          )}
+          {plan.status === 'public' && (
+            <button
+              onClick={() => handleStatusChange('private')}
+              className="px-3 py-1.5 bg-yellow-500 text-white rounded-lg text-xs font-medium hover:bg-yellow-600 transition-colors"
+            >
+              非公開にする
+            </button>
+          )}
+          {plan.status === 'private' && (
+            <button
+              onClick={() => handleStatusChange('public')}
+              className="px-3 py-1.5 bg-green-500 text-white rounded-lg text-xs font-medium hover:bg-green-600 transition-colors"
+            >
+              再公開する
+            </button>
+          )}
+          {(plan.status === 'public' || plan.status === 'private') && (
+            <Link
+              href={`/super-admin/plans/${plan.id}/price-change`}
+              className="px-3 py-1.5 bg-orange-500 text-white rounded-lg text-xs font-medium hover:bg-orange-600 transition-colors"
+            >
+              価格変更
+            </Link>
+          )}
+        </div>
+      </div>
+
+      {/* タブ */}
+      <div className="flex gap-1 mb-6 border-b border-slate-200">
+        {(['basic', 'price', 'history'] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+              activeTab === tab
+                ? 'border-orange-500 text-orange-600'
+                : 'border-transparent text-slate-500 hover:text-slate-700'
+            }`}
+          >
+            {tab === 'basic' ? '基本情報' : tab === 'price' ? '価格設定' : '価格変更履歴'}
+          </button>
+        ))}
+      </div>
+
+      {/* 基本情報タブ */}
+      {activeTab === 'basic' && (
+        <div className="bg-white rounded-xl border border-slate-200 p-6 space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-xs font-medium text-slate-500 mb-1">plan_key</label>
+              <code className="font-mono text-sm bg-slate-100 px-2 py-1 rounded">{plan.plan_key}</code>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-slate-500 mb-1">種別</label>
+              <span className="text-sm text-slate-700">{plan.plan_type}</span>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">表示名 *</label>
+            <input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              disabled={!isEditable}
+              className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:bg-slate-50"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">説明</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              disabled={!isEditable}
+              rows={4}
+              className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:bg-slate-50"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">表示順</label>
+            <input
+              type="number"
+              value={displayOrder}
+              onChange={(e) => setDisplayOrder(Number(e.target.value))}
+              disabled={!isEditable}
+              className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:bg-slate-50"
+            />
+          </div>
+
+          <div className="flex items-center gap-4 pt-2">
+            <div className="text-sm text-slate-500">最大メンバー: {plan.max_members ?? '無制限'}</div>
+            <div className="text-sm text-slate-500">試用期間: {plan.trial_days} 日</div>
+          </div>
+
+          {saveError && (
+            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+              {saveError}
+            </div>
+          )}
+          {saveSuccess && (
+            <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg text-sm">
+              保存しました
+            </div>
+          )}
+
+          {isEditable && (
+            <div className="flex justify-end pt-2">
+              <button
+                onClick={handleSave}
+                disabled={isSaving}
+                className="px-5 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600 transition-colors disabled:opacity-50"
+              >
+                {isSaving ? '保存中...' : '保存する'}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 価格設定タブ */}
+      {activeTab === 'price' && (
+        <div className="bg-white rounded-xl border border-slate-200 p-6 space-y-4">
+          <div className="grid grid-cols-2 gap-6">
+            <div>
+              <label className="block text-xs font-medium text-slate-500 mb-1">月額</label>
+              <p className="text-2xl font-bold text-slate-800">
+                {plan.monthly_price_jpy != null ? `¥${plan.monthly_price_jpy.toLocaleString()}` : '—'}
+              </p>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-slate-500 mb-1">年額</label>
+              <p className="text-2xl font-bold text-slate-800">
+                {plan.yearly_price_jpy != null ? `¥${plan.yearly_price_jpy.toLocaleString()}` : '—'}
+              </p>
+            </div>
+          </div>
+
+          <div className="pt-2 border-t border-slate-100">
+            <p className="text-xs font-medium text-slate-500 mb-2">Stripe 連携</p>
+            <div className="space-y-2 text-sm">
+              <div className="flex items-center gap-2">
+                <span className="text-slate-500">Product ID:</span>
+                <code className="font-mono text-xs bg-slate-100 px-2 py-0.5 rounded">
+                  {plan.stripe_product_id ?? '未設定'}
+                </code>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-slate-500">Price ID:</span>
+                <code className="font-mono text-xs bg-slate-100 px-2 py-0.5 rounded">
+                  {plan.stripe_price_id ? `${plan.stripe_price_id.slice(0, 12)}...` : '未設定'}
+                </code>
+              </div>
+            </div>
+          </div>
+
+          {(plan.status === 'public' || plan.status === 'private') && (
+            <div className="pt-4">
+              <Link
+                href={`/super-admin/plans/${plan.id}/price-change`}
+                className="inline-block px-4 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600 transition-colors"
+              >
+                価格変更フローを開始
+              </Link>
+              <p className="text-xs text-slate-400 mt-2">
+                価格変更は影響シミュレーション → 確認 → 実行の 3 ステップで行います
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 価格変更履歴タブ */}
+      {activeTab === 'history' && (
+        <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 border-b border-slate-200">
+              <tr>
+                <th className="text-left px-4 py-3 font-medium text-slate-600">変更日</th>
+                <th className="text-right px-4 py-3 font-medium text-slate-600">旧月額</th>
+                <th className="text-right px-4 py-3 font-medium text-slate-600">新月額</th>
+                <th className="text-left px-4 py-3 font-medium text-slate-600">適用範囲</th>
+                <th className="text-left px-4 py-3 font-medium text-slate-600">理由</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {(plan.price_history ?? []).map((h) => (
+                <tr key={h.id} className="hover:bg-slate-50">
+                  <td className="px-4 py-3 text-slate-600">
+                    {new Date(h.created_at).toLocaleDateString('ja-JP')}
+                  </td>
+                  <td className="px-4 py-3 text-right text-slate-500">
+                    {h.old_monthly_price_jpy != null ? `¥${h.old_monthly_price_jpy.toLocaleString()}` : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-right font-medium text-slate-800">
+                    {h.new_monthly_price_jpy != null ? `¥${h.new_monthly_price_jpy.toLocaleString()}` : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600 text-xs">{h.applies_to}</td>
+                  <td className="px-4 py-3 text-slate-500 text-xs truncate max-w-xs">{h.reason ?? '—'}</td>
+                </tr>
+              ))}
+              {(plan.price_history ?? []).length === 0 && (
+                <tr>
+                  <td colSpan={5} className="px-4 py-6 text-center text-slate-400">
+                    価格変更履歴がありません
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(super-admin)/plans/[id]/price-change/page.tsx
+++ b/src/app/(super-admin)/plans/[id]/price-change/page.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+/**
+ * /super-admin/plans/[id]/price-change — 価格変更フロー
+ * operator/03-ui-spec.md §24 (価格変更モーダル) / operator/04-plan-management.md §3.3 準拠
+ *
+ * Step1: 新価格入力 + 影響シミュレーション
+ * Step2: 確認 → 実行
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+type ImpactData = {
+  affected_subscription_count: number;
+  affected_mrr_change_jpy: number;
+  current_monthly_price_jpy: number;
+  new_monthly_price_jpy: number;
+  applies_to: string;
+};
+
+type Plan = {
+  id: string;
+  plan_key: string;
+  display_name: string;
+  monthly_price_jpy: number | null;
+  yearly_price_jpy: number | null;
+  status: string;
+};
+
+const APPLIES_TO_LABELS: Record<string, string> = {
+  new_only: '新規契約のみ',
+  on_renewal: '次回更新時から全契約',
+  immediately: '即時に全契約 (日割り適用)',
+};
+
+export default function PriceChangePage() {
+  const params = useParams();
+  const router = useRouter();
+  const planId = params.id as string;
+
+  const [plan, setPlan] = useState<Plan | null>(null);
+  const [newMonthlyPrice, setNewMonthlyPrice] = useState('');
+  const [newYearlyPrice, setNewYearlyPrice] = useState('');
+  const [appliesTo, setAppliesTo] = useState<'new_only' | 'on_renewal' | 'immediately'>('new_only');
+  const [reason, setReason] = useState('');
+  const [effectiveAt, setEffectiveAt] = useState(new Date().toISOString().slice(0, 16));
+  const [impact, setImpact] = useState<ImpactData | null>(null);
+  const [isSimulating, setIsSimulating] = useState(false);
+  const [isExecuting, setIsExecuting] = useState(false);
+  const [step, setStep] = useState<1 | 2>(1);
+  const [error, setError] = useState('');
+  const [simulateError, setSimulateError] = useState('');
+
+  useEffect(() => {
+    const fetchPlan = async () => {
+      const res = await fetch(`/api/super-admin/plans/${planId}`);
+      const data = await res.json() as { data?: Plan };
+      if (data.data) {
+        setPlan(data.data);
+        setNewMonthlyPrice(data.data.monthly_price_jpy != null ? String(data.data.monthly_price_jpy) : '');
+        setNewYearlyPrice(data.data.yearly_price_jpy != null ? String(data.data.yearly_price_jpy) : '');
+      }
+    };
+    fetchPlan();
+  }, [planId]);
+
+  const handleSimulate = useCallback(async () => {
+    if (!newMonthlyPrice && !newYearlyPrice) {
+      setSimulateError('月額または年額を入力してください');
+      return;
+    }
+    setIsSimulating(true);
+    setSimulateError('');
+    try {
+      const params = new URLSearchParams();
+      if (newMonthlyPrice) params.set('new_monthly_price_jpy', newMonthlyPrice);
+      params.set('applies_to', appliesTo);
+      const res = await fetch(`/api/super-admin/plans/${planId}/price-impact?${params.toString()}`);
+      const data = await res.json() as { data?: ImpactData; error?: { message: string } };
+      if (!res.ok) {
+        setSimulateError(data.error?.message ?? 'シミュレーションに失敗しました');
+        return;
+      }
+      setImpact(data.data!);
+    } catch {
+      setSimulateError('ネットワークエラー');
+    } finally {
+      setIsSimulating(false);
+    }
+  }, [newMonthlyPrice, newYearlyPrice, appliesTo, planId]);
+
+  const handleExecute = async () => {
+    if (!reason) {
+      setError('変更理由を入力してください');
+      return;
+    }
+    setIsExecuting(true);
+    setError('');
+    try {
+      const res = await fetch(`/api/super-admin/plans/${planId}/price-change`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          new_monthly_price_jpy: newMonthlyPrice ? Number(newMonthlyPrice) : null,
+          new_yearly_price_jpy: newYearlyPrice ? Number(newYearlyPrice) : null,
+          applies_to: appliesTo,
+          reason,
+          effective_at: new Date(effectiveAt).toISOString(),
+        }),
+      });
+      const data = await res.json() as { error?: { message: string } };
+      if (!res.ok) {
+        setError(data.error?.message ?? '価格変更に失敗しました');
+        return;
+      }
+      router.push(`/super-admin/plans/${planId}?tab=history`);
+    } catch {
+      setError('ネットワークエラー');
+    } finally {
+      setIsExecuting(false);
+    }
+  };
+
+  if (!plan) {
+    return <div className="flex items-center justify-center h-48 text-slate-400">読み込み中...</div>;
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      {/* ヘッダー */}
+      <div className="flex items-center gap-3 mb-6">
+        <Link href={`/super-admin/plans/${planId}`} className="text-slate-400 hover:text-slate-600 transition-colors text-sm">
+          ← {plan.display_name}
+        </Link>
+        <span className="text-slate-300">/</span>
+        <h1 className="text-xl font-bold text-slate-900">価格変更</h1>
+      </div>
+
+      {/* Step 1: 価格入力 + シミュレーション */}
+      {step === 1 && (
+        <div className="space-y-6">
+          <div className="bg-white rounded-xl border border-slate-200 p-6 space-y-4">
+            <h2 className="text-base font-semibold text-slate-800">現在の価格</h2>
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <span className="text-slate-500">月額:</span>{' '}
+                <strong>{plan.monthly_price_jpy != null ? `¥${plan.monthly_price_jpy.toLocaleString()}` : '—'}</strong>
+              </div>
+              <div>
+                <span className="text-slate-500">年額:</span>{' '}
+                <strong>{plan.yearly_price_jpy != null ? `¥${plan.yearly_price_jpy.toLocaleString()}` : '—'}</strong>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-slate-200 p-6 space-y-4">
+            <h2 className="text-base font-semibold text-slate-800">新しい価格</h2>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">新しい月額 (JPY)</label>
+                <input
+                  type="number"
+                  value={newMonthlyPrice}
+                  onChange={(e) => setNewMonthlyPrice(e.target.value)}
+                  min="0"
+                  className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">新しい年額 (JPY)</label>
+                <input
+                  type="number"
+                  value={newYearlyPrice}
+                  onChange={(e) => setNewYearlyPrice(e.target.value)}
+                  min="0"
+                  className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">適用範囲</label>
+              <select
+                value={appliesTo}
+                onChange={(e) => setAppliesTo(e.target.value as typeof appliesTo)}
+                className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              >
+                {Object.entries(APPLIES_TO_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
+              </select>
+              {appliesTo === 'immediately' && (
+                <p className="text-xs text-red-600 mt-1">
+                  即時適用は全アクティブ契約に影響します。慎重に選択してください。
+                </p>
+              )}
+            </div>
+
+            {simulateError && (
+              <div className="bg-red-50 border border-red-200 text-red-700 px-3 py-2 rounded text-sm">
+                {simulateError}
+              </div>
+            )}
+
+            <button
+              onClick={handleSimulate}
+              disabled={isSimulating}
+              className="w-full py-2.5 border-2 border-orange-500 text-orange-600 rounded-lg text-sm font-medium hover:bg-orange-50 transition-colors disabled:opacity-50"
+            >
+              {isSimulating ? 'シミュレーション中...' : '影響をシミュレーション'}
+            </button>
+
+            {/* 影響シミュレーション結果 */}
+            {impact && (
+              <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
+                <h3 className="text-sm font-semibold text-orange-800 mb-3">影響シミュレーション結果</h3>
+                <div className="grid grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <span className="text-orange-600">影響契約数:</span>{' '}
+                    <strong className="text-orange-800">{impact.affected_subscription_count.toLocaleString()} 件</strong>
+                  </div>
+                  <div>
+                    <span className="text-orange-600">MRR 変化:</span>{' '}
+                    <strong className={`${impact.affected_mrr_change_jpy >= 0 ? 'text-green-700' : 'text-red-700'}`}>
+                      {impact.affected_mrr_change_jpy >= 0 ? '+' : ''}
+                      ¥{impact.affected_mrr_change_jpy.toLocaleString()}
+                    </strong>
+                  </div>
+                </div>
+                <p className="text-xs text-orange-600 mt-2">
+                  適用範囲: {APPLIES_TO_LABELS[impact.applies_to]}
+                </p>
+              </div>
+            )}
+          </div>
+
+          {impact && (
+            <div className="flex justify-end">
+              <button
+                onClick={() => setStep(2)}
+                className="px-6 py-2.5 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600 transition-colors"
+              >
+                確認ステップへ →
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Step 2: 確認・理由入力 → 実行 */}
+      {step === 2 && impact && (
+        <div className="space-y-6">
+          <div className="bg-orange-50 border border-orange-300 rounded-xl p-6">
+            <h2 className="text-base font-semibold text-orange-800 mb-4">価格変更の確認</h2>
+            <div className="space-y-3 text-sm">
+              <div className="flex justify-between">
+                <span className="text-orange-600">プラン:</span>
+                <strong>{plan.display_name} ({plan.plan_key})</strong>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-orange-600">旧月額 → 新月額:</span>
+                <strong>
+                  ¥{(plan.monthly_price_jpy ?? 0).toLocaleString()} → ¥{Number(newMonthlyPrice).toLocaleString()}
+                </strong>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-orange-600">適用範囲:</span>
+                <strong>{APPLIES_TO_LABELS[appliesTo]}</strong>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-orange-600">影響契約数:</span>
+                <strong>{impact.affected_subscription_count.toLocaleString()} 件</strong>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-orange-600">MRR 変化:</span>
+                <strong className={impact.affected_mrr_change_jpy >= 0 ? 'text-green-700' : 'text-red-700'}>
+                  {impact.affected_mrr_change_jpy >= 0 ? '+' : ''}
+                  ¥{impact.affected_mrr_change_jpy.toLocaleString()}
+                </strong>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-slate-200 p-6 space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">変更理由 * (監査ログに記録されます)</label>
+              <textarea
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                rows={3}
+                required
+                className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+                placeholder="例: 物価上昇に伴うインフレ調整"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">適用開始日時</label>
+              <input
+                type="datetime-local"
+                value={effectiveAt}
+                onChange={(e) => setEffectiveAt(e.target.value)}
+                className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              />
+            </div>
+
+            {error && (
+              <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+                {error}
+              </div>
+            )}
+
+            <div className="flex gap-3 justify-between">
+              <button
+                onClick={() => setStep(1)}
+                className="px-4 py-2 border border-slate-200 text-slate-700 rounded-lg text-sm hover:bg-slate-50 transition-colors"
+              >
+                ← 戻る
+              </button>
+              <button
+                onClick={handleExecute}
+                disabled={isExecuting || !reason}
+                className="px-6 py-2 bg-red-500 text-white rounded-lg text-sm font-medium hover:bg-red-600 transition-colors disabled:opacity-50"
+              >
+                {isExecuting ? '実行中...' : '価格変更を実行する'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(super-admin)/plans/new/page.tsx
+++ b/src/app/(super-admin)/plans/new/page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+/**
+ * /super-admin/plans/new — プラン新規作成
+ * operator/03-ui-spec.md §23 / operator/04-plan-management.md §3.1 準拠
+ *
+ * 9 種公式 plan_key のみ UI から作成可能 (設計書 §4 確定方針)
+ */
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+const OFFICIAL_PLANS = [
+  { plan_key: 'free', display_name: 'Free', plan_type: 'personal', monthly_price_jpy: 0 },
+  { plan_key: 'pro', display_name: 'Pro', plan_type: 'personal', monthly_price_jpy: 980 },
+  { plan_key: 'family_basic', display_name: 'Family Basic', plan_type: 'family', monthly_price_jpy: 1480 },
+  { plan_key: 'family_pro', display_name: 'Family Pro', plan_type: 'family', monthly_price_jpy: 2480 },
+  { plan_key: 'family_addon', display_name: 'Family Addon', plan_type: 'family', monthly_price_jpy: 280 },
+  { plan_key: 'org_starter', display_name: 'Org Starter', plan_type: 'org', monthly_price_jpy: 580 },
+  { plan_key: 'org_standard', display_name: 'Org Standard', plan_type: 'org', monthly_price_jpy: 980 },
+  { plan_key: 'org_pro', display_name: 'Org Pro', plan_type: 'org', monthly_price_jpy: 1980 },
+  { plan_key: 'org_enterprise', display_name: 'Org Enterprise', plan_type: 'org', monthly_price_jpy: null },
+] as const;
+
+type OfficialPlanKey = typeof OFFICIAL_PLANS[number]['plan_key'];
+
+export default function PlanNewPage() {
+  const router = useRouter();
+  const [selectedKey, setSelectedKey] = useState<OfficialPlanKey | ''>('');
+  const [displayName, setDisplayName] = useState('');
+  const [description, setDescription] = useState('');
+  const [monthlyPrice, setMonthlyPrice] = useState('');
+  const [yearlyPrice, setYearlyPrice] = useState('');
+  const [maxMembers, setMaxMembers] = useState('');
+  const [trialDays, setTrialDays] = useState('0');
+  const [planType, setPlanType] = useState<'personal' | 'family' | 'org'>('personal');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSelectTemplate = (key: OfficialPlanKey) => {
+    const template = OFFICIAL_PLANS.find((p) => p.plan_key === key);
+    if (!template) return;
+    setSelectedKey(key);
+    setDisplayName(template.display_name);
+    setPlanType(template.plan_type as 'personal' | 'family' | 'org');
+    setMonthlyPrice(template.monthly_price_jpy != null ? String(template.monthly_price_jpy) : '');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedKey) {
+      setError('プランテンプレートを選択してください');
+      return;
+    }
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const res = await fetch('/api/super-admin/plans', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          plan_key: selectedKey,
+          display_name: displayName,
+          plan_type: planType,
+          description: description || undefined,
+          monthly_price_jpy: monthlyPrice !== '' ? Number(monthlyPrice) : null,
+          yearly_price_jpy: yearlyPrice !== '' ? Number(yearlyPrice) : null,
+          max_members: maxMembers !== '' ? Number(maxMembers) : null,
+          trial_days: Number(trialDays),
+        }),
+      });
+
+      const data = await res.json() as { data?: { id: string }; error?: { message: string } };
+      if (!res.ok) {
+        setError(data.error?.message ?? '作成に失敗しました');
+        return;
+      }
+      router.push(`/super-admin/plans/${data.data!.id}`);
+    } catch {
+      setError('ネットワークエラーが発生しました');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      {/* ヘッダー */}
+      <div className="flex items-center gap-3 mb-6">
+        <Link href="/super-admin/plans" className="text-slate-400 hover:text-slate-600 transition-colors">
+          ← 一覧に戻る
+        </Link>
+        <span className="text-slate-300">/</span>
+        <h1 className="text-xl font-bold text-slate-900">新規プラン作成</h1>
+      </div>
+
+      <div className="bg-blue-50 border border-blue-200 text-blue-700 px-4 py-3 rounded-lg mb-6 text-sm">
+        <strong>設計上の制約:</strong> 9 種公式プランから選択してください。プランの種別・plan_key は変更できません。
+        追加設定 (価格、説明等) はテンプレート選択後に入力します。
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* テンプレート選択 */}
+        <div className="bg-white rounded-xl border border-slate-200 p-6">
+          <h2 className="text-base font-semibold text-slate-800 mb-4">1. プランテンプレート選択</h2>
+          <div className="grid grid-cols-3 gap-2">
+            {OFFICIAL_PLANS.map((p) => (
+              <button
+                key={p.plan_key}
+                type="button"
+                onClick={() => handleSelectTemplate(p.plan_key)}
+                className={`px-3 py-2.5 rounded-lg border text-left transition-all ${
+                  selectedKey === p.plan_key
+                    ? 'border-orange-500 bg-orange-50 text-orange-700'
+                    : 'border-slate-200 hover:border-slate-300 text-slate-700'
+                }`}
+              >
+                <div className="text-xs font-mono text-slate-400">{p.plan_key}</div>
+                <div className="text-sm font-medium mt-0.5">{p.display_name}</div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 基本情報 */}
+        {selectedKey && (
+          <div className="bg-white rounded-xl border border-slate-200 p-6 space-y-4">
+            <h2 className="text-base font-semibold text-slate-800">2. 基本情報</h2>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">表示名 *</label>
+              <input
+                type="text"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                required
+                className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+                placeholder="例: Pro"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">説明</label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+                className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+                placeholder="プランの説明 (Markdown 使用可)"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">月額 (JPY)</label>
+                <input
+                  type="number"
+                  value={monthlyPrice}
+                  onChange={(e) => setMonthlyPrice(e.target.value)}
+                  min="0"
+                  className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  placeholder="0"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">年額 (JPY)</label>
+                <input
+                  type="number"
+                  value={yearlyPrice}
+                  onChange={(e) => setYearlyPrice(e.target.value)}
+                  min="0"
+                  className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  placeholder="未設定"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">最大メンバー数</label>
+                <input
+                  type="number"
+                  value={maxMembers}
+                  onChange={(e) => setMaxMembers(e.target.value)}
+                  min="1"
+                  className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  placeholder="無制限"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">
+                  試用期間 (日)
+                  {planType === 'org' && <span className="text-red-500 ml-1 text-xs">組織プランは 0 固定</span>}
+                </label>
+                <input
+                  type="number"
+                  value={trialDays}
+                  onChange={(e) => setTrialDays(e.target.value)}
+                  min="0"
+                  disabled={planType === 'org'}
+                  className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:bg-slate-100"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        <div className="flex gap-3 justify-end">
+          <Link
+            href="/super-admin/plans"
+            className="px-4 py-2 border border-slate-200 text-slate-700 rounded-lg text-sm hover:bg-slate-50 transition-colors"
+          >
+            キャンセル
+          </Link>
+          <button
+            type="submit"
+            disabled={isLoading || !selectedKey}
+            className="px-6 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600 transition-colors disabled:opacity-50"
+          >
+            {isLoading ? '作成中...' : 'draft で作成'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/plans/page.tsx
+++ b/src/app/(super-admin)/plans/page.tsx
@@ -1,0 +1,121 @@
+/**
+ * /super-admin/plans — プラン定義・販売管理 一覧
+ * operator/03-ui-spec.md §23 準拠
+ */
+
+import Link from 'next/link';
+import { createClient } from '@/lib/supabase/server';
+
+const STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  draft: { label: '下書き', color: 'bg-slate-100 text-slate-600' },
+  public: { label: '公開中', color: 'bg-green-100 text-green-700' },
+  private: { label: '非公開', color: 'bg-yellow-100 text-yellow-700' },
+  deprecated: { label: '廃止', color: 'bg-red-100 text-red-700' },
+};
+
+const TYPE_LABELS: Record<string, { label: string; color: string }> = {
+  personal: { label: '個人', color: 'bg-blue-100 text-blue-700' },
+  family: { label: '家族', color: 'bg-purple-100 text-purple-700' },
+  org: { label: '組織', color: 'bg-orange-100 text-orange-700' },
+};
+
+export default async function PlansPage() {
+  const supabase = createClient();
+
+  const { data: plans, error } = await supabase
+    .from('subscription_plans')
+    .select('*')
+    .order('display_order', { ascending: true });
+
+  return (
+    <div>
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">プラン管理</h1>
+          <p className="text-sm text-slate-500 mt-1">subscription_plans の CRUD、価格変更、公開状態管理</p>
+        </div>
+        <Link
+          href="/super-admin/plans/new"
+          className="px-4 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600 transition-colors"
+        >
+          + 新規プラン作成
+        </Link>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-4 text-sm">
+          データの取得に失敗しました: {error.message}
+        </div>
+      )}
+
+      {/* テーブル */}
+      <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 border-b border-slate-200">
+            <tr>
+              <th className="text-left px-4 py-3 font-medium text-slate-600">plan_key</th>
+              <th className="text-left px-4 py-3 font-medium text-slate-600">表示名</th>
+              <th className="text-left px-4 py-3 font-medium text-slate-600">種別</th>
+              <th className="text-right px-4 py-3 font-medium text-slate-600">月額</th>
+              <th className="text-right px-4 py-3 font-medium text-slate-600">年額</th>
+              <th className="text-center px-4 py-3 font-medium text-slate-600">パッケージ数</th>
+              <th className="text-center px-4 py-3 font-medium text-slate-600">ステータス</th>
+              <th className="text-right px-4 py-3 font-medium text-slate-600">表示順</th>
+              <th className="text-center px-4 py-3 font-medium text-slate-600">操作</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {(plans ?? []).map((plan) => {
+              const statusInfo = STATUS_LABELS[plan.status] ?? { label: plan.status, color: 'bg-slate-100 text-slate-600' };
+              const typeInfo = TYPE_LABELS[plan.plan_type] ?? { label: plan.plan_type, color: 'bg-slate-100 text-slate-600' };
+              return (
+                <tr key={plan.id} className="hover:bg-slate-50 transition-colors">
+                  <td className="px-4 py-3">
+                    <code className="font-mono text-xs bg-slate-100 px-2 py-0.5 rounded">{plan.plan_key}</code>
+                  </td>
+                  <td className="px-4 py-3 font-medium text-slate-800">{plan.display_name}</td>
+                  <td className="px-4 py-3">
+                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${typeInfo.color}`}>
+                      {typeInfo.label}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right text-slate-700">
+                    {plan.monthly_price_jpy != null ? `¥${plan.monthly_price_jpy.toLocaleString()}` : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-right text-slate-700">
+                    {plan.yearly_price_jpy != null ? `¥${plan.yearly_price_jpy.toLocaleString()}` : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-center text-slate-700">
+                    {(plan.feature_packages as string[] | null)?.length ?? 0}
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${statusInfo.color}`}>
+                      {statusInfo.label}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right text-slate-500">{plan.display_order}</td>
+                  <td className="px-4 py-3 text-center">
+                    <Link
+                      href={`/super-admin/plans/${plan.id}`}
+                      className="text-orange-500 hover:text-orange-600 font-medium text-xs"
+                    >
+                      編集
+                    </Link>
+                  </td>
+                </tr>
+              );
+            })}
+            {(plans ?? []).length === 0 && (
+              <tr>
+                <td colSpan={9} className="px-4 py-8 text-center text-slate-400">
+                  プランがありません
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/super-admin/coupons/[code]/redemptions/route.ts
+++ b/src/app/api/super-admin/coupons/[code]/redemptions/route.ts
@@ -1,0 +1,82 @@
+/**
+ * GET /api/super-admin/coupons/[code]/redemptions — クーポン適用履歴
+ *
+ * operator/01-data-model.md §3.6 準拠
+ * 権限: super_admin のみ
+ *
+ * NOTE: [code] は URL パスの動的パラメータ。クーポンコード文字列で検索する。
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { createClient } from '@/lib/supabase/server';
+import { CouponRedemptionsQuerySchema } from '@/lib/super-admin/coupons-schemas';
+
+type RouteContext = { params: { code: string } };
+
+export async function GET(request: NextRequest, { params }: RouteContext) {
+  try {
+    await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    // クーポンコードからクーポンを取得
+    const { data: coupon, error: couponErr } = await supabase
+      .from('coupons')
+      .select('id, code')
+      .eq('code', params.code)
+      .single();
+
+    if (couponErr || !coupon) {
+      return NextResponse.json(
+        { error: { code: 'OP_COUPON_NOT_FOUND', message: 'クーポンが見つかりません' } },
+        { status: 404 }
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const queryResult = CouponRedemptionsQuerySchema.safeParse({
+      page: searchParams.get('page') ?? undefined,
+      per_page: searchParams.get('per_page') ?? undefined,
+    });
+
+    if (!queryResult.success) {
+      return NextResponse.json(
+        { error: { code: 'OP_INVALID_QUERY', message: queryResult.error.message } },
+        { status: 400 }
+      );
+    }
+
+    const { page, per_page } = queryResult.data;
+    const offset = (page - 1) * per_page;
+
+    const { data: redemptions, error, count } = await supabase
+      .from('coupon_redemptions')
+      .select('*', { count: 'exact' })
+      .eq('coupon_id', coupon.id)
+      .order('redeemed_at', { ascending: false })
+      .range(offset, offset + per_page - 1);
+
+    if (error) {
+      console.error('[super-admin/coupons/[code]/redemptions GET]', error);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: error.message } },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      data: redemptions,
+      meta: { total: count ?? 0, page, per_page, coupon_code: coupon.code },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/coupons/[code]/redemptions GET]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}

--- a/src/app/api/super-admin/coupons/[id]/route.ts
+++ b/src/app/api/super-admin/coupons/[id]/route.ts
@@ -1,0 +1,203 @@
+/**
+ * GET    /api/super-admin/coupons/[id] — クーポン詳細
+ * PATCH  /api/super-admin/coupons/[id] — クーポン更新
+ * DELETE /api/super-admin/coupons/[id] — クーポン削除
+ *
+ * operator/01-data-model.md §3.5 / operator/04-plan-management.md §4.1 準拠
+ * 権限: super_admin のみ
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { createClient } from '@/lib/supabase/server';
+import { CouponUpdateSchema } from '@/lib/super-admin/coupons-schemas';
+
+type RouteContext = { params: { id: string } };
+
+export async function GET(_request: NextRequest, { params }: RouteContext) {
+  try {
+    await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const { data: coupon, error } = await supabase
+      .from('coupons')
+      .select('*')
+      .eq('id', params.id)
+      .single();
+
+    if (error || !coupon) {
+      return NextResponse.json(
+        { error: { code: 'OP_COUPON_NOT_FOUND', message: 'クーポンが見つかりません' } },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ data: coupon });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/coupons/[id] GET]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteContext) {
+  try {
+    const user = await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const body = await request.json();
+    const parseResult = CouponUpdateSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: { code: 'OP_INVALID_INPUT', message: parseResult.error.message, details: parseResult.error.issues } },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+    const updateData: Record<string, unknown> = {};
+
+    if (input.display_name !== undefined) updateData.display_name = input.display_name;
+    if (input.status !== undefined) updateData.status = input.status;
+    if (input.valid_until !== undefined) updateData.valid_until = input.valid_until;
+    if (input.max_uses !== undefined) updateData.max_uses = input.max_uses;
+    if (input.applicable_plans !== undefined) updateData.applicable_plans = input.applicable_plans;
+    if (input.applicable_to !== undefined) updateData.applicable_to = input.applicable_to;
+    if (input.gross_margin_preview_jpy !== undefined) updateData.gross_margin_preview_jpy = input.gross_margin_preview_jpy;
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json(
+        { error: { code: 'OP_NO_UPDATE', message: '更新するフィールドがありません' } },
+        { status: 400 }
+      );
+    }
+
+    const { data: existing, error: fetchErr } = await supabase
+      .from('coupons')
+      .select('id, code')
+      .eq('id', params.id)
+      .single();
+
+    if (fetchErr || !existing) {
+      return NextResponse.json(
+        { error: { code: 'OP_COUPON_NOT_FOUND', message: 'クーポンが見つかりません' } },
+        { status: 404 }
+      );
+    }
+
+    const { data: updated, error } = await supabase
+      .from('coupons')
+      .update(updateData)
+      .eq('id', params.id)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('[super-admin/coupons/[id] PATCH]', error);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: error.message } },
+        { status: 500 }
+      );
+    }
+
+    // 監査ログ記録
+    try {
+      await supabase.from('admin_audit_logs').insert({
+        actor_id: user.id,
+        target_id: params.id,
+        target_type: 'coupon',
+        action_type: 'update_coupon',
+        details: { code: existing.code, changes: updateData },
+        severity: 'info',
+        ip_address: request.headers.get('x-forwarded-for'),
+      });
+    } catch (auditErr) {
+      console.warn('[super-admin/coupons/[id] PATCH] audit log failed (graceful):', auditErr);
+    }
+
+    return NextResponse.json({ data: updated });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/coupons/[id] PATCH]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteContext) {
+  try {
+    const user = await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const { data: existing, error: fetchErr } = await supabase
+      .from('coupons')
+      .select('id, code, uses_count')
+      .eq('id', params.id)
+      .single();
+
+    if (fetchErr || !existing) {
+      return NextResponse.json(
+        { error: { code: 'OP_COUPON_NOT_FOUND', message: 'クーポンが見つかりません' } },
+        { status: 404 }
+      );
+    }
+
+    // 利用中 (uses_count > 0) のクーポンは削除不可
+    if (existing.uses_count > 0) {
+      return NextResponse.json(
+        { error: { code: 'OP_COUPON_IN_USE', message: '利用実績があるクーポンは削除できません。paused に変更してください。' } },
+        { status: 409 }
+      );
+    }
+
+    const { error: deleteErr } = await supabase
+      .from('coupons')
+      .delete()
+      .eq('id', params.id);
+
+    if (deleteErr) {
+      console.error('[super-admin/coupons/[id] DELETE]', deleteErr);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: deleteErr.message } },
+        { status: 500 }
+      );
+    }
+
+    // 監査ログ記録
+    try {
+      await supabase.from('admin_audit_logs').insert({
+        actor_id: user.id,
+        target_id: params.id,
+        target_type: 'coupon',
+        action_type: 'delete_coupon',
+        details: { code: existing.code },
+        severity: 'warn',
+        ip_address: request.headers.get('x-forwarded-for'),
+      });
+    } catch (auditErr) {
+      console.warn('[super-admin/coupons/[id] DELETE] audit log failed (graceful):', auditErr);
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/coupons/[id] DELETE]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}

--- a/src/app/api/super-admin/coupons/route.ts
+++ b/src/app/api/super-admin/coupons/route.ts
@@ -1,0 +1,163 @@
+/**
+ * GET  /api/super-admin/coupons — クーポン一覧
+ * POST /api/super-admin/coupons — クーポン新規作成
+ *
+ * operator/01-data-model.md §3.5 / operator/04-plan-management.md §4.1 準拠
+ * 権限: super_admin のみ (sales/admin も閲覧可だが super_admin で統一)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { createClient } from '@/lib/supabase/server';
+import {
+  CouponCreateSchema,
+  CouponsQuerySchema,
+} from '@/lib/super-admin/coupons-schemas';
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const { searchParams } = request.nextUrl;
+    const queryResult = CouponsQuerySchema.safeParse({
+      status: searchParams.get('status') ?? undefined,
+      applicable_to: searchParams.get('applicable_to') ?? undefined,
+      page: searchParams.get('page') ?? undefined,
+      per_page: searchParams.get('per_page') ?? undefined,
+    });
+
+    if (!queryResult.success) {
+      return NextResponse.json(
+        { error: { code: 'OP_INVALID_QUERY', message: queryResult.error.message } },
+        { status: 400 }
+      );
+    }
+
+    const { status, applicable_to, page, per_page } = queryResult.data;
+    const offset = (page - 1) * per_page;
+
+    let query = supabase
+      .from('coupons')
+      .select('*', { count: 'exact' })
+      .order('created_at', { ascending: false })
+      .range(offset, offset + per_page - 1);
+
+    if (status) query = query.eq('status', status);
+    if (applicable_to) query = query.eq('applicable_to', applicable_to);
+
+    const { data, error, count } = await query;
+
+    if (error) {
+      console.error('[super-admin/coupons GET]', error);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: error.message } },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      data,
+      meta: { total: count ?? 0, page, per_page },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/coupons GET]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const body = await request.json();
+    const parseResult = CouponCreateSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: { code: 'OP_INVALID_INPUT', message: parseResult.error.message, details: parseResult.error.issues } },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    const { data: coupon, error } = await supabase
+      .from('coupons')
+      .insert({
+        code: input.code,
+        display_name: input.display_name ?? null,
+        discount_type: input.discount_type,
+        discount_value: input.discount_value,
+        applicable_plans: input.applicable_plans ?? [],
+        applicable_to: input.applicable_to ?? 'all',
+        valid_from: input.valid_from,
+        valid_until: input.valid_until,
+        max_uses: input.max_uses ?? null,
+        per_user_limit: input.per_user_limit ?? 1,
+        duration_months: input.duration_months ?? null,
+        gross_margin_preview_jpy: input.gross_margin_preview_jpy ?? null,
+        status: 'active',
+        created_by: user.id,
+        uses_count: 0,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === '23505') {
+        return NextResponse.json(
+          { error: { code: 'OP_COUPON_CODE_DUPLICATE', message: 'クーポンコードが既に存在します' } },
+          { status: 409 }
+        );
+      }
+      console.error('[super-admin/coupons POST]', error);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: error.message } },
+        { status: 500 }
+      );
+    }
+
+    // 監査ログ記録 (クーポン作成は課金影響 → severity='warn')
+    try {
+      await supabase.from('admin_audit_logs').insert({
+        actor_id: user.id,
+        target_id: coupon.id,
+        target_type: 'coupon',
+        action_type: 'create_coupon',
+        details: {
+          code: input.code,
+          discount_type: input.discount_type,
+          discount_value: input.discount_value,
+          applicable_to: input.applicable_to,
+          valid_from: input.valid_from,
+          valid_until: input.valid_until,
+          max_uses: input.max_uses,
+        },
+        severity: 'warn',
+        ip_address: request.headers.get('x-forwarded-for'),
+      });
+    } catch (auditErr) {
+      console.warn('[super-admin/coupons POST] audit log failed (graceful):', auditErr);
+    }
+
+    return NextResponse.json({ data: coupon }, { status: 201 });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/coupons POST]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}

--- a/src/app/api/super-admin/feature-packages/[id]/route.ts
+++ b/src/app/api/super-admin/feature-packages/[id]/route.ts
@@ -1,0 +1,186 @@
+/**
+ * GET    /api/super-admin/feature-packages/[id] — 機能パッケージ詳細
+ * PATCH  /api/super-admin/feature-packages/[id] — 機能パッケージ更新
+ * DELETE /api/super-admin/feature-packages/[id] — 機能パッケージ削除
+ *
+ * operator/01-data-model.md §3.3 準拠
+ * 権限: super_admin のみ
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { createClient } from '@/lib/supabase/server';
+import { FeaturePackageUpdateSchema } from '@/lib/super-admin/feature-packages-schemas';
+
+type RouteContext = { params: { id: string } };
+
+export async function GET(_request: NextRequest, { params }: RouteContext) {
+  try {
+    await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const { data: pkg, error } = await supabase
+      .from('feature_packages')
+      .select('*')
+      .eq('id', params.id)
+      .single();
+
+    if (error || !pkg) {
+      return NextResponse.json(
+        { error: { code: 'OP_PACKAGE_NOT_FOUND', message: '機能パッケージが見つかりません' } },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ data: pkg });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/feature-packages/[id] GET]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteContext) {
+  try {
+    const user = await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const body = await request.json();
+    const parseResult = FeaturePackageUpdateSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: { code: 'OP_INVALID_INPUT', message: parseResult.error.message, details: parseResult.error.issues } },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+    const updateData: Record<string, unknown> = { updated_at: new Date().toISOString() };
+
+    if (input.display_name !== undefined) updateData.display_name = input.display_name;
+    if (input.description !== undefined) updateData.description = input.description;
+    if (input.feature_flags !== undefined) updateData.feature_flags = input.feature_flags;
+    if (input.display_order !== undefined) updateData.display_order = input.display_order;
+    if (input.status !== undefined) updateData.status = input.status;
+
+    const { data: updated, error } = await supabase
+      .from('feature_packages')
+      .update(updateData)
+      .eq('id', params.id)
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return NextResponse.json(
+          { error: { code: 'OP_PACKAGE_NOT_FOUND', message: '機能パッケージが見つかりません' } },
+          { status: 404 }
+        );
+      }
+      console.error('[super-admin/feature-packages/[id] PATCH]', error);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: error.message } },
+        { status: 500 }
+      );
+    }
+
+    // 監査ログ記録
+    try {
+      await supabase.from('admin_audit_logs').insert({
+        actor_id: user.id,
+        target_id: params.id,
+        target_type: 'feature_package',
+        action_type: 'update_feature_package',
+        details: { changes: updateData },
+        severity: 'info',
+        ip_address: request.headers.get('x-forwarded-for'),
+      });
+    } catch (auditErr) {
+      console.warn('[super-admin/feature-packages/[id] PATCH] audit log failed (graceful):', auditErr);
+    }
+
+    return NextResponse.json({ data: updated });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/feature-packages/[id] PATCH]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteContext) {
+  try {
+    const user = await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const { data: existing, error: fetchErr } = await supabase
+      .from('feature_packages')
+      .select('id, package_key, status')
+      .eq('id', params.id)
+      .single();
+
+    if (fetchErr || !existing) {
+      return NextResponse.json(
+        { error: { code: 'OP_PACKAGE_NOT_FOUND', message: '機能パッケージが見つかりません' } },
+        { status: 404 }
+      );
+    }
+
+    const { error: deleteErr } = await supabase
+      .from('feature_packages')
+      .delete()
+      .eq('id', params.id);
+
+    if (deleteErr) {
+      // FK 制約違反 (subscription_plans.feature_packages 配列に含まれている場合は削除不可)
+      if (deleteErr.code === '23503') {
+        return NextResponse.json(
+          { error: { code: 'OP_PACKAGE_IN_USE', message: 'プランで使用中の機能パッケージは削除できません' } },
+          { status: 409 }
+        );
+      }
+      console.error('[super-admin/feature-packages/[id] DELETE]', deleteErr);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: deleteErr.message } },
+        { status: 500 }
+      );
+    }
+
+    // 監査ログ記録
+    try {
+      await supabase.from('admin_audit_logs').insert({
+        actor_id: user.id,
+        target_id: params.id,
+        target_type: 'feature_package',
+        action_type: 'delete_feature_package',
+        details: { package_key: existing.package_key },
+        severity: 'warn',
+        ip_address: request.headers.get('x-forwarded-for'),
+      });
+    } catch (auditErr) {
+      console.warn('[super-admin/feature-packages/[id] DELETE] audit log failed (graceful):', auditErr);
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/feature-packages/[id] DELETE]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}

--- a/src/app/api/super-admin/feature-packages/route.ts
+++ b/src/app/api/super-admin/feature-packages/route.ts
@@ -1,0 +1,144 @@
+/**
+ * GET  /api/super-admin/feature-packages — 機能パッケージ一覧
+ * POST /api/super-admin/feature-packages — 機能パッケージ新規作成
+ *
+ * operator/01-data-model.md §3.3 / operator/02-api-spec.md 準拠
+ * 権限: super_admin のみ
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { createClient } from '@/lib/supabase/server';
+import {
+  FeaturePackageCreateSchema,
+  FeaturePackagesQuerySchema,
+} from '@/lib/super-admin/feature-packages-schemas';
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const { searchParams } = request.nextUrl;
+    const queryResult = FeaturePackagesQuerySchema.safeParse({
+      status: searchParams.get('status') ?? undefined,
+      page: searchParams.get('page') ?? undefined,
+      per_page: searchParams.get('per_page') ?? undefined,
+    });
+
+    if (!queryResult.success) {
+      return NextResponse.json(
+        { error: { code: 'OP_INVALID_QUERY', message: queryResult.error.message } },
+        { status: 400 }
+      );
+    }
+
+    const { status, page, per_page } = queryResult.data;
+    const offset = (page - 1) * per_page;
+
+    let query = supabase
+      .from('feature_packages')
+      .select('*', { count: 'exact' })
+      .order('display_order', { ascending: true })
+      .range(offset, offset + per_page - 1);
+
+    if (status) query = query.eq('status', status);
+
+    const { data, error, count } = await query;
+
+    if (error) {
+      console.error('[super-admin/feature-packages GET]', error);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: error.message } },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      data,
+      meta: { total: count ?? 0, page, per_page },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/feature-packages GET]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const body = await request.json();
+    const parseResult = FeaturePackageCreateSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: { code: 'OP_INVALID_INPUT', message: parseResult.error.message, details: parseResult.error.issues } },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    const { data: pkg, error } = await supabase
+      .from('feature_packages')
+      .insert({
+        package_key: input.package_key,
+        display_name: input.display_name,
+        description: input.description ?? null,
+        feature_flags: input.feature_flags,
+        display_order: input.display_order ?? 0,
+        status: 'active',
+      })
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === '23505') {
+        return NextResponse.json(
+          { error: { code: 'OP_PACKAGE_KEY_DUPLICATE', message: 'package_key が既に存在します' } },
+          { status: 409 }
+        );
+      }
+      console.error('[super-admin/feature-packages POST]', error);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: error.message } },
+        { status: 500 }
+      );
+    }
+
+    // 監査ログ記録
+    try {
+      await supabase.from('admin_audit_logs').insert({
+        actor_id: user.id,
+        target_id: pkg.id,
+        target_type: 'feature_package',
+        action_type: 'create_feature_package',
+        details: { package_key: input.package_key, display_name: input.display_name },
+        severity: 'info',
+        ip_address: request.headers.get('x-forwarded-for'),
+      });
+    } catch (auditErr) {
+      console.warn('[super-admin/feature-packages POST] audit log failed (graceful):', auditErr);
+    }
+
+    return NextResponse.json({ data: pkg }, { status: 201 });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/feature-packages POST]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}

--- a/src/app/api/super-admin/plans/[id]/price-change/route.ts
+++ b/src/app/api/super-admin/plans/[id]/price-change/route.ts
@@ -1,0 +1,184 @@
+/**
+ * POST /api/super-admin/plans/[id]/price-change — 価格変更実行
+ *
+ * operator/02-api-spec.md §17 / operator/04-plan-management.md §3.3 /
+ * operator/05-stripe-integration.md 準拠
+ *
+ * 権限: super_admin のみ
+ *
+ * Stripe Secret Key 未設定時はモック動作 (graceful degradation)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { createClient } from '@/lib/supabase/server';
+import { PriceChangeSchema } from '@/lib/super-admin/plans-schemas';
+
+type RouteContext = { params: { id: string } };
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  try {
+    const user = await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const body = await request.json();
+    const parseResult = PriceChangeSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: { code: 'OP_INVALID_INPUT', message: parseResult.error.message, details: parseResult.error.issues } },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    // プランを取得
+    const { data: plan, error: planErr } = await supabase
+      .from('subscription_plans')
+      .select('*')
+      .eq('id', params.id)
+      .single();
+
+    if (planErr || !plan) {
+      return NextResponse.json(
+        { error: { code: 'OP_PLAN_NOT_FOUND', message: 'プランが見つかりません' } },
+        { status: 404 }
+      );
+    }
+
+    // draft は価格変更 API を使う必要なし (PATCH で対応)
+    if (plan.status === 'draft') {
+      return NextResponse.json(
+        { error: { code: 'OP_PLAN_DRAFT_USE_PATCH', message: 'draft プランは PATCH API で価格変更してください' } },
+        { status: 422 }
+      );
+    }
+
+    let newStripePriceId: string | null = null;
+
+    // Stripe Price 作成 (STRIPE_SECRET_KEY が設定されている場合のみ)
+    if (process.env.STRIPE_SECRET_KEY && plan.stripe_product_id) {
+      try {
+        // Edge Function stripe-price-sync を呼ぶ (operator/04-plan-management.md §3.3 準拠)
+        const baseUrl =
+          process.env.NEXT_PUBLIC_APP_URL ??
+          (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
+
+        const edgeFnUrl = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/stripe-price-sync`;
+        const edgeRes = await fetch(edgeFnUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
+          },
+          body: JSON.stringify({
+            plan_id: params.id,
+            stripe_product_id: plan.stripe_product_id,
+            new_monthly_price_jpy: input.new_monthly_price_jpy,
+            new_yearly_price_jpy: input.new_yearly_price_jpy,
+            applies_to: input.applies_to,
+            actor_id: user.id,
+            reason: input.reason,
+          }),
+        });
+
+        if (edgeRes.ok) {
+          const edgeData = (await edgeRes.json()) as { new_stripe_price_id?: string };
+          newStripePriceId = edgeData.new_stripe_price_id ?? null;
+        } else {
+          console.warn('[super-admin/price-change] Edge Function stripe-price-sync failed, continuing with DB-only update');
+        }
+      } catch (stripeErr) {
+        console.warn('[super-admin/price-change] Stripe integration error (graceful degradation):', stripeErr);
+      }
+    } else {
+      console.warn('[super-admin/price-change] STRIPE_SECRET_KEY not set or stripe_product_id missing — mock mode');
+    }
+
+    // DB 更新: subscription_plans
+    const planUpdate: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    if (input.new_monthly_price_jpy != null) planUpdate.monthly_price_jpy = input.new_monthly_price_jpy;
+    if (input.new_yearly_price_jpy != null) planUpdate.yearly_price_jpy = input.new_yearly_price_jpy;
+    if (newStripePriceId) planUpdate.stripe_price_id = newStripePriceId;
+
+    const { error: updateErr } = await supabase
+      .from('subscription_plans')
+      .update(planUpdate)
+      .eq('id', params.id);
+
+    if (updateErr) {
+      console.error('[super-admin/price-change POST]', updateErr);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: updateErr.message } },
+        { status: 500 }
+      );
+    }
+
+    // plan_price_history に INSERT (operator/01-data-model.md §3.4 準拠)
+    const { error: historyErr } = await supabase.from('plan_price_history').insert({
+      plan_id: params.id,
+      old_monthly_price_jpy: plan.monthly_price_jpy,
+      new_monthly_price_jpy: input.new_monthly_price_jpy ?? plan.monthly_price_jpy,
+      old_yearly_price_jpy: plan.yearly_price_jpy,
+      new_yearly_price_jpy: input.new_yearly_price_jpy ?? plan.yearly_price_jpy,
+      old_stripe_price_id: plan.stripe_price_id,
+      new_stripe_price_id: newStripePriceId,
+      changed_by: user.id,
+      reason: input.reason,
+      effective_at: input.effective_at,
+      applies_to: input.applies_to,
+    });
+
+    if (historyErr) {
+      console.error('[super-admin/price-change POST] price_history INSERT failed:', historyErr);
+      // 非致命的: 続行
+    }
+
+    // 監査ログ記録 (severity='warn' — 課金影響操作)
+    try {
+      await supabase.from('admin_audit_logs').insert({
+        actor_id: user.id,
+        target_id: params.id,
+        target_type: 'subscription_plan',
+        action_type: 'change_price',
+        details: {
+          plan_key: plan.plan_key,
+          old_monthly_price_jpy: plan.monthly_price_jpy,
+          new_monthly_price_jpy: input.new_monthly_price_jpy,
+          old_yearly_price_jpy: plan.yearly_price_jpy,
+          new_yearly_price_jpy: input.new_yearly_price_jpy,
+          applies_to: input.applies_to,
+          reason: input.reason,
+          stripe_mock: !newStripePriceId,
+        },
+        severity: 'warn',
+        ip_address: request.headers.get('x-forwarded-for'),
+      });
+    } catch (auditErr) {
+      console.warn('[super-admin/price-change POST] audit log failed (graceful):', auditErr);
+    }
+
+    return NextResponse.json({
+      data: {
+        plan_id: params.id,
+        plan_key: plan.plan_key,
+        new_monthly_price_jpy: input.new_monthly_price_jpy,
+        new_yearly_price_jpy: input.new_yearly_price_jpy,
+        new_stripe_price_id: newStripePriceId,
+        applies_to: input.applies_to,
+        stripe_mock: !newStripePriceId,
+      },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/price-change POST]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}

--- a/src/app/api/super-admin/plans/[id]/price-impact/route.ts
+++ b/src/app/api/super-admin/plans/[id]/price-impact/route.ts
@@ -1,0 +1,97 @@
+/**
+ * GET /api/super-admin/plans/[id]/price-impact — 価格変更影響シミュレーション
+ *
+ * operator/02-api-spec.md §17 / operator/04-plan-management.md §3.3 準拠
+ * 権限: super_admin のみ
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { createClient } from '@/lib/supabase/server';
+import { PriceImpactQuerySchema } from '@/lib/super-admin/plans-schemas';
+
+type RouteContext = { params: { id: string } };
+
+export async function GET(request: NextRequest, { params }: RouteContext) {
+  try {
+    await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const { searchParams } = request.nextUrl;
+    const queryResult = PriceImpactQuerySchema.safeParse({
+      new_monthly_price_jpy: searchParams.get('new_monthly_price_jpy') ?? undefined,
+      applies_to: searchParams.get('applies_to') ?? undefined,
+    });
+
+    if (!queryResult.success) {
+      return NextResponse.json(
+        { error: { code: 'OP_INVALID_QUERY', message: queryResult.error.message } },
+        { status: 400 }
+      );
+    }
+
+    // プランを取得
+    const { data: plan, error: planErr } = await supabase
+      .from('subscription_plans')
+      .select('id, plan_key, monthly_price_jpy, plan_type')
+      .eq('id', params.id)
+      .single();
+
+    if (planErr || !plan) {
+      return NextResponse.json(
+        { error: { code: 'OP_PLAN_NOT_FOUND', message: 'プランが見つかりません' } },
+        { status: 404 }
+      );
+    }
+
+    // 影響する personal_subscriptions 数を計算 (operator/04-plan-management.md §3.3 SQL 準拠)
+    const { data: impactData, error: impactErr } = await supabase
+      .from('personal_subscriptions')
+      .select('id, user_id', { count: 'exact' })
+      .eq('plan_key', plan.plan_key)
+      .in('status', ['active', 'trialing', 'paused'])
+      .not('stripe_subscription_id', 'is', null)
+      .limit(5);
+
+    if (impactErr) {
+      console.error('[super-admin/plans/[id]/price-impact GET]', impactErr);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: impactErr.message } },
+        { status: 500 }
+      );
+    }
+
+    const { count: affectedCount } = await supabase
+      .from('personal_subscriptions')
+      .select('*', { count: 'exact', head: true })
+      .eq('plan_key', plan.plan_key)
+      .in('status', ['active', 'trialing', 'paused'])
+      .not('stripe_subscription_id', 'is', null);
+
+    const currentMonthlyPrice = plan.monthly_price_jpy ?? 0;
+    const newMonthlyPrice = queryResult.data.new_monthly_price_jpy ?? currentMonthlyPrice;
+    const affectedSubscriptionCount = affectedCount ?? 0;
+    const affectedMrrChange = (newMonthlyPrice - currentMonthlyPrice) * affectedSubscriptionCount;
+
+    return NextResponse.json({
+      data: {
+        affected_subscription_count: affectedSubscriptionCount,
+        affected_mrr_change_jpy: affectedMrrChange,
+        current_monthly_price_jpy: currentMonthlyPrice,
+        new_monthly_price_jpy: newMonthlyPrice,
+        applies_to: queryResult.data.applies_to ?? 'new_only',
+        affected_user_sample: (impactData ?? []).map((s) => ({ user_id: s.user_id })),
+      },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/plans/[id]/price-impact GET]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}

--- a/src/app/api/super-admin/plans/[id]/route.ts
+++ b/src/app/api/super-admin/plans/[id]/route.ts
@@ -1,0 +1,244 @@
+/**
+ * GET   /api/super-admin/plans/[id] — プラン詳細
+ * PATCH /api/super-admin/plans/[id] — プラン編集
+ * DELETE /api/super-admin/plans/[id] — プラン削除 (draft のみ)
+ *
+ * operator/02-api-spec.md §17 / operator/04-plan-management.md §3.1 準拠
+ * 権限: super_admin のみ
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { createClient } from '@/lib/supabase/server';
+import { PlanUpdateSchema } from '@/lib/super-admin/plans-schemas';
+
+type RouteContext = { params: { id: string } };
+
+export async function GET(_request: NextRequest, { params }: RouteContext) {
+  try {
+    await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const { data: plan, error } = await supabase
+      .from('subscription_plans')
+      .select('*')
+      .eq('id', params.id)
+      .single();
+
+    if (error || !plan) {
+      return NextResponse.json(
+        { error: { code: 'OP_PLAN_NOT_FOUND', message: 'プランが見つかりません' } },
+        { status: 404 }
+      );
+    }
+
+    // 価格変更履歴を追加取得
+    const { data: priceHistory } = await supabase
+      .from('plan_price_history')
+      .select('*')
+      .eq('plan_id', params.id)
+      .order('created_at', { ascending: false })
+      .limit(20);
+
+    return NextResponse.json({ data: { ...plan, price_history: priceHistory ?? [] } });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/plans/[id] GET]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: RouteContext) {
+  try {
+    const user = await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    // 既存プランを取得
+    const { data: existing, error: fetchErr } = await supabase
+      .from('subscription_plans')
+      .select('*')
+      .eq('id', params.id)
+      .single();
+
+    if (fetchErr || !existing) {
+      return NextResponse.json(
+        { error: { code: 'OP_PLAN_NOT_FOUND', message: 'プランが見つかりません' } },
+        { status: 404 }
+      );
+    }
+
+    const body = await request.json();
+    const parseResult = PlanUpdateSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: { code: 'OP_INVALID_INPUT', message: parseResult.error.message, details: parseResult.error.issues } },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    // status 別の更新可能フィールド制限 (operator/04-plan-management.md §3.1)
+    if (existing.status === 'public' || existing.status === 'private') {
+      // public/private では display_name / description / banner_url / feature_packages のみ
+      const allowedKeys = ['display_name', 'description', 'banner_url', 'feature_package_ids', 'display_order'];
+      const inputKeys = Object.keys(input).filter((k) => input[k as keyof typeof input] !== undefined);
+      const disallowedKeys = inputKeys.filter((k) => !allowedKeys.includes(k));
+      if (disallowedKeys.length > 0) {
+        return NextResponse.json(
+          {
+            error: {
+              code: 'OP_PLAN_STATUS_LOCKED',
+              message: `公開中プランでは ${disallowedKeys.join(', ')} は変更できません。価格変更は price-change API を使用してください。`,
+            },
+          },
+          { status: 422 }
+        );
+      }
+    }
+
+    if (existing.status === 'deprecated') {
+      // deprecated では migration_message のみ
+      const allowedKeys: string[] = [];
+      const inputKeys = Object.keys(input).filter((k) => input[k as keyof typeof input] !== undefined);
+      const disallowedKeys = inputKeys.filter((k) => !allowedKeys.includes(k));
+      if (disallowedKeys.length > 0) {
+        return NextResponse.json(
+          { error: { code: 'OP_PLAN_DEPRECATED_LOCKED', message: '廃止済みプランは変更できません' } },
+          { status: 422 }
+        );
+      }
+    }
+
+    const updateData: Record<string, unknown> = {};
+    if (input.display_name !== undefined) updateData.display_name = input.display_name;
+    if (input.description !== undefined) updateData.description = input.description;
+    if (input.banner_url !== undefined) updateData.banner_url = input.banner_url;
+    if (input.feature_package_ids !== undefined) updateData.feature_packages = input.feature_package_ids;
+    if (input.display_order !== undefined) updateData.display_order = input.display_order;
+    if (input.max_members !== undefined) updateData.max_members = input.max_members;
+    if (input.max_family_seats !== undefined) updateData.max_family_seats = input.max_family_seats;
+    if (input.trial_days !== undefined) updateData.trial_days = input.trial_days;
+    if (input.min_contract_months !== undefined) updateData.min_contract_months = input.min_contract_months;
+    if (input.auto_renew_default !== undefined) updateData.auto_renew_default = input.auto_renew_default;
+    if (input.stripe_product_id !== undefined) updateData.stripe_product_id = input.stripe_product_id;
+    if (input.status !== undefined) updateData.status = input.status;
+    if (input.ends_at !== undefined) updateData.ends_at = input.ends_at;
+    updateData.updated_at = new Date().toISOString();
+
+    const { data: updated, error: updateErr } = await supabase
+      .from('subscription_plans')
+      .update(updateData)
+      .eq('id', params.id)
+      .select()
+      .single();
+
+    if (updateErr) {
+      console.error('[super-admin/plans/[id] PATCH]', updateErr);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: updateErr.message } },
+        { status: 500 }
+      );
+    }
+
+    // 監査ログ記録
+    try {
+      await supabase.from('admin_audit_logs').insert({
+        actor_id: user.id,
+        target_id: params.id,
+        target_type: 'subscription_plan',
+        action_type: 'update_plan',
+        details: { changes: updateData, plan_key: existing.plan_key },
+        severity: 'info',
+        ip_address: request.headers.get('x-forwarded-for'),
+      });
+    } catch (auditErr) {
+      console.warn('[super-admin/plans/[id] PATCH] audit log failed (graceful):', auditErr);
+    }
+
+    return NextResponse.json({ data: updated });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/plans/[id] PATCH]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteContext) {
+  try {
+    const user = await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const { data: existing, error: fetchErr } = await supabase
+      .from('subscription_plans')
+      .select('id, status, plan_key')
+      .eq('id', params.id)
+      .single();
+
+    if (fetchErr || !existing) {
+      return NextResponse.json(
+        { error: { code: 'OP_PLAN_NOT_FOUND', message: 'プランが見つかりません' } },
+        { status: 404 }
+      );
+    }
+
+    // draft のみ削除可能
+    if (existing.status !== 'draft') {
+      return NextResponse.json(
+        { error: { code: 'OP_PLAN_NOT_DRAFT', message: 'draft 状態のプランのみ削除できます' } },
+        { status: 422 }
+      );
+    }
+
+    const { error: deleteErr } = await supabase
+      .from('subscription_plans')
+      .delete()
+      .eq('id', params.id);
+
+    if (deleteErr) {
+      console.error('[super-admin/plans/[id] DELETE]', deleteErr);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: deleteErr.message } },
+        { status: 500 }
+      );
+    }
+
+    // 監査ログ記録
+    try {
+      await supabase.from('admin_audit_logs').insert({
+        actor_id: user.id,
+        target_id: params.id,
+        target_type: 'subscription_plan',
+        action_type: 'delete_plan',
+        details: { plan_key: existing.plan_key },
+        severity: 'warn',
+        ip_address: request.headers.get('x-forwarded-for'),
+      });
+    } catch (auditErr) {
+      console.warn('[super-admin/plans/[id] DELETE] audit log failed (graceful):', auditErr);
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/plans/[id] DELETE]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}

--- a/src/app/api/super-admin/plans/route.ts
+++ b/src/app/api/super-admin/plans/route.ts
@@ -1,0 +1,158 @@
+/**
+ * GET  /api/super-admin/plans — プラン一覧
+ * POST /api/super-admin/plans — プラン新規作成 (draft)
+ *
+ * operator/02-api-spec.md §17 準拠
+ * 権限: super_admin のみ
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { createClient } from '@/lib/supabase/server';
+import {
+  PlanCreateSchema,
+  PlansQuerySchema,
+} from '@/lib/super-admin/plans-schemas';
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const { searchParams } = request.nextUrl;
+    const queryResult = PlansQuerySchema.safeParse({
+      type: searchParams.get('type') ?? undefined,
+      status: searchParams.get('status') ?? undefined,
+      page: searchParams.get('page') ?? undefined,
+      per_page: searchParams.get('per_page') ?? undefined,
+    });
+
+    if (!queryResult.success) {
+      return NextResponse.json(
+        { error: { code: 'OP_INVALID_QUERY', message: queryResult.error.message } },
+        { status: 400 }
+      );
+    }
+
+    const { type, status, page, per_page } = queryResult.data;
+    const offset = (page - 1) * per_page;
+
+    let query = supabase
+      .from('subscription_plans')
+      .select('*', { count: 'exact' })
+      .order('display_order', { ascending: true })
+      .range(offset, offset + per_page - 1);
+
+    if (type) query = query.eq('plan_type', type);
+    if (status) query = query.eq('status', status);
+
+    const { data, error, count } = await query;
+
+    if (error) {
+      console.error('[super-admin/plans GET]', error);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: error.message } },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      data,
+      meta: { total: count ?? 0, page, per_page },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/plans GET]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireRole(['super_admin']);
+    const supabase = createClient();
+
+    const body = await request.json();
+    const parseResult = PlanCreateSchema.safeParse(body);
+
+    if (!parseResult.success) {
+      return NextResponse.json(
+        { error: { code: 'OP_INVALID_INPUT', message: parseResult.error.message, details: parseResult.error.issues } },
+        { status: 400 }
+      );
+    }
+
+    const input = parseResult.data;
+
+    // feature_packages 配列を UUID[] に変換
+    const featurePackageIds = input.feature_package_ids ?? [];
+
+    const { data: plan, error } = await supabase
+      .from('subscription_plans')
+      .insert({
+        plan_key: input.plan_key,
+        display_name: input.display_name,
+        plan_type: input.plan_type,
+        description: input.description ?? null,
+        monthly_price_jpy: input.monthly_price_jpy ?? null,
+        yearly_price_jpy: input.yearly_price_jpy ?? null,
+        max_members: input.max_members ?? null,
+        max_family_seats: input.max_family_seats ?? null,
+        feature_packages: featurePackageIds,
+        display_order: input.display_order ?? 0,
+        trial_days: input.trial_days ?? 0,
+        min_contract_months: input.min_contract_months ?? 1,
+        auto_renew_default: input.auto_renew_default ?? true,
+        banner_url: input.banner_url ?? null,
+        status: 'draft',
+      })
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === '23505') {
+        return NextResponse.json(
+          { error: { code: 'OP_PLAN_KEY_DUPLICATE', message: 'plan_key が既に存在します' } },
+          { status: 409 }
+        );
+      }
+      console.error('[super-admin/plans POST]', error);
+      return NextResponse.json(
+        { error: { code: 'OP_DB_ERROR', message: error.message } },
+        { status: 500 }
+      );
+    }
+
+    // 監査ログ記録 (operator/07-audit-monitoring §3 準拠)
+    try {
+      await supabase.from('admin_audit_logs').insert({
+        actor_id: user.id,
+        target_id: plan.id,
+        target_type: 'subscription_plan',
+        action_type: 'create_plan',
+        details: { plan_key: input.plan_key, display_name: input.display_name, plan_type: input.plan_type },
+        severity: 'info',
+        ip_address: request.headers.get('x-forwarded-for'),
+      });
+    } catch (auditErr) {
+      console.warn('[super-admin/plans POST] audit log failed (graceful):', auditErr);
+    }
+
+    return NextResponse.json({ data: plan }, { status: 201 });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } }, { status: 403 });
+    }
+    console.error('[super-admin/plans POST]', err);
+    return NextResponse.json({ error: { code: 'OP_INTERNAL_ERROR', message: '内部エラー' } }, { status: 500 });
+  }
+}

--- a/src/lib/super-admin/coupons-schemas.ts
+++ b/src/lib/super-admin/coupons-schemas.ts
@@ -1,0 +1,83 @@
+/**
+ * super_admin クーポン API 用 Zod スキーマ
+ * operator/01-data-model.md §3.5-3.6 / operator/04-plan-management.md §4.1 準拠
+ *
+ * route.ts には inline 定義しない (family/02 §15.6.1 確定ルール)。
+ */
+
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const DISCOUNT_TYPES = ['fixed', 'percentage'] as const;
+export const COUPON_APPLICABLE_TO = ['all', 'personal', 'family', 'org'] as const;
+export const COUPON_STATUSES = ['active', 'paused', 'expired'] as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// スキーマ定義
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** クーポン新規作成リクエスト */
+export const CouponCreateSchema = z.object({
+  code: z
+    .string()
+    .min(1)
+    .max(50)
+    .regex(/^[A-Z0-9_-]+$/, '英大文字・数字・アンダースコア・ハイフンのみ'),
+  display_name: z.string().max(200).optional(),
+  discount_type: z.enum(DISCOUNT_TYPES),
+  discount_value: z.number().positive('0より大きい値を指定してください'),
+  applicable_plans: z.array(z.string().uuid()).optional().default([]),
+  applicable_to: z.enum(COUPON_APPLICABLE_TO).optional().default('all'),
+  valid_from: z.string().datetime(),
+  valid_until: z.string().datetime(),
+  max_uses: z.number().int().min(1).nullable().optional(),
+  per_user_limit: z.number().int().min(1).optional().default(1),
+  duration_months: z.number().int().min(1).nullable().optional(),
+  gross_margin_preview_jpy: z.number().int().nullable().optional(),
+}).refine((data) => {
+  // パーセントは 0〜100
+  if (data.discount_type === 'percentage' && data.discount_value > 100) {
+    return false;
+  }
+  return true;
+}, { message: 'パーセント割引は 100% 以下にしてください', path: ['discount_value'] })
+  .refine((data) => {
+    // valid_from < valid_until
+    return new Date(data.valid_from) < new Date(data.valid_until);
+  }, { message: '有効開始日は終了日より前にしてください', path: ['valid_until'] });
+
+export type CouponCreateInput = z.infer<typeof CouponCreateSchema>;
+
+/** クーポン更新リクエスト */
+export const CouponUpdateSchema = z.object({
+  display_name: z.string().max(200).nullable().optional(),
+  status: z.enum(COUPON_STATUSES).optional(),
+  valid_until: z.string().datetime().optional(),
+  max_uses: z.number().int().min(1).nullable().optional(),
+  applicable_plans: z.array(z.string().uuid()).optional(),
+  applicable_to: z.enum(COUPON_APPLICABLE_TO).optional(),
+  gross_margin_preview_jpy: z.number().int().nullable().optional(),
+});
+
+export type CouponUpdateInput = z.infer<typeof CouponUpdateSchema>;
+
+/** クーポン一覧クエリパラメータ */
+export const CouponsQuerySchema = z.object({
+  status: z.enum(COUPON_STATUSES).optional(),
+  applicable_to: z.enum(COUPON_APPLICABLE_TO).optional(),
+  page: z.coerce.number().int().min(1).optional().default(1),
+  per_page: z.coerce.number().int().min(1).max(200).optional().default(50),
+});
+
+export type CouponsQueryInput = z.infer<typeof CouponsQuerySchema>;
+
+/** クーポン適用履歴クエリパラメータ */
+export const CouponRedemptionsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).optional().default(1),
+  per_page: z.coerce.number().int().min(1).max(200).optional().default(50),
+});
+
+export type CouponRedemptionsQueryInput = z.infer<typeof CouponRedemptionsQuerySchema>;

--- a/src/lib/super-admin/feature-packages-schemas.ts
+++ b/src/lib/super-admin/feature-packages-schemas.ts
@@ -1,0 +1,53 @@
+/**
+ * super_admin 機能パッケージ API 用 Zod スキーマ
+ * operator/01-data-model.md §3.3 / operator/02-api-spec.md 準拠
+ *
+ * route.ts には inline 定義しない (family/02 §15.6.1 確定ルール)。
+ */
+
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const FEATURE_PACKAGE_STATUSES = ['active', 'deprecated'] as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// スキーマ定義
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 機能パッケージ新規作成リクエスト */
+export const FeaturePackageCreateSchema = z.object({
+  package_key: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(/^[a-z0-9_]+$/, '英小文字・数字・アンダースコアのみ'),
+  display_name: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  feature_flags: z.array(z.string().max(100)).min(1, '少なくとも1つの機能フラグを指定してください'),
+  display_order: z.number().int().min(0).optional().default(0),
+});
+
+export type FeaturePackageCreateInput = z.infer<typeof FeaturePackageCreateSchema>;
+
+/** 機能パッケージ更新リクエスト */
+export const FeaturePackageUpdateSchema = z.object({
+  display_name: z.string().min(1).max(200).optional(),
+  description: z.string().max(2000).nullable().optional(),
+  feature_flags: z.array(z.string().max(100)).min(1).optional(),
+  display_order: z.number().int().min(0).optional(),
+  status: z.enum(FEATURE_PACKAGE_STATUSES).optional(),
+});
+
+export type FeaturePackageUpdateInput = z.infer<typeof FeaturePackageUpdateSchema>;
+
+/** 一覧クエリパラメータ */
+export const FeaturePackagesQuerySchema = z.object({
+  status: z.enum(FEATURE_PACKAGE_STATUSES).optional(),
+  page: z.coerce.number().int().min(1).optional().default(1),
+  per_page: z.coerce.number().int().min(1).max(200).optional().default(50),
+});
+
+export type FeaturePackagesQueryInput = z.infer<typeof FeaturePackagesQuerySchema>;

--- a/src/lib/super-admin/plans-schemas.ts
+++ b/src/lib/super-admin/plans-schemas.ts
@@ -1,0 +1,124 @@
+/**
+ * super_admin プラン定義 API 用 Zod スキーマ
+ * operator/02-api-spec.md §17 / operator/04-plan-management.md §3.1 準拠
+ *
+ * route.ts には inline 定義しない (family/02 §15.6.1 確定ルール)。
+ * このファイルから import して使用する。
+ */
+
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 9 種公式 plan_key (operator/01-data-model.md §3.2 seed) */
+export const OFFICIAL_PLAN_KEYS = [
+  'free',
+  'pro',
+  'family_basic',
+  'family_pro',
+  'family_addon',
+  'org_starter',
+  'org_standard',
+  'org_pro',
+  'org_enterprise',
+] as const;
+
+export const PLAN_TYPES = ['personal', 'family', 'org'] as const;
+export const PLAN_STATUSES = ['draft', 'public', 'private', 'deprecated'] as const;
+export const PRICE_APPLIES_TO = ['new_only', 'on_renewal', 'immediately'] as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// スキーマ定義
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** プラン新規作成リクエスト */
+export const PlanCreateSchema = z.object({
+  plan_key: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(/^[a-z0-9_]+$/, '英小文字・数字・アンダースコアのみ'),
+  display_name: z.string().min(1).max(200),
+  plan_type: z.enum(PLAN_TYPES),
+  description: z.string().max(5000).optional(),
+  monthly_price_jpy: z.number().int().min(0).nullable().optional(),
+  yearly_price_jpy: z.number().int().min(0).nullable().optional(),
+  max_members: z.number().int().min(1).nullable().optional(),
+  max_family_seats: z.number().int().min(0).nullable().optional(),
+  feature_package_ids: z.array(z.string().uuid()).optional().default([]),
+  display_order: z.number().int().min(0).optional().default(0),
+  trial_days: z.number().int().min(0).optional().default(0),
+  min_contract_months: z.number().int().min(1).optional().default(1),
+  auto_renew_default: z.boolean().optional().default(true),
+  banner_url: z.string().url().nullable().optional(),
+}).refine((data) => {
+  // 組織プランは trial_days = 0 を強制
+  if (data.plan_type === 'org' && (data.trial_days ?? 0) > 0) {
+    return false;
+  }
+  return true;
+}, { message: '組織プランには試用期間を設定できません', path: ['trial_days'] });
+
+export type PlanCreateInput = z.infer<typeof PlanCreateSchema>;
+
+/** プラン更新リクエスト (status 別制限は API で適用) */
+export const PlanUpdateSchema = z.object({
+  display_name: z.string().min(1).max(200).optional(),
+  description: z.string().max(5000).nullable().optional(),
+  banner_url: z.string().url().nullable().optional(),
+  feature_package_ids: z.array(z.string().uuid()).optional(),
+  display_order: z.number().int().min(0).optional(),
+  max_members: z.number().int().min(1).nullable().optional(),
+  max_family_seats: z.number().int().min(0).nullable().optional(),
+  trial_days: z.number().int().min(0).optional(),
+  min_contract_months: z.number().int().min(1).optional(),
+  auto_renew_default: z.boolean().optional(),
+  stripe_product_id: z.string().max(255).nullable().optional(),
+  status: z.enum(PLAN_STATUSES).optional(),
+  ends_at: z.string().datetime().nullable().optional(),
+});
+
+export type PlanUpdateInput = z.infer<typeof PlanUpdateSchema>;
+
+/** 価格変更リクエスト */
+export const PriceChangeSchema = z.object({
+  new_monthly_price_jpy: z.number().int().min(0).nullable().optional(),
+  new_yearly_price_jpy: z.number().int().min(0).nullable().optional(),
+  applies_to: z.enum(PRICE_APPLIES_TO),
+  reason: z.string().min(1).max(1000),
+  effective_at: z.string().datetime(),
+}).refine((data) => {
+  // 少なくとも月額か年額のどちらかを指定
+  return data.new_monthly_price_jpy != null || data.new_yearly_price_jpy != null;
+}, { message: '月額または年額のいずれかを指定してください' });
+
+export type PriceChangeInput = z.infer<typeof PriceChangeSchema>;
+
+/** deprecate リクエスト */
+export const PlanDeprecateSchema = z.object({
+  superseded_by_plan_id: z.string().uuid().nullable().optional(),
+  ends_at: z.string().datetime(),
+  migration_message: z.string().min(1).max(2000),
+});
+
+export type PlanDeprecateInput = z.infer<typeof PlanDeprecateSchema>;
+
+/** 一覧クエリパラメータ */
+export const PlansQuerySchema = z.object({
+  type: z.enum(PLAN_TYPES).optional(),
+  status: z.enum(PLAN_STATUSES).optional(),
+  page: z.coerce.number().int().min(1).optional().default(1),
+  per_page: z.coerce.number().int().min(1).max(200).optional().default(50),
+});
+
+export type PlansQueryInput = z.infer<typeof PlansQuerySchema>;
+
+/** 価格影響シミュレーション クエリパラメータ */
+export const PriceImpactQuerySchema = z.object({
+  new_monthly_price_jpy: z.coerce.number().int().min(0).optional(),
+  applies_to: z.enum(PRICE_APPLIES_TO).optional(),
+});
+
+export type PriceImpactQueryInput = z.infer<typeof PriceImpactQuerySchema>;


### PR DESCRIPTION
## Summary

- `(super-admin)/` 配下に super_admin ロールガード付き layout + plans / feature-packages / coupons の 3 機能 UI (計 11 画面) を実装
- `api/super-admin/` 配下に対応 API (plans 5 本 + feature-packages 2 本 + coupons 3 本 = 計 10 エンドポイント) を実装
- `src/lib/super-admin/` に Zod スキーマを集約 (route.ts への inline 定義なし)

## 実装詳細

### 認証ガード
- 全 route.ts で `requireRole(['super_admin'])` を適用
- layout.tsx は Server Component で同ヘルパーを呼び出し、失敗時は `/login?redirect=/super-admin/plans` へ redirect

### 監査ログ (admin_audit_logs INSERT)
以下の全破壊的操作で INSERT:
- `create_plan` / `update_plan` / `delete_plan` (severity: info / warn)
- `change_price` (severity: warn — 課金影響)
- `create_feature_package` / `update_feature_package` / `delete_feature_package`
- `create_coupon` (severity: warn) / `update_coupon` / `delete_coupon` (severity: warn)

計 **11 箇所** で admin_audit_logs INSERT

### Stripe Price 連携
- `STRIPE_SECRET_KEY` 未設定 or `stripe_product_id` 未設定時はモック動作 (console.warn + DB のみ更新)
- 設定済み時は Edge Function `stripe-price-sync` 経由で `stripe.prices.create` を呼び出す
- `plan_price_history` に変更前後の価格を記録

### UI 設計制約
- 9 種公式 plan_key (`free` / `pro` / `family_basic` / `family_pro` / `family_addon` / `org_starter` / `org_standard` / `org_pro` / `org_enterprise`) 以外を作成する経路を UI に出さない (設計書 §4 確定方針)
- 価格変更フローは「影響シミュレーション → 確認 → 実行」の 2 ステップ

## DOD チェックリスト

- [x] (super-admin) 配下に layout + plans/feature-packages/coupons の 3 機能 UI
- [x] api/super-admin 配下に対応 API
- [x] schemas.ts に Zod 集約 (route.ts は import のみ)
- [x] requireRole(['super_admin']) 全 API で必須
- [x] admin_audit_logs INSERT (全破壊的操作 11 箇所)
- [x] `npx tsc --noEmit` — 新規ファイルの型エラーなし (既存 posthog/react-confetti/focus-trap-react の既知エラーのみ)

## 改修禁止範囲

以下を一切編集していないことを確認:
- `src/app/(admin)/**` — 非触
- `src/app/api/admin/**` — 非触
- `src/lib/auth/**` — 非触
- `supabase/migrations/**` — 非触