### PR TITLE
feat(operator): D — Finance 売上ダッシュボード + 請求書 救済 PR

### DIFF
--- a/src/app/admin/finance/exports/page.tsx
+++ b/src/app/admin/finance/exports/page.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState } from "react";
+
+type ExportType = "revenue" | "invoices" | "subscriptions" | "nps";
+
+interface ExportConfig {
+  type: ExportType;
+  label: string;
+  description: string;
+  icon: string;
+}
+
+const EXPORT_CONFIGS: ExportConfig[] = [
+  {
+    type: "revenue",
+    label: "収益スナップショット",
+    description: "revenue_snapshots テーブルの MRR/ARR/ユーザー数データ",
+    icon: "📈",
+  },
+  {
+    type: "invoices",
+    label: "請求書ログ",
+    description: "stripe_webhook_events の invoice イベント一覧",
+    icon: "🧾",
+  },
+  {
+    type: "subscriptions",
+    label: "サブスクリプション",
+    description: "personal_subscriptions の契約一覧 (PII: user_id のみ)",
+    icon: "💳",
+  },
+  {
+    type: "nps",
+    label: "NPS 回答",
+    description: "nps_surveys テーブルのスコア/コメント (PII: user_id のみ)",
+    icon: "⭐",
+  },
+];
+
+export default function ExportsPage() {
+  const [selectedType, setSelectedType] = useState<ExportType>("revenue");
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleExport = async () => {
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const body = {
+        export_type: selectedType,
+        from: from || undefined,
+        to: to || undefined,
+        format: "csv",
+      };
+
+      const res = await fetch("/api/admin/finance/exports", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const json = await res.json() as { error?: { message?: string } };
+        throw new Error(json.error?.message ?? `HTTP ${res.status}`);
+      }
+
+      // CSV をダウンロード
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const contentDisposition = res.headers.get("Content-Disposition") ?? "";
+      const filenameMatch = contentDisposition.match(/filename="([^"]+)"/);
+      const filename = filenameMatch?.[1] ?? `${selectedType}_export.csv`;
+
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+
+      setSuccess(true);
+    } catch (e: unknown) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const selectedConfig = EXPORT_CONFIGS.find((c) => c.type === selectedType);
+
+  return (
+    <div className="p-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-800">CSV エクスポート</h1>
+        <p className="text-sm text-slate-500 mt-1">finance データの CSV ダウンロード</p>
+      </div>
+
+      <div className="max-w-2xl">
+        {/* エクスポート種別選択 */}
+        <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-6 mb-6">
+          <h2 className="text-base font-semibold text-slate-700 mb-4">エクスポート種別</h2>
+          <div className="grid grid-cols-2 gap-3">
+            {EXPORT_CONFIGS.map((config) => (
+              <button
+                key={config.type}
+                onClick={() => setSelectedType(config.type)}
+                className={`flex items-start gap-3 p-4 rounded-xl border text-left transition-all ${
+                  selectedType === config.type
+                    ? "border-indigo-300 bg-indigo-50"
+                    : "border-slate-200 hover:border-slate-300 hover:bg-slate-50"
+                }`}
+              >
+                <span className="text-2xl">{config.icon}</span>
+                <div>
+                  <div className={`text-sm font-medium ${selectedType === config.type ? "text-indigo-700" : "text-slate-700"}`}>
+                    {config.label}
+                  </div>
+                  <div className="text-xs text-slate-400 mt-0.5">{config.description}</div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 期間設定 */}
+        <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-6 mb-6">
+          <h2 className="text-base font-semibold text-slate-700 mb-4">期間フィルタ (任意)</h2>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-xs text-slate-500 mb-1">開始日</label>
+              <input
+                type="date"
+                value={from}
+                onChange={(e) => setFrom(e.target.value)}
+                className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-slate-500 mb-1">終了日</label>
+              <input
+                type="date"
+                value={to}
+                onChange={(e) => setTo(e.target.value)}
+                className="w-full border border-slate-200 rounded-lg px-3 py-2 text-sm"
+              />
+            </div>
+          </div>
+          <p className="text-xs text-slate-400 mt-3">
+            未設定の場合は全期間のデータを出力します。
+          </p>
+        </div>
+
+        {/* エクスポートボタン */}
+        <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <span className="text-2xl">{selectedConfig?.icon}</span>
+            <div>
+              <div className="font-semibold text-slate-800">{selectedConfig?.label}</div>
+              <div className="text-xs text-slate-400">{selectedConfig?.description}</div>
+            </div>
+          </div>
+
+          {error && (
+            <div className="mb-4 bg-red-50 border border-red-200 rounded-lg p-3 text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+          {success && (
+            <div className="mb-4 bg-green-50 border border-green-200 rounded-lg p-3 text-green-700 text-sm">
+              CSV ダウンロードを開始しました
+            </div>
+          )}
+
+          <button
+            onClick={handleExport}
+            disabled={loading}
+            className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-indigo-600 text-white font-medium rounded-xl hover:bg-indigo-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          >
+            {loading ? (
+              <>
+                <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                生成中...
+              </>
+            ) : (
+              <>
+                <span>📥</span>
+                CSV ダウンロード
+              </>
+            )}
+          </button>
+
+          <p className="text-xs text-slate-400 mt-3 text-center">
+            エクスポートは監査ログに記録されます
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/finance/invoices/[id]/page.tsx
+++ b/src/app/admin/finance/invoices/[id]/page.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+
+interface InvoiceDetail {
+  id: string;
+  stripe_event_id: string;
+  event_type: string;
+  processing_status: string;
+  user_id: string | null;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+  amount_paid: number | null;
+  amount_due: number | null;
+  currency: string | null;
+  invoice_number: string | null;
+  invoice_pdf: string | null;
+  period_start: string | null;
+  period_end: string | null;
+  stripe_links: {
+    customer: string | null;
+    subscription: string | null;
+    invoice: string | null;
+  };
+  received_at: string;
+  processed_at: string | null;
+  error_message: string | null;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    completed: "bg-green-100 text-green-700",
+    processing: "bg-yellow-100 text-yellow-700",
+    failed: "bg-red-100 text-red-700",
+    pending: "bg-slate-100 text-slate-600",
+  };
+  return (
+    <span className={`inline-block text-xs font-semibold px-2 py-1 rounded ${colors[status] ?? "bg-slate-100 text-slate-600"}`}>
+      {status}
+    </span>
+  );
+}
+
+function formatAmount(amount: number | null, currency: string | null) {
+  if (amount == null) return "-";
+  const divisor = currency?.toLowerCase() === "jpy" ? 1 : 100;
+  const value = amount / divisor;
+  if (currency?.toLowerCase() === "jpy") return `¥${value.toLocaleString()}`;
+  return `${currency?.toUpperCase()} ${value.toFixed(2)}`;
+}
+
+export default function InvoiceDetailPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const [invoice, setInvoice] = useState<InvoiceDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`/api/admin/finance/invoices/${id}`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.error) setError(json.error.message);
+        else setInvoice(json.data as InvoiceDetail);
+      })
+      .catch((e: unknown) => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="p-8 flex justify-center py-16">
+        <div className="w-8 h-8 border-4 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error || !invoice) {
+    return (
+      <div className="p-8">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">
+          {error ?? "請求書が見つかりません"}
+        </div>
+        <Link href="/admin/finance/invoices" className="mt-4 inline-block text-indigo-600 hover:underline text-sm">
+          ← 一覧に戻る
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8">
+      <div className="flex items-center gap-3 mb-6">
+        <Link href="/admin/finance/invoices" className="text-indigo-600 hover:text-indigo-800 text-sm">
+          ← 請求書一覧
+        </Link>
+      </div>
+
+      <div className="flex items-start justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-800">
+            請求書詳細
+          </h1>
+          {invoice.invoice_number && (
+            <p className="text-slate-500 mt-1 font-mono">{invoice.invoice_number}</p>
+          )}
+        </div>
+        <StatusBadge status={invoice.processing_status} />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* 基本情報 */}
+        <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-6">
+          <h2 className="text-base font-semibold text-slate-700 mb-4">基本情報</h2>
+          <dl className="space-y-3">
+            <div className="flex justify-between text-sm">
+              <dt className="text-slate-500">イベント種別</dt>
+              <dd className="font-medium text-slate-700">{invoice.event_type}</dd>
+            </div>
+            <div className="flex justify-between text-sm">
+              <dt className="text-slate-500">支払金額</dt>
+              <dd className="font-bold text-slate-800 text-base">
+                {formatAmount(invoice.amount_paid, invoice.currency)}
+              </dd>
+            </div>
+            <div className="flex justify-between text-sm">
+              <dt className="text-slate-500">請求金額</dt>
+              <dd className="font-medium text-slate-700">
+                {formatAmount(invoice.amount_due, invoice.currency)}
+              </dd>
+            </div>
+            <div className="flex justify-between text-sm">
+              <dt className="text-slate-500">対象期間</dt>
+              <dd className="text-slate-700 text-right">
+                {invoice.period_start
+                  ? `${new Date(invoice.period_start).toLocaleDateString("ja-JP")} 〜 ${invoice.period_end ? new Date(invoice.period_end).toLocaleDateString("ja-JP") : "-"}`
+                  : "-"}
+              </dd>
+            </div>
+            <div className="flex justify-between text-sm">
+              <dt className="text-slate-500">受信日時</dt>
+              <dd className="text-slate-700">
+                {new Date(invoice.received_at).toLocaleString("ja-JP")}
+              </dd>
+            </div>
+            {invoice.processed_at && (
+              <div className="flex justify-between text-sm">
+                <dt className="text-slate-500">処理完了</dt>
+                <dd className="text-slate-700">
+                  {new Date(invoice.processed_at).toLocaleString("ja-JP")}
+                </dd>
+              </div>
+            )}
+            {invoice.error_message && (
+              <div className="text-sm">
+                <dt className="text-red-500 mb-1">エラー</dt>
+                <dd className="bg-red-50 rounded px-3 py-2 text-red-700 text-xs font-mono">
+                  {invoice.error_message}
+                </dd>
+              </div>
+            )}
+          </dl>
+        </div>
+
+        {/* Stripe リンク */}
+        <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-6">
+          <h2 className="text-base font-semibold text-slate-700 mb-4">Stripe リンク</h2>
+          <div className="space-y-3">
+            {invoice.stripe_links.customer && (
+              <a
+                href={invoice.stripe_links.customer}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-between p-3 border border-slate-200 rounded-lg hover:border-indigo-300 hover:bg-indigo-50 transition-colors"
+              >
+                <span className="text-sm text-slate-700">Stripe Customer</span>
+                <span className="text-xs text-indigo-600 font-mono">
+                  {invoice.stripe_customer_id} ↗
+                </span>
+              </a>
+            )}
+            {invoice.stripe_links.subscription && (
+              <a
+                href={invoice.stripe_links.subscription}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-between p-3 border border-slate-200 rounded-lg hover:border-indigo-300 hover:bg-indigo-50 transition-colors"
+              >
+                <span className="text-sm text-slate-700">Stripe Subscription</span>
+                <span className="text-xs text-indigo-600 font-mono">
+                  {invoice.stripe_subscription_id} ↗
+                </span>
+              </a>
+            )}
+            {invoice.stripe_links.invoice && (
+              <a
+                href={invoice.stripe_links.invoice}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-between p-3 border border-indigo-200 rounded-lg bg-indigo-50 hover:bg-indigo-100 transition-colors"
+              >
+                <span className="text-sm font-medium text-indigo-700">Stripe Invoice で開く</span>
+                <span className="text-indigo-600">↗</span>
+              </a>
+            )}
+            {invoice.invoice_pdf && (
+              <a
+                href={invoice.invoice_pdf}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-between p-3 border border-slate-200 rounded-lg hover:border-slate-300 transition-colors"
+              >
+                <span className="text-sm text-slate-700">請求書 PDF ダウンロード</span>
+                <span className="text-slate-500">↓</span>
+              </a>
+            )}
+          </div>
+
+          {invoice.user_id && (
+            <div className="mt-4 pt-4 border-t border-slate-100">
+              <div className="text-xs text-slate-500 mb-1">ユーザー ID</div>
+              <div className="font-mono text-xs text-slate-700 break-all">{invoice.user_id}</div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* イベント ID */}
+      <div className="mt-6 bg-slate-50 rounded-xl border border-slate-100 p-4">
+        <div className="text-xs text-slate-400 mb-1">Stripe Event ID</div>
+        <div className="font-mono text-sm text-slate-700">{invoice.stripe_event_id}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/finance/invoices/page.tsx
+++ b/src/app/admin/finance/invoices/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import type { InvoiceItem } from "@/lib/admin/finance-schemas";
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    completed: "bg-green-100 text-green-700",
+    processing: "bg-yellow-100 text-yellow-700",
+    failed: "bg-red-100 text-red-700",
+    pending: "bg-slate-100 text-slate-600",
+  };
+  return (
+    <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded ${colors[status] ?? "bg-slate-100 text-slate-600"}`}>
+      {status}
+    </span>
+  );
+}
+
+function formatAmount(amount: number | null, currency: string | null) {
+  if (amount == null) return "-";
+  const divisor = currency?.toLowerCase() === "jpy" ? 1 : 100;
+  const value = amount / divisor;
+  if (currency?.toLowerCase() === "jpy") {
+    return `¥${value.toLocaleString()}`;
+  }
+  return `${currency?.toUpperCase()} ${value.toFixed(2)}`;
+}
+
+export default function InvoicesPage() {
+  const [invoices, setInvoices] = useState<InvoiceItem[]>([]);
+  const [meta, setMeta] = useState<{ total: number; page: number; per_page: number } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [statusFilter, setStatusFilter] = useState("");
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+
+  const fetchData = (currentPage = 1) => {
+    setLoading(true);
+    const params = new URLSearchParams({ page: String(currentPage), per_page: "50" });
+    if (statusFilter) params.set("status", statusFilter);
+    if (from) params.set("from", from);
+    if (to) params.set("to", to);
+
+    fetch(`/api/admin/finance/invoices?${params}`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.error) setError(json.error.message);
+        else {
+          setInvoices(json.data as InvoiceItem[]);
+          setMeta(json.meta as typeof meta);
+        }
+      })
+      .catch((e: unknown) => setError(String(e)))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchData(page);
+  }, [page]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSearch = () => {
+    setPage(1);
+    fetchData(1);
+  };
+
+  return (
+    <div className="p-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-800">請求書一覧</h1>
+        <p className="text-sm text-slate-500 mt-1">stripe_webhook_events — invoice イベント</p>
+      </div>
+
+      {/* フィルタ */}
+      <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-4 mb-6 flex flex-wrap gap-3 items-end">
+        <div>
+          <label className="block text-xs text-slate-500 mb-1">ステータス</label>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm"
+          >
+            <option value="">すべて</option>
+            <option value="completed">completed</option>
+            <option value="processing">processing</option>
+            <option value="failed">failed</option>
+            <option value="pending">pending</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-slate-500 mb-1">受信日 FROM</label>
+          <input type="date" value={from} onChange={(e) => setFrom(e.target.value)} className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm" />
+        </div>
+        <div>
+          <label className="block text-xs text-slate-500 mb-1">受信日 TO</label>
+          <input type="date" value={to} onChange={(e) => setTo(e.target.value)} className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm" />
+        </div>
+        <button
+          onClick={handleSearch}
+          className="px-4 py-1.5 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 transition-colors"
+        >
+          検索
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <div className="w-8 h-8 border-4 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : error ? (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">{error}</div>
+      ) : (
+        <>
+          <div className="bg-white rounded-xl border border-slate-100 shadow-sm overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-slate-50 border-b border-slate-100">
+                  <tr>
+                    {["イベント ID", "種別", "請求書番号", "金額", "ステータス", "受信日時", "詳細"].map((h) => (
+                      <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-slate-500 whitespace-nowrap">
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-50">
+                  {invoices.length === 0 ? (
+                    <tr>
+                      <td colSpan={7} className="px-4 py-8 text-center text-slate-400">データがありません</td>
+                    </tr>
+                  ) : (
+                    invoices.map((inv) => (
+                      <tr key={inv.id} className="hover:bg-slate-50 transition-colors">
+                        <td className="px-4 py-3 font-mono text-xs text-slate-500 max-w-32 truncate">{inv.stripe_event_id}</td>
+                        <td className="px-4 py-3 text-slate-600">{inv.event_type}</td>
+                        <td className="px-4 py-3 font-mono text-xs">{inv.invoice_number ?? "-"}</td>
+                        <td className="px-4 py-3 font-semibold text-slate-800">
+                          {formatAmount(inv.amount_paid, inv.currency)}
+                        </td>
+                        <td className="px-4 py-3"><StatusBadge status={inv.status} /></td>
+                        <td className="px-4 py-3 text-slate-500 text-xs whitespace-nowrap">
+                          {new Date(inv.received_at).toLocaleString("ja-JP")}
+                        </td>
+                        <td className="px-4 py-3">
+                          <Link
+                            href={`/admin/finance/invoices/${inv.id}`}
+                            className="text-indigo-600 hover:text-indigo-800 text-xs font-medium"
+                          >
+                            詳細
+                          </Link>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {meta && meta.total > meta.per_page && (
+            <div className="flex items-center justify-between mt-4">
+              <span className="text-sm text-slate-500">全 {meta.total} 件 / ページ {meta.page}</span>
+              <div className="flex gap-2">
+                <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page <= 1} className="px-3 py-1.5 text-sm border border-slate-200 rounded-lg disabled:opacity-40 hover:bg-slate-50">前へ</button>
+                <button onClick={() => setPage((p) => p + 1)} disabled={page * meta.per_page >= meta.total} className="px-3 py-1.5 text-sm border border-slate-200 rounded-lg disabled:opacity-40 hover:bg-slate-50">次へ</button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/finance/nps/page.tsx
+++ b/src/app/admin/finance/nps/page.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { NpsSummary, CsatSummary } from "@/lib/admin/finance-schemas";
+
+interface NpsApiResponse {
+  nps: NpsSummary;
+  csat: CsatSummary;
+}
+
+function ScoreBar({ label, count, total, color }: { label: string; count: number; total: number; color: string }) {
+  const pct = total > 0 ? (count / total) * 100 : 0;
+  return (
+    <div className="flex items-center gap-3">
+      <div className="text-sm text-slate-500 w-20 shrink-0">{label}</div>
+      <div className="flex-1 bg-slate-100 rounded-full h-2">
+        <div className={`h-2 rounded-full ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+      <div className="text-sm font-medium text-slate-700 w-16 text-right">
+        {count} ({pct.toFixed(1)}%)
+      </div>
+    </div>
+  );
+}
+
+export default function NpsPage() {
+  const [data, setData] = useState<NpsApiResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [planKey, setPlanKey] = useState("");
+
+  const fetchData = () => {
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (from) params.set("from", from);
+    if (to) params.set("to", to);
+    if (planKey) params.set("plan_key", planKey);
+
+    fetch(`/api/admin/finance/nps?${params}`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.error) setError(json.error.message);
+        else setData(json.data as NpsApiResponse);
+      })
+      .catch((e: unknown) => setError(String(e)))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="p-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-800">NPS / CSAT</h1>
+        <p className="text-sm text-slate-500 mt-1">Net Promoter Score & Customer Satisfaction</p>
+      </div>
+
+      {/* フィルタ */}
+      <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-4 mb-6 flex flex-wrap gap-3 items-end">
+        <div>
+          <label className="block text-xs text-slate-500 mb-1">期間 FROM</label>
+          <input type="date" value={from} onChange={(e) => setFrom(e.target.value)} className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm" />
+        </div>
+        <div>
+          <label className="block text-xs text-slate-500 mb-1">期間 TO</label>
+          <input type="date" value={to} onChange={(e) => setTo(e.target.value)} className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm" />
+        </div>
+        <div>
+          <label className="block text-xs text-slate-500 mb-1">プラン</label>
+          <select value={planKey} onChange={(e) => setPlanKey(e.target.value)} className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm">
+            <option value="">すべて</option>
+            <option value="free">free</option>
+            <option value="pro">pro</option>
+            <option value="family_basic">family_basic</option>
+            <option value="family_pro">family_pro</option>
+            <option value="org_starter">org_starter</option>
+            <option value="org_standard">org_standard</option>
+            <option value="org_pro">org_pro</option>
+          </select>
+        </div>
+        <button
+          onClick={fetchData}
+          className="px-4 py-1.5 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 transition-colors"
+        >
+          適用
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <div className="w-8 h-8 border-4 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : error ? (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">{error}</div>
+      ) : data ? (
+        <div className="space-y-6">
+          {/* NPS スコア */}
+          <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-6">
+            <h2 className="text-base font-semibold text-slate-700 mb-5">NPS (Net Promoter Score)</h2>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+              <div className="text-center p-4 bg-indigo-50 rounded-xl">
+                <div className="text-3xl font-bold text-indigo-700">{data.nps.nps_score}</div>
+                <div className="text-xs text-indigo-500 mt-1">NPS スコア</div>
+              </div>
+              <div className="text-center p-4 bg-slate-50 rounded-xl">
+                <div className="text-2xl font-bold text-slate-700">{data.nps.total_responses}</div>
+                <div className="text-xs text-slate-400 mt-1">回答数</div>
+              </div>
+              <div className="text-center p-4 bg-slate-50 rounded-xl">
+                <div className="text-2xl font-bold text-slate-700">{data.nps.avg_score}</div>
+                <div className="text-xs text-slate-400 mt-1">平均スコア</div>
+              </div>
+              <div className="text-center p-4 bg-slate-50 rounded-xl">
+                <div className="text-2xl font-bold text-slate-700">{data.nps.response_rate}%</div>
+                <div className="text-xs text-slate-400 mt-1">回答率</div>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <ScoreBar
+                label="推薦者 (9-10)"
+                count={data.nps.promoters}
+                total={data.nps.total_responses}
+                color="bg-green-500"
+              />
+              <ScoreBar
+                label="中立 (7-8)"
+                count={data.nps.passives}
+                total={data.nps.total_responses}
+                color="bg-yellow-400"
+              />
+              <ScoreBar
+                label="批判者 (0-6)"
+                count={data.nps.detractors}
+                total={data.nps.total_responses}
+                color="bg-red-400"
+              />
+            </div>
+          </div>
+
+          {/* CSAT */}
+          <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-6">
+            <h2 className="text-base font-semibold text-slate-700 mb-5">CSAT (Customer Satisfaction)</h2>
+            <div className="grid grid-cols-2 gap-4 mb-6">
+              <div className="text-center p-4 bg-indigo-50 rounded-xl">
+                <div className="text-3xl font-bold text-indigo-700">{data.csat.avg_score}</div>
+                <div className="text-xs text-indigo-500 mt-1">平均スコア (1-5)</div>
+              </div>
+              <div className="text-center p-4 bg-slate-50 rounded-xl">
+                <div className="text-2xl font-bold text-slate-700">{data.csat.total_responses}</div>
+                <div className="text-xs text-slate-400 mt-1">回答数</div>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              {[5, 4, 3, 2, 1].map((score) => (
+                <ScoreBar
+                  key={score}
+                  label={`★ ${score}`}
+                  count={data.csat.score_distribution[String(score)] ?? 0}
+                  total={data.csat.total_responses}
+                  color={score >= 4 ? "bg-green-500" : score === 3 ? "bg-yellow-400" : "bg-red-400"}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* 最近のコメント */}
+          {data.nps.recent_comments.length > 0 && (
+            <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-6">
+              <h2 className="text-base font-semibold text-slate-700 mb-4">最近の NPS コメント</h2>
+              <div className="space-y-3">
+                {data.nps.recent_comments.map((c) => (
+                  <div key={c.id} className="border border-slate-100 rounded-lg p-4">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span className={`text-sm font-bold ${c.score >= 9 ? "text-green-600" : c.score >= 7 ? "text-yellow-600" : "text-red-600"}`}>
+                        {c.score}点
+                      </span>
+                      {c.plan_key && (
+                        <span className="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded">
+                          {c.plan_key}
+                        </span>
+                      )}
+                      {c.responded_at && (
+                        <span className="text-xs text-slate-400">
+                          {new Date(c.responded_at).toLocaleDateString("ja-JP")}
+                        </span>
+                      )}
+                    </div>
+                    {c.comment && (
+                      <p className="text-sm text-slate-600">{c.comment}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/admin/finance/page.tsx
+++ b/src/app/admin/finance/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import type { FinanceDashboard } from "@/lib/admin/finance-schemas";
+
+function KpiCard({
+  label,
+  value,
+  sub,
+  icon,
+  highlight,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  icon: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`bg-white rounded-xl border p-5 shadow-sm ${highlight ? "border-indigo-200" : "border-slate-100"}`}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-slate-500 text-sm font-medium">{label}</span>
+        <span className="text-xl">{icon}</span>
+      </div>
+      <div className="text-2xl font-bold text-slate-800">{value}</div>
+      {sub && <div className="text-xs text-slate-400 mt-1">{sub}</div>}
+    </div>
+  );
+}
+
+function formatJpy(n: number) {
+  if (n >= 1_000_000) return `¥${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `¥${(n / 1_000).toFixed(1)}K`;
+  return `¥${n.toLocaleString()}`;
+}
+
+export default function FinanceDashboardPage() {
+  const [data, setData] = useState<FinanceDashboard | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/admin/finance/dashboard")
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.error) {
+          setError(json.error.message);
+        } else {
+          setData(json.data as FinanceDashboard);
+        }
+      })
+      .catch((e: unknown) => setError(String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="p-8 flex items-center justify-center min-h-96">
+        <div className="w-10 h-10 border-4 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">
+          エラー: {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="p-8">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-800">売上ダッシュボード</h1>
+          <p className="text-sm text-slate-500 mt-1">Finance &bull; リアルタイム KPI</p>
+        </div>
+        <a
+          href="https://dashboard.stripe.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 transition-colors"
+        >
+          <span>Stripe Dashboard</span>
+          <span>↗</span>
+        </a>
+      </div>
+
+      {/* KPI Grid */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+        <KpiCard
+          label="今月の MRR"
+          value={formatJpy(data.current_mrr_jpy)}
+          icon="💴"
+          highlight
+        />
+        <KpiCard
+          label="ARR"
+          value={formatJpy(data.current_arr_jpy)}
+          icon="📅"
+        />
+        <KpiCard
+          label="Churn Rate"
+          value={`${data.churn_rate}%`}
+          sub="月次解約率"
+          icon="📉"
+        />
+        <KpiCard
+          label="LTV"
+          value={formatJpy(data.ltv_jpy)}
+          sub="ライフタイムバリュー"
+          icon="💎"
+        />
+      </div>
+
+      {/* MRR 内訳 */}
+      <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-6 mb-6">
+        <h2 className="text-base font-semibold text-slate-700 mb-4">MRR 内訳</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div>
+            <div className="text-xs text-slate-400 mb-1">新規 MRR</div>
+            <div className="text-lg font-bold text-green-600">{formatJpy(data.new_mrr_jpy)}</div>
+          </div>
+          <div>
+            <div className="text-xs text-slate-400 mb-1">拡張 MRR</div>
+            <div className="text-lg font-bold text-blue-600">{formatJpy(data.expansion_mrr_jpy)}</div>
+          </div>
+          <div>
+            <div className="text-xs text-slate-400 mb-1">縮小 MRR</div>
+            <div className="text-lg font-bold text-yellow-600">{formatJpy(data.contraction_mrr_jpy)}</div>
+          </div>
+          <div>
+            <div className="text-xs text-slate-400 mb-1">解約 MRR</div>
+            <div className="text-lg font-bold text-red-600">{formatJpy(data.churned_mrr_jpy)}</div>
+          </div>
+        </div>
+      </div>
+
+      {/* ユーザー数 */}
+      <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-6 mb-6">
+        <h2 className="text-base font-semibold text-slate-700 mb-4">アクティブ契約数</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div>
+            <div className="text-xs text-slate-400 mb-1">個人課金者</div>
+            <div className="text-xl font-bold text-slate-800">
+              {data.personal_active_users.toLocaleString()}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-slate-400 mb-1">家族グループ</div>
+            <div className="text-xl font-bold text-slate-800">
+              {data.family_active_groups.toLocaleString()}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-slate-400 mb-1">法人</div>
+            <div className="text-xl font-bold text-slate-800">
+              {data.org_active_orgs.toLocaleString()}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-slate-400 mb-1">MAU</div>
+            <div className="text-xl font-bold text-slate-800">
+              {data.mau.toLocaleString()}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* クイックリンク */}
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        {[
+          { href: "/admin/finance/revenue", label: "収益推移グラフ", icon: "📈" },
+          { href: "/admin/finance/invoices", label: "請求書一覧", icon: "🧾" },
+          { href: "/admin/finance/reconciliation", label: "Stripe 整合チェック", icon: "🔄" },
+          { href: "/admin/finance/nps", label: "NPS / CSAT", icon: "⭐" },
+          { href: "/admin/finance/exports", label: "CSV エクスポート", icon: "📥" },
+        ].map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="bg-white border border-slate-100 rounded-xl p-4 flex items-center gap-3 hover:border-indigo-200 hover:shadow-sm transition-all"
+          >
+            <span className="text-2xl">{item.icon}</span>
+            <span className="text-sm font-medium text-slate-700">{item.label}</span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/finance/reconciliation/page.tsx
+++ b/src/app/admin/finance/reconciliation/page.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface ReconciliationData {
+  discrepancies: Array<{
+    id: string;
+    type: string;
+    stripe_subscription_id: string | null;
+    stripe_status: string | null;
+    db_status: string | null;
+    user_id: string | null;
+    detail: string;
+    detected_at: string;
+  }>;
+  db_summary: {
+    total_active_in_db: number;
+    by_status: Record<string, number>;
+  };
+  stripe_summary: {
+    stripe_available: boolean;
+    total_active_in_stripe?: number;
+    message?: string;
+  };
+}
+
+interface ApiMeta {
+  total: number;
+  page: number;
+  per_page: number;
+  note?: string;
+}
+
+function TypeBadge({ type }: { type: string }) {
+  const colors: Record<string, string> = {
+    missing_in_db: "bg-red-100 text-red-700",
+    status_mismatch: "bg-yellow-100 text-yellow-700",
+    amount_mismatch: "bg-orange-100 text-orange-700",
+  };
+  return (
+    <span className={`text-xs font-medium px-2 py-0.5 rounded ${colors[type] ?? "bg-slate-100 text-slate-600"}`}>
+      {type}
+    </span>
+  );
+}
+
+export default function ReconciliationPage() {
+  const [data, setData] = useState<ReconciliationData | null>(null);
+  const [meta, setMeta] = useState<ApiMeta | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+
+  const fetchData = (currentPage = 1) => {
+    setLoading(true);
+    const params = new URLSearchParams({ page: String(currentPage), per_page: "50" });
+    if (from) params.set("from", from);
+    if (to) params.set("to", to);
+
+    fetch(`/api/admin/finance/reconciliation?${params}`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.error) setError(json.error.message);
+        else {
+          setData(json.data as ReconciliationData);
+          setMeta(json.meta as ApiMeta);
+        }
+      })
+      .catch((e: unknown) => setError(String(e)))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchData(page);
+  }, [page]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="p-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-800">Stripe 整合チェック</h1>
+        <p className="text-sm text-slate-500 mt-1">DB ↔ Stripe の subscription status 差分 (日次 cron 結果)</p>
+      </div>
+
+      {meta?.note && (
+        <div className="mb-4 bg-blue-50 border border-blue-200 rounded-lg p-3 text-blue-700 text-sm">
+          {meta.note}
+        </div>
+      )}
+
+      {/* サマリー */}
+      {data && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+          <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-5">
+            <div className="text-xs text-slate-400 mb-1">DB アクティブ数</div>
+            <div className="text-2xl font-bold text-slate-800">
+              {data.db_summary.total_active_in_db.toLocaleString()}
+            </div>
+            <div className="mt-2 space-y-1">
+              {Object.entries(data.db_summary.by_status).map(([status, count]) => (
+                <div key={status} className="flex justify-between text-xs text-slate-500">
+                  <span>{status}</span>
+                  <span className="font-medium">{count}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-5">
+            <div className="text-xs text-slate-400 mb-1">Stripe (active)</div>
+            {data.stripe_summary.stripe_available ? (
+              <div className="text-2xl font-bold text-slate-800">
+                {data.stripe_summary.total_active_in_stripe?.toLocaleString() ?? "-"}
+              </div>
+            ) : (
+              <div className="text-sm text-slate-400 mt-2">
+                {data.stripe_summary.message ?? "Stripe Secret 未設定"}
+              </div>
+            )}
+          </div>
+
+          <div className={`rounded-xl border shadow-sm p-5 ${(meta?.total ?? 0) > 0 ? "bg-red-50 border-red-200" : "bg-green-50 border-green-200"}`}>
+            <div className={`text-xs mb-1 ${(meta?.total ?? 0) > 0 ? "text-red-400" : "text-green-400"}`}>
+              不一致件数
+            </div>
+            <div className={`text-2xl font-bold ${(meta?.total ?? 0) > 0 ? "text-red-700" : "text-green-700"}`}>
+              {meta?.total ?? 0}
+            </div>
+            {(meta?.total ?? 0) === 0 && (
+              <div className="text-xs text-green-600 mt-2">整合OK</div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* フィルタ */}
+      <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-4 mb-6 flex flex-wrap gap-3 items-end">
+        <div>
+          <label className="block text-xs text-slate-500 mb-1">検出日 FROM</label>
+          <input type="date" value={from} onChange={(e) => setFrom(e.target.value)} className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm" />
+        </div>
+        <div>
+          <label className="block text-xs text-slate-500 mb-1">検出日 TO</label>
+          <input type="date" value={to} onChange={(e) => setTo(e.target.value)} className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm" />
+        </div>
+        <button
+          onClick={() => { setPage(1); fetchData(1); }}
+          className="px-4 py-1.5 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 transition-colors"
+        >
+          検索
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <div className="w-8 h-8 border-4 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : error ? (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">{error}</div>
+      ) : (
+        <>
+          <div className="bg-white rounded-xl border border-slate-100 shadow-sm overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-slate-50 border-b border-slate-100">
+                  <tr>
+                    {["種別", "Stripe Sub ID", "Stripe Status", "DB Status", "ユーザー ID", "詳細", "検出日時"].map((h) => (
+                      <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-slate-500 whitespace-nowrap">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-50">
+                  {(data?.discrepancies ?? []).length === 0 ? (
+                    <tr>
+                      <td colSpan={7} className="px-4 py-8 text-center text-slate-400">
+                        不一致は検出されていません
+                      </td>
+                    </tr>
+                  ) : (
+                    (data?.discrepancies ?? []).map((d) => (
+                      <tr key={d.id} className="hover:bg-slate-50 transition-colors">
+                        <td className="px-4 py-3"><TypeBadge type={d.type} /></td>
+                        <td className="px-4 py-3 font-mono text-xs text-slate-500 max-w-40 truncate">
+                          {d.stripe_subscription_id ?? "-"}
+                        </td>
+                        <td className="px-4 py-3 text-slate-600">{d.stripe_status ?? "-"}</td>
+                        <td className="px-4 py-3 text-slate-600">{d.db_status ?? "-"}</td>
+                        <td className="px-4 py-3 font-mono text-xs text-slate-400 max-w-32 truncate">
+                          {d.user_id ?? "-"}
+                        </td>
+                        <td className="px-4 py-3 text-slate-500 text-xs max-w-48 truncate">{d.detail}</td>
+                        <td className="px-4 py-3 text-slate-400 text-xs whitespace-nowrap">
+                          {new Date(d.detected_at).toLocaleString("ja-JP")}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {meta && meta.total > meta.per_page && (
+            <div className="flex items-center justify-between mt-4">
+              <span className="text-sm text-slate-500">全 {meta.total} 件</span>
+              <div className="flex gap-2">
+                <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page <= 1} className="px-3 py-1.5 text-sm border border-slate-200 rounded-lg disabled:opacity-40 hover:bg-slate-50">前へ</button>
+                <button onClick={() => setPage((p) => p + 1)} disabled={page * meta.per_page >= meta.total} className="px-3 py-1.5 text-sm border border-slate-200 rounded-lg disabled:opacity-40 hover:bg-slate-50">次へ</button>
+              </div>
+            </div>
+          )}
+
+          <div className="mt-6 bg-amber-50 border border-amber-200 rounded-lg p-4">
+            <div className="text-sm font-medium text-amber-800 mb-1">自動修復は無効</div>
+            <div className="text-xs text-amber-700">
+              不整合を検出した場合、自動修復は行いません。原因を確認の上、super_admin が手動で修正してください。
+              (operator/09-runbook.md §2.1 参照)
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/finance/revenue/page.tsx
+++ b/src/app/admin/finance/revenue/page.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { RevenueSnapshot } from "@/lib/admin/finance-schemas";
+
+function formatJpy(n: number) {
+  if (n >= 1_000_000) return `¥${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `¥${(n / 1_000).toFixed(1)}K`;
+  return `¥${n.toLocaleString()}`;
+}
+
+export default function RevenueListPage() {
+  const [snapshots, setSnapshots] = useState<RevenueSnapshot[]>([]);
+  const [meta, setMeta] = useState<{
+    total: number;
+    page: number;
+    per_page: number;
+    summary?: { avg_mrr_jpy: number; latest_mrr_jpy: number; latest_arr_jpy: number };
+  } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [page, setPage] = useState(1);
+
+  const fetchData = (currentPage = 1) => {
+    setLoading(true);
+    const params = new URLSearchParams({ page: String(currentPage), per_page: "24" });
+    if (from) params.set("from", from);
+    if (to) params.set("to", to);
+
+    fetch(`/api/admin/finance/revenue?${params}`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.error) {
+          setError(json.error.message);
+        } else {
+          setSnapshots(json.data as RevenueSnapshot[]);
+          setMeta(json.meta as typeof meta);
+        }
+      })
+      .catch((e: unknown) => setError(String(e)))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchData(page);
+  }, [page]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSearch = () => {
+    setPage(1);
+    fetchData(1);
+  };
+
+  return (
+    <div className="p-8">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-800">収益推移</h1>
+          <p className="text-sm text-slate-500 mt-1">revenue_snapshots — 日次スナップショット</p>
+        </div>
+      </div>
+
+      {/* フィルタ */}
+      <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-4 mb-6 flex flex-wrap gap-3 items-end">
+        <div>
+          <label className="block text-xs text-slate-500 mb-1">開始日</label>
+          <input
+            type="date"
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+            className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-slate-500 mb-1">終了日</label>
+          <input
+            type="date"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            className="border border-slate-200 rounded-lg px-3 py-1.5 text-sm"
+          />
+        </div>
+        <button
+          onClick={handleSearch}
+          className="px-4 py-1.5 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 transition-colors"
+        >
+          検索
+        </button>
+      </div>
+
+      {/* サマリー */}
+      {meta?.summary && (
+        <div className="grid grid-cols-3 gap-4 mb-6">
+          <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-4">
+            <div className="text-xs text-slate-400 mb-1">最新 MRR</div>
+            <div className="text-xl font-bold text-slate-800">
+              {formatJpy(meta.summary.latest_mrr_jpy)}
+            </div>
+          </div>
+          <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-4">
+            <div className="text-xs text-slate-400 mb-1">最新 ARR</div>
+            <div className="text-xl font-bold text-slate-800">
+              {formatJpy(meta.summary.latest_arr_jpy)}
+            </div>
+          </div>
+          <div className="bg-white rounded-xl border border-slate-100 shadow-sm p-4">
+            <div className="text-xs text-slate-400 mb-1">期間平均 MRR</div>
+            <div className="text-xl font-bold text-slate-800">
+              {formatJpy(meta.summary.avg_mrr_jpy)}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* テーブル */}
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <div className="w-8 h-8 border-4 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : error ? (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">{error}</div>
+      ) : (
+        <>
+          <div className="bg-white rounded-xl border border-slate-100 shadow-sm overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-slate-50 border-b border-slate-100">
+                  <tr>
+                    {["日付", "Total MRR", "ARR", "個人 MAU", "個人 MRR", "組織数", "組織 MRR", "新規", "解約"].map((h) => (
+                      <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-slate-500 whitespace-nowrap">
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-50">
+                  {snapshots.length === 0 ? (
+                    <tr>
+                      <td colSpan={9} className="px-4 py-8 text-center text-slate-400">
+                        データがありません
+                      </td>
+                    </tr>
+                  ) : (
+                    snapshots.map((s) => (
+                      <tr key={s.date} className="hover:bg-slate-50 transition-colors">
+                        <td className="px-4 py-3 font-mono text-slate-700">{s.date}</td>
+                        <td className="px-4 py-3 font-semibold text-slate-800">{formatJpy(s.total_mrr_jpy)}</td>
+                        <td className="px-4 py-3 text-slate-600">{formatJpy(s.total_arr_jpy)}</td>
+                        <td className="px-4 py-3 text-slate-600">{s.personal_active_users.toLocaleString()}</td>
+                        <td className="px-4 py-3 text-slate-600">{formatJpy(s.personal_mrr_jpy)}</td>
+                        <td className="px-4 py-3 text-slate-600">{s.org_active_orgs.toLocaleString()}</td>
+                        <td className="px-4 py-3 text-slate-600">{formatJpy(s.org_mrr_jpy)}</td>
+                        <td className="px-4 py-3 text-green-600">{s.new_signups}</td>
+                        <td className="px-4 py-3 text-red-500">{s.cancellations}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* ページネーション */}
+          {meta && meta.total > meta.per_page && (
+            <div className="flex items-center justify-between mt-4">
+              <span className="text-sm text-slate-500">
+                全 {meta.total} 件 / ページ {meta.page}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page <= 1}
+                  className="px-3 py-1.5 text-sm border border-slate-200 rounded-lg disabled:opacity-40 hover:bg-slate-50"
+                >
+                  前へ
+                </button>
+                <button
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={page * meta.per_page >= meta.total}
+                  className="px-3 py-1.5 text-sm border border-slate-200 rounded-lg disabled:opacity-40 hover:bg-slate-50"
+                >
+                  次へ
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/finance/dashboard/route.ts
+++ b/src/app/api/admin/finance/dashboard/route.ts
@@ -1,0 +1,148 @@
+/**
+ * GET /api/admin/finance/dashboard
+ * 売上ダッシュボード KPI
+ * operator/02-api-spec.md §9
+ * 権限: admin, super_admin, finance
+ */
+import { NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { createClient } from '@/lib/supabase/server';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const user = await requireRole(['admin', 'super_admin', 'finance']);
+    const supabase = createClient();
+
+    // 最新スナップショット (今月と先月) を revenue_snapshots から取得
+    const today = new Date();
+    const thisMonthStart = new Date(today.getFullYear(), today.getMonth(), 1)
+      .toISOString()
+      .slice(0, 10);
+    const lastMonthStart = new Date(today.getFullYear(), today.getMonth() - 1, 1)
+      .toISOString()
+      .slice(0, 10);
+    const lastMonthEnd = new Date(today.getFullYear(), today.getMonth(), 0)
+      .toISOString()
+      .slice(0, 10);
+
+    // 今月の最新スナップショット
+    const { data: currentSnap } = await supabase
+      .from('revenue_snapshots')
+      .select('*')
+      .gte('date', thisMonthStart)
+      .order('date', { ascending: false })
+      .limit(1)
+      .single();
+
+    // 先月の最新スナップショット (比較用)
+    const { data: lastMonthSnap } = await supabase
+      .from('revenue_snapshots')
+      .select('*')
+      .gte('date', lastMonthStart)
+      .lte('date', lastMonthEnd)
+      .order('date', { ascending: false })
+      .limit(1)
+      .single();
+
+    // スナップショットがなければ personal_subscriptions から直接集計
+    let currentMrrJpy = currentSnap?.total_mrr_jpy ?? 0;
+    let currentArrJpy = currentSnap?.total_arr_jpy ?? 0;
+    let personalActiveUsers = currentSnap?.personal_active_users ?? 0;
+    let familyActiveGroups = currentSnap?.family_active_groups ?? 0;
+    let orgActiveOrgs = currentSnap?.org_active_orgs ?? 0;
+    let mau = 0;
+
+    if (!currentSnap) {
+      // フォールバック: personal_subscriptions から直接集計
+      const { data: activeSubs } = await supabase
+        .from('personal_subscriptions')
+        .select('plan_key, subscription_plans(monthly_price_jpy)')
+        .in('status', ['active', 'trialing']);
+
+      if (activeSubs) {
+        personalActiveUsers = activeSubs.length;
+        // @ts-ignore: join type
+        const monthlyTotal = activeSubs.reduce((sum, s) => sum + (s.subscription_plans?.monthly_price_jpy ?? 0), 0);
+        currentMrrJpy = monthlyTotal;
+        currentArrJpy = monthlyTotal * 12;
+      }
+    }
+
+    // MAU は daily_active_users から
+    const { data: dauRecord } = await supabase
+      .from('daily_active_users')
+      .select('mau')
+      .eq('plan_type', 'all')
+      .eq('plan_key', '')
+      .order('date', { ascending: false })
+      .limit(1)
+      .single();
+    mau = dauRecord?.mau ?? 0;
+
+    // チャーンレート計算
+    // churn_rate = (先月のキャンセル数 / 先月初頭のアクティブ数) * 100
+    const lastMonthMrr = lastMonthSnap?.total_mrr_jpy ?? 1;
+    const churnedMrrJpy = lastMonthSnap?.cancellations
+      ? Math.round((lastMonthSnap.cancellations / Math.max(1, lastMonthSnap.personal_active_users)) * lastMonthMrr)
+      : 0;
+    const churnRate = lastMonthMrr > 0
+      ? Math.round((churnedMrrJpy / lastMonthMrr) * 100 * 10) / 10
+      : 0;
+
+    // LTV = MRR / churn_rate (churn が 0 の場合は N/A として 0 返却)
+    const ltvJpy = churnRate > 0
+      ? Math.round(currentMrrJpy / (churnRate / 100) / Math.max(1, personalActiveUsers))
+      : 0;
+
+    // 新規/拡張/縮小/解約 MRR (スナップショットの upgrade/downgrade/cancellation カウントから概算)
+    const newMrrJpy = currentSnap
+      ? Math.round((currentSnap.new_signups ?? 0) * (currentMrrJpy / Math.max(1, personalActiveUsers)))
+      : 0;
+    const expansionMrrJpy = currentSnap
+      ? Math.round((currentSnap.upgrade_count ?? 0) * (currentMrrJpy / Math.max(1, personalActiveUsers)) * 0.3)
+      : 0;
+    const contractionMrrJpy = currentSnap
+      ? Math.round((currentSnap.downgrade_count ?? 0) * (currentMrrJpy / Math.max(1, personalActiveUsers)) * 0.2)
+      : 0;
+
+    void user; // 認証確認済み
+
+    return NextResponse.json({
+      data: {
+        current_mrr_jpy: currentMrrJpy,
+        current_arr_jpy: currentArrJpy,
+        churn_rate: churnRate,
+        ltv_jpy: ltvJpy,
+        new_mrr_jpy: newMrrJpy,
+        expansion_mrr_jpy: expansionMrrJpy,
+        contraction_mrr_jpy: contractionMrrJpy,
+        churned_mrr_jpy: churnedMrrJpy,
+        personal_active_users: personalActiveUsers,
+        family_active_groups: familyActiveGroups,
+        org_active_orgs: orgActiveOrgs,
+        mau,
+      },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHENTICATED', message: err.message } },
+        { status: 401 },
+      );
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json(
+        { error: { code: 'OP_PERMISSION_DENIED', message: err.message } },
+        { status: 403 },
+      );
+    }
+    console.error('[finance/dashboard] unexpected error:', err);
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/finance/exports/route.ts
+++ b/src/app/api/admin/finance/exports/route.ts
@@ -1,0 +1,129 @@
+/**
+ * POST /api/admin/finance/exports
+ * CSV エクスポート生成
+ * 権限: admin, super_admin, finance
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { createClient } from '@/lib/supabase/server';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { ExportRequestSchema } from '@/lib/admin/finance-schemas';
+
+export const dynamic = 'force-dynamic';
+
+/** 配列データを CSV 文字列に変換するシンプルなヘルパー */
+function toCsv(headers: string[], rows: Record<string, unknown>[]): string {
+  const escape = (v: unknown): string => {
+    const s = v == null ? '' : String(v);
+    return s.includes(',') || s.includes('"') || s.includes('\n')
+      ? `"${s.replace(/"/g, '""')}"`
+      : s;
+  };
+  const headerLine = headers.map(escape).join(',');
+  const dataLines = rows.map((row) => headers.map((h) => escape(row[h])).join(','));
+  return [headerLine, ...dataLines].join('\n');
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireRole(['admin', 'super_admin', 'finance']);
+    const supabase = createClient();
+
+    const body = await request.json() as unknown;
+    const req = ExportRequestSchema.parse(body);
+
+    let csvContent = '';
+    let filename = '';
+
+    if (req.export_type === 'revenue') {
+      let dbQuery = supabase
+        .from('revenue_snapshots')
+        .select('date, total_mrr_jpy, total_arr_jpy, personal_active_users, org_active_orgs, new_signups, cancellations, computed_at')
+        .order('date', { ascending: false });
+      if (req.from) dbQuery = dbQuery.gte('date', req.from);
+      if (req.to) dbQuery = dbQuery.lte('date', req.to);
+      const { data } = await dbQuery;
+      const headers = ['date', 'total_mrr_jpy', 'total_arr_jpy', 'personal_active_users', 'org_active_orgs', 'new_signups', 'cancellations', 'computed_at'];
+      csvContent = toCsv(headers, (data ?? []) as Record<string, unknown>[]);
+      filename = `revenue_${new Date().toISOString().slice(0, 10)}.csv`;
+    } else if (req.export_type === 'invoices') {
+      let dbQuery = supabase
+        .from('stripe_webhook_events')
+        .select('id, event_type, processing_status, received_at, processed_at, error_message')
+        .in('event_type', ['invoice.paid', 'invoice.payment_failed'])
+        .order('received_at', { ascending: false });
+      if (req.from) dbQuery = dbQuery.gte('received_at', req.from);
+      if (req.to) dbQuery = dbQuery.lte('received_at', req.to);
+      const { data } = await dbQuery;
+      const headers = ['id', 'event_type', 'processing_status', 'received_at', 'processed_at', 'error_message'];
+      csvContent = toCsv(headers, (data ?? []) as Record<string, unknown>[]);
+      filename = `invoices_${new Date().toISOString().slice(0, 10)}.csv`;
+    } else if (req.export_type === 'subscriptions') {
+      let dbQuery = supabase
+        .from('personal_subscriptions')
+        .select('id, user_id, plan_key, status, starts_at, current_period_start, current_period_end, cancelled_at, created_at')
+        .order('created_at', { ascending: false });
+      if (req.from) dbQuery = dbQuery.gte('created_at', req.from);
+      if (req.to) dbQuery = dbQuery.lte('created_at', req.to);
+      const { data } = await dbQuery;
+      const headers = ['id', 'user_id', 'plan_key', 'status', 'starts_at', 'current_period_start', 'current_period_end', 'cancelled_at', 'created_at'];
+      csvContent = toCsv(headers, (data ?? []) as Record<string, unknown>[]);
+      filename = `subscriptions_${new Date().toISOString().slice(0, 10)}.csv`;
+    } else if (req.export_type === 'nps') {
+      let dbQuery = supabase
+        .from('nps_surveys')
+        .select('id, user_id, score, comment, plan_key, sent_at, responded_at')
+        .order('sent_at', { ascending: false });
+      if (req.from) dbQuery = dbQuery.gte('sent_at', req.from);
+      if (req.to) dbQuery = dbQuery.lte('sent_at', req.to);
+      const { data } = await dbQuery;
+      const headers = ['id', 'user_id', 'score', 'comment', 'plan_key', 'sent_at', 'responded_at'];
+      csvContent = toCsv(headers, (data ?? []) as Record<string, unknown>[]);
+      filename = `nps_${new Date().toISOString().slice(0, 10)}.csv`;
+    }
+
+    // 監査ログ記録 (破壊的操作ではないが export はログ対象とする)
+    try {
+      await supabase.from('admin_audit_logs').insert({
+        actor_id: user.id,
+        action_type: 'admin.finance.export',
+        target_type: 'finance_data',
+        severity: 'info',
+        details: {
+          export_type: req.export_type,
+          from: req.from,
+          to: req.to,
+        },
+        ip_address: null,
+      });
+    } catch {
+      // graceful: ログ失敗でもエクスポートは返す
+    }
+
+    return new NextResponse(csvContent, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHENTICATED', message: err.message } },
+        { status: 401 },
+      );
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json(
+        { error: { code: 'OP_PERMISSION_DENIED', message: err.message } },
+        { status: 403 },
+      );
+    }
+    console.error('[finance/exports] unexpected error:', err);
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/finance/invoices/[id]/route.ts
+++ b/src/app/api/admin/finance/invoices/[id]/route.ts
@@ -1,0 +1,108 @@
+/**
+ * GET /api/admin/finance/invoices/[id]
+ * 個別請求書詳細
+ * operator/02-api-spec.md §9
+ * 権限: admin, super_admin, finance
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { createClient } from '@/lib/supabase/server';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    await requireRole(['admin', 'super_admin', 'finance']);
+    const supabase = createClient();
+
+    const { data: evt, error } = await supabase
+      .from('stripe_webhook_events')
+      .select('*')
+      .eq('id', params.id)
+      .single();
+
+    if (error || !evt) {
+      return NextResponse.json(
+        { error: { code: 'NOT_FOUND', message: '請求書が見つかりません' } },
+        { status: 404 },
+      );
+    }
+
+    const payload = (evt.payload as Record<string, unknown>) ?? {};
+    const invoiceObj = (payload as { data?: { object?: Record<string, unknown> } })?.data?.object ?? {};
+
+    const stripeCustomerId = (invoiceObj as { customer?: string })?.customer ?? null;
+    const stripeSubscriptionId = (invoiceObj as { subscription?: string })?.subscription ?? null;
+
+    // personal_subscriptions から user_id を取得 (stripe_subscription_id で結合)
+    let userId: string | null = null;
+    if (stripeSubscriptionId) {
+      const { data: sub } = await supabase
+        .from('personal_subscriptions')
+        .select('user_id, plan_key')
+        .eq('stripe_subscription_id', stripeSubscriptionId)
+        .single();
+      userId = sub?.user_id ?? null;
+    }
+
+    // Stripe Dashboard リンク生成
+    const stripeBase = process.env.NODE_ENV === 'production'
+      ? 'https://dashboard.stripe.com'
+      : 'https://dashboard.stripe.com/test';
+
+    const invoice = {
+      id: evt.id,
+      stripe_event_id: evt.id,
+      event_type: evt.event_type,
+      processing_status: evt.processing_status,
+      user_id: userId,
+      stripe_customer_id: stripeCustomerId,
+      stripe_subscription_id: stripeSubscriptionId,
+      amount_paid: (invoiceObj as { amount_paid?: number })?.amount_paid ?? null,
+      amount_due: (invoiceObj as { amount_due?: number })?.amount_due ?? null,
+      currency: (invoiceObj as { currency?: string })?.currency ?? null,
+      invoice_number: (invoiceObj as { number?: string })?.number ?? null,
+      invoice_pdf: (invoiceObj as { invoice_pdf?: string })?.invoice_pdf ?? null,
+      period_start: (invoiceObj as { period_start?: number })?.period_start
+        ? new Date(((invoiceObj as { period_start: number }).period_start) * 1000).toISOString()
+        : null,
+      period_end: (invoiceObj as { period_end?: number })?.period_end
+        ? new Date(((invoiceObj as { period_end: number }).period_end) * 1000).toISOString()
+        : null,
+      stripe_links: {
+        customer: stripeCustomerId ? `${stripeBase}/customers/${stripeCustomerId}` : null,
+        subscription: stripeSubscriptionId ? `${stripeBase}/subscriptions/${stripeSubscriptionId}` : null,
+        invoice: (invoiceObj as { id?: string })?.id
+          ? `${stripeBase}/invoices/${(invoiceObj as { id: string }).id}`
+          : null,
+      },
+      received_at: evt.received_at,
+      processed_at: evt.processed_at ?? null,
+      error_message: evt.error_message ?? null,
+    };
+
+    return NextResponse.json({ data: invoice });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHENTICATED', message: err.message } },
+        { status: 401 },
+      );
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json(
+        { error: { code: 'OP_PERMISSION_DENIED', message: err.message } },
+        { status: 403 },
+      );
+    }
+    console.error('[finance/invoices/[id]] unexpected error:', err);
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/finance/invoices/route.ts
+++ b/src/app/api/admin/finance/invoices/route.ts
@@ -1,0 +1,109 @@
+/**
+ * GET /api/admin/finance/invoices
+ * 請求書一覧 (stripe_webhook_events 由来)
+ * operator/02-api-spec.md §9
+ * 権限: admin, super_admin, finance
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { createClient } from '@/lib/supabase/server';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { InvoiceQuerySchema } from '@/lib/admin/finance-schemas';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireRole(['admin', 'super_admin', 'finance']);
+    const supabase = createClient();
+
+    const { searchParams } = new URL(request.url);
+    const query = InvoiceQuerySchema.parse({
+      page: searchParams.get('page') ?? undefined,
+      per_page: searchParams.get('per_page') ?? undefined,
+      status: searchParams.get('status') ?? undefined,
+      from: searchParams.get('from') ?? undefined,
+      to: searchParams.get('to') ?? undefined,
+    });
+
+    // stripe_webhook_events テーブルから invoice 関連イベントを取得
+    let dbQuery = supabase
+      .from('stripe_webhook_events')
+      .select('*', { count: 'exact' })
+      .in('event_type', ['invoice.paid', 'invoice.payment_failed', 'invoice.upcoming'])
+      .order('received_at', { ascending: false });
+
+    if (query.status) {
+      dbQuery = dbQuery.eq('processing_status', query.status);
+    }
+    if (query.from) {
+      dbQuery = dbQuery.gte('received_at', query.from);
+    }
+    if (query.to) {
+      dbQuery = dbQuery.lte('received_at', query.to);
+    }
+
+    const offset = (query.page - 1) * query.per_page;
+    dbQuery = dbQuery.range(offset, offset + query.per_page - 1);
+
+    const { data: events, count, error } = await dbQuery;
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    // payload から invoice 情報を抽出
+    const invoices = (events ?? []).map((evt) => {
+      const payload = (evt.payload as Record<string, unknown>) ?? {};
+      const invoiceObj = (payload as { data?: { object?: Record<string, unknown> } })?.data?.object ?? {};
+
+      return {
+        id: evt.id,
+        stripe_event_id: evt.id,
+        event_type: evt.event_type,
+        user_id: null,
+        stripe_customer_id: (invoiceObj as { customer?: string })?.customer ?? null,
+        stripe_subscription_id: (invoiceObj as { subscription?: string })?.subscription ?? null,
+        amount_paid: (invoiceObj as { amount_paid?: number })?.amount_paid ?? null,
+        currency: (invoiceObj as { currency?: string })?.currency ?? null,
+        status: evt.processing_status,
+        invoice_number: (invoiceObj as { number?: string })?.number ?? null,
+        period_start: (invoiceObj as { period_start?: number })?.period_start
+          ? new Date(((invoiceObj as { period_start: number }).period_start) * 1000).toISOString()
+          : null,
+        period_end: (invoiceObj as { period_end?: number })?.period_end
+          ? new Date(((invoiceObj as { period_end: number }).period_end) * 1000).toISOString()
+          : null,
+        received_at: evt.received_at,
+        processed_at: evt.processed_at ?? null,
+      };
+    });
+
+    return NextResponse.json({
+      data: invoices,
+      meta: {
+        total: count ?? 0,
+        page: query.page,
+        per_page: query.per_page,
+      },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHENTICATED', message: err.message } },
+        { status: 401 },
+      );
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json(
+        { error: { code: 'OP_PERMISSION_DENIED', message: err.message } },
+        { status: 403 },
+      );
+    }
+    console.error('[finance/invoices] unexpected error:', err);
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/finance/nps/route.ts
+++ b/src/app/api/admin/finance/nps/route.ts
@@ -1,0 +1,136 @@
+/**
+ * GET /api/admin/finance/nps
+ * NPS / CSAT 集計
+ * operator/01-data-model.md §3.14
+ * 権限: admin, super_admin, finance
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { createClient } from '@/lib/supabase/server';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { NpsQuerySchema } from '@/lib/admin/finance-schemas';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireRole(['admin', 'super_admin', 'finance']);
+    const supabase = createClient();
+
+    const { searchParams } = new URL(request.url);
+    const query = NpsQuerySchema.parse({
+      from: searchParams.get('from') ?? undefined,
+      to: searchParams.get('to') ?? undefined,
+      plan_key: searchParams.get('plan_key') ?? undefined,
+    });
+
+    // NPS サーベイ集計
+    let npsQuery = supabase
+      .from('nps_surveys')
+      .select('id, score, comment, plan_key, responded_at')
+      .not('responded_at', 'is', null);
+
+    if (query.from) npsQuery = npsQuery.gte('sent_at', query.from);
+    if (query.to) npsQuery = npsQuery.lte('sent_at', query.to);
+    if (query.plan_key) npsQuery = npsQuery.eq('plan_key', query.plan_key);
+
+    const { data: npsResponses, error: npsError } = await npsQuery.order('responded_at', { ascending: false });
+
+    if (npsError) throw new Error(npsError.message);
+
+    const responses = npsResponses ?? [];
+    const total = responses.length;
+    const promoters = responses.filter((r) => r.score >= 9).length;
+    const passives = responses.filter((r) => r.score >= 7 && r.score <= 8).length;
+    const detractors = responses.filter((r) => r.score <= 6).length;
+    const npsScore = total > 0
+      ? Math.round(((promoters - detractors) / total) * 100 * 10) / 10
+      : 0;
+    const avgScore = total > 0
+      ? Math.round(responses.reduce((s, r) => s + r.score, 0) / total * 10) / 10
+      : 0;
+
+    // 送信数 (responded_at なし含む)
+    let sentQuery = supabase.from('nps_surveys').select('id', { count: 'exact', head: true });
+    if (query.from) sentQuery = sentQuery.gte('sent_at', query.from);
+    if (query.to) sentQuery = sentQuery.lte('sent_at', query.to);
+    if (query.plan_key) sentQuery = sentQuery.eq('plan_key', query.plan_key);
+    const { count: sentCount } = await sentQuery;
+
+    const responseRate = (sentCount ?? 0) > 0
+      ? Math.round((total / (sentCount ?? 1)) * 100 * 10) / 10
+      : 0;
+
+    // CSAT 集計
+    let csatQuery = supabase
+      .from('csat_feedbacks')
+      .select('id, score, comment, ticket_id, created_at');
+    if (query.from) csatQuery = csatQuery.gte('created_at', query.from);
+    if (query.to) csatQuery = csatQuery.lte('created_at', query.to);
+
+    const { data: csatResponses, error: csatError } = await csatQuery.order('created_at', { ascending: false });
+
+    if (csatError) throw new Error(csatError.message);
+
+    const csatData = csatResponses ?? [];
+    const csatTotal = csatData.length;
+    const csatAvg = csatTotal > 0
+      ? Math.round(csatData.reduce((s, r) => s + r.score, 0) / csatTotal * 10) / 10
+      : 0;
+    const csatDist: Record<string, number> = { '1': 0, '2': 0, '3': 0, '4': 0, '5': 0 };
+    for (const r of csatData) {
+      csatDist[String(r.score)] = (csatDist[String(r.score)] ?? 0) + 1;
+    }
+
+    return NextResponse.json({
+      data: {
+        nps: {
+          total_responses: total,
+          promoters,
+          passives,
+          detractors,
+          nps_score: npsScore,
+          avg_score: avgScore,
+          response_rate: responseRate,
+          recent_comments: responses.slice(0, 10).map((r) => ({
+            id: r.id,
+            score: r.score,
+            comment: r.comment,
+            plan_key: r.plan_key,
+            responded_at: r.responded_at,
+          })),
+        },
+        csat: {
+          total_responses: csatTotal,
+          avg_score: csatAvg,
+          score_distribution: csatDist,
+          recent_feedbacks: csatData.slice(0, 10).map((r) => ({
+            id: r.id,
+            score: r.score,
+            comment: r.comment,
+            ticket_id: r.ticket_id,
+            created_at: r.created_at,
+          })),
+        },
+      },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHENTICATED', message: err.message } },
+        { status: 401 },
+      );
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json(
+        { error: { code: 'OP_PERMISSION_DENIED', message: err.message } },
+        { status: 403 },
+      );
+    }
+    console.error('[finance/nps] unexpected error:', err);
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/finance/reconciliation/route.ts
+++ b/src/app/api/admin/finance/reconciliation/route.ts
@@ -1,0 +1,138 @@
+/**
+ * GET /api/admin/finance/reconciliation
+ * Stripe ↔ DB 整合チェック結果表示
+ * operator/05-stripe-integration.md §8
+ * operator/02-api-spec.md §22 (cron/stripe-reconcile 結果の参照 API)
+ * 権限: admin, super_admin (finance は閲覧のみ、設計書 §11 参照)
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { createClient } from '@/lib/supabase/server';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    // reconciliation は admin / super_admin 限定
+    // (finance は DB 側のみ表示)
+    const user = await requireRole(['admin', 'super_admin', 'finance']);
+    const isAdminOrSuperAdmin = user.roles.some((r) => ['admin', 'super_admin'].includes(r));
+
+    const supabase = createClient();
+
+    // admin_audit_logs から reconciliation discrepancy を取得
+    const { searchParams } = new URL(request.url);
+    const from = searchParams.get('from');
+    const to = searchParams.get('to');
+    const page = parseInt(searchParams.get('page') ?? '1', 10);
+    const perPage = parseInt(searchParams.get('per_page') ?? '50', 10);
+
+    let logsQuery = supabase
+      .from('admin_audit_logs')
+      .select('*', { count: 'exact' })
+      .eq('action_type', 'system.stripe.reconcile_discrepancy')
+      .order('created_at', { ascending: false });
+
+    if (from) logsQuery = logsQuery.gte('created_at', from);
+    if (to) logsQuery = logsQuery.lte('created_at', to);
+
+    const offset = (page - 1) * perPage;
+    logsQuery = logsQuery.range(offset, offset + perPage - 1);
+
+    const { data: logs, count, error: logsError } = await logsQuery;
+
+    if (logsError) {
+      throw new Error(logsError.message);
+    }
+
+    // discrepancy 統計
+    const discrepancies = (logs ?? []).map((log) => {
+      const details = (log.details as Record<string, unknown>) ?? {};
+      return {
+        id: log.id,
+        type: (details.type as string) ?? 'unknown',
+        stripe_subscription_id: (details.stripe_subscription_id as string) ?? null,
+        stripe_status: (details.stripe_status as string) ?? null,
+        db_status: (details.db_status as string) ?? null,
+        stripe_amount: (details.stripe_amount as number) ?? null,
+        db_amount: (details.db_amount as number) ?? null,
+        user_id: log.target_id ?? null,
+        detail: (details.detail as string) ?? '',
+        detected_at: log.created_at,
+      };
+    });
+
+    // DB 側サマリー (finance も閲覧可)
+    const { data: dbSubs } = await supabase
+      .from('personal_subscriptions')
+      .select('id, status, stripe_subscription_id')
+      .in('status', ['active', 'trialing', 'past_due', 'grace']);
+
+    const dbSummary = {
+      total_active_in_db: dbSubs?.length ?? 0,
+      by_status: (dbSubs ?? []).reduce<Record<string, number>>((acc, s) => {
+        acc[s.status] = (acc[s.status] ?? 0) + 1;
+        return acc;
+      }, {}),
+    };
+
+    // Stripe API 呼び出し (admin/super_admin のみ、Secret 未設定時は graceful)
+    let stripeData: { total_active_in_stripe: number; stripe_available: boolean } | null = null;
+    if (isAdminOrSuperAdmin && process.env.STRIPE_SECRET_KEY) {
+      try {
+        const stripeBaseUrl = 'https://api.stripe.com/v1/subscriptions?status=active&limit=1';
+        const stripeRes = await fetch(stripeBaseUrl, {
+          headers: {
+            Authorization: `Bearer ${process.env.STRIPE_SECRET_KEY}`,
+          },
+        });
+        if (stripeRes.ok) {
+          const stripeJson = await stripeRes.json() as { data: unknown[]; has_more?: boolean };
+          stripeData = {
+            total_active_in_stripe: stripeJson.data?.length ?? 0,
+            stripe_available: true,
+          };
+        } else {
+          stripeData = { total_active_in_stripe: 0, stripe_available: false };
+        }
+      } catch {
+        stripeData = { total_active_in_stripe: 0, stripe_available: false };
+      }
+    }
+
+    return NextResponse.json({
+      data: {
+        discrepancies,
+        db_summary: dbSummary,
+        stripe_summary: stripeData ?? { stripe_available: false, message: 'Stripe Secret 未設定またはアクセス権限なし' },
+      },
+      meta: {
+        total: count ?? 0,
+        page,
+        per_page: perPage,
+        note: !isAdminOrSuperAdmin
+          ? 'finance ロールは DB 側データのみ表示。Stripe API 呼び出しには admin / super_admin が必要です。'
+          : undefined,
+      },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHENTICATED', message: err.message } },
+        { status: 401 },
+      );
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json(
+        { error: { code: 'OP_PERMISSION_DENIED', message: err.message } },
+        { status: 403 },
+      );
+    }
+    console.error('[finance/reconciliation] unexpected error:', err);
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/finance/revenue/route.ts
+++ b/src/app/api/admin/finance/revenue/route.ts
@@ -1,0 +1,95 @@
+/**
+ * GET /api/admin/finance/revenue
+ * 収益スナップショット一覧 + 集計
+ * operator/02-api-spec.md §20
+ * 権限: admin, super_admin, finance
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { requireRole } from '@/lib/auth/helpers';
+import { createClient } from '@/lib/supabase/server';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { RevenueQuerySchema } from '@/lib/admin/finance-schemas';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireRole(['admin', 'super_admin', 'finance']);
+    const supabase = createClient();
+
+    const { searchParams } = new URL(request.url);
+    const query = RevenueQuerySchema.parse({
+      from: searchParams.get('from') ?? undefined,
+      to: searchParams.get('to') ?? undefined,
+      granularity: searchParams.get('granularity') ?? undefined,
+      segment: searchParams.get('segment') ?? undefined,
+      page: searchParams.get('page') ?? undefined,
+      per_page: searchParams.get('per_page') ?? undefined,
+    });
+
+    let dbQuery = supabase
+      .from('revenue_snapshots')
+      .select('*', { count: 'exact' })
+      .order('date', { ascending: false });
+
+    if (query.from) {
+      dbQuery = dbQuery.gte('date', query.from);
+    }
+    if (query.to) {
+      dbQuery = dbQuery.lte('date', query.to);
+    }
+
+    const offset = (query.page - 1) * query.per_page;
+    dbQuery = dbQuery.range(offset, offset + query.per_page - 1);
+
+    const { data: snapshots, count, error } = await dbQuery;
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    // 集計サマリー
+    const { data: summary } = await supabase
+      .from('revenue_snapshots')
+      .select('total_mrr_jpy, total_arr_jpy, new_signups, cancellations')
+      .gte('date', query.from ?? new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10))
+      .order('date', { ascending: false })
+      .limit(30);
+
+    const avgMrr = summary && summary.length > 0
+      ? Math.round(summary.reduce((s, r) => s + (r.total_mrr_jpy ?? 0), 0) / summary.length)
+      : 0;
+
+    return NextResponse.json({
+      data: snapshots ?? [],
+      meta: {
+        total: count ?? 0,
+        page: query.page,
+        per_page: query.per_page,
+        summary: {
+          avg_mrr_jpy: avgMrr,
+          latest_mrr_jpy: snapshots?.[0]?.total_mrr_jpy ?? 0,
+          latest_arr_jpy: snapshots?.[0]?.total_arr_jpy ?? 0,
+        },
+      },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHENTICATED', message: err.message } },
+        { status: 401 },
+      );
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json(
+        { error: { code: 'OP_PERMISSION_DENIED', message: err.message } },
+        { status: 403 },
+      );
+    }
+    console.error('[finance/revenue] unexpected error:', err);
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/admin/finance-schemas.ts
+++ b/src/lib/admin/finance-schemas.ts
@@ -1,0 +1,173 @@
+/**
+ * Finance ドメイン Zod スキーマ集約
+ * operator/02-api-spec.md §9, §20 準拠
+ */
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dashboard KPI
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const FinanceDashboardSchema = z.object({
+  current_mrr_jpy: z.number().int().nonnegative(),
+  current_arr_jpy: z.number().int().nonnegative(),
+  churn_rate: z.number().nonnegative(),
+  ltv_jpy: z.number().int().nonnegative(),
+  new_mrr_jpy: z.number().int().nonnegative(),
+  expansion_mrr_jpy: z.number().int().nonnegative(),
+  contraction_mrr_jpy: z.number().int().nonnegative(),
+  churned_mrr_jpy: z.number().int().nonnegative(),
+  personal_active_users: z.number().int().nonnegative(),
+  family_active_groups: z.number().int().nonnegative(),
+  org_active_orgs: z.number().int().nonnegative(),
+  mau: z.number().int().nonnegative(),
+});
+
+export type FinanceDashboard = z.infer<typeof FinanceDashboardSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Revenue Snapshot
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const RevenueSnapshotSchema = z.object({
+  date: z.string(),
+  personal_active_users: z.number().int(),
+  personal_mrr_jpy: z.number().int(),
+  family_active_groups: z.number().int(),
+  family_mrr_jpy: z.number().int(),
+  org_active_orgs: z.number().int(),
+  org_active_seats: z.number().int(),
+  org_mrr_jpy: z.number().int(),
+  total_mrr_jpy: z.number().int(),
+  total_arr_jpy: z.number().int(),
+  new_signups: z.number().int(),
+  cancellations: z.number().int(),
+  upgrade_count: z.number().int(),
+  downgrade_count: z.number().int(),
+  trial_starts: z.number().int(),
+  trial_conversions: z.number().int(),
+  computed_at: z.string(),
+});
+
+export type RevenueSnapshot = z.infer<typeof RevenueSnapshotSchema>;
+
+export const RevenueQuerySchema = z.object({
+  from: z.string().optional(),
+  to: z.string().optional(),
+  granularity: z.enum(['day', 'week', 'month']).optional().default('month'),
+  segment: z.enum(['personal', 'family', 'org', 'all']).optional().default('all'),
+  page: z.coerce.number().int().positive().optional().default(1),
+  per_page: z.coerce.number().int().positive().max(200).optional().default(50),
+});
+
+export type RevenueQuery = z.infer<typeof RevenueQuerySchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invoice (stripe_webhook_events 由来)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const InvoiceItemSchema = z.object({
+  id: z.string(),
+  stripe_event_id: z.string(),
+  event_type: z.string(),
+  user_id: z.string().nullable(),
+  stripe_customer_id: z.string().nullable(),
+  stripe_subscription_id: z.string().nullable(),
+  amount_paid: z.number().nullable(),
+  currency: z.string().nullable(),
+  status: z.string(),
+  invoice_number: z.string().nullable(),
+  period_start: z.string().nullable(),
+  period_end: z.string().nullable(),
+  received_at: z.string(),
+  processed_at: z.string().nullable(),
+});
+
+export type InvoiceItem = z.infer<typeof InvoiceItemSchema>;
+
+export const InvoiceQuerySchema = z.object({
+  page: z.coerce.number().int().positive().optional().default(1),
+  per_page: z.coerce.number().int().positive().max(200).optional().default(50),
+  status: z.enum(['pending', 'processing', 'completed', 'failed']).optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+});
+
+export type InvoiceQuery = z.infer<typeof InvoiceQuerySchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reconciliation
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ReconciliationItemSchema = z.object({
+  type: z.enum(['missing_in_db', 'status_mismatch', 'amount_mismatch']),
+  stripe_subscription_id: z.string().nullable(),
+  stripe_status: z.string().nullable(),
+  db_status: z.string().nullable(),
+  stripe_amount: z.number().nullable(),
+  db_amount: z.number().nullable(),
+  user_id: z.string().nullable(),
+  detail: z.string(),
+  detected_at: z.string(),
+});
+
+export type ReconciliationItem = z.infer<typeof ReconciliationItemSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NPS / CSAT
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const NpsSummarySchema = z.object({
+  total_responses: z.number().int(),
+  promoters: z.number().int(),
+  passives: z.number().int(),
+  detractors: z.number().int(),
+  nps_score: z.number(),
+  avg_score: z.number(),
+  response_rate: z.number(),
+  recent_comments: z.array(z.object({
+    id: z.string(),
+    score: z.number().int(),
+    comment: z.string().nullable(),
+    plan_key: z.string().nullable(),
+    responded_at: z.string().nullable(),
+  })),
+});
+
+export type NpsSummary = z.infer<typeof NpsSummarySchema>;
+
+export const CsatSummarySchema = z.object({
+  total_responses: z.number().int(),
+  avg_score: z.number(),
+  score_distribution: z.record(z.string(), z.number().int()),
+  recent_feedbacks: z.array(z.object({
+    id: z.string(),
+    score: z.number().int(),
+    comment: z.string().nullable(),
+    ticket_id: z.string().nullable(),
+    created_at: z.string(),
+  })),
+});
+
+export type CsatSummary = z.infer<typeof CsatSummarySchema>;
+
+export const NpsQuerySchema = z.object({
+  from: z.string().optional(),
+  to: z.string().optional(),
+  plan_key: z.string().optional(),
+});
+
+export type NpsQuery = z.infer<typeof NpsQuerySchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Export
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ExportRequestSchema = z.object({
+  export_type: z.enum(['revenue', 'invoices', 'subscriptions', 'nps']),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  format: z.literal('csv').default('csv'),
+});
+
+export type ExportRequest = z.infer<typeof ExportRequestSchema>;


### PR DESCRIPTION
## 概要

PR #817(`feat/operator-g-super-admin-advanced`)に混入していた D の Finance 作業ファイルを抽出し、最新 main に整合させた救済 PR。

## 取り込みファイル(15ファイル)

### Zod schema
- `src/lib/admin/finance-schemas.ts`: Finance ドメインスキーマ集約

### API routes (7本)
- `GET /api/admin/finance/dashboard`: MRR/ARR/churn/LTV KPI
- `GET /api/admin/finance/revenue`: 収益スナップショット一覧
- `GET /api/admin/finance/invoices`: 請求書一覧
- `GET /api/admin/finance/invoices/[id]`: 個別請求書詳細 + Stripe deep link
- `GET /api/admin/finance/reconciliation`: Stripe ↔ DB 整合チェック
- `GET /api/admin/finance/nps`: NPS / CSAT 集計
- `POST /api/admin/finance/exports`: CSV エクスポート

### UI pages (7画面)
- `src/app/admin/finance/`: ダッシュボード・収益・請求書・照合・NPS・エクスポート

## 修正内容

- `(admin)/finance/*` → `admin/finance/*` パス変換(PR #821 実 segment 化対応)
- 内部リンク `/finance/*` → `/admin/finance/*` 修正
- 全 API routes に `export const dynamic = 'force-dynamic'` 追加

## 除外対象

- `src/lib/auth/*`: 基盤-A PR #814 で main 入り済
- `src/app/(admin)/layout.tsx`: C PR #819 で作成済
- `src/app/(super-admin)/*`, `src/app/api/super-admin/*`: G の作業

## 検証

- `npx tsc --noEmit`: エラーなし
- `npx next build`: Compiled successfully / Generating static pages 170/170 完了
- `requireRole(['admin', 'super_admin', 'finance'])` ガード保持確認済