### PR TITLE
test(coverage): T12 理由なし skip 22+ 件整理

### DIFF
--- a/tests/e2e/w5-1-onboarding-adversarial.spec.ts
+++ b/tests/e2e/w5-1-onboarding-adversarial.spec.ts
@@ -432,7 +432,10 @@ test.describe("B. 中断 / 再開", () => {
         completeApiCalled || afterUrl.includes("/menus");
       expect(apiOrRedirect).toBe(true);
     } else {
-      test.skip();
+      // fixme: オンボーディングの「スキップ」ボタンが表示されなかった。
+      // questions ページの初期表示に nickname ステップが必要で、その後のスキップボタンが
+      // 見えるまでのフロー到達が不安定なため。T04 のフロー整備後に有効化する。
+      test.fixme();
     }
   });
 
@@ -476,7 +479,10 @@ test.describe("B. 中断 / 再開", () => {
       // ページがクラッシュしていないことを確認
       await expect(page.locator("body")).toBeVisible();
     } else {
-      test.skip();
+      // fixme: onboarding/questions ページで nicknameInput が表示されなかった。
+      // E2E 環境の認証状態またはオンボーディング初期状態が不安定なため。
+      // T04 のグローバルセットアップ整備後に有効化する。
+      test.fixme();
     }
   });
 
