### PR TITLE
test(family/09): Maestro flow 12 件 + login-as-new-user 共通 flow 追加

### DIFF
--- a/apps/mobile/maestro/flows/_shared/login-as-new-user.yaml
+++ b/apps/mobile/maestro/flows/_shared/login-as-new-user.yaml
@@ -1,0 +1,79 @@
+appId: com.homegohan.app
+env:
+  E2E_NEW_USER_EMAIL: ${E2E_TOUR_NEW_USER_EMAIL}
+  E2E_NEW_USER_PASSWORD: ${E2E_TOUR_NEW_USER_PASSWORD}
+---
+# _shared/login-as-new-user.yaml
+# 新規 signup → onboarding 完走 → /handson-tour 自動到達まで共通フロー
+# 前提: 環境変数 E2E_TOUR_NEW_USER_EMAIL / E2E_TOUR_NEW_USER_PASSWORD が設定済み
+#       E2E_TOUR_NEW_USER_EMAIL は signup 済みのアカウントであること
+#       (既存 auth/04 同様に事前に Supabase Auth でユーザーを作成しておく)
+
+# --- Step 1: 現在状態をリセットしてウェルカム画面へ ---
+- runFlow:
+    file: "./ensure-welcome.yaml"
+
+# --- Step 2: 新規登録 (ウェルカム画面から signup) ---
+- tapOn:
+    text: "新規登録"
+- extendedWaitUntil:
+    visible:
+      id: "signup-screen"
+    timeout: 10000
+- tapOn:
+    id: "signup-email-input"
+- eraseText: 100
+- inputText: ${E2E_NEW_USER_EMAIL}
+- tapOn:
+    id: "signup-password-input"
+- eraseText: 100
+- inputText: ${E2E_NEW_USER_PASSWORD}
+- tapOn:
+    id: "signup-button"
+
+# メール確認済み前提で onboarding 画面へ遷移
+# (テスト用アカウントはメール確認スキップ設定済み)
+- extendedWaitUntil:
+    visible:
+      id: "onboarding-welcome-screen"
+    timeout: 15000
+
+# Expo dev build の LogBox を閉じる
+- runFlow:
+    file: "./dismiss-logbox.yaml"
+
+# --- Step 3: onboarding を最速で完走 (maintain ルート) ---
+# onboarding 最初の個人情報入力画面
+- extendedWaitUntil:
+    visible:
+      id: "onboarding-questions-screen"
+    timeout: 10000
+
+# onboarding-welcome を通過
+- runFlow:
+    when:
+      visible:
+        id: "onboarding-welcome-screen"
+    commands:
+      - tapOn:
+          id: "onboarding-start-button"
+          optional: true
+      - tapOn:
+          text: "はじめる"
+          optional: true
+
+# --- Step 4: onboarding 設問完走 (nutrition_goal=maintain) ---
+- runFlow:
+    file: "./complete-onboarding-maintain.yaml"
+
+# complete-onboarding-maintain.yaml の末尾で home-screen に到達する
+# しかし新規ユーザーは /handson-tour に自動遷移するため
+# tour-step-0 が表示されるまで待機
+- extendedWaitUntil:
+    visible:
+      id: "tour-step-0"
+    timeout: 15000
+
+# Expo dev build の LogBox を閉じる
+- runFlow:
+    file: "./dismiss-logbox.yaml"

--- a/apps/mobile/maestro/flows/handson-tour/01-show-on-onboarding-complete.yaml
+++ b/apps/mobile/maestro/flows/handson-tour/01-show-on-onboarding-complete.yaml
@@ -1,0 +1,34 @@
+appId: com.homegohan.app
+name: "Handson Tour - 01: onboarding 完了後に /handson-tour へ自動遷移"
+tags: ["handson-tour", "critical", "P1"]
+---
+# シナリオ: onboarding 完了 → /handson-tour に自動遷移、tour-step-0 が表示される
+# 確認ポイント:
+#   - onboarding-complete-cta-button タップ後、home-screen ではなく tour-step-0 に遷移
+#   - tour-step-0-title / tour-step-0-subtitle が表示される
+#   - tour-step-0-start / tour-step-0-skip ボタンが表示される
+
+# 新規ユーザー signup → onboarding 完走 → tour-step-0 到達
+- runFlow:
+    file: "../_shared/login-as-new-user.yaml"
+
+# /handson-tour の tour-step-0 が表示されることを確認
+- assertVisible:
+    id: "tour-step-0"
+
+- assertVisible:
+    id: "tour-step-0-title"
+
+- assertVisible:
+    id: "tour-step-0-subtitle"
+
+# はじめる / あとで ボタンが両方表示される
+- assertVisible:
+    id: "tour-step-0-start"
+
+- assertVisible:
+    id: "tour-step-0-skip"
+
+# home-screen はまだ表示されていないことを確認
+- assertNotVisible:
+    id: "home-screen"

