### PR TITLE
test(coverage): T11 TestFlight 煙テスト整備

### DIFF
--- a/apps/mobile/maestro/smoke.yaml
+++ b/apps/mobile/maestro/smoke.yaml
@@ -1,4 +1,141 @@
 appId: com.homegohan.app
 ---
+# smoke.yaml — TestFlight / 実機 smoke テスト
+#
+# カバー範囲: 起動 → ログイン → ホーム表示 → 5 タブ遷移 → ログアウト
+#
+# 環境変数 (実行前に設定):
+#   E2E_USER_EMAIL    : テスト用メールアドレス
+#   E2E_USER_PASSWORD : テスト用パスワード
+#
+# 実行:
+#   maestro test apps/mobile/maestro/smoke.yaml
+#   または apps/mobile ディレクトリから:
+#   npm run test:e2e:smoke
+
+# ─── 1. アプリ起動 ────────────────────────────────────────────────────────────
 - launchApp
-- assertVisible: ".*"
+- extendedWaitUntil:
+    visible:
+      id: "welcome-screen"
+    timeout: 15000
+
+# ─── 2. ログイン ─────────────────────────────────────────────────────────────
+- tapOn:
+    id: "welcome-login-button"
+- extendedWaitUntil:
+    visible:
+      id: "login-screen"
+    timeout: 10000
+
+# メールアドレス入力
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_USER_EMAIL}
+
+# パスワード入力
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_USER_PASSWORD}
+
+# ログイン実行
+- tapOn:
+    id: "login-button"
+
+# ─── 3. ホーム画面表示確認 ───────────────────────────────────────────────────
+- extendedWaitUntil:
+    visible:
+      id: "webview-home"
+    timeout: 20000
+
+# Expo dev build の Console Error/Warning オーバーレイを閉じる (TestFlight では不要だが念のため)
+- tapOn:
+    text: "Dismiss"
+    optional: true
+- tapOn:
+    text: "Minimize"
+    optional: true
+
+# ─── 4. タブ遷移 — 献立 (menus) ─────────────────────────────────────────────
+- tapOn:
+    id: "tab-menus"
+- extendedWaitUntil:
+    visible:
+      id: "webview-menus"
+    timeout: 15000
+
+# ─── 5. タブ遷移 — スキャン (meals) ─────────────────────────────────────────
+# meals タブはラベル非表示のため text でタップ
+- tapOn:
+    text: "スキャン"
+    optional: true
+- waitForAnimationToEnd:
+    timeout: 3000
+- assertVisible:
+    id: "webview-meals"
+
+# ─── 6. タブ遷移 — 比較 (comparison) ────────────────────────────────────────
+- tapOn:
+    id: "tab-comparison"
+- extendedWaitUntil:
+    visible:
+      id: "webview-comparison"
+    timeout: 15000
+
+# ─── 7. タブ遷移 — マイページ (profile) ──────────────────────────────────────
+- tapOn:
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible:
+      id: "webview-profile"
+    timeout: 15000
+
+# ─── 8. ホームへ戻る ─────────────────────────────────────────────────────────
+- tapOn:
+    id: "tab-home"
+- extendedWaitUntil:
+    visible:
+      id: "webview-home"
+    timeout: 15000
+
+# ─── 9. ログアウト ───────────────────────────────────────────────────────────
+# プロファイルタブ → 設定 → ログアウト
+- tapOn:
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible:
+      id: "profile-screen"
+    timeout: 15000
+- scroll
+- waitForAnimationToEnd:
+    timeout: 2000
+- scrollUntilVisible:
+    element:
+      id: "profile-settings-button"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    id: "profile-settings-button"
+- extendedWaitUntil:
+    visible:
+      id: "settings-screen"
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      id: "settings-logout-button"
+    direction: DOWN
+    timeout: 10000
+- tapOn:
+    id: "settings-logout-button"
+- extendedWaitUntil:
+    visible:
+      id: "settings-logout-confirm-button"
+    timeout: 5000
+- tapOn:
+    id: "settings-logout-confirm-button"
+
+# ─── 10. ウェルカム画面に戻ることを確認 ──────────────────────────────────────
+- extendedWaitUntil:
+    visible:
+      id: "welcome-screen"
+    timeout: 15000

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,7 +10,8 @@
     "web": "expo start --web",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:e2e:smoke": "maestro test maestro/smoke.yaml"
   },
   "dependencies": {
     "@expo-google-fonts/noto-sans-jp": "^0.4.3",

--- a/docs/operations/mobile-smoke-test.md
+++ b/docs/operations/mobile-smoke-test.md
@@ -1,0 +1,129 @@
+# Mobile Smoke Test — TestFlight 実機検証手順
+
+TestFlight にビルドを提出した後、実機で Maestro smoke テストを走らせる手順です。
+
+---
+
+## 前提条件
+
+| 要件 | 確認方法 |
+|------|----------|
+| Maestro CLI インストール済み | `maestro --version` |
+| iOS 実機が Mac に接続されている | `idevice_id -l` または Xcode Devices |
+| TestFlight アプリ経由でビルドをインストール済み | TestFlight アプリで最新ビルドを確認 |
+| テスト用アカウントが用意済み | Supabase Auth でオンボーディング完了済みのユーザー |
+
+### Maestro CLI のインストール
+
+```bash
+curl -Ls https://get.maestro.mobile.dev | bash
+```
+
+インストール後、ターミナルを再起動してパスを通してください。
+
+---
+
+## ステップ 1: IPA ビルドと TestFlight 提出
+
+```bash
+# 1. CocoaPods PATH 設定 (Homebrew Ruby 依存)
+export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
+export GEM_PATH="/opt/homebrew/opt/ruby/gems"
+
+# 2. EAS ローカルビルド
+cd apps/mobile
+eas build --platform ios --local --non-interactive --profile production
+
+# 3. TestFlight 提出
+eas submit --platform ios --path <generated .ipa path> --non-interactive
+```
+
+TestFlight でビルドを内部テスター向けに公開し、実機にインストールしてください。
+
+---
+
+## ステップ 2: 環境変数の設定
+
+```bash
+export E2E_USER_EMAIL="<テストユーザーのメールアドレス>"
+export E2E_USER_PASSWORD="<テストユーザーのパスワード>"
+```
+
+テストユーザーは:
+- オンボーディングが完了済み (`onboarding_completed_at` が非 NULL)
+- `admin` / `super_admin` ロールを持たない一般ユーザー
+
+---
+
+## ステップ 3: 実機で Maestro smoke テストを実行
+
+```bash
+# apps/mobile ディレクトリから実行
+cd apps/mobile
+npm run test:e2e:smoke
+
+# または直接 maestro コマンドで実行
+maestro test maestro/smoke.yaml
+```
+
+Maestro は USB 接続または Wi-Fi 経由で実機を自動検出します。複数デバイスが接続されている場合は `--device <device-id>` オプションで指定してください。
+
+```bash
+# デバイス一覧確認
+maestro hierarchy
+
+# 特定デバイスを指定して実行
+maestro --device <device-id> test maestro/smoke.yaml
+```
+
+---
+
+## ステップ 4: 結果確認
+
+smoke テストは以下のフローをカバーします:
+
+1. アプリ起動 → ウェルカム画面表示
+2. ログインボタンタップ → メール + パスワード入力 → ログイン
+3. ホーム画面 (`webview-home`) 表示確認
+4. 献立タブ (`tab-menus`) 遷移確認
+5. スキャンタブ (meals) 遷移確認
+6. 比較タブ (`tab-comparison`) 遷移確認
+7. マイページタブ (`tab-profile`) 遷移確認
+8. ホームに戻る確認
+9. プロファイル → 設定 → ログアウト実行
+10. ウェルカム画面に戻ることを確認
+
+すべてのステップがグリーンであれば、TestFlight ビルドの基本動作は問題ありません。
+
+---
+
+## トラブルシューティング
+
+### Maestro がデバイスを検出できない
+
+- USB ケーブルが正しく接続されているか確認
+- `idevice_id -l` でデバイス UUID が表示されるか確認
+- 実機の「このコンピュータを信頼しますか？」ダイアログを承認
+
+### ログイン画面が表示されない
+
+- `E2E_USER_EMAIL` / `E2E_USER_PASSWORD` が正しく設定されているか確認
+- TestFlight ビルドの `appId` が `com.homegohan.app` であることを確認
+
+### タブ遷移でタイムアウト
+
+- TestFlight ビルドはネットワーク経由で WebView を読み込むため、通常より時間がかかる場合があります
+- 安定した Wi-Fi 接続環境で実行してください
+
+### meals タブが見つからない
+
+- meals (スキャン) タブはタブバーラベルが非表示のため、アイコンの位置で認識されます
+- テストが失敗する場合は `maestro hierarchy` でUI要素ツリーを確認してください
+
+---
+
+## 参考
+
+- Maestro 公式ドキュメント: https://maestro.mobile.dev
+- EAS Build ドキュメント: https://docs.expo.dev/build/introduction/
+- TestFlight 提出フロー: `docs/operations/` 内の `eas-build-submit-handoff-*.md`


### PR DESCRIPTION
## Summary

- `apps/mobile/maestro/smoke.yaml` を実用的な smoke flow に拡充
  - 起動 → ログイン → ホーム表示 → 5 タブ遷移 (home/menus/meals/comparison/profile) → ログアウト の 10 ステップ
  - 既存の `_shared/login.yaml` / `_shared/logout.yaml` パターンを参考に、testID ベースの要素指定で安定性を確保
- `apps/mobile/package.json` に `"test:e2e:smoke": "maestro test maestro/smoke.yaml"` を追加
  - `cd apps/mobile && npm run test:e2e:smoke` で実行可能
- `docs/operations/mobile-smoke-test.md` 新規作成
  - IPA ビルド (`eas build --local`) → TestFlight 提出 (`eas submit`) → 実機 Maestro 実行の 4 ステップ手順
  - 環境変数設定、複数デバイス指定、トラブルシューティングを明記

## Test plan

- [ ] YAML 構文チェック: `python3 -c "import yaml; list(yaml.safe_load_all(open('apps/mobile/maestro/smoke.yaml').read()))"` がエラーなし
- [ ] `cd apps/mobile && npm run test:e2e:smoke` で Maestro が起動することを確認 (実機 or シミュレーター接続時)
- [ ] smoke flow の 10 ステップが実機でグリーンになることを確認

Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)