### PR TITLE
feat(family/09): Phase 4 — sandbox 90 日自動削除 cron + tutorial_complete description 修正

### DIFF
--- a/apps/mobile/app/handson-tour/graduate.tsx
+++ b/apps/mobile/app/handson-tour/graduate.tsx
@@ -203,6 +203,16 @@ export default function HandsonTourGraduate() {
               <Text style={styles.badgeLabel}>{i18n.step4.badge_label}</Text>
             </View>
 
+            {/* バッジ disclaimer */}
+            <Text
+              style={styles.badgeDisclaimer}
+              testID="tour-step-4-badge-disclaimer"
+              accessibilityLabel="バッジの注意書き"
+              accessibilityRole="text"
+            >
+              {i18n.step4.badge_disclaimer_body}
+            </Text>
+
             {/* ホームへボタン */}
             <Pressable
               testID="tour-step-4-go-home"
@@ -322,6 +332,15 @@ const styles = StyleSheet.create({
     color: '#2563EB',
     fontWeight: '600',
     textAlign: 'center',
+  },
+  badgeDisclaimer: {
+    fontSize: 12,
+    color: '#6B7280',
+    textAlign: 'center',
+    lineHeight: 18,
+    marginBottom: 32,
+    maxWidth: 280,
+    paddingHorizontal: 8,
   },
   homeButton: {
     backgroundColor: '#2563EB',

--- a/packages/handson-tour-shared/src/i18n.ts
+++ b/packages/handson-tour-shared/src/i18n.ts
@@ -110,7 +110,7 @@ export const HANDSON_TOUR_I18N_JA = {
       a11y_title: 'ステップ 4 / 5、{nickname} さん、もう 2 つバッジを獲得しています',
     },
 
-    // ====== Step 4 卒業 (12 キー) ======
+    // ====== Step 4 卒業 (14 キー) ======
     step4: {
       // saving
       saving_text: '完了処理中...',
@@ -120,6 +120,10 @@ export const HANDSON_TOUR_I18N_JA = {
       subtitle: '{nickname} さん、これで homegohan を使いこなせます',
       badge_label: '獲得バッジ: 使い方マスター',
       home_button: 'ホームへ',
+
+      // badge disclaimer (app store 審査対策 / Q16 リスク低減策 #3)
+      badge_disclaimer_title: '',
+      badge_disclaimer_body: 'このバッジは「使い方を学んだ記念」として表示されます。\n課金や特典、商品購入には一切連動しません。',
 
       // error
       error_title: '電波が悪いみたい',

--- a/supabase/migrations/20260508140000_handson_tour_phase4_cleanup.sql
+++ b/supabase/migrations/20260508140000_handson_tour_phase4_cleanup.sql
@@ -1,0 +1,123 @@
+-- =====================================================
+-- Migration: handson_tour_phase4_cleanup
+-- Source: docs/design/family/09 Phase 4 Q16 リスク低減策 #2 #5
+-- 対象:
+--   1. badges.tutorial_complete の description を審査対応表記に修正
+--   2. pg_cron で sandbox 行 90 日自動削除ジョブを登録
+-- Idempotent: yes (OR REPLACE / IF NOT EXISTS / ON CONFLICT DO UPDATE)
+-- =====================================================
+
+BEGIN;
+
+-- =====================================================
+-- Task 1: tutorial_complete バッジ description 更新
+-- 目的: Apple/Google 審査で "sandbox 操作で実バッジ付与" と
+--       誤解されないよう、学習目的を明記する
+-- =====================================================
+
+UPDATE badges
+SET description = 'はじめての使い方ガイド完走 — 学習の進捗を示すゲーミフィケーション(課金・特典には連動しません)'
+WHERE code = 'tutorial_complete';
+
+-- =====================================================
+-- Task 2: pg_cron 拡張有効化
+-- =====================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- =====================================================
+-- Task 3: sandbox 自動削除関数
+--   - meals (is_sandbox=true, 90 日超) を削除
+--     → meal_nutrition_estimates は meals FK ON DELETE CASCADE で連動
+--   - user_daily_meals (is_sandbox=true, 90 日超) を削除
+--   - 削除件数を admin_audit_logs に記録
+-- SECURITY DEFINER: service_role のみ EXECUTE を許可
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION cleanup_handson_tour_sandbox_rows()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_meals_deleted   INT;
+  v_daily_deleted   INT;
+BEGIN
+  -- meals 削除 (meal_nutrition_estimates は CASCADE で自動削除)
+  WITH d AS (
+    DELETE FROM meals
+    WHERE is_sandbox = true
+      AND created_at < NOW() - INTERVAL '90 days'
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO v_meals_deleted FROM d;
+
+  -- user_daily_meals 削除
+  WITH d AS (
+    DELETE FROM user_daily_meals
+    WHERE is_sandbox = true
+      AND created_at < NOW() - INTERVAL '90 days'
+    RETURNING 1
+  )
+  SELECT COUNT(*) INTO v_daily_deleted FROM d;
+
+  -- 監査ログ記録 (actor_id は NULL 許容: PR #830 で NOT NULL 解除済)
+  INSERT INTO admin_audit_logs (action_type, target_type, severity, details)
+  VALUES (
+    'handson_tour_sandbox_cleanup',
+    'cron_job',
+    'info',
+    jsonb_build_object(
+      'meals_deleted',       v_meals_deleted,
+      'daily_meals_deleted', v_daily_deleted
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'meals_deleted',       v_meals_deleted,
+    'daily_meals_deleted', v_daily_deleted
+  );
+END;
+$$;
+
+-- 権限設定: anon / authenticated からは実行不可、service_role のみ
+REVOKE EXECUTE ON FUNCTION cleanup_handson_tour_sandbox_rows() FROM anon, authenticated;
+GRANT  EXECUTE ON FUNCTION cleanup_handson_tour_sandbox_rows() TO service_role;
+
+-- =====================================================
+-- Task 4: pg_cron ジョブ登録
+--   毎日 04:00 UTC (= JST 13:00) に実行
+--   idempotent: 既存ジョブ名が衝突する場合は schedule を更新
+-- =====================================================
+
+SELECT cron.schedule(
+  'handson-tour-sandbox-cleanup',   -- jobname (unique)
+  '0 4 * * *',                      -- cron 式: 毎日 04:00 UTC
+  'SELECT cleanup_handson_tour_sandbox_rows();'
+);
+
+-- =====================================================
+-- COMMENT ON
+-- =====================================================
+
+COMMENT ON FUNCTION cleanup_handson_tour_sandbox_rows() IS
+  'handson tour の sandbox 行 (is_sandbox=true, 90 日超) を meals / user_daily_meals から削除し、削除件数を admin_audit_logs に記録する。pg_cron により毎日 04:00 UTC に実行される。';
+
+COMMIT;
+
+-- =====================================================
+-- 実行確認クエリ (migration 適用後に手動で確認)
+-- =====================================================
+-- pg_cron ジョブ登録確認:
+--   SELECT * FROM cron.job WHERE jobname = 'handson-tour-sandbox-cleanup';
+--
+-- 直近の実行履歴確認:
+--   SELECT * FROM cron.job_run_details WHERE jobid = (
+--     SELECT jobid FROM cron.job WHERE jobname = 'handson-tour-sandbox-cleanup'
+--   ) ORDER BY start_time DESC LIMIT 10;
+--
+-- 監査ログ確認:
+--   SELECT * FROM admin_audit_logs
+--   WHERE action_type = 'handson_tour_sandbox_cleanup'
+--   ORDER BY created_at DESC LIMIT 10;

--- a/supabase/rollbacks/handson_tour_phase4_cleanup.sql
+++ b/supabase/rollbacks/handson_tour_phase4_cleanup.sql
@@ -1,0 +1,35 @@
+-- =====================================================
+-- Rollback: handson_tour_phase4_cleanup
+-- Source: docs/design/family/09 Phase 4 Q16 リスク低減策 #2 #5
+-- NOTE: Supabase CLI は rollback ファイルを自動 apply しない。
+--       本番ロールバック時は手動で実行する。
+-- =====================================================
+
+BEGIN;
+
+-- =====================================================
+-- pg_cron ジョブ削除
+-- =====================================================
+
+SELECT cron.unschedule('handson-tour-sandbox-cleanup');
+
+-- =====================================================
+-- cleanup 関数削除
+-- =====================================================
+
+DROP FUNCTION IF EXISTS cleanup_handson_tour_sandbox_rows();
+
+-- =====================================================
+-- tutorial_complete バッジ description を旧値に戻す
+-- 注意: 旧値が不明な場合は NULL に戻すか、適切な文字列を設定すること
+-- =====================================================
+
+UPDATE badges
+SET description = NULL
+WHERE code = 'tutorial_complete'
+  AND description = 'はじめての使い方ガイド完走 — 学習の進捗を示すゲーミフィケーション(課金・特典には連動しません)';
+
+-- pg_cron 拡張は他のジョブが使用している可能性があるため DROP しない
+-- 必要な場合は手動で: DROP EXTENSION IF EXISTS pg_cron;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Q16 リスク低減策 **#2** (バッジ description 修正): `badges.tutorial_complete` の description を学習目的明記表記に変更。Apple/Google 審査で「sandbox 操作で実バッジ付与」と誤解されるリスクを低減
- Q16 リスク低減策 **#5** (sandbox データ自動削除): `cleanup_handson_tour_sandbox_rows()` 関数を作成し、pg_cron で毎日 04:00 UTC (JST 13:00) に実行。`meals` / `user_daily_meals` の `is_sandbox=true` かつ 90 日超の行を削除し、`admin_audit_logs` に結果を記録
- `meal_nutrition_estimates` は `meals` FK の `ON DELETE CASCADE` により自動削除
- `actor_id` は NULL 許容 (PR #830 で NOT NULL 解除済)
- rollback SQL を `supabase/rollbacks/handson_tour_phase4_cleanup.sql` に併設

## Migration ファイル

`supabase/migrations/20260508140000_handson_tour_phase4_cleanup.sql`

## Test plan

- [ ] `supabase db push` でエラーなく適用されること
- [ ] `SELECT * FROM cron.job WHERE jobname = 'handson-tour-sandbox-cleanup';` でジョブが登録されていること
- [ ] `SELECT description FROM badges WHERE code = 'tutorial_complete';` で新 description が確認できること
- [ ] `SELECT cleanup_handson_tour_sandbox_rows();` を手動実行し、`admin_audit_logs` に記録されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)