### PR TITLE
test(coverage): T13 PR CI に MVP スイート追加

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ on:
         required: false
         default: "https://homegohan-app.vercel.app"
       full_suite:
-        description: "Run full E2E suite (認証必須テスト含む). PR では常に smoke のみ."
+        description: "Run full E2E suite (認証必須テスト含む). PR では常に MVP スイートのみ."
         required: false
         default: "false"
         type: choice
@@ -31,8 +31,8 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # smoke のみなら 10 分で十分。フルスイートは 30 分を上限とする。
-    timeout-minutes: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.full_suite == 'true') && 30 || 10 }}
+    # MVP スイート (01-05 spec) は 15 分。フルスイートは 30 分を上限とする。
+    timeout-minutes: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.full_suite == 'true') && 30 || 15 }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -51,15 +51,16 @@ jobs:
           PLAYWRIGHT_BASE_URL: ${{ github.event.inputs.base_url || 'https://homegohan-app.vercel.app' }}
           E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
           E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
-        # PR では認証不要の smoke テストのみ実行する。
+        # PR では MVP スイート (tests/e2e/01-*.spec.ts 〜 05-*.spec.ts) を実行する。
         # GitHub Actions の Egress IP から Supabase Auth へのログインが
-        # rate limit / 遅延で失敗し 30 分 job timeout する問題を回避するため。
-        # フルスイートは workflow_dispatch で full_suite=true を指定して手動実行する。
+        # rate limit / 遅延で失敗し job timeout する問題を回避するため、
+        # 認証必須テストを含むフルスイートは workflow_dispatch で full_suite=true を
+        # 指定して手動実行する。
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.full_suite }}" = "true" ]; then
             npx playwright test --max-failures=10
           else
-            npx playwright test tests/e2e/smoke.spec.ts
+            npm run test:e2e:mvp
           fi
       - if: always()
         uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing Guide
+
+## PR を出す前のローカルチェック
+
+### E2E テスト (MVP スイート) — 必須
+
+PR を出す前に、必ずローカルで MVP スイートを実行してください。
+
+```bash
+npm run test:e2e:mvp
+```
+
+このコマンドは `tests/e2e/01-*.spec.ts` 〜 `05-*.spec.ts` の 5 spec を実行します。
+
+> **注意**: CI (GitHub Actions) でも PR トリガーで同じ MVP スイートが自動実行されます。
+> ただし CI コスト削減のため、将来的に PR トリガーの E2E を一時停止する場合は
+> ローカル実行結果を PR 本文に貼り付けて確認を取ってください。
+
+### フルスイートを手動実行する場合
+
+認証必須テストを含むフルスイートは GitHub Actions の `workflow_dispatch` で実行します。
+
+1. GitHub リポジトリの Actions タブを開く
+2. `e2e` ワークフローを選択
+3. "Run workflow" から `full_suite=true` を指定して実行
+
+### ローカルで特定 spec だけ実行する場合
+
+```bash
+# 特定の spec のみ
+npx playwright test tests/e2e/01-login.spec.ts
+
+# レポートを UI で確認
+npm run test:e2e:report
+```
+
+## コミットメッセージ
+
+Conventional Commits 形式 + 日本語サマリを使用してください。
+
+```
+feat: 新機能の概要
+fix: バグ修正の概要
+test: テスト追加・修正
+chore: 雑務・設定変更
+```


### PR DESCRIPTION
## 概要

PR トリガーの E2E を smoke 2 件から MVP スイート (01-05 spec) に拡張する。

## 変更内容

- `.github/workflows/e2e.yml`: PR 時に `npm run test:e2e:mvp` を実行するよう変更。timeout を 10 分 → 15 分に拡張
- `CONTRIBUTING.md` 新規作成: PR 前にローカルで `npm run test:e2e:mvp` を必須とする旨を明記

## 動作

- **PR トリガー**: `tests/e2e/01-*.spec.ts` 〜 `05-*.spec.ts` の 5 spec を実行 (認証不要な MVP スイート)
- **workflow_dispatch (full_suite=true)**: 従来通り全スイートを実行
- Playwright report は常に artifact として upload (14 日間保持)

## テスト計画

- [ ] YAML 構文チェック済み (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] `npm run test:e2e:mvp` スクリプトが package.json に存在することを確認済み
- [ ] 既存の workflow_dispatch フルスイート実行パスを維持していることを確認済み

Closes #855