--- a/apps/mobile/maestro/flows/handson-tour/02-step0-start-button.yaml
+++ b/apps/mobile/maestro/flows/handson-tour/02-step0-start-button.yaml
@@ -1,0 +1,38 @@
+appId: com.homegohan.app
+name: "Handson Tour - 02: Step 0「はじめる」タップ → Step 1 へ遷移"
+tags: ["handson-tour", "critical", "P1"]
+---
+# シナリオ: Step 0 で「はじめる」タップ → Step 1 へ遷移
+# 確認ポイント:
+#   - tour-step-0-start タップ後に tour-step-0 が非表示
+#   - Step 1 の intro または meal-camera-button が表示される
+#   - TODO: tour-step-1-intro testID 未実装、別 PR で fix
+
+- runFlow:
+    file: "../_shared/login-as-new-user.yaml"
+
+- assertVisible:
+    id: "tour-step-0"
+
+# 「はじめる」ボタンをタップ
+- tapOn:
+    id: "tour-step-0-start"
+
+# Step 0 が非表示になる
+- assertNotVisible:
+    id: "tour-step-0"
+
+# Step 1 intro または camera-button が表示される
+# TODO: testID tour-step-1-intro は未実装。別 PR で fix。暫定テキストマッチで代替
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          id: "meal-camera-button"
+      - visible:
+          text: "カメラ"
+          optional: true
+    timeout: 10000
+
+# meal-camera-button が Spotlight で表示されることを確認
+- assertVisible:
+    id: "meal-camera-button"

--- a/apps/mobile/maestro/flows/handson-tour/03-step0-skip-button.yaml
+++ b/apps/mobile/maestro/flows/handson-tour/03-step0-skip-button.yaml
@@ -1,0 +1,41 @@
+appId: com.homegohan.app
+name: "Handson Tour - 03: Step 0「あとで」タップ → /home へ遷移"
+tags: ["handson-tour", "critical", "P1"]
+---
+# シナリオ: Step 0 で「あとで」タップ → /home へ遷移
+# 確認ポイント:
+#   - tour-step-0-skip タップ後に home-screen が表示される
+#   - tour-step-0 は表示されない
+#   - アプリ再起動後も tour-step-0 は表示されない (handson_tour_skipped_at がセットされている)
+
+- runFlow:
+    file: "../_shared/login-as-new-user.yaml"
+
+- assertVisible:
+    id: "tour-step-0"
+
+# 「あとで」ボタンをタップ
+- tapOn:
+    id: "tour-step-0-skip"
+
+# home-screen に遷移することを確認
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# tour-step-0 は表示されていないことを確認
+- assertNotVisible:
+    id: "tour-step-0"
+
+# アプリを再起動しても tour は表示されない (handson_tour_skipped_at セット確認)
+- killApp
+- launchApp
+
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 15000
+
+- assertNotVisible:
+    id: "tour-step-0"

--- a/apps/mobile/maestro/flows/handson-tour/04-step1-meal-photo-flow.yaml
+++ b/apps/mobile/maestro/flows/handson-tour/04-step1-meal-photo-flow.yaml
@@ -1,0 +1,88 @@
+appId: com.homegohan.app
+name: "Handson Tour - 04: Step 1 写真追加 → first_bite バッジ獲得 → Step 2"
+tags: ["handson-tour", "P1"]
+---
+# シナリオ: Step 1 カメラボタン → 撮影モック → 結果表示 → 保存 → first_bite バッジ獲得 → Step 2
+# 確認ポイント:
+#   - meal-camera-button が Spotlight 表示される
+#   - 撮影は sandbox モックなので自動進行 (カメラ不要)
+#   - meal-result-dish-name / meal-result-calories が表示される
+#   - meal-save-button タップ後 API 呼び出し
+#   - first_bite バッジ獲得通知 (toast または overlay)
+#   - Step 2 に遷移する
+# TODO: tour-step-1-intro / meal-analyzing-view testID 未実装。別 PR で fix
+
+- runFlow:
+    file: "../_shared/login-as-new-user.yaml"
+
+- assertVisible:
+    id: "tour-step-0"
+
+# Step 0 を通過
+- tapOn:
+    id: "tour-step-0-start"
+
+# Step 1: intro 吹き出し (TODO: tour-step-1-intro testID 未実装、テキストで代替)
+- waitForAnimationToEnd:
+    timeout: 4000
+- assertVisible:
+    text: "カメラ"
+    optional: true
+
+# meal-camera-button が Spotlight 表示される
+- extendedWaitUntil:
+    visible:
+      id: "meal-camera-button"
+    timeout: 10000
+
+# 撮影モック: sandbox flow では自動的に mock 画像が選択される
+# (実機では実際のカメラを開くが sandbox モードでは skip)
+# waitForAnimationToEnd で auto-advance を待つ
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# 解析中ビュー (TODO: meal-analyzing-view testID 確認、存在しない場合は skip)
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# 結果画面が表示される
+- extendedWaitUntil:
+    visible:
+      id: "meal-result-dish-name"
+    timeout: 10000
+
+# 料理名: sandbox mock = 「鶏の唐揚げ定食」
+- assertVisible:
+    id: "meal-result-dish-name"
+
+# 保存ボタンを Spotlight で示す
+- extendedWaitUntil:
+    visible:
+      id: "meal-save-button"
+    timeout: 5000
+
+- tapOn:
+    id: "meal-save-button"
+
+# API 呼び出し待機 (~500ms + バッジ付与)
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# first_bite バッジ取得 toast/overlay 確認
+# TODO: badge-card-first_bite testID は mobile 未実装。テキストマッチで代替
+- assertVisible:
+    text: "first_bite"
+    optional: true
+- assertVisible:
+    text: "バッジ"
+    optional: true
+
+# Step 2 intro が表示される
+# TODO: tour-step-2-intro testID 未実装。別 PR で fix。暫定テキストマッチで代替
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          text: "献立"
+      - visible:
+          text: "メニュー"
+    timeout: 10000

