### PR TITLE
chore(cccloud): Claude Code Cloud 起動用ファイル整備

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,78 @@
-# E2E テスト用認証情報 (.env.local に実値を設定)
-# ローカル実行時は .env.local にコピーして値を埋める
+# =====================================================
+# homegohan 環境変数サンプル
+# =====================================================
+# ローカル開発: このファイルを `.env.local` にコピーして実値を設定
+# CCCloud: 環境設定 UI の "Environment Variables" に同形式で貼り付け
+# Vercel: Project Settings > Environment Variables から登録
+#
+# 詳細手順は ENV_SETUP.md と SETUP_ENV.sh を参照
+# =====================================================
 
+# ---- Supabase (必須) -----------------------------------
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+# Supabase Storage の publishable key (画像系)
+SUPABASE_STORAGE_PUBLISHABLE_KEY=
+
+# ---- App メタ (必須) -----------------------------------
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_APP_NAME=homegohan
+# Vercel デプロイ時は自動注入される
+# NEXT_PUBLIC_VERCEL_ENV=
+# VERCEL_URL=
+
+# ---- AI 系 (機能利用時に必須) --------------------------
+# 画像認識・チャット (Gemini)
+GOOGLE_AI_STUDIO_API_KEY=
+GEMINI_VISION_MODEL=gemini-2.0-flash-exp
+GEMINI_CLASSIFY_MODEL=gemini-2.0-flash-exp
+GEMINI_IMAGE_MODEL=gemini-3-pro-image-preview
+
+# xAI (Grok) — fast-llm.ts (献立 / チャット)
+XAI_API_KEY=
+XAI_BASE_URL=https://api.x.ai/v1
+
+# OpenAI (一部エンドポイントで利用)
+OPENAI_API_KEY=
+
+# Anthropic (将来の産業医アドバイス用)
+# ANTHROPIC_API_KEY=
+
+# ---- 課金 (Stripe) -------------------------------------
+# operator-F 開発時に必須。本番 / test を切り替え
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
+
+# ---- メール送信 (Resend) -------------------------------
+# サポート問合せ・申込通知
+RESEND_API_KEY=
+ADMIN_NOTIFICATION_EMAIL=
+
+# ---- Rate limit / Cache (Upstash Redis、オプション) ----
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# ---- 監視 (オプション) ---------------------------------
+SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_DSN=
+BETTER_STACK_TOKEN=
+
+# ---- アナリティクス (PostHog、family/09 で必須) --------
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# ---- Cron 認証 (Vercel Cron 用) ------------------------
+CRON_SECRET=
+
+# ---- E2E テスト用 (CI / ローカル E2E) ------------------
+# 実値は CI Secret に置き、ローカルは .env.local に
 E2E_USER_EMAIL=
-# 注意: # を含むパスワードはダブルクォートで囲む (dotenv が # 以降をコメントとして扱うため)
+# 注: # を含むパスワードはダブルクォートで囲む
 E2E_USER_PASSWORD=""
-
-# Playwright 実行対象 URL (デフォルト: http://localhost:3000)
-# 本番 / ステージングを直接叩く場合は以下を設定
 PLAYWRIGHT_BASE_URL=https://homegohan-app.vercel.app
+
+# ---- バージョン表示 (CI で自動注入推奨) ----------------
+NEXT_PUBLIC_APP_VERSION=
+NEXT_PUBLIC_BUILD_DATE=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,3 +55,49 @@ CI では GitHub Secrets に登録する。
 ## 無視対象
 
 `homegohan-app/` ディレクトリ (旧ツリーの残骸) は無視する。編集・参照しない。
