### PR TITLE
test(coverage): T03 sample-meal.webp 最適化 + CDN ヘッダ

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,6 +15,15 @@ const nextConfig = {
   async headers() {
     return [
       {
+        source: '/handson-tour/(.*)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
         source: '/(.*)',
         headers: [
           {


### PR DESCRIPTION
## Summary

- `next.config.mjs` に `/handson-tour/(.*)` ルートの長期 CDN キャッシュヘッダを追加
  - `Cache-Control: public, max-age=31536000, immutable`
- `sample-meal.webp` は既に最適化済みのため再エンコード不要

## ファイルサイズ before/after

| ファイル | before | after |
|---|---|---|
| `public/handson-tour/sample-meal.webp` | 94 KB (95,848 bytes) | 変更なし (100KB 以下) |
| `apps/mobile/assets/handson-tour/sample-meal.webp` | 94 KB (95,848 bytes) | 変更なし (100KB 以下) |

> 仕様では「5MB → ~80KB」と記載されていたが、worktree 上のファイルは既に 94KB (<100KB) であったため、
> 受け入れ条件を満たす状態のまま再エンコードをスキップしました。

## Changes

- `next.config.mjs`: `headers()` 配列の先頭に `/handson-tour/(.*)` ルールを追加

## Test plan

- [ ] `npm run typecheck` — パス
- [ ] `npm run lint` — 既存エラー (T03 と無関係) のみ
- [ ] E2E: `tests/e2e/tour/03-step1-photo.spec.ts` で表示確認

Closes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)