--- a/apps/mobile/maestro/flows/handson-tour/05-step2-menu-generate-flow.yaml
+++ b/apps/mobile/maestro/flows/handson-tour/05-step2-menu-generate-flow.yaml
@@ -1,0 +1,116 @@
+appId: com.homegohan.app
+name: "Handson Tour - 05: Step 2 簡単メニュー生成 → planner バッジ → Step 3"
+tags: ["handson-tour", "P1"]
+---
+# シナリオ: Step 2 簡単メニュー toggle → 生成 → 結果 → 追加 → planner バッジ → Step 3
+# 確認ポイント:
+#   - Step 2 の intro 吹き出し後、toggle/generate ボタンが Spotlight で表示
+#   - v4-generate-button タップ → ローディング → 結果カード
+#   - v4-add-to-menu-button タップ → API 呼び出し
+#   - planner バッジ獲得通知
+#   - Step 3 の tour-step-3-loading が表示される
+# TODO: v4-no-cook-toggle / v4-generate-button / v4-result-card / v4-add-to-menu-button
+#       は mobile 未実装 (web 既存)。別 PR で fix。暫定テキストマッチで代替
+
+- runFlow:
+    file: "../_shared/login-as-new-user.yaml"
+
+- assertVisible:
+    id: "tour-step-0"
+
+- tapOn:
+    id: "tour-step-0-start"
+
+# Step 1 を高速通過 (save-button まで)
+- waitForAnimationToEnd:
+    timeout: 6000
+
+- extendedWaitUntil:
+    visible:
+      id: "meal-save-button"
+    timeout: 15000
+
+- tapOn:
+    id: "meal-save-button"
+
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# Step 2 intro 吹き出し待機
+# TODO: tour-step-2-intro testID 未実装。別 PR で fix。テキストマッチで代替
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          text: "献立"
+      - visible:
+          text: "メニュー"
+      - visible:
+          text: "生成"
+    timeout: 15000
+
+- waitForAnimationToEnd:
+    timeout: 4000
+
+# 簡単メニュー toggle (TODO: v4-simple-only-toggle testID mobile 未実装、別 PR で fix)
+- tapOn:
+    id: "v4-simple-only-toggle"
+    optional: true
+- tapOn:
+    text: "簡単"
+    optional: true
+
+# TODO: tour-next-button を挟む場合の対応 (Step 2 ガイドの進行に依存)
+- tapOn:
+    id: "tour-next-button"
+    optional: true
+
+# 生成ボタン (TODO: v4-generate-button testID mobile 未実装、別 PR で fix)
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          id: "v4-generate-button"
+      - visible:
+          text: "生成する"
+    timeout: 10000
+
+- tapOn:
+    id: "v4-generate-button"
+    optional: true
+- tapOn:
+    text: "生成する"
+    optional: true
+
+# ローディング待機 (TODO: v4-loading-spinner testID 未実装、別 PR で fix)
+- waitForAnimationToEnd:
+    timeout: 8000
+
+# 結果カード確認 (TODO: v4-result-card / v4-result-dish-name testID 未実装、別 PR で fix)
+- assertVisible:
+    id: "v4-result-card"
+    optional: true
+- assertVisible:
+    text: "豚肉"
+    optional: true
+
+# 献立に追加ボタン (TODO: v4-add-to-menu-button testID 未実装、別 PR で fix)
+- tapOn:
+    id: "v4-add-to-menu-button"
+    optional: true
+- tapOn:
+    text: "献立に追加"
+    optional: true
+
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# planner バッジ取得確認
+# TODO: badge-card-planner testID は mobile 未実装。テキストマッチで代替
+- assertVisible:
+    text: "planner"
+    optional: true
+
+# Step 3: tour-step-3-loading が表示される
+- extendedWaitUntil:
+    visible:
+      id: "tour-step-3-loading"
+    timeout: 15000

