### PR TITLE
fix(operator): 単独 DEFERRABLE 構文エラー修正(supabase db push 復旧)

### DIFF
--- a/supabase/migrations/20260508120000_operator_phase_4_5_foundation.sql
+++ b/supabase/migrations/20260508120000_operator_phase_4_5_foundation.sql
@@ -302,9 +302,11 @@ CREATE TABLE IF NOT EXISTS coupon_redemptions (
   id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   coupon_id                   UUID NOT NULL REFERENCES coupons(id),
   user_id                     UUID REFERENCES auth.users(id),
-  organization_id             UUID DEFERRABLE INITIALLY DEFERRED,
+  organization_id             UUID,
   -- NOTE: organizations テーブルは org/ ドメイン (02-organization-management) で作成される。
-  -- coupon_redemptions は 01-operator-admin で先に作成されるため DEFERRABLE INITIALLY DEFERRED を付与。
+  -- coupon_redemptions が先行するため、FK は後続 migration で
+  -- ALTER TABLE coupon_redemptions ADD CONSTRAINT ... REFERENCES organizations(id)
+  -- として付与する (PG は CREATE TABLE 時に DEFERRABLE 単独指定不可、要 REFERENCES)。
   subscription_target         VARCHAR(20) NOT NULL
     CHECK (subscription_target IN ('personal', 'org')),
   applied_to_subscription_id  UUID NOT NULL,
@@ -660,7 +662,8 @@ CREATE TABLE IF NOT EXISTS support_tickets (
   resolved_at   TIMESTAMPTZ,
   closed_at     TIMESTAMPTZ,
   -- 組織・家族関連付け (任意)
-  organization_id UUID DEFERRABLE INITIALLY DEFERRED,
+  -- organizations FK は org ドメイン migration で ALTER TABLE で付与
+  organization_id UUID,
   created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -773,8 +776,8 @@ CREATE TABLE IF NOT EXISTS sales_leads (
   assigned_to     UUID REFERENCES auth.users(id),
   estimated_acv   INT,
   notes           TEXT,
-  -- 契約後の組織 ID
-  converted_org_id UUID DEFERRABLE INITIALLY DEFERRED,
+  -- 契約後の組織 ID (organizations FK は org ドメイン migration で ALTER TABLE で付与)
+  converted_org_id UUID,
   created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );


### PR DESCRIPTION
## Summary

\`npx supabase db push --linked --include-all\` で \`SQLSTATE 42601 misplaced DEFERRABLE clause\` エラー。foundation migration の 3 つの UUID 列が \`REFERENCES\` なしで \`DEFERRABLE INITIALLY DEFERRED\` を付けていたため。

## 修正対象 (3 箇所、いずれも organizations への forward-FK を意図)

| テーブル | 列 |
|---|---|
| coupon_redemptions | organization_id |
| support_tickets | organization_id |
| sales_leads | converted_org_id |

3 箇所とも \`UUID DEFERRABLE INITIALLY DEFERRED\` → \`UUID\` (制約なし) に変更。FK は org ドメイン migration で organizations 作成後に \`ALTER TABLE ... ADD CONSTRAINT ... REFERENCES organizations(id)\` で付与する旨をコメント追記。

## Test plan

- [ ] PR merge 後、堀さんローカルで再度 \`npx --yes supabase@2.62.10 db push --linked --include-all\` を実行
- [ ] \`Deploy Supabase Migrations\` workflow を main で再実行して緑確認
- [ ] handson_tour migration 適用後の状態で、foundation migration の 29 テーブル (subscription_plans / personal_subscriptions / coupons / coupon_redemptions / admin_audit_logs / support_tickets / sales_leads 等) が作成されること

## Refs

- 直前の \`db push\` ログ: \`Applying migration 20260508120000_operator_phase_4_5_foundation.sql... ERROR: misplaced DEFERRABLE clause (SQLSTATE 42601) At statement: 29\`
- PR #816 で投入された foundation migration の構文バグ