### PR TITLE
fix(operator): admin_audit_logs.admin_id → actor_id RENAME 追加

### DIFF
--- a/supabase/migrations/20260508120000_operator_phase_4_5_foundation.sql
+++ b/supabase/migrations/20260508120000_operator_phase_4_5_foundation.sql
@@ -534,6 +534,20 @@ CREATE TABLE IF NOT EXISTS admin_audit_logs (
   created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- 既存テーブルの旧列名 'admin_id' を 'actor_id' に RENAME (canonical: actor_id)。
+-- prod では旧運用の admin_id を残したまま運用していたため、ここで正規化する。
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'admin_audit_logs' AND column_name = 'admin_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'admin_audit_logs' AND column_name = 'actor_id'
+  ) THEN
+    ALTER TABLE admin_audit_logs RENAME COLUMN admin_id TO actor_id;
+  END IF;
+END $$;
+
 ALTER TABLE admin_audit_logs
   ADD COLUMN IF NOT EXISTS target_type          VARCHAR(30),
   ADD COLUMN IF NOT EXISTS severity             VARCHAR(20) NOT NULL DEFAULT 'info',


### PR DESCRIPTION
## Summary

`db push` で `column actor_id does not exist` エラー。prod の既存 admin_audit_logs は `admin_id` 列で運用されていたため、migration の `CREATE TABLE IF NOT EXISTS` がスキップされて actor_id が作られず、後続 ALTER で fail。

冪等な RENAME ブロックを追加 (admin_id あり & actor_id なし の場合のみ実行)。

## 確認済み prod スキーマ
`id / admin_id / action_type / target_id / details / created_at / ip_address / user_agent / severity`

## Test plan
- [ ] PR merge 後 `db push` 再実行で foundation migration が前進
- [ ] admin_audit_logs に actor_id 列ができ、admin_id 列が消えること
- [ ] 既存 47 行のデータが保持されること