+
+---
+
+## Claude Code Cloud (claude.ai/code) 動作要件
+
+### 起動時 setup
+- `.claude/settings.json` の SessionStart hook、または環境設定 UI の "Setup Script" に
+  `bash scripts/setup-cccloud.sh` を登録すると依存解決される
+- スクリプトは Cloud 環境のみで動作 (`CLAUDE_CODE_REMOTE` 等を検知)、ローカルでは no-op
+
+### 環境変数
+必須・任意の全変数は `.env.example` 参照。CCCloud では環境設定 UI の Environment Variables に同形式で貼り付け。
+**注: 現状 CCCloud に専用シークレットストアは無し**。シークレット値は環境を編集できる人全員から見える前提で扱うこと (Stripe live key 等は CCCloud に置かない方針推奨)。
+
+### 利用可能なコマンド (Cloud 動作可)
+| 用途 | コマンド |
+|---|---|
+| 開発サーバー | `npm run dev` |
+| Lint | `npm run lint` |
+| 型チェック | `npm run typecheck` |
+| Vitest unit | `npm test` |
+| Playwright E2E | `npm run test:e2e` (要 PLAYWRIGHT_BASE_URL or 起動済 dev) |
+| Supabase migration 確認 | `npx supabase@2.62.10 db diff` 等 |
+
+### Cloud で **実行不可** なコマンド
+- `npm run mobile:ios` / `mobile:android` (Xcode / Android SDK / シミュレータ依存)
+- `eas build --local` (CocoaPods / Xcode 依存、TestFlight 提出は堀さんローカル)
+- 任意の MCP ツール (ProxmoxMCP / SSH-MCP / Cloudflare 等のローカル MCP は CCCloud では未登録)
+
+### Network 制約
+CCCloud のデフォルト `Trusted` レベルでは Stripe / Supabase / Vercel API はホワイトリスト外。アクセス必要なら環境設定 > Network access で `Custom` を選び以下を追加:
+```
+*.supabase.co
+api.stripe.com
+api.vercel.com
+api.x.ai
+generativelanguage.googleapis.com
+api.openai.com
+api.resend.com
+us.i.posthog.com
+*.upstash.io
+```
+または `Full` (全許可)。
+
+### 引き継ぎ
+新セッション開始時は `docs/handover/2026-05-08.md` を Read してから着手 (リポジトリ内に複製済み、CCCloud / ローカル両方から読める)。