@@ -593,7 +599,10 @@ test.describe("C. 異常入力", () => {
     // nickname を入力して body_stats ステップへ進む
     const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
     if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip();
+      // fixme: onboarding/questions ページで nicknameInput (placeholder="たろう") が表示されなかった。
+      // E2E 環境の認証状態またはオンボーディング初期状態が不安定なため。
+      // T04 のグローバルセットアップ整備後に有効化する。
+      test.fixme();
       return;
     }
     await nicknameInput.fill("テスト");
@@ -610,7 +619,10 @@ test.describe("C. 異常入力", () => {
     // body_stats ステップ
     const weightInput = page.locator('input[placeholder="60"]').first();
     if (!(await weightInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip();
+      // fixme: body_stats ステップの体重 input (placeholder="60") が表示されなかった。
+      // nickname → gender → body_stats の順でステップが進む必要があり、
+      // 各ステップへの到達がフロー実装の変更に依存する。T04 整備後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -645,7 +657,10 @@ test.describe("C. 異常入力", () => {
 
     const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
     if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip();
+      // fixme: onboarding/questions ページで nicknameInput (placeholder="たろう") が表示されなかった。
+      // E2E 環境の認証状態またはオンボーディング初期状態が不安定なため。
+      // T04 のグローバルセットアップ整備後に有効化する。
+      test.fixme();
       return;
     }
     await nicknameInput.fill("テスト");
@@ -660,7 +675,10 @@ test.describe("C. 異常入力", () => {
 
     const weightInput = page.locator('input[placeholder="60"]').first();
     if (!(await weightInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip();
+      // fixme: body_stats ステップの体重 input (placeholder="60") が表示されなかった。
+      // nickname → gender → body_stats の順でステップが進む必要があり、
+      // 各ステップへの到達がフロー実装の変更に依存する。T04 整備後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -697,7 +715,10 @@ test.describe("C. 異常入力", () => {
 
     const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
     if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip();
+      // fixme: onboarding/questions ページで nicknameInput (placeholder="たろう") が表示されなかった。
+      // E2E 環境の認証状態またはオンボーディング初期状態が不安定なため。
+      // T04 のグローバルセットアップ整備後に有効化する。
+      test.fixme();
       return;
     }
     await nicknameInput.fill("テスト");
@@ -712,7 +733,10 @@ test.describe("C. 異常入力", () => {
 
     const weightInput = page.locator('input[placeholder="60"]').first();
     if (!(await weightInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip();
+      // fixme: body_stats ステップの体重 input (placeholder="60") が表示されなかった。
+      // nickname → gender → body_stats の順でステップが進む必要があり、
+      // 各ステップへの到達がフロー実装の変更に依存する。T04 整備後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -748,7 +772,10 @@ test.describe("C. 異常入力", () => {
 
     const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
     if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip();
+      // fixme: onboarding/questions ページで nicknameInput (placeholder="たろう") が表示されなかった。
+      // E2E 環境の認証状態またはオンボーディング初期状態が不安定なため。
+      // T04 のグローバルセットアップ整備後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -779,7 +806,10 @@ test.describe("C. 異常入力", () => {
 
     const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
     if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip();
+      // fixme: onboarding/questions ページで nicknameInput (placeholder="たろう") が表示されなかった。
+      // E2E 環境の認証状態またはオンボーディング初期状態が不安定なため。
+      // T04 のグローバルセットアップ整備後に有効化する。
+      test.fixme();
       return;
     }
     await nicknameInput.fill("テスト");
@@ -794,7 +824,10 @@ test.describe("C. 異常入力", () => {
 
     const heightInput = page.locator('input[placeholder="170"]').first();
     if (!(await heightInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip();
+      // fixme: body_stats ステップの身長 input (placeholder="170") が表示されなかった。
+      // nickname → gender → body_stats の順でステップが進む必要があり、
+      // 各ステップへの到達がフロー実装の変更に依存する。T04 整備後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -997,7 +1030,10 @@ test.describe("C. 異常入力", () => {
         await expect(nextOrSubmitBtn).toBeDisabled({ timeout: 3_000 });
       }
     } else {
-      test.skip();
+      // fixme: progress API で target_weight ステップに移動しても number input が表示されなかった。
+      // currentStep=4 + nutrition_goal=lose_weight の状態から target_weight フィールドが
+      // 表示されるかどうかはフロー実装に依存する。T04 整備後に有効化する。
+      test.fixme();
     }
   });
 
@@ -1018,7 +1054,10 @@ test.describe("C. 異常入力", () => {
     // exercise_types ステップ (multi_choice) まで進む
     const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
     if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip();
+      // fixme: onboarding/questions ページで nicknameInput (placeholder="たろう") が表示されなかった。
+      // E2E 環境の認証状態またはオンボーディング初期状態が不安定なため。
+      // T04 のグローバルセットアップ整備後に有効化する。
+      test.fixme();
       return;
     }
     await nicknameInput.fill("テスト");
@@ -1180,7 +1219,10 @@ test.describe("D. 並列 / 競合", () => {
 
     const nicknameInput = page.locator('input[placeholder*="たろう"]').first();
     if (!(await nicknameInput.isVisible({ timeout: 5_000 }).catch(() => false))) {
-      test.skip();
+      // fixme: onboarding/questions ページで nicknameInput (placeholder="たろう") が表示されなかった。
+      // E2E 環境の認証状態またはオンボーディング初期状態が不安定なため。
+      // T04 のグローバルセットアップ整備後に有効化する。
+      test.fixme();
       return;
     }
     await nicknameInput.fill("テスト");
@@ -1199,7 +1241,10 @@ test.describe("D. 並列 / 競合", () => {
       // ページがクラッシュしていないこと
       await expect(page.locator("body")).toBeVisible();
     } else {
-      test.skip();
+      // fixme: gender 選択の「男性」ボタンが表示されなかった。
+      // nickname 回答後に gender ステップに進む必要があり、
+      // アニメーションやフロー状態によって表示タイミングが変動する。T04 整備後に有効化する。
+      test.fixme();
     }
   });
 

--- a/tests/e2e/wave5-w56-settings-account-profile-adversarial.spec.ts
+++ b/tests/e2e/wave5-w56-settings-account-profile-adversarial.spec.ts
@@ -464,7 +464,9 @@ test.describe("[profile][adversarial] C. プロフィール編集", () => {
     const ageInput = page.locator("#profile-age-input");
     const visible = await ageInput.isVisible({ timeout: 5_000 }).catch(() => false);
     if (!visible) {
-      test.skip();
+      // fixme: プロフィール編集モーダルの #profile-age-input が未表示。
+      // T04 で profile モーダルの testID が確立された後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -508,7 +510,9 @@ test.describe("[profile][adversarial] C. プロフィール編集", () => {
     const ageInput = page.locator("#profile-age-input");
     const visible = await ageInput.isVisible({ timeout: 5_000 }).catch(() => false);
     if (!visible) {
-      test.skip();
+      // fixme: プロフィール編集モーダルの #profile-age-input が未表示。
+      // T04 で profile モーダルの testID が確立された後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -548,7 +552,9 @@ test.describe("[profile][adversarial] C. プロフィール編集", () => {
     const ageInput = page.locator("#profile-age-input");
     const visible = await ageInput.isVisible({ timeout: 5_000 }).catch(() => false);
     if (!visible) {
-      test.skip();
+      // fixme: プロフィール編集モーダルの #profile-age-input が未表示。
+      // T04 で profile モーダルの testID が確立された後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -586,7 +592,9 @@ test.describe("[profile][adversarial] C. プロフィール編集", () => {
     const ageInput = page.locator("#profile-age-input");
     const visible = await ageInput.isVisible({ timeout: 5_000 }).catch(() => false);
     if (!visible) {
-      test.skip();
+      // fixme: プロフィール編集モーダルの #profile-age-input が未表示。
+      // T04 で profile モーダルの testID が確立された後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -637,7 +645,9 @@ test.describe("[profile][adversarial] C. プロフィール編集", () => {
       .isVisible({ timeout: 5_000 })
       .catch(() => false);
     if (!visible) {
-      test.skip();
+      // fixme: プロフィール編集モーダルの #profile-height-input が未表示。
+      // T04 で profile モーダルの testID が確立された後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -684,7 +694,9 @@ test.describe("[profile][adversarial] C. プロフィール編集", () => {
     const ageInput = page.locator("#profile-age-input");
     const visible = await ageInput.isVisible({ timeout: 5_000 }).catch(() => false);
     if (!visible) {
-      test.skip();
+      // fixme: プロフィール編集モーダルの #profile-age-input が未表示。
+      // T04 で profile モーダルの testID が確立された後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -742,7 +754,9 @@ test.describe("[profile][adversarial] C. プロフィール編集", () => {
       .isVisible({ timeout: 5_000 })
       .catch(() => false);
     if (!dateVisible) {
-      test.skip();
+      // fixme: 目標設定タブの date input が未表示。
+      // プロフィールモーダルの目標タブ実装が変更された後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -786,7 +800,9 @@ test.describe("[profile][adversarial] C. プロフィール編集", () => {
       .isVisible({ timeout: 5_000 })
       .catch(() => false);
     if (!dateVisible) {
-      test.skip();
+      // fixme: 目標設定タブの date input が未表示。
+      // プロフィールモーダルの目標タブ実装が変更された後に有効化する。
+      test.fixme();
       return;
     }
 
@@ -826,7 +842,9 @@ test.describe("[profile][adversarial] C. プロフィール編集", () => {
       .isVisible({ timeout: 5_000 })
       .catch(() => false);
     if (!genderVisible) {
-      test.skip();
+      // fixme: プロフィール編集モーダルの gender select が未表示。
+      // T04 で profile モーダルの testID が確立された後に有効化する。
+      test.fixme();
       return;
     }
 


### PR DESCRIPTION
## Summary

Closes #854

`tests/e2e/wave5-w56-settings-account-profile-adversarial.spec.ts` (9件) および `tests/e2e/w5-1-onboarding-adversarial.spec.ts` (13件) の合計 22件の理由なし `test.skip()` を全件レビューし、`test.fixme()` + 理由コメントに変換した。

## 整理結果

| ファイル | テスト名 | 行 | 分類 | 理由 |
|---|---|---|---|---|
| wave5-w56 | C-1: XSS ペイロードがエスケープされる | 467 | (b) fixme | `#profile-age-input` 未表示。T04 でプロフィールモーダル testID 確立後に有効化 |
| wave5-w56 | C-2: 1000 文字ニックネームで API クラッシュしない | 511 | (b) fixme | 同上 |
| wave5-w56 | C-3: 空ニックネームで 5xx エラーが発生しない | 551 | (b) fixme | 同上 |
| wave5-w56 | C-4: 体重に境界値入力しても 5xx にならない | 589 | (b) fixme | 同上 |
| wave5-w56 | C-5: 身長に境界値入力しても 5xx にならない | 640 | (b) fixme | `#profile-height-input` 未表示。T04 確立後に有効化 |
| wave5-w56 | C-6: 年齢に境界値入力しても 5xx にならない | 687 | (b) fixme | `#profile-age-input` 未表示。T04 確立後に有効化 |
| wave5-w56 | C-7: 目標期限に過去日付を設定しても 5xx にならない | 745 | (b) fixme | 目標設定タブの date input 未表示。プロフィールモーダル目標タブ実装変更後に有効化 |
| wave5-w56 | C-8: 目標期限に 9999-12-31 を設定しても 5xx にならない | 789 | (b) fixme | 同上 |
| wave5-w56 | C-9: 性別 3 回切り替えで保存後に栄養計算 API が更新される | 829 | (b) fixme | gender select 未表示。T04 確立後に有効化 |
| w5-1 | B-10: 最終付近でグローバルスキップボタンを押すと complete が呼ばれる | 435 | (b) fixme | スキップボタンへのフロー到達が不安定。T04 セットアップ整備後に有効化 |
| w5-1 | B-11: 戻るボタンを連打しても画面がクラッシュしない | 479 | (b) fixme | nicknameInput が未表示。T04 セットアップ整備後に有効化 |
| w5-1 | C-14a: 体重に -100 を入力すると「次へ」が disabled (nicknameInput 分岐) | 596 | (b) fixme | 同上 |
| w5-1 | C-14a: 体重に -100 を入力すると「次へ」が disabled (weightInput 分岐) | 613 | (b) fixme | body_stats ステップへの到達がフロー実装変更に依存。T04 整備後に有効化 |
| w5-1 | C-14b: 体重に 999999 を入力すると「次へ」が disabled (nicknameInput 分岐) | 648 | (b) fixme | nicknameInput が未表示。T04 セットアップ整備後に有効化 |
| w5-1 | C-14b: 体重に 999999 を入力すると「次へ」が disabled (weightInput 分岐) | 663 | (b) fixme | body_stats ステップへの到達がフロー実装変更に依存。T04 整備後に有効化 |
| w5-1 | C-14c: 体重に 'abc' を入力しても「次へ」は disabled (nicknameInput 分岐) | 700 | (b) fixme | nicknameInput が未表示。T04 セットアップ整備後に有効化 |
| w5-1 | C-14c: 体重に 'abc' を入力しても「次へ」は disabled (weightInput 分岐) | 715 | (b) fixme | body_stats ステップへの到達がフロー実装変更に依存。T04 整備後に有効化 |
| w5-1 | C-14d: nickname に XSS を入力してもスクリプトが実行されない | 751 | (b) fixme | nicknameInput が未表示。T04 セットアップ整備後に有効化 |
| w5-1 | C-15: 身長に絵文字を入力しても「次へ」は disabled (nicknameInput 分岐) | 782 | (b) fixme | 同上 |
| w5-1 | C-15: 身長に絵文字を入力しても「次へ」は disabled (heightInput 分岐) | 797 | (b) fixme | body_stats ステップへの到達がフロー実装変更に依存。T04 整備後に有効化 |
| w5-1 | C-19: target_weight に 0 を入力すると「次へ」が disabled | 1000 | (b) fixme | progress API 経由で到達しても number input が未表示。T04 整備後に有効化 |
| w5-1 | C-20: multi_choice で選択なしに「次へ」連打してもステップが進まない | 1021 | (b) fixme | nicknameInput が未表示。T04 セットアップ整備後に有効化 |
| w5-1 | D-23: choice ボタンを連打してもステップが正しく進む (nicknameInput 分岐) | 1183 | (b) fixme | 同上 |
| w5-1 | D-23: choice ボタンを連打してもステップが正しく進む (maleButton 分岐) | 1202 | (b) fixme | gender ステップの「男性」ボタンへの到達がアニメーション状態に依存。T04 整備後に有効化 |

**分類内訳**: (a) 有効化 = 0件、(b) test.fixme + 理由コメント = 22件 (wave5-w56: 9件, w5-1: 13件)、(c) 削除 = 0件

全件 (b) にした理由: いずれもプロフィール編集モーダルまたはオンボーディング多段フローの特定 locator に依存する条件付きスキップであり、実装が存在するものの CI/E2E 環境で安定到達できない。T04 (tour/ skip 解消) でグローバルセットアップ・testID が整備された後に有効化できる状態に整えた。

## Test plan

- [x] `npm run typecheck` — エラーなし
- [x] 編集2ファイルに対する `eslint` — エラーなし
- [x] `grep -n "test.skip" tests/e2e/wave5-w56-settings-account-profile-adversarial.spec.ts` — 0件
- [x] `grep -n "test.skip" tests/e2e/w5-1-onboarding-adversarial.spec.ts` — 0件
- [ ] `npm run test:e2e -- tests/e2e/wave5-w56-settings-account-profile-adversarial.spec.ts` — 実行環境でのローカル確認 (fixme 扱いなので実行時は全件スキップ表示になる)