--- a/apps/mobile/maestro/flows/handson-tour/06-step3-badges-display.yaml
+++ b/apps/mobile/maestro/flows/handson-tour/06-step3-badges-display.yaml
@@ -1,0 +1,98 @@
+appId: com.homegohan.app
+name: "Handson Tour - 06: Step 3 バッジ表示確認 → 「次へ」→ Step 4"
+tags: ["handson-tour", "P1"]
+---
+# シナリオ: Step 3 tour-step-3-loading 表示 → 14 種バッジ表示確認 → 「次へ」タップ → Step 4
+# 確認ポイント:
+#   - tour-step-3-loading が表示される
+#   - バッジ読み込み後に各バッジが表示される
+#   - tour-step-4-saving または tour-step-4-graduate に遷移する
+# TODO: tour-step-3-intro / badge-card-* testID は mobile 未実装。別 PR で fix
+# TODO: 14 種バッジ全て確認するには badge-card-{code} の testID 実装が必要
+
+- runFlow:
+    file: "../_shared/login-as-new-user.yaml"
+
+- assertVisible:
+    id: "tour-step-0"
+
+- tapOn:
+    id: "tour-step-0-start"
+
+# Step 1 高速通過
+- waitForAnimationToEnd:
+    timeout: 6000
+
+- extendedWaitUntil:
+    visible:
+      id: "meal-save-button"
+    timeout: 15000
+
+- tapOn:
+    id: "meal-save-button"
+
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# Step 2 高速通過: 生成→追加
+- waitForAnimationToEnd:
+    timeout: 6000
+
+- tapOn:
+    id: "v4-generate-button"
+    optional: true
+- tapOn:
+    text: "生成する"
+    optional: true
+
+- waitForAnimationToEnd:
+    timeout: 8000
+
+- tapOn:
+    id: "v4-add-to-menu-button"
+    optional: true
+- tapOn:
+    text: "献立に追加"
+    optional: true
+
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# Step 3: tour-step-3-loading が表示される
+- extendedWaitUntil:
+    visible:
+      id: "tour-step-3-loading"
+    timeout: 15000
+
+- assertVisible:
+    id: "tour-step-3-loading"
+
+# バッジ読み込み完了を待つ
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# tour-step-3-intro 吹き出し (TODO: testID 未実装、別 PR で fix)
+# バッジカード確認 (TODO: badge-card-* testID 未実装。テキストマッチで代替)
+- assertVisible:
+    text: "first_bite"
+    optional: true
+- assertVisible:
+    text: "planner"
+    optional: true
+
+# 「次へ」ボタンで Step 4 へ
+- tapOn:
+    id: "tour-next-button"
+    optional: true
+- tapOn:
+    text: "次へ"
+    optional: true
+
+# Step 4: tour-step-4-saving または tour-step-4-graduate に遷移
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          id: "tour-step-4-saving"
+      - visible:
+          id: "tour-step-4-graduate"
+    timeout: 15000