--- a/docs/handover/2026-05-08.md
+++ b/docs/handover/2026-05-08.md
@@ -1,0 +1,261 @@
+# homegohan-app 引き継ぎプロンプト (2026-05-08 時点)
+
+> 前回引き継ぎ `~/handover-pr798.md` (2026-05-07) の続き。新スレッドの最初に貼り付けて使う。
+> 前回ハンドオーバーから 1 日で family/09 + operator Phase 1-3 並列実装、Migration CI 障害修正、設計書 canonical sweep まで完了。
+
+---
+
+## あなたの役割
+
+メインセッションの Opus はオーケストレーター。CLAUDE.md ポリシー:
+- 計画 / 委譲 / 検証 / 統合 の 4 役割
+- ファイル Read/Edit/Write、Grep/Glob、Bash は Task ツールで implementer/researcher に委譲
+- 例外 1: 設計書・戦略文書・引き継ぎは Opus 直接 (memory: feedback-design-doc-direct, feedback-handover-direct-read)
+- 例外 2: 並列 agent PR の conflict は Opus 直接解決 (memory: feedback-merge-conflict-handling)
+
+---
+
+## リポジトリ現状 (2026-05-08 時点)
+
+| 項目 | 値 |
+|---|---|
+| リポ | `DaisukeHori/homegohan-app` |
+| main commit | `6b2d0b85` (PR #823 の後) → PR #825/#826 が後続で merge 済み (本ハンドオーバー作成時点で main 最新は 826 後の commit) |
+| ローカルブランチ | main + 一時ブランチ少数 (worktree-agent-* は全削除済) |
+| worktree | `.claude/worktrees/agent-*` ゼロ (cleanup 完了) |
+| オープン Issue | 30 件 (前ハンドオーバーから未消化、PR との紐付け不明確) |
+| 設計書 | 42 + family/09 25 + operator Phase 4-5 追加 |
+
+---
+
+## 直近 24h で完了したこと (2026-05-07 → 2026-05-08)
+
+### family/09 ハンズオンチュートリアル (8 PR)
+- PR #803 (Phase 1-A migration) / #804 (Phase 1-B 共通 package) / #805 (Phase 1-B API 4 本) / #807 (Phase 2-B Mobile UI) / #809 (Phase 2-A Web UI) / #806 (Phase 3-B Mobile sandbox) / #808 (Phase 3-A Web sandbox) / #811 (planner バッジ) / #812 (Phase 4-A PostHog) / #813 #815 (Tour 接続) / #810 (route.ts schema export bug fix)
+
+### operator 管理画面 Phase 1-3 (並列 implementer 救済 4 PR 含む)
+- PR #816 (基盤-B 29 テーブル DDL + 9 plan_key seed + RLS) / #818 (B super_admin プラン管理 UI/API) / #819 (C admin ユーザー管理 + モデレーション、後に 'banned' role 違反 → #823 で frozen_at 列に書き換え救済) / #820 (E support/sales) / #814 (認証 helper requireRole/requireOrgRole) / #821 (coupons slug 衝突 hot fix + (admin)/(super-admin) route group → 実 segment) / #822 (G super-admin 高度機能 rescue) / #824 (D Finance 売上ダッシュボード rescue)
+- 失敗した PR #817 は close、#822/#824 で救済
+
+### Migration CI 障害修正 (本日の最終タスク)
+- 症状: main の `Deploy Supabase Migrations` が `column "user_id" does not exist (SQLSTATE 42703)` で fail
+- 根本原因: 設計書 `operator/01 §3.26` が実スキーマ未確認のまま記述 → migration + API code がそれに追従
+- **PR #825 (MERGED)** — migration `20260508093813_handson_tour.sql` + `20260508130000_user_profiles_frozen_at.sql` + 3 API ファイル fix
+  - `user_profiles.user_id` → `id` (auth.users(id) FK が PK)
+  - `meal_logs` → `meals` (db_audit_fixes 由来の実テーブル)
+  - `weekly_menus` → `user_daily_meals` (date_based_model_migration 由来)
+- **PR #826 (MERGED)** — 設計書 14 ファイル canonical sweep
+  - operator/01 §3.26 + family/09 配下 13 ファイル
+  - 検証: `grep -rn 'meal_logs\|weekly_menus' docs/design/...` がゼロ
+
+### Cleanup
+- ローカル merged ブランチ 155 件削除 (`worktree-agent-*` ゼロ達成)
+- リモート merged ブランチ整理済み
+- `operator/03-ui-spec.md` line 708 / `operator/CLAUDE.md` line 139 の URL 表記を実 segment 化に整合
+
+---
+
+## 🔴 P0 最優先 (新スレで即実行)
+
+### 1. Migration CI 緑化の確認
+PR #825 merge で migration 内容は修正済だが、実際に main の `Deploy Supabase Migrations` workflow が緑になったかは未確認。
+```bash
+gh run list --branch main --workflow "Deploy Supabase Migrations" --limit 3 \
+  --json status,conclusion,headSha,createdAt
+```
+- 緑なら → 本番 Supabase に handson_tour 関連列・テーブル・RPC・badges seed 全反映済
+- 失敗していれば → ログ確認し追加 fix
+
+### 2. 設計書と既存実装の乖離調査 (再発防止)
+今回 `meal_logs` / `weekly_menus` という存在しないテーブル名で書かれた設計書が migration を壊した。同種の "実スキーマと不一致な設計" が他にないか確認:
+```bash
+# 設計書に出てくるテーブル名を抽出して、実 schema (migrations) と突合
+researcher にデリゲートで確認させる
+```
+特に注意:
+- `health_checkups` 系列の列名 (要件定義由来の想定列名と実装ズレ)
+- operator/01 §3.x の他章 (§3.26 と同様の実スキーマ未確認パターン)
+
+---
+
+## 🟡 P1 (Phase 4-5 残スコープ)
+
+### family/09 Phase 4 — a11y + Analytics
+未消化の Q16 リスク低減策 5 項目:
+- Notes for Review に「教育目的バッジ・購入促進なし」明記
+- バッジ description を「学習の進捗を示すゲーミフィケーション」に
+- Step 4 卒業画面に「これは記念バッジで、課金や特典には連動しません」disclaimer
+- App Store / Play Store 説明文に「ハンズオン形式で 90 秒で使い方を学べます」追記
+- sandbox 行 90 日自動削除 (v2 持ち越しでも OK、要判断)
+
+その他 Phase 4 未着手:
+- `sample-meal.webp` 化 (現在 5MB、目標 ~80KB) — `apps/mobile/assets/sandbox/karaage.jpg` 等の最適化
+- PostHog dashboard 公開 (10 イベントの発火確認、cohort 分析)
+
+### family/09 Phase 5 — E2E テスト
+- Playwright 7 spec (`tests/e2e/handson-tour-*.spec.ts`)
+- Maestro 12 flow (`apps/mobile/maestro/flows/handson-tour/*.yaml`)
+- 設計書: `docs/design/family/09-onboarding-handson-tour/11-testing.md`
+
+### operator Phase 4 (operator-F)
+未着手。要件定義 03 §15.12 §15.17 + `docs/design/operator/05-stripe-integration.md` + `08-cron-batches.md`
+- Stripe webhook 実装 (`/api/webhooks/stripe`、idempotency via `stripe_webhook_events`)
+- Vercel Cron 11 本 (license_expire / freeze_grace / archive_purge / trial_reminder / stripe-reconcile / etc.)
+- **要 API キー**: Stripe (test+live)、Sentry、BetterStack — 開発開始時に堀さんに確認
+
+---
+
+## 🟢 P2 (テストカバレッジ追加)
+
+### 今回スコープの実装に対応するテストが未作成
+- operator (admin/super-admin UI、API、coupons、finance dashboard) の Vitest spec
+- family/09 ハンズオンチュートリアル全体の Playwright spec
+- Maestro hands-on flow
+
+Phase 5 で family/09 分は対応するが、operator 分は別途計画必要。
+
+### 既存 P1 ブロッカー (前ハンドオーバーから持ち越し)
+- **Issue #626**: testID 不足 (Maestro flow が参照する ID が画面コードに無い)
+- **Issue #627**: Maestro runner が 5 分以上 stuck (timeout 未設定 + worktree 冪等化必要)
+- **Issue #629**: AI Chat error 常時表示 (E2E user 権限 or Edge Function)
+- **Issue #630**: `01-login.yaml` が単一障害点
+- **Issue #631**: `.app` artifact 永続化で 15 分ビルド skip
+
+---
+
+## 設計書 canonical / 暗黙ルール (再発防止に必須)
+
+### DDL canonical
+- **`docs/design/operator/01-data-model.md` が DDL の唯一の真実**
+- 新テーブル追加もここに書く、他は参照のみ
+- ⚠️ §3.x で記述する際は **必ず実スキーマ** (`supabase/migrations/*.sql`) を grep して列名・テーブル名を確認
+
+### Canonical な enum / リスト
+
+**plan_keys (9 種)**:
+```
+free / pro / family_basic / family_pro / family_addon /
+org_starter / org_standard / org_pro / org_enterprise
+```
+
+**roles (12 種、TEXT[] 配列)** — `banned` 等の追加は禁止 (PR #823 で frozen_at 列方式に書き換え済):
+```
+user / support / sales / finance / content_moderator /
+org_member / org_viewer / org_manager / org_admin /
+org_industrial_doctor / admin / super_admin
+```
+
+**SubscriptionStatus (7 値、cross/08 canonical)**
+
+### route group は使わない
+- ❌ `src/app/(admin)/...` `src/app/(super-admin)/...`
+- ✅ `src/app/admin/...` `src/app/super-admin/...` (実 segment)
+- 理由: route group `(admin)/support` と `(support)/support` が同 URL `/support` に解決して Next.js build error。PR #821 で全面修正済。
+
+### Next.js dynamic route の slug 名統一
+- 同一階層で異なる slug 名は不可: `[id]/route.ts` と `[code]/redemptions/route.ts` が共存できない
+- PR #821 で `coupons/[code]` を `coupons/[id]` に統一済
+
+### Next.js route.ts の export
+- HTTP method handler (GET/POST/etc) + 予約済 export (runtime/dynamic 等) のみ可
+- Zod schema 等の任意 export は build error → `src/lib/<domain>/schemas.ts` に集約 (PR #810 で確立)
+
+---
+
+## iOS 配布 (memory `project-homegohan-ios-distribution` から)
+
+TestFlight 経由 4 ステップ:
+1. `git pull origin main`
+2. `cd apps/mobile && export PATH="/opt/homebrew/lib/ruby/gems/3.4.0/bin:/opt/homebrew/opt/ruby/bin:$PATH"` (★Homebrew Ruby、CocoaPods 依存)
+3. `eas build --platform ios --profile production --local --non-interactive` で `build-{ts}.ipa` 生成
+4. `eas submit --platform ios --path <ipa> --non-interactive` で TestFlight 提出
+
+`app.json` に `usesNonExemptEncryption: false` 設定済 (PR #800)。
+
+---
+
+## 並列 implementer 起動の注意点 (今回の教訓)
+
+### Round 4 の事故 (2026-05-08)
+PR #817 で D implementer が **誤ったブランチ** (operator-G の rescue 用) に commit してしまい、`src/lib/auth/*` 重複作成 + `(admin)/layout.tsx` 重複が発生。Opus 直接で:
+- PR #817 を close
+- PR #822 (G rescue) と PR #824 (D rescue) で個別に救済
+
+### 教訓
+- 並列起動時は `worktree isolation` で物理的にディレクトリを分ける (`isolation: "worktree"`)
+- 起動プロンプトでブランチ名・ベース commit を **明示** + agent 側で `git branch --show-current` を最初に確認させる
+- ファイル境界を厳密に分割 (例: A は `coupons/` 系のみ、B は `users/` 系のみ)
+- 完了後 Opus が verify、必要なら conflict 直接解決 (memory)
+
+### モジュラーモノリスでは 30+ files は並列 implementer
+1 人の implementer に 100 files は禁止。Opus がモジュール境界で分割。
+
+---
+
+## 既存 memory (新スレで自動ロード済)
+
+- Conventional Commits prefix + 日本語、Co-Authored-By Claude 付けない
+- 設計書・引き継ぎは Opus 直接、コードは implementer 委譲
+- モジュラーモノリスは並列 implementer (30+ files)
+- EAS Build 前にローカル `npm ci` + 型チェック必須
+- audit results は cross-check 必須 (researcher の false negative が多い)
+- Subagent model preference: bug-fix flow は `model: "sonnet"` (Sonnet 4.6) default
+- Supabase 初期化は指示された project_id だけ対象、他 project には絶対触らない
+- iOS TestFlight 配布の 4 ステップ
+- 設計書 canonical 単一ソース原則
+- 並列 agent PR の conflict は Opus 直接解決 (オーケストレーター直接実行禁止より優先)
+
+---
+
+## 秘密情報 / Key
+
+前ハンドオーバーから引き続き、Stripe / Supabase / Resend / Cloudflare / xAI / Gemini / Anthropic 各 Key は **会話に登場せず**。gh / git は OS 側既存認証。引き継ぎ不要。
+
+operator-F (Stripe webhook + cron) 開発開始時に堀さんから:
+- Stripe test + live API key
+- Sentry DSN
+- BetterStack source token
+を受け取る必要がある。
+
+---
+
+## 作業開始時の推奨アクション
+
+```bash
+cd /Users/horidaisuke/homegohan
+git pull origin main
+
+# 1. Migration CI が緑化したか確認
+gh run list --branch main --workflow "Deploy Supabase Migrations" --limit 3 \
+  --json status,conclusion,headSha,createdAt
+
+# 2. 緑なら handson_tour 関連が本番 Supabase に反映済 → Phase 4 着手
+# 3. 失敗していれば、ログを確認して追加 fix
+gh run view <RUN_ID> --log-failed | head -100
+```
+
+緑確認後は **Phase 4-A の Q16 5 項目** か **operator-F (Stripe webhook + cron)** のどちらに進むか堀さんに確認。
+
+---
+
+## 主要 PR 履歴 (本ハンドオーバー期間、参照用)
+
+| PR | 内容 | merge 状態 |
+|---|---|---|
+| #803 | family/09 Phase 1-A migration | merged (修正前、CI 失敗の遠因) |
+| #804 | Phase 1-B 共通 package | merged |
+| #805 | Phase 1-B API 4 本 | merged |
+| #806-#809 | Phase 2-A/B + 3-A/B (Web/Mobile UI + sandbox 対応) | merged |
+| #810 | route.ts schema export bug fix | merged |
+| #811-#813 | planner バッジ + PostHog + Tour 接続 | merged |
+| #814 | 認証 helper (requireRole 等) | merged |
+| #815 | Web Tour 接続 | merged |
+| #816 | operator 基盤-B 29 テーブル DDL | merged |
+| #817 | operator 救済 (誤ブランチ事故) | **closed** (#822/#824 で代替) |
+| #818-#820 | operator B/C/E (super_admin / admin users / support+sales) | merged |
+| #821 | coupons slug 衝突 + route group → 実 segment hot fix | merged |
+| #822 | operator G rescue (super-admin 高度機能) | merged |
+| #823 | operator C 'banned' ロール違反 → frozen_at 列に書き換え | merged |
+| #824 | operator D rescue (Finance 売上ダッシュボード) | merged |
+| #825 | handson_tour スキーマ参照誤り fix (migration + API code) | merged |
+| #826 | 設計書 14 ファイル canonical sweep | merged |

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:mvp": "playwright test tests/e2e/0[1-5]-*.spec.ts --reporter=list",

--- a/scripts/setup-cccloud.sh
+++ b/scripts/setup-cccloud.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# =====================================================
+# Claude Code Cloud (claude.ai/code) Bootstrap Script
+# =====================================================
+# CCCloud セッション開始時に自動実行される setup スクリプト。
+# - .claude/settings.json の SessionStart hook から呼ばれる場合
+# - もしくは CCCloud 環境設定 UI の "Setup Script" に直接登録する場合
+# どちらでも動くようにしてある。
+#
+# ローカル開発時 (CCCloud 以外) は no-op で終了する。
+# 強制実行したい場合は環境変数 FORCE_SETUP=1 を渡す。
+# =====================================================
+
+set -euo pipefail
+
+# Cloud 環境判定 (CLAUDE_CODE_REMOTE / CODESPACES / CCC_* 等)
+IS_CLOUD="${CLAUDE_CODE_REMOTE:-}${CODESPACES:-}${CLOUD_SHELL:-}"
+if [ -z "$IS_CLOUD" ] && [ "${FORCE_SETUP:-0}" != "1" ]; then
+  echo "[setup-cccloud] ローカル環境のため skip (FORCE_SETUP=1 で強制実行可)"
+  exit 0
+fi
+
+echo "[setup-cccloud] 開始"
+
+# --- Node 依存解決 ---
+if [ -f package-lock.json ]; then
+  echo "[setup-cccloud] npm ci"
+  npm ci --prefer-offline --no-audit --progress=false
+else
+  echo "[setup-cccloud] npm install"
+  npm install --no-audit --progress=false
+fi
+
+# --- 外部 CLI (apt が使える場合のみ) ---
+if command -v apt-get >/dev/null 2>&1; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "[setup-cccloud] gh CLI を install"
+    (curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg) || true
+    sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg || true
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    sudo apt-get update -qq && sudo apt-get install -y -qq gh || true
+  fi
+fi
+
+# Supabase CLI (npx で都度実行する方針なのでグローバル install しない)
+echo "[setup-cccloud] supabase CLI は 'npx supabase@2.62.10 ...' で利用"
+
+# EAS CLI (mobile build は CCCloud では実行しない想定だが、念のため)
+if [ "${INSTALL_EAS:-0}" = "1" ]; then
+  npm install -g eas-cli || true
+fi
+
+# --- Playwright ブラウザ (E2E が cloud で必要なら 1 回 install) ---
+if [ "${INSTALL_PLAYWRIGHT:-0}" = "1" ]; then
+  npx playwright install --with-deps chromium || true
+fi
+
+echo "[setup-cccloud] 完了"


### PR DESCRIPTION
## Summary

claude.ai/code (CCCloud) でブラウザから本リポジトリを開いて即作業着手できるよう、必要ファイルを整備。

## 変更内容

- ✅ \`scripts/setup-cccloud.sh\` 追加 (Cloud 環境でのみ動作する bootstrap)
- ✅ \`docs/handover/2026-05-08.md\` 追加 (\$HOME 外の handover を repo 内にコピー)
- ✅ \`.env.example\` を E2E 限定 → 全カテゴリ (Supabase / Stripe / Resend / PostHog / xAI / Gemini / OpenAI / Upstash / Sentry / BetterStack / Cron / Vercel) に拡張
- ✅ \`package.json\` に \`typecheck: tsc --noEmit\` 追加
- ✅ \`CLAUDE.md\` に "Claude Code Cloud 動作要件" セクション追加 (利用可能コマンド / Network 制約 / 引き継ぎ参照)

## 残タスク (本 PR スコープ外、user 側で実施)

- \`.claude/settings.json\` の整備 (権限設定なので user 判断)
- CCCloud UI で Environment Variables / Network access / Setup Script 登録

## Test plan

- [ ] CCCloud で本リポジトリを開き、新規セッションで \`docs/handover/2026-05-08.md\` を読み込めるか確認
- [ ] \`bash scripts/setup-cccloud.sh\` がローカルで no-op、\`FORCE_SETUP=1\` で npm ci 実行されるか確認
- [ ] \`npm run typecheck\` が通るか確認