### PR TITLE
fix(operator): admin_audit_logs.severity の既存データを canonical に正規化

### DIFF
--- a/supabase/migrations/20260508120000_operator_phase_4_5_foundation.sql
+++ b/supabase/migrations/20260508120000_operator_phase_4_5_foundation.sql
@@ -544,7 +544,14 @@ ALTER TABLE admin_audit_logs
   ADD COLUMN IF NOT EXISTS actor_email_snapshot VARCHAR(255),
   ADD COLUMN IF NOT EXISTS actor_role_snapshot  VARCHAR(50);
 
--- severity の CHECK 制約を追加(既存カラムの場合は既に存在する可能性あり)
+-- 既存データの severity 値を canonical 3 値 (info / warn / critical) に正規化。
+-- 旧運用の 'high' は意味的に critical 相当。'warning' / 'error' / 'debug' 等の
+-- legacy 値が混入していた場合の保険として canonical 外の値を一律 'info' にフォールバック。
+UPDATE admin_audit_logs SET severity = 'critical' WHERE severity = 'high';
+UPDATE admin_audit_logs SET severity = 'warn'     WHERE severity IN ('warning', 'error');
+UPDATE admin_audit_logs SET severity = 'info'     WHERE severity NOT IN ('info', 'warn', 'critical');
+
+-- severity の CHECK 制約を追加 (既存制約があればスキップ)
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.table_constraints


### PR DESCRIPTION
## Summary

\`db push\` で \`admin_audit_logs_severity_check\` 制約が既存データ ('high' 38件) で違反 → SQLSTATE 23514。CHECK 追加前に UPDATE で canonical 3 値に正規化。

## 修正

CHECK 追加直前に 3 つの UPDATE:
- \`'high'\` → \`'critical'\`
- \`'warning'\` / \`'error'\` → \`'warn'\`
- canonical 外の任意値 → \`'info'\`

## 確認済み実 prod データ
\`\`\`
 severity  | cnt
-----------+-----
 high      |  38
 info      |   9
\`\`\`

正規化後は all in {info, warn, critical} で CHECK 通る。

## Test plan

- [ ] PR merge 後 \`db push\` を再実行
- [ ] 本番 admin_audit_logs.severity が canonical 3 値のみになっているか確認