--- a/apps/mobile/maestro/flows/handson-tour/07-step4-graduate-and-home.yaml
+++ b/apps/mobile/maestro/flows/handson-tour/07-step4-graduate-and-home.yaml
@@ -1,0 +1,140 @@
+appId: com.homegohan.app
+name: "Handson Tour - 07: Step 4 卒業画面 → tutorial_complete バッジ → ホームへ"
+tags: ["handson-tour", "critical", "P1"]
+---
+# シナリオ: Step 4 卒業画面 → tutorial_complete バッジ表示 → disclaimer 表示 → 「ホームへ」→ /home toast
+# 確認ポイント:
+#   - tour-step-4-saving (完了処理中 spinner) が表示される
+#   - tour-step-4-graduate (卒業画面) が表示される
+#   - tour-step-4-badge-disclaimer が表示される (PR #833 で追加済)
+#   - tour-step-4-go-home タップ後 home-screen に遷移
+#   - home-screen で welcome toast が表示される (tour-step-5-toast)
+#   - アプリ再起動後もツアーは表示されない (handson_tour_completed_at セット)
+
+- runFlow:
+    file: "../_shared/login-as-new-user.yaml"
+
+- assertVisible:
+    id: "tour-step-0"
+
+- tapOn:
+    id: "tour-step-0-start"
+
+# Step 1 高速通過
+- waitForAnimationToEnd:
+    timeout: 6000
+
+- extendedWaitUntil:
+    visible:
+      id: "meal-save-button"
+    timeout: 15000
+
+- tapOn:
+    id: "meal-save-button"
+
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# Step 2 高速通過
+- waitForAnimationToEnd:
+    timeout: 6000
+
+- tapOn:
+    id: "v4-generate-button"
+    optional: true
+- tapOn:
+    text: "生成する"
+    optional: true
+
+- waitForAnimationToEnd:
+    timeout: 8000
+
+- tapOn:
+    id: "v4-add-to-menu-button"
+    optional: true
+- tapOn:
+    text: "献立に追加"
+    optional: true
+
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# Step 3 高速通過: バッジ確認 → 次へ
+- extendedWaitUntil:
+    visible:
+      id: "tour-step-3-loading"
+    timeout: 15000
+
+- waitForAnimationToEnd:
+    timeout: 5000
+
+- tapOn:
+    id: "tour-next-button"
+    optional: true
+- tapOn:
+    text: "次へ"
+    optional: true
+
+# Step 4: tour-step-4-saving が表示される
+- extendedWaitUntil:
+    visible:
+      id: "tour-step-4-saving"
+    timeout: 15000
+
+# 完了処理待機
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# 卒業画面が表示される
+- extendedWaitUntil:
+    visible:
+      id: "tour-step-4-graduate"
+    timeout: 10000
+
+- assertVisible:
+    id: "tour-step-4-graduate"
+
+# tutorial_complete バッジが表示される
+# TODO: tour-step-4-badge-card testID 確認。PR #833 で追加済みの想定
+- assertVisible:
+    id: "tour-step-4-badge-disclaimer"
+
+# disclaimer テキスト確認 (サンドボックスデータの注記)
+- assertVisible:
+    text: "サンドボックス"
+    optional: true
+
+# ボタン活性化を待つ (5 秒 delay)
+- waitForAnimationToEnd:
+    timeout: 6000
+
+# 「ホームへ」タップ
+- tapOn:
+    id: "tour-step-4-go-home"
+
+# home-screen に遷移
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 15000
+
+# welcome toast 確認 (tour-step-5-toast)
+- assertVisible:
+    id: "tour-step-5-toast"
+    optional: true
+
+# toast が自動 dismiss されることを待つ
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# アプリ再起動後もツアーは表示されない
+- killApp
+- launchApp
+
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 15000
+
+- assertNotVisible:
+    id: "tour-step-0"

--- a/apps/mobile/maestro/flows/handson-tour/08-skip-mid-step.yaml
+++ b/apps/mobile/maestro/flows/handson-tour/08-skip-mid-step.yaml
@@ -1,0 +1,73 @@
+appId: com.homegohan.app
+name: "Handson Tour - 08: Step 1 途中で「あとで」タップ → /home へ遷移"
+tags: ["handson-tour", "P1"]
+---
+# シナリオ: Step 1 の途中で「あとで」タップ → /home へ遷移、handson_tour_skipped_at セット確認
+# 確認ポイント:
+#   - Step 1 中に tour-skip-button が表示される
+#   - タップ後 home-screen に遷移する
+#   - アプリ再起動後もツアーは表示されない (handson_tour_skipped_at がセット)
+# TODO: tour-skip-button testID が Step 1 中に表示されるかどうか実装確認が必要
+
+- runFlow:
+    file: "../_shared/login-as-new-user.yaml"
+
+- assertVisible:
+    id: "tour-step-0"
+
+- tapOn:
+    id: "tour-step-0-start"
+
+# Step 1 に遷移: intro または camera-button が表示されるまで待機
+- extendedWaitUntil:
+    visible:
+      id: "meal-camera-button"
+    timeout: 10000
+
+# Step 1 途中で「あとで」タップ
+# TODO: tour-skip-button が Step 1 中に表示されるか確認。実装次第で testID 変更の可能性あり
+- assertVisible:
+    id: "tour-skip-button"
+    optional: true
+- assertVisible:
+    text: "あとで"
+    optional: true
+
+- tapOn:
+    id: "tour-skip-button"
+    optional: true
+- tapOn:
+    text: "あとで"
+    optional: true
+
+# 確認ダイアログが出る場合は「スキップ」または「確認」を選択
+- tapOn:
+    text: "スキップ"
+    optional: true
+- tapOn:
+    text: "確認"
+    optional: true
+
+# home-screen に遷移することを確認
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 15000
+
+- assertNotVisible:
+    id: "tour-step-0"
+- assertNotVisible:
+    id: "meal-camera-button"
+
+# アプリ再起動後もツアーは表示されない
+# handson_tour_skipped_at がセットされているため
+- killApp
+- launchApp
+
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 15000
+
+- assertNotVisible:
+    id: "tour-step-0"

--- a/apps/mobile/maestro/flows/handson-tour/09-existing-user-auto-skip.yaml
+++ b/apps/mobile/maestro/flows/handson-tour/09-existing-user-auto-skip.yaml
@@ -1,0 +1,60 @@
+appId: com.homegohan.app
+name: "Handson Tour - 09: 既存 user (meals あり) → /handson-tour 直リンクで /home リダイレクト"
+tags: ["handson-tour", "P2"]
+---
+# シナリオ: 既存 user (meals 1 件あり) でログイン → /handson-tour 直リンク → /home へ即リダイレクト
+# 確認ポイント:
+#   - E2E_TOUR_EXISTING_USER_EMAIL (meals を持つ既存 user) でログイン
+#   - /handson-tour に deep link でアクセスしても tour-step-0 は表示されない
+#   - home-screen に即リダイレクトされる
+# 前提: E2E_TOUR_EXISTING_USER_EMAIL / E2E_TOUR_EXISTING_USER_PASSWORD に
+#        is_sandbox=false の meals を持つテストユーザーが設定済みであること
+# 備考: shouldShowHandsonTour() の condition C (既存 user auto skip) を確認するシナリオ
+
+# まず既存 user でログイン
+- runFlow:
+    file: "../_shared/ensure-welcome.yaml"
+
+- tapOn:
+    text: "ログイン"
+
+- extendedWaitUntil:
+    visible:
+      id: "login-screen"
+    timeout: 10000
+
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_TOUR_EXISTING_USER_EMAIL}
+
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_TOUR_EXISTING_USER_PASSWORD}
+
+- tapOn:
+    id: "login-button"
+
+# home-screen に遷移 (既存 user なのでツアーはスキップ)
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 15000
+
+# tour-step-0 は表示されない
+- assertNotVisible:
+    id: "tour-step-0"
+
+# /handson-tour に deep link でアクセス
+# (launchApp で URL scheme を指定)
+- launchApp:
+    arguments:
+      - "homegohan://handson-tour"
+
+# tour は表示されず home-screen に戻る
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 15000
+
+- assertNotVisible:
+    id: "tour-step-0"

--- a/apps/mobile/maestro/flows/handson-tour/10-admin-role-bypass.yaml
+++ b/apps/mobile/maestro/flows/handson-tour/10-admin-role-bypass.yaml
@@ -1,0 +1,73 @@
+appId: com.homegohan.app
+name: "Handson Tour - 10: admin role → /handson-tour 直リンクで /home リダイレクト"
+tags: ["handson-tour", "P2"]
+---
+# シナリオ: admin role user でログイン → /handson-tour 直リンク → /home へ即リダイレクト
+# 確認ポイント:
+#   - E2E_TOUR_ADMIN_EMAIL (admin ロールのテストユーザー) でログイン
+#   - /handson-tour に deep link でアクセスしても tour-step-0 は表示されない
+#   - home-screen に即リダイレクトされる
+# 前提: E2E_TOUR_ADMIN_EMAIL / E2E_TOUR_ADMIN_PASSWORD に admin role ユーザーが設定済み
+# 備考: shouldShowHandsonTour() の condition D (admin role bypass) を確認するシナリオ
+
+# admin role でログイン
+- runFlow:
+    file: "../_shared/ensure-welcome.yaml"
+
+- tapOn:
+    text: "ログイン"
+
+- extendedWaitUntil:
+    visible:
+      id: "login-screen"
+    timeout: 10000
+
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_TOUR_ADMIN_EMAIL}
+
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_TOUR_ADMIN_PASSWORD}
+
+- tapOn:
+    id: "login-button"
+
+# admin は home-screen または admin console に遷移
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          id: "home-screen"
+      - visible:
+          text: "Admin Console"
+    timeout: 15000
+
+# admin console にいる場合は home に戻る
+- runFlow:
+    when:
+      visible:
+        text: "Admin Console"
+    file: "../_shared/back-from-admin.yaml"
+
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# tour-step-0 は表示されない
+- assertNotVisible:
+    id: "tour-step-0"
+
+# /handson-tour に deep link でアクセス
+- launchApp:
+    arguments:
+      - "homegohan://handson-tour"
+
+# admin は tour をバイパスして home に戻る
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 15000
+
+- assertNotVisible:
+    id: "tour-step-0"

--- a/apps/mobile/maestro/flows/handson-tour/11-replay-from-settings.yaml
+++ b/apps/mobile/maestro/flows/handson-tour/11-replay-from-settings.yaml
@@ -1,0 +1,98 @@
+appId: com.homegohan.app
+name: "Handson Tour - 11: 完走済 user → /settings → 再開ボタン → Step 0 再表示"
+tags: ["handson-tour", "P2"]
+---
+# シナリオ: 完走済 user → /settings → settings-restart-handson-tour タップ → Step 0 再表示
+# 確認ポイント:
+#   - 完走済 user (E2E_TOUR_COMPLETED_EMAIL) でログイン
+#   - settings 画面に移動
+#   - settings-restart-handson-tour ボタンが表示される
+#   - タップ後 tour-step-0 が表示される
+# 前提: E2E_TOUR_COMPLETED_EMAIL / E2E_TOUR_COMPLETED_PASSWORD に
+#        handson_tour_completed_at が設定済みのテストユーザーを用意
+# 備考: force replay (§4.1 シナリオ 10) を Maestro で確認するシナリオ
+
+# 完走済 user でログイン
+- runFlow:
+    file: "../_shared/ensure-welcome.yaml"
+
+- tapOn:
+    text: "ログイン"
+
+- extendedWaitUntil:
+    visible:
+      id: "login-screen"
+    timeout: 10000
+
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_TOUR_COMPLETED_EMAIL}
+
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_TOUR_COMPLETED_PASSWORD}
+
+- tapOn:
+    id: "login-button"
+
+# home-screen に遷移 (完走済みなのでツアーはスキップ)
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 15000
+
+# tour-step-0 は表示されない (完走済み)
+- assertNotVisible:
+    id: "tour-step-0"
+
+# Profile タブ → 設定画面に移動
+- tapOn:
+    id: "tab-profile"
+
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 10000
+
+- tapOn:
+    id: "profile-settings-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "settings-screen"
+    timeout: 10000
+
+# settings-restart-handson-tour ボタンまでスクロール
+- scrollUntilVisible:
+    element:
+      id: "settings-restart-handson-tour"
+    direction: DOWN
+    timeout: 10000
+
+- assertVisible:
+    id: "settings-restart-handson-tour"
+
+# 再開ボタンをタップ
+- tapOn:
+    id: "settings-restart-handson-tour"
+
+# 確認ダイアログが出る場合
+- tapOn:
+    text: "確認"
+    optional: true
+- tapOn:
+    text: "やり直す"
+    optional: true
+
+# tour-step-0 が再表示される
+- extendedWaitUntil:
+    visible:
+      id: "tour-step-0"
+    timeout: 15000
+
+- assertVisible:
+    id: "tour-step-0"
+- assertVisible:
+    id: "tour-step-0-start"
+- assertVisible:
+    id: "tour-step-0-skip"

--- a/apps/mobile/maestro/flows/handson-tour/12-back-button-during-tour.yaml
+++ b/apps/mobile/maestro/flows/handson-tour/12-back-button-during-tour.yaml
@@ -1,0 +1,116 @@
+appId: com.homegohan.app
+name: "Handson Tour - 12: Step 1 でデバイス戻るボタン → 確認モーダル → キャンセル / 確定"
+tags: ["handson-tour", "P2"]
+---
+# シナリオ: Step 1 でデバイス戻るボタン → 確認モーダル → キャンセル / 確定の両分岐
+# 確認ポイント:
+#   - Step 1 中に Android 戻るボタン (Back) を押すと確認モーダルが出る
+#   - 「キャンセル」→ Step 1 に戻る
+#   - 再度 Back → 「確定」→ home-screen に遷移 (handson_tour_skipped_at セット)
+# 備考: iOS では Back gesture (edge swipe) で同様の動作を想定
+#        Android 実機では pressKey: Back で戻るボタンを押せる
+#        iOS では Maestro の pressKey: Back は機能しない場合あり (iOS back gesture 非対応)
+
+- runFlow:
+    file: "../_shared/login-as-new-user.yaml"
+
+- assertVisible:
+    id: "tour-step-0"
+
+- tapOn:
+    id: "tour-step-0-start"
+
+# Step 1 に遷移
+- extendedWaitUntil:
+    visible:
+      id: "meal-camera-button"
+    timeout: 10000
+
+# ===== 分岐A: 戻るボタン → キャンセル → Step 1 に戻る =====
+
+# デバイスの戻るボタンを押す
+# iOS: back gesture (edge swipe) / Android: Back key
+- pressKey: Back
+  # iOS では Back key が効かない場合があるため optional
+- tapOn:
+    text: "戻る"
+    optional: true
+
+# 確認モーダルが表示される
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          text: "中断しますか"
+      - visible:
+          text: "あとで"
+      - visible:
+          text: "キャンセル"
+    timeout: 5000
+
+# 「キャンセル」をタップして Step 1 に戻る
+- tapOn:
+    text: "キャンセル"
+    optional: true
+- tapOn:
+    text: "続ける"
+    optional: true
+
+# Step 1 に戻っていることを確認
+- extendedWaitUntil:
+    visible:
+      id: "meal-camera-button"
+    timeout: 10000
+
+- assertVisible:
+    id: "meal-camera-button"
+
+# ===== 分岐B: 戻るボタン → 確定 → home へ =====
+
+# 再度戻るボタン
+- pressKey: Back
+- tapOn:
+    text: "戻る"
+    optional: true
+
+# 確認モーダルが再表示される
+- extendedWaitUntil:
+    anyOf:
+      - visible:
+          text: "中断しますか"
+      - visible:
+          text: "あとで"
+    timeout: 5000
+
+# 「確定」または「あとで」をタップ
+- tapOn:
+    text: "確定"
+    optional: true
+- tapOn:
+    text: "あとで"
+    optional: true
+- tapOn:
+    text: "スキップ"
+    optional: true
+
+# home-screen に遷移
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 15000
+
+- assertNotVisible:
+    id: "tour-step-0"
+- assertNotVisible:
+    id: "meal-camera-button"
+
+# アプリ再起動後も tour は表示されない (handson_tour_skipped_at セット)
+- killApp
+- launchApp
+
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 15000
+
+- assertNotVisible:
+    id: "tour-step-0"


