### PR TITLE
fix(e2e): infra ブロッカー 4-5 件解消 (#630 #636 #638 #639 #641)

### DIFF
--- a/apps/mobile/maestro/README.md
+++ b/apps/mobile/maestro/README.md
@@ -32,6 +32,39 @@ maestro test maestro/smoke.yaml
 - Android: Android Studio + エミュレーター起動済み
 - アプリビルド済み (`expo run:ios` or `expo run:android`)
 
+## E2E テストユーザーのデータリセット
+
+テスト前にユーザー状態をリセットする必要がある場合 (issue #636 / #638):
+
+```bash
+# リポジトリルートから
+npm run test:e2e:reset-data
+
+# または直接
+bash apps/mobile/maestro/scripts/reset-test-users.sh
+```
+
+前提:
+- `.env.local` に `NEXT_PUBLIC_SUPABASE_URL` と `SUPABASE_SERVICE_ROLE_KEY` が設定済み
+- `reset_e2e_test_users` RPC が Supabase に適用済み (`supabase/migrations/20260508150000_reset_e2e_test_users.sql`)
+
+リセット内容:
+- `E2E_USER_03` (`e2e-user-03@*.test`): `onboarding_completed_at` を NULL に戻す
+- `E2E_USER_04` (`e2e-user-04@*.test`): `auth.users` から削除 (cascade で profiles も削除)
+
+## mock サーバーが必要な flow
+
+一部の異常系テスト (特定 HTTP エラーのシミュレーション) は実際の Supabase では再現できないため、
+mock サーバー環境でのみ実行してください:
+
+```bash
+# mock サーバーを起動した状態で
+MAESTRO_RUN_NETWORK_FAULT=1 maestro test maestro/flows/auth/16-signup-api-500-error.yaml
+```
+
+`MAESTRO_RUN_NETWORK_FAULT` が未設定または `"1"` 以外の場合、これらの flow は自動的にスキップされます。
+(issue #641 参照)
+
 ## 並列実行スクリプト
 
 ```bash

--- a/apps/mobile/maestro/flows/_shared/early-exit.yaml
+++ b/apps/mobile/maestro/flows/_shared/early-exit.yaml
@@ -1,0 +1,10 @@
+appId: com.homegohan.app
+---
+# _shared/early-exit.yaml
+# mock サーバーなど特定環境でのみ実行すべき flow から呼ぶ「早期終了」共通フロー。
+# このファイルを runFlow で呼ぶと、以降のステップをスキップして flow を正常終了させる。
+# 使い方:
+#   - runFlow: ../_shared/early-exit.yaml
+# 上記呼び出し後のステップは実行されない (Maestro は flow ファイルの末尾まで実行したものとみなす)。
+
+# 何もせず正常終了 — ここに何もないことが「スキップ」を意味する

--- a/apps/mobile/maestro/flows/auth/01-login-existing-user-to-home.yaml
+++ b/apps/mobile/maestro/flows/auth/01-login-existing-user-to-home.yaml
@@ -4,25 +4,9 @@ env:
   E2E_USER_PASSWORD: ${E2E_USER_01_PASSWORD}
 ---
 # 01: 既存ユーザーで login → home 到達
+# Note: ログイン共通フローは _shared/login.yaml に集約。
+#       ここではその canonical flow を呼ぶだけにして単一障害点を排除。
 - launchApp
-# 前の状態をリセット (ホーム or Admin Console にいる場合)
-- runFlow:
-    file: "../_shared/ensure-welcome.yaml"
+- runFlow: ../_shared/login.yaml
 - assertVisible:
-    text: "ほめゴハン"
-- tapOn:
-    text: "ログイン"
-- assertVisible:
-    id: "login-screen"
-- tapOn:
-    id: "email-input"
-- inputText: ${E2E_USER_EMAIL}
-- tapOn:
-    id: "password-input"
-- inputText: ${E2E_USER_PASSWORD}
-- tapOn:
-    id: "login-button"
-- extendedWaitUntil:
-    visible:
-      id: "home-screen"
-    timeout: 10000
+    id: "home-screen"

--- a/apps/mobile/maestro/flows/auth/06-welcome-signup-login-e2e.yaml
+++ b/apps/mobile/maestro/flows/auth/06-welcome-signup-login-e2e.yaml
@@ -45,9 +45,10 @@ env:
     id: "login-screen"
 
 # Step 5: 既存ユーザーでログインして home 到達
-- clearText
+# clearText (引数なし) は Maestro 2.x で不正。eraseText に変更。 (#639)
 - tapOn:
     id: "email-input"
+- eraseText: 100
 - inputText: ${E2E_USER_EMAIL}
 - tapOn:
     id: "password-input"

--- a/apps/mobile/maestro/flows/auth/16-signup-api-500-error.yaml
+++ b/apps/mobile/maestro/flows/auth/16-signup-api-500-error.yaml
@@ -1,8 +1,25 @@
 appId: com.homegohan.app
+env:
+  # MAESTRO_RUN_NETWORK_FAULT を "1" に設定した場合のみ全 assertion を実行する。
+  # ローカル開発・CI 通常実行では mock サーバーがないため assertion をスキップする。
+  # 実行方法 (mock サーバー環境):
+  #   MAESTRO_RUN_NETWORK_FAULT=1 maestro test auth/16-signup-api-500-error.yaml
+  # See: issue #641
+  MAESTRO_RUN_NETWORK_FAULT: ${MAESTRO_RUN_NETWORK_FAULT:-0}
 ---
 # 16: signup: API 500 エラー
-# Note: Supabase が内部エラーを返した場合のエラーハンドリング確認
-# テスト環境では不正な URL 設定や、mock により 500 を再現
+# SKIP 条件: MAESTRO_RUN_NETWORK_FAULT != "1"
+#   → mock サーバー環境でのみ実行可。ローカル開発では early-exit でスキップ。
+#   → 実 Supabase に api500test@example.com を投げても 500 は返らないため。
+#   参照: issue #641 "auth/16 signup-api-500-error は mock 必要"
+
+# mock サーバーが有効でなければ早期終了 (スキップ扱い)
+- runFlow:
+    when:
+      condition: ${MAESTRO_RUN_NETWORK_FAULT} != "1"
+    file: "../_shared/early-exit.yaml"
+
+# 以下は MAESTRO_RUN_NETWORK_FAULT=1 のときのみ実行される
 - launchApp
 # 前の状態をリセット (ホーム or Admin Console にいる場合)
 - runFlow:

--- a/apps/mobile/maestro/scripts/reset-test-users.sh
+++ b/apps/mobile/maestro/scripts/reset-test-users.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# E2E test user の DB 状態をテスト前提にリセット
+# 要 SUPABASE_SERVICE_ROLE_KEY と NEXT_PUBLIC_SUPABASE_URL (.env.local から読込)
+#
+# 解決する問題:
+#   - issue #636: E2E_USER_03 が onboarding 完了済のため onboarding 系テストが fail
+#   - issue #638: E2E_USER_04 が signup 済のため signup 系テストが fail
+#
+# 使い方:
+#   bash apps/mobile/maestro/scripts/reset-test-users.sh
+#   npm run test:e2e:reset-data
+#
+# 前提: リポジトリルートに .env.local が存在し、以下が設定されていること
+#   NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co
+#   SUPABASE_SERVICE_ROLE_KEY=<service_role_key>
+#
+# 呼び出す Supabase RPC:
+#   reset_e2e_test_users() — supabase/migrations/*_reset_e2e_test_users.sql で定義
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+ENV_FILE="${REPO_ROOT}/.env.local"
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "[reset-test-users] ERROR: .env.local が見つかりません: ${ENV_FILE}" >&2
+  exit 1
+fi
+
+# .env.local から必要な変数のみ抽出してエクスポート
+source <(grep -E '^(NEXT_PUBLIC_SUPABASE_URL|SUPABASE_SERVICE_ROLE_KEY)=' "${ENV_FILE}" | sed 's/^/export /')
+
+if [[ -z "${NEXT_PUBLIC_SUPABASE_URL:-}" ]]; then
+  echo "[reset-test-users] ERROR: NEXT_PUBLIC_SUPABASE_URL が未設定です" >&2
+  exit 1
+fi
+
+if [[ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]]; then
+  echo "[reset-test-users] ERROR: SUPABASE_SERVICE_ROLE_KEY が未設定です" >&2
+  exit 1
+fi
+
+echo "[reset-test-users] Supabase: ${NEXT_PUBLIC_SUPABASE_URL}"
+echo "[reset-test-users] RPC reset_e2e_test_users() を実行中..."
+
+RESPONSE=$(curl -sS -w "\n%{http_code}" \
+  -X POST "${NEXT_PUBLIC_SUPABASE_URL}/rest/v1/rpc/reset_e2e_test_users" \
+  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{}')
+
+HTTP_STATUS=$(echo "${RESPONSE}" | tail -n1)
+BODY=$(echo "${RESPONSE}" | head -n-1)
+
+if [[ "${HTTP_STATUS}" -ge 200 && "${HTTP_STATUS}" -lt 300 ]]; then
+  echo "[reset-test-users] done (HTTP ${HTTP_STATUS})"
+else
+  echo "[reset-test-users] ERROR: HTTP ${HTTP_STATUS}" >&2
+  echo "[reset-test-users] Response: ${BODY}" >&2
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "diagnostic:v4-benchmark": "node scripts/diagnostics/v4-benchmark.js",
     "mobile:start": "npm --workspace apps/mobile run start",
     "mobile:ios": "npm --workspace apps/mobile run ios",
-    "mobile:android": "npm --workspace apps/mobile run android"
+    "mobile:android": "npm --workspace apps/mobile run android",
+    "test:e2e:reset-data": "bash apps/mobile/maestro/scripts/reset-test-users.sh"
   },
   "engines": {
     "node": "20.x"

--- a/supabase/migrations/20260508150000_reset_e2e_test_users.sql
+++ b/supabase/migrations/20260508150000_reset_e2e_test_users.sql
@@ -1,0 +1,54 @@
+-- E2E テストユーザーの DB 状態をテスト前提にリセットする RPC
+-- 解決: issue #636 (USER_03 onboarding 完了済) / issue #638 (USER_04 既登録)
+--
+-- 呼び出し: reset-test-users.sh または npm run test:e2e:reset-data
+-- 権限: service_role のみ実行可 (SECURITY DEFINER)
+
+CREATE OR REPLACE FUNCTION public.reset_e2e_test_users()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user03_id uuid;
+  v_user04_id uuid;
+BEGIN
+  -- USER_03: onboarding_completed_at を NULL に戻す
+  -- 対象: メールアドレスが e2e-user-03@*.test パターン
+  SELECT au.id INTO v_user03_id
+  FROM auth.users au
+  WHERE au.email ~ '^e2e-user-03@.+\.test$'
+  LIMIT 1;
+
+  IF v_user03_id IS NOT NULL THEN
+    UPDATE public.user_profiles
+    SET onboarding_completed_at = NULL
+    WHERE id = v_user03_id;
+
+    RAISE NOTICE 'USER_03 (%) の onboarding_completed_at を NULL にリセットしました', v_user03_id;
+  ELSE
+    RAISE NOTICE 'USER_03 (e2e-user-03@*.test) が見つかりません。スキップします';
+  END IF;
+
+  -- USER_04: auth.users から DELETE (cascade で user_profiles も削除)
+  -- 対象: メールアドレスが e2e-user-04@*.test パターン
+  SELECT au.id INTO v_user04_id
+  FROM auth.users au
+  WHERE au.email ~ '^e2e-user-04@.+\.test$'
+  LIMIT 1;
+
+  IF v_user04_id IS NOT NULL THEN
+    DELETE FROM auth.users WHERE id = v_user04_id;
+    RAISE NOTICE 'USER_04 (%) を auth.users から削除しました (cascade)', v_user04_id;
+  ELSE
+    RAISE NOTICE 'USER_04 (e2e-user-04@*.test) が見つかりません。スキップします';
+  END IF;
+END;
+$$;
+
+-- service_role のみに EXECUTE 権限を付与
+-- (SECURITY DEFINER なので呼び出し者権限ではなく関数定義者権限で動く)
+REVOKE ALL ON FUNCTION public.reset_e2e_test_users() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.reset_e2e_test_users() FROM anon;
+REVOKE ALL ON FUNCTION public.reset_e2e_test_users() FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.reset_e2e_test_users() TO service_role;


### PR DESCRIPTION
## Summary

E2E インフラのブロッカー 4-5 件を 1 PR で解消。

### #630 — Maestro flow 単一障害点の解消

- `auth/01-login-existing-user-to-home.yaml` がログイン処理をインラインで持っており、`_shared/login.yaml` と二重管理になっていた
- `_shared/login.yaml` を canonical login flow とし、`auth/01` はそれを `runFlow` で呼ぶだけに変更
- 変更ファイル数: 1 (auth/01-login-existing-user-to-home.yaml)
- 他の flow (ai/, health/, home/ 等) はすでに `_shared/login.yaml` を参照しており変更不要

### #636 / #638 — テストデータリセット

- `apps/mobile/maestro/scripts/reset-test-users.sh` を新規作成
  - `.env.local` から Supabase 接続情報を読み込み RPC を呼ぶ
  - `USER_03` の `onboarding_completed_at` を NULL に戻す
  - `USER_04` を `auth.users` から DELETE (cascade で profiles も削除)
- `supabase/migrations/20260508150000_reset_e2e_test_users.sql` を新規作成
  - `reset_e2e_test_users()` RPC を SECURITY DEFINER で定義
  - `service_role` のみ EXECUTE 可
- `package.json` に `test:e2e:reset-data` スクリプトを追加

### #639 — auth/06 の clearText 不正コマンド

- `auth/06-welcome-signup-login-e2e.yaml` line 48 の `- clearText` (引数なし) は Maestro 2.x でエラー
- `- eraseText: 100` に置換

差分:
```yaml
-  - clearText
+  - eraseText: 100
```

### #641 — auth/16 signup-api-500-error は mock 必要

- `_shared/early-exit.yaml` を新規作成 (スキップ用の空 flow)
- `auth/16-signup-api-500-error.yaml` に `MAESTRO_RUN_NETWORK_FAULT` 環境変数チェックを追加
  - `MAESTRO_RUN_NETWORK_FAULT=1` の場合のみ full assertion を実行
  - それ以外は `early-exit.yaml` で早期終了 (スキップ扱い)
- `README.md` に mock サーバー実行方法と reset-data 使い方を追記

## Test plan

- [ ] `maestro test apps/mobile/maestro/flows/auth/01-login-existing-user-to-home.yaml` が `_shared/login.yaml` を通じてパスする
- [ ] `npm run test:e2e:reset-data` が `.env.local` を読んで Supabase RPC を呼ぶ
- [ ] `maestro test apps/mobile/maestro/flows/auth/06-welcome-signup-login-e2e.yaml` で `eraseText: 100` が正常動作する
- [ ] `MAESTRO_RUN_NETWORK_FAULT` 未設定で `auth/16` を実行すると skip される (exit 0)
- [ ] `MAESTRO_RUN_NETWORK_FAULT=1` で `auth/16` を実行すると full assertion が実行される

🤖 Generated with [Claude Code](https://claude.com/claude-code)