### PR TITLE
test(coverage): T09 モバイル admin Maestro flow

### DIFF
--- a/apps/mobile/app/(admin)/admin/announcements.tsx
+++ b/apps/mobile/app/(admin)/admin/announcements.tsx
@@ -96,7 +96,7 @@ export default function AdminAnnouncementsPage() {
   }
 
   return (
-    <ScrollView style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
+    <ScrollView testID="admin-announcements-screen" style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
       {/* Header */}
       <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}>
         <Pressable onPress={() => router.back()} hitSlop={8}>
@@ -106,11 +106,12 @@ export default function AdminAnnouncementsPage() {
       </View>
 
       {/* Create Form */}
-      <Card>
+      <Card testID="admin-announcements-create-form">
         <View style={{ gap: spacing.md }}>
           <SectionHeader title="新規作成" />
-          <Input value={title} onChangeText={setTitle} placeholder="タイトル" />
+          <Input testID="admin-announcements-title-input" value={title} onChangeText={setTitle} placeholder="タイトル" />
           <Input
+            testID="admin-announcements-content-input"
             value={content}
             onChangeText={setContent}
             placeholder="内容"
@@ -136,7 +137,7 @@ export default function AdminAnnouncementsPage() {
               {isPublic ? "公開: ON" : "公開: OFF"}
             </Text>
           </Pressable>
-          <Button onPress={create} loading={isSubmitting} disabled={isSubmitting}>
+          <Button testID="admin-announcements-create-button" onPress={create} loading={isSubmitting} disabled={isSubmitting}>
             {isSubmitting ? "作成中..." : "作成"}
           </Button>
         </View>
@@ -164,9 +165,9 @@ export default function AdminAnnouncementsPage() {
       ) : items.length === 0 ? (
         <EmptyState icon={<Ionicons name="megaphone-outline" size={40} color={colors.textMuted} />} message="お知らせがありません。" />
       ) : (
-        <View style={{ gap: spacing.sm }}>
+        <View testID="admin-announcements-list" style={{ gap: spacing.sm }}>
           {items.map((a) => (
-            <Card key={a.id}>
+            <Card key={a.id} testID={`admin-announcement-item-${a.id}`}>
               <View style={{ gap: spacing.sm }}>
                 <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
                   <Ionicons name="megaphone" size={18} color={colors.accent} />

--- a/apps/mobile/app/(admin)/admin/audit-logs.tsx
+++ b/apps/mobile/app/(admin)/admin/audit-logs.tsx
@@ -57,7 +57,7 @@ export default function AdminAuditLogsPage() {
   }, []);
 
   return (
-    <ScrollView style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
+    <ScrollView testID="admin-audit-logs-screen" style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
       {/* Header */}
       <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}>
         <Pressable onPress={() => router.back()} hitSlop={8}>
@@ -71,11 +71,12 @@ export default function AdminAuditLogsPage() {
         <View style={{ gap: spacing.md }}>
           <SectionHeader title="フィルター" />
           <Input
+            testID="admin-audit-logs-filter-input"
             value={actionType}
             onChangeText={setActionType}
             placeholder="action_type で絞り込み（任意）"
           />
-          <Button onPress={load}>
+          <Button testID="admin-audit-logs-search-button" onPress={load}>
             検索
           </Button>
         </View>
@@ -103,9 +104,9 @@ export default function AdminAuditLogsPage() {
       ) : items.length === 0 ? (
         <EmptyState icon={<Ionicons name="document-text-outline" size={40} color={colors.textMuted} />} message="ログがありません。" />
       ) : (
-        <View style={{ gap: spacing.sm }}>
+        <View testID="admin-audit-logs-list" style={{ gap: spacing.sm }}>
           {items.slice(0, 100).map((l) => (
-            <Card key={l.id}>
+            <Card key={l.id} testID={`admin-audit-log-item-${l.id}`}>
               <View style={{ gap: spacing.sm }}>
                 <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
                   <Ionicons name="document-text" size={18} color={colors.textLight} />

--- a/apps/mobile/app/(admin)/admin/index.tsx
+++ b/apps/mobile/app/(admin)/admin/index.tsx
@@ -55,7 +55,7 @@ export default function AdminHomePage() {
   }, []);
 
   return (
-    <ScrollView style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
+    <ScrollView testID="admin-dashboard-screen" style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
       {/* Header */}
       <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
         <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}>
@@ -64,16 +64,16 @@ export default function AdminHomePage() {
           </Pressable>
           <Text style={{ fontSize: 22, fontWeight: "800", color: colors.text }}>Admin Console</Text>
         </View>
-        <Pressable onPress={load} hitSlop={8}>
+        <Pressable testID="admin-dashboard-refresh" onPress={load} hitSlop={8}>
           <Ionicons name="refresh" size={22} color={colors.textMuted} />
         </Pressable>
       </View>
 
       {/* Navigation */}
       <SectionHeader title="Menu" />
-      <View style={{ gap: spacing.sm }}>
+      <View testID="admin-dashboard-nav" style={{ gap: spacing.sm }}>
         {NAV_ITEMS.map((item) => (
-          <Card key={item.href} onPress={() => router.push(item.href as any)}>
+          <Card key={item.href} testID={`admin-nav-${item.label.toLowerCase()}`} onPress={() => router.push(item.href as any)}>
             <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}>
               <View style={{ width: 40, height: 40, borderRadius: radius.md, backgroundColor: item.bg, alignItems: "center", justifyContent: "center" }}>
                 <Ionicons name={item.icon} size={20} color={item.color} />

--- a/apps/mobile/app/(admin)/admin/inquiries.tsx
+++ b/apps/mobile/app/(admin)/admin/inquiries.tsx
@@ -64,7 +64,7 @@ export default function AdminInquiriesPage() {
   }, [status]);
 
   return (
-    <ScrollView style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
+    <ScrollView testID="admin-inquiries-screen" style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
       {/* Header */}
       <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
         <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}>
@@ -73,13 +73,14 @@ export default function AdminInquiriesPage() {
           </Pressable>
           <Text style={{ fontSize: 22, fontWeight: "800", color: colors.text }}>Inquiries</Text>
         </View>
-        <Pressable onPress={load} hitSlop={8}>
+        <Pressable testID="admin-inquiries-refresh" onPress={load} hitSlop={8}>
           <Ionicons name="refresh" size={22} color={colors.textMuted} />
         </Pressable>
       </View>
 
       {/* Status Filter */}
       <ChipSelector
+        testIDPrefix="admin-inquiries-status"
         options={STATUS_OPTIONS}
         selected={status}
         onSelect={setStatus}
@@ -99,9 +100,9 @@ export default function AdminInquiriesPage() {
       ) : items.length === 0 ? (
         <EmptyState icon={<Ionicons name="chatbubbles-outline" size={40} color={colors.textMuted} />} message="問い合わせがありません。" />
       ) : (
-        <View style={{ gap: spacing.sm }}>
+        <View testID="admin-inquiries-list" style={{ gap: spacing.sm }}>
           {items.map((i) => (
-            <Card key={i.id} onPress={() => router.push(`/admin/inquiries/${i.id}`)}>
+            <Card key={i.id} testID={`admin-inquiry-item-${i.id}`} onPress={() => router.push(`/admin/inquiries/${i.id}`)}>
               <View style={{ gap: spacing.sm }}>
                 <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
                   <Ionicons name="chatbubble-ellipses" size={18} color={colors.accent} />

--- a/apps/mobile/app/(admin)/admin/inquiries/[id].tsx
+++ b/apps/mobile/app/(admin)/admin/inquiries/[id].tsx
@@ -93,7 +93,7 @@ export default function AdminInquiryDetailPage() {
   }
 
   return (
-    <ScrollView style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
+    <ScrollView testID="admin-inquiry-detail-screen" style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
       {/* Header */}
       <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}>
         <Pressable onPress={() => router.back()} hitSlop={8}>
@@ -168,7 +168,7 @@ export default function AdminInquiryDetailPage() {
                 style={{ minHeight: 100, textAlignVertical: "top" }}
               />
 
-              <Button onPress={save} loading={isSaving} disabled={isSaving}>
+              <Button testID="admin-inquiry-detail-save-button" onPress={save} loading={isSaving} disabled={isSaving}>
                 {isSaving ? "保存中..." : "保存"}
               </Button>
             </View>

--- a/apps/mobile/app/(admin)/admin/moderation.tsx
+++ b/apps/mobile/app/(admin)/admin/moderation.tsx
@@ -95,7 +95,7 @@ export default function AdminModerationPage() {
   }
 
   return (
-    <ScrollView style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
+    <ScrollView testID="admin-moderation-screen" style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
       {/* Header */}
       <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
         <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}>
@@ -104,13 +104,14 @@ export default function AdminModerationPage() {
           </Pressable>
           <Text style={{ fontSize: 22, fontWeight: "800", color: colors.text }}>Moderation</Text>
         </View>
-        <Pressable onPress={load} hitSlop={8}>
+        <Pressable testID="admin-moderation-refresh" onPress={load} hitSlop={8}>
           <Ionicons name="refresh" size={22} color={colors.textMuted} />
         </Pressable>
       </View>
 
       {/* Status Filter */}
       <ChipSelector
+        testIDPrefix="admin-moderation-status"
         options={STATUS_OPTIONS}
         selected={status}
         onSelect={setStatus}

--- a/apps/mobile/app/(admin)/admin/organizations.tsx
+++ b/apps/mobile/app/(admin)/admin/organizations.tsx
@@ -79,7 +79,7 @@ export default function AdminOrganizationsPage() {
   }
 
   return (
-    <ScrollView style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
+    <ScrollView testID="admin-organizations-screen" style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
       {/* Header */}
       <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
         <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}>
@@ -88,17 +88,17 @@ export default function AdminOrganizationsPage() {
           </Pressable>
           <Text style={{ fontSize: 22, fontWeight: "800", color: colors.text }}>Organizations</Text>
         </View>
-        <Pressable onPress={load} hitSlop={8}>
+        <Pressable testID="admin-organizations-refresh" onPress={load} hitSlop={8}>
           <Ionicons name="refresh" size={22} color={colors.textMuted} />
         </Pressable>
       </View>
 
       {/* Create Form */}
-      <Card>
+      <Card testID="admin-organizations-create-form">
         <View style={{ gap: spacing.md }}>
           <SectionHeader title="新規作成" />
-          <Input value={name} onChangeText={setName} placeholder="組織名" />
-          <Button onPress={create} loading={isSubmitting} disabled={isSubmitting}>
+          <Input testID="admin-organizations-name-input" value={name} onChangeText={setName} placeholder="組織名" />
+          <Button testID="admin-organizations-create-button" onPress={create} loading={isSubmitting} disabled={isSubmitting}>
             {isSubmitting ? "作成中..." : "作成"}
           </Button>
         </View>
@@ -119,9 +119,9 @@ export default function AdminOrganizationsPage() {
       ) : items.length === 0 ? (
         <EmptyState icon={<Ionicons name="business-outline" size={40} color={colors.textMuted} />} message="組織がありません。" />
       ) : (
-        <View style={{ gap: spacing.sm }}>
+        <View testID="admin-organizations-list" style={{ gap: spacing.sm }}>
           {items.map((o) => (
-            <Card key={o.id}>
+            <Card key={o.id} testID={`admin-org-item-${o.id}`}>
               <View style={{ gap: spacing.sm }}>
                 <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
                   <View style={{ width: 40, height: 40, borderRadius: radius.md, backgroundColor: colors.successLight, alignItems: "center", justifyContent: "center" }}>

--- a/apps/mobile/app/(admin)/admin/users.tsx
+++ b/apps/mobile/app/(admin)/admin/users.tsx
@@ -85,7 +85,7 @@ export default function AdminUsersPage() {
   }
 
   return (
-    <ScrollView style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
+    <ScrollView testID="admin-users-screen" style={{ flex: 1, backgroundColor: colors.bg }} contentContainerStyle={{ paddingTop: 56, paddingHorizontal: spacing.lg, paddingBottom: spacing["3xl"], gap: spacing.lg }}>
       {/* Header */}
       <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.md }}>
         <Pressable onPress={() => router.back()} hitSlop={8}>
@@ -99,11 +99,12 @@ export default function AdminUsersPage() {
         <View style={{ gap: spacing.md }}>
           <SectionHeader title="検索" />
           <Input
+            testID="admin-users-search-input"
             value={q}
             onChangeText={setQ}
             placeholder="nickname or id で検索"
           />
-          <Button onPress={load}>
+          <Button testID="admin-users-search-button" onPress={load}>
             検索
           </Button>
         </View>
@@ -122,9 +123,9 @@ export default function AdminUsersPage() {
       ) : items.length === 0 ? (
         <EmptyState icon={<Ionicons name="people-outline" size={40} color={colors.textMuted} />} message="ユーザーがいません。" />
       ) : (
-        <View style={{ gap: spacing.sm }}>
+        <View testID="admin-users-list" style={{ gap: spacing.sm }}>
           {items.map((u) => (
-            <Card key={u.id}>
+            <Card key={u.id} testID={`admin-user-item-${u.id}`}>
               <View style={{ gap: spacing.sm }}>
                 <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.sm }}>
                   <View

--- a/apps/mobile/maestro/flows/_shared/login-as-admin.yaml
+++ b/apps/mobile/maestro/flows/_shared/login-as-admin.yaml
@@ -1,0 +1,32 @@
+appId: com.homegohan.app
+---
+# _shared/login-as-admin.yaml: admin ロールでログインして Admin Console まで遷移する共通フロー
+# 前提: env に E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD が設定されていること
+- launchApp
+- runFlow:
+    file: "./ensure-welcome.yaml"
+- tapOn:
+    text: "ログイン"
+- extendedWaitUntil:
+    visible:
+      id: "login-screen"
+    timeout: 10000
+- tapOn:
+    id: "email-input"
+- inputText: ${E2E_ADMIN_EMAIL}
+- tapOn:
+    id: "password-input"
+- inputText: ${E2E_ADMIN_PASSWORD}
+- tapOn:
+    id: "login-button"
+- extendedWaitUntil:
+    visible:
+      id: "admin-dashboard-screen"
+    timeout: 30000
+# Expo dev build の Console Error/Warning オーバーレイを閉じる
+- tapOn:
+    text: "Dismiss"
+    optional: true
+- tapOn:
+    text: "Minimize"
+    optional: true

--- a/apps/mobile/maestro/flows/admin/01-dashboard.yaml
+++ b/apps/mobile/maestro/flows/admin/01-dashboard.yaml
@@ -1,0 +1,35 @@
+appId: com.homegohan.app
+env:
+  E2E_ADMIN_EMAIL: ${E2E_ADMIN_EMAIL}
+  E2E_ADMIN_PASSWORD: ${E2E_ADMIN_PASSWORD}
+---
+# 01: admin ロールでログイン → Admin Console ダッシュボード表示確認 + リフレッシュ操作
+- runFlow:
+    file: "../_shared/login-as-admin.yaml"
+
+# ダッシュボード画面の表示確認
+- assertVisible:
+    id: "admin-dashboard-screen"
+- assertVisible:
+    text: "Admin Console"
+
+# ナビゲーションメニューの表示確認
+- assertVisible:
+    id: "admin-dashboard-nav"
+
+# 主要操作: リフレッシュボタンをタップ
+- tapOn:
+    id: "admin-dashboard-refresh"
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# スクロールして統計カード表示確認
+- scroll
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# クリーンアップ: ログアウト
+- runFlow:
+    file: "../_shared/back-from-admin.yaml"
+- runFlow:
+    file: "../_shared/logout.yaml"

--- a/apps/mobile/maestro/flows/admin/02-users.yaml
+++ b/apps/mobile/maestro/flows/admin/02-users.yaml
@@ -1,0 +1,53 @@
+appId: com.homegohan.app
+env:
+  E2E_ADMIN_EMAIL: ${E2E_ADMIN_EMAIL}
+  E2E_ADMIN_PASSWORD: ${E2E_ADMIN_PASSWORD}
+---
+# 02: admin → Users 画面表示確認 + 検索操作
+- runFlow:
+    file: "../_shared/login-as-admin.yaml"
+
+# ダッシュボードから Users ナビゲーションをタップ
+- tapOn:
+    id: "admin-nav-users"
+- extendedWaitUntil:
+    visible:
+      id: "admin-users-screen"
+    timeout: 15000
+
+# Users 画面の表示確認
+- assertVisible:
+    text: "Users"
+
+# 主要操作: 検索フィルター入力 → 検索
+- tapOn:
+    id: "admin-users-search-input"
+- inputText: "test"
+- tapOn:
+    id: "admin-users-search-button"
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# スクロールしてユーザーリスト表示確認
+- scroll
+
+# クリーンアップ: ダッシュボードに戻ってログアウト
+- tapOn:
+    text: "Admin Console"
+    optional: true
+- runFlow:
+    when:
+      visible:
+        id: "admin-dashboard-screen"
+    file: "../_shared/back-from-admin.yaml"
+- runFlow:
+    when:
+      visible:
+        id: "admin-users-screen"
+    commands:
+      - tapOn:
+          point: "5%,7%"
+- runFlow:
+    file: "../_shared/back-from-admin.yaml"
+- runFlow:
+    file: "../_shared/logout.yaml"

--- a/apps/mobile/maestro/flows/admin/03-moderation.yaml
+++ b/apps/mobile/maestro/flows/admin/03-moderation.yaml
@@ -1,0 +1,47 @@
+appId: com.homegohan.app
+env:
+  E2E_ADMIN_EMAIL: ${E2E_ADMIN_EMAIL}
+  E2E_ADMIN_PASSWORD: ${E2E_ADMIN_PASSWORD}
+---
+# 03: admin → Moderation 画面表示確認 + ステータスフィルター操作
+- runFlow:
+    file: "../_shared/login-as-admin.yaml"
+
+# ダッシュボードから Moderation ナビゲーションをタップ
+- tapOn:
+    id: "admin-nav-moderation"
+- extendedWaitUntil:
+    visible:
+      id: "admin-moderation-screen"
+    timeout: 15000
+
+# Moderation 画面の表示確認
+- assertVisible:
+    text: "Moderation"
+
+# 主要操作: ステータスフィルターで "Resolved" に切り替え
+- tapOn:
+    id: "admin-moderation-status-resolved"
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# スクロールしてコンテンツ確認
+- scroll
+
+# "Pending" フィルターに戻す
+- tapOn:
+    id: "admin-moderation-status-pending"
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# クリーンアップ: ダッシュボードに戻ってログアウト
+- tapOn:
+    point: "5%,7%"
+- extendedWaitUntil:
+    visible:
+      id: "admin-dashboard-screen"
+    timeout: 10000
+- runFlow:
+    file: "../_shared/back-from-admin.yaml"
+- runFlow:
+    file: "../_shared/logout.yaml"

--- a/apps/mobile/maestro/flows/admin/04-audit-logs.yaml
+++ b/apps/mobile/maestro/flows/admin/04-audit-logs.yaml
@@ -1,0 +1,53 @@
+appId: com.homegohan.app
+env:
+  E2E_ADMIN_EMAIL: ${E2E_ADMIN_EMAIL}
+  E2E_ADMIN_PASSWORD: ${E2E_ADMIN_PASSWORD}
+---
+# 04: admin → Audit Logs 画面表示確認 + アクションタイプフィルター操作
+- runFlow:
+    file: "../_shared/login-as-admin.yaml"
+
+# ダッシュボードから Audit Logs ナビゲーションをタップ
+- tapOn:
+    id: "admin-nav-audit logs"
+- extendedWaitUntil:
+    visible:
+      id: "admin-audit-logs-screen"
+    timeout: 15000
+
+# Audit Logs 画面の表示確認
+- assertVisible:
+    text: "Audit Logs"
+
+# 主要操作: action_type フィルター入力 → 検索
+- tapOn:
+    id: "admin-audit-logs-filter-input"
+- inputText: "user_ban"
+- tapOn:
+    id: "admin-audit-logs-search-button"
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# スクロールしてログリスト確認
+- scroll
+
+# フィルタークリアして再検索
+- tapOn:
+    id: "admin-audit-logs-filter-input"
+- clearText
+- tapOn:
+    id: "admin-audit-logs-search-button"
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# クリーンアップ: ダッシュボードに戻ってログアウト
+- tapOn:
+    point: "5%,7%"
+- extendedWaitUntil:
+    visible:
+      id: "admin-dashboard-screen"
+    timeout: 10000
+- runFlow:
+    file: "../_shared/back-from-admin.yaml"
+- runFlow:
+    file: "../_shared/logout.yaml"

--- a/apps/mobile/maestro/flows/admin/05-announcements.yaml
+++ b/apps/mobile/maestro/flows/admin/05-announcements.yaml
@@ -1,0 +1,49 @@
+appId: com.homegohan.app
+env:
+  E2E_ADMIN_EMAIL: ${E2E_ADMIN_EMAIL}
+  E2E_ADMIN_PASSWORD: ${E2E_ADMIN_PASSWORD}
+---
+# 05: admin → Announcements 画面表示確認 + お知らせ作成フォーム操作
+- runFlow:
+    file: "../_shared/login-as-admin.yaml"
+
+# ダッシュボードから Announcements ナビゲーションをタップ
+- tapOn:
+    id: "admin-nav-announcements"
+- extendedWaitUntil:
+    visible:
+      id: "admin-announcements-screen"
+    timeout: 15000
+
+# Announcements 画面の表示確認
+- assertVisible:
+    text: "Announcements"
+
+# 作成フォームの表示確認
+- assertVisible:
+    id: "admin-announcements-create-form"
+
+# 主要操作: タイトルと内容を入力する（実際の作成は副作用が大きいためフォーム入力まで）
+- tapOn:
+    id: "admin-announcements-title-input"
+- inputText: "E2E テスト用お知らせ"
+- tapOn:
+    id: "admin-announcements-content-input"
+- inputText: "これは Maestro E2E テストによる自動入力です。"
+
+# スクロールして一覧確認
+- scroll
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# クリーンアップ: ダッシュボードに戻ってログアウト
+- tapOn:
+    point: "5%,7%"
+- extendedWaitUntil:
+    visible:
+      id: "admin-dashboard-screen"
+    timeout: 10000
+- runFlow:
+    file: "../_shared/back-from-admin.yaml"
+- runFlow:
+    file: "../_shared/logout.yaml"

--- a/apps/mobile/maestro/flows/admin/06-inquiries.yaml
+++ b/apps/mobile/maestro/flows/admin/06-inquiries.yaml
@@ -1,0 +1,69 @@
+appId: com.homegohan.app
+env:
+  E2E_ADMIN_EMAIL: ${E2E_ADMIN_EMAIL}
+  E2E_ADMIN_PASSWORD: ${E2E_ADMIN_PASSWORD}
+---
+# 06: admin → Inquiries 一覧表示確認 + ステータスフィルター + 詳細画面遷移
+- runFlow:
+    file: "../_shared/login-as-admin.yaml"
+
+# ダッシュボードから Inquiries ナビゲーションをタップ
+- tapOn:
+    id: "admin-nav-inquiries"
+- extendedWaitUntil:
+    visible:
+      id: "admin-inquiries-screen"
+    timeout: 15000
+
+# Inquiries 画面の表示確認
+- assertVisible:
+    text: "Inquiries"
+
+# 主要操作: ステータスフィルターで "In Progress" に切り替え
+- tapOn:
+    id: "admin-inquiries-status-in_progress"
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# "Pending" フィルターに戻す
+- tapOn:
+    id: "admin-inquiries-status-pending"
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# リスト表示確認（データがある場合は先頭アイテムをタップして詳細へ）
+- runFlow:
+    when:
+      visible:
+        id: "admin-inquiries-list"
+    commands:
+      - tapOn:
+          id: "admin-inquiries-list"
+      - waitForAnimationToEnd:
+          timeout: 3000
+      # 詳細画面が開いた場合は戻る
+      - runFlow:
+          when:
+            visible:
+              id: "admin-inquiry-detail-screen"
+          commands:
+            - assertVisible:
+                text: "Inquiry Detail"
+            - tapOn:
+                point: "5%,7%"
+            - extendedWaitUntil:
+                visible:
+                  id: "admin-inquiries-screen"
+                timeout: 10000
+
+# クリーンアップ: ダッシュボードに戻ってログアウト
+- tapOn:
+    point: "5%,7%"
+- extendedWaitUntil:
+    visible:
+      id: "admin-dashboard-screen"
+    timeout: 10000
+- runFlow:
+    file: "../_shared/back-from-admin.yaml"
+- runFlow:
+    file: "../_shared/logout.yaml"

--- a/apps/mobile/maestro/flows/admin/07-organizations.yaml
+++ b/apps/mobile/maestro/flows/admin/07-organizations.yaml
@@ -1,0 +1,52 @@
+appId: com.homegohan.app
+env:
+  E2E_ADMIN_EMAIL: ${E2E_ADMIN_EMAIL}
+  E2E_ADMIN_PASSWORD: ${E2E_ADMIN_PASSWORD}
+---
+# 07: admin → Organizations 画面表示確認 + 組織作成フォーム操作
+- runFlow:
+    file: "../_shared/login-as-admin.yaml"
+
+# ダッシュボードから Organizations ナビゲーションをタップ
+- tapOn:
+    id: "admin-nav-organizations"
+- extendedWaitUntil:
+    visible:
+      id: "admin-organizations-screen"
+    timeout: 15000
+
+# Organizations 画面の表示確認
+- assertVisible:
+    text: "Organizations"
+
+# 作成フォームの表示確認
+- assertVisible:
+    id: "admin-organizations-create-form"
+
+# 主要操作: 組織名入力（実際の作成は副作用があるためフォーム入力まで）
+- tapOn:
+    id: "admin-organizations-name-input"
+- inputText: "E2E テスト組織"
+
+# スクロールして組織リスト確認
+- scroll
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# リフレッシュ操作
+- tapOn:
+    id: "admin-organizations-refresh"
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# クリーンアップ: ダッシュボードに戻ってログアウト
+- tapOn:
+    point: "5%,7%"
+- extendedWaitUntil:
+    visible:
+      id: "admin-dashboard-screen"
+    timeout: 10000
+- runFlow:
+    file: "../_shared/back-from-admin.yaml"
+- runFlow:
+    file: "../_shared/logout.yaml"


### PR DESCRIPTION
## Summary

- `apps/mobile/maestro/flows/admin/` ディレクトリを新設し、admin 7 画面の Maestro flow を追加
- `_shared/login-as-admin.yaml` を追加し、admin ログイン → Admin Console 到達を共通フロー化
- 各 admin 画面に `testID` を追加し、Maestro から要素を特定可能にした

## 追加 flow 一覧

| ファイル | 対象画面 | 主要操作 |
|---|---|---|
| `01-dashboard.yaml` | `admin/index.tsx` | リフレッシュボタン tap + スクロール |
| `02-users.yaml` | `admin/users.tsx` | 検索入力 + 検索ボタン tap |
| `03-moderation.yaml` | `admin/moderation.tsx` | ステータスフィルター切り替え |
| `04-audit-logs.yaml` | `admin/audit-logs.tsx` | action_type フィルター入力 + 検索 |
| `05-announcements.yaml` | `admin/announcements.tsx` | 作成フォーム入力 (title + content) |
| `06-inquiries.yaml` | `admin/inquiries.tsx` + `[id].tsx` | ステータスフィルター + 詳細画面遷移 |
| `07-organizations.yaml` | `admin/organizations.tsx` | 組織名入力 + リフレッシュ |

## 追加 testID 一覧

- `admin-dashboard-screen`, `admin-dashboard-nav`, `admin-nav-{label}` など各画面ルートと主要要素

## Test plan

- [ ] シミュレータを起動し `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` を設定
- [ ] `maestro test apps/mobile/maestro/flows/admin/` で全 flow が pass することを確認

Closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)