### PR DESCRIPTION
## 概要

`apps/mobile/maestro/flows/handson-tour/` を新設し、Handson Tour の E2E Maestro flow を 12 件追加。共通 helper `_shared/login-as-new-user.yaml` も合わせて追加。

## 12 シナリオ一覧

| ファイル | シナリオ | 優先度 |
|---|---|---|
| `01-show-on-onboarding-complete.yaml` | onboarding 完了 → /handson-tour 自動遷移、tour-step-0 表示確認 | P1 |
| `02-step0-start-button.yaml` | Step 0「はじめる」タップ → Step 1 遷移 | P1 |
| `03-step0-skip-button.yaml` | Step 0「あとで」タップ → /home 遷移 + 再起動確認 | P1 |
| `04-step1-meal-photo-flow.yaml` | Step 1 撮影 → 結果 → 保存 → first_bite バッジ → Step 2 | P1 |
| `05-step2-menu-generate-flow.yaml` | Step 2 メニュー生成 → 結果 → 追加 → planner バッジ → Step 3 | P1 |
| `06-step3-badges-display.yaml` | Step 3 ローディング → バッジ確認 → 次へ → Step 4 | P1 |
| `07-step4-graduate-and-home.yaml` | Step 4 卒業 → disclaimer → ホームへ → toast + 再起動確認 | P1 (happy path) |
| `08-skip-mid-step.yaml` | Step 1 途中「あとで」→ /home + skipped_at セット確認 | P1 |
| `09-existing-user-auto-skip.yaml` | 既存 user (meals あり) → /handson-tour 直リンク → /home リダイレクト | P2 |
| `10-admin-role-bypass.yaml` | admin role → /handson-tour 直リンク → /home リダイレクト | P2 |
| `11-replay-from-settings.yaml` | 完走済 user → settings 再開ボタン → Step 0 再表示 | P2 |
| `12-back-button-during-tour.yaml` | Step 1 でデバイス戻るボタン → 確認モーダル → キャンセル/確定両分岐 | P2 |

## 不足 testID 一覧 (TODO: 別 PR で fix)

以下の testID は Mobile 側未実装のため `optional: true` + `text:` マッチで代替し、コメントで明示。

| testID | 使用 flow | 状態 |
|---|---|---|
| `tour-step-1-intro` | 02, 04 | Mobile 未実装 |
| `meal-analyzing-view` | 04 | 確認が必要 |
| `tour-step-2-intro` | 05, 06 | Mobile 未実装 |
| `v4-simple-only-toggle` / `v4-generate-button` / `v4-result-card` / `v4-add-to-menu-button` | 05, 06 | Mobile 未実装 (web 既存) |
| `v4-loading-spinner` | 05 | 未実装 |
| `tour-step-3-intro` | 06 | Mobile 未実装 |
| `badge-card-first_bite` / `badge-card-planner` | 04, 05, 06 | Mobile 未実装 |
| `tour-skip-button` (Step 1 中表示) | 08 | 表示されるか実装確認が必要 |
| `settings-restart-handson-tour` | 11 | 実装済みか確認要 |

## 新規追加環境変数 (E2E 実行時に必要)

```
E2E_TOUR_NEW_USER_EMAIL / E2E_TOUR_NEW_USER_PASSWORD
E2E_TOUR_EXISTING_USER_EMAIL / E2E_TOUR_EXISTING_USER_PASSWORD
E2E_TOUR_ADMIN_EMAIL / E2E_TOUR_ADMIN_PASSWORD
E2E_TOUR_COMPLETED_EMAIL / E2E_TOUR_COMPLETED_PASSWORD
```

## ローカル実行手順

```bash
cd apps/mobile && maestro test maestro/flows/handson-tour/
# P1 のみ
cd apps/mobile && maestro test maestro/flows/handson-tour/ --include-tags P1
```