### PR TITLE
test(coverage): T16 AI チャット abort / Push 通知テスト

### DIFF
--- a/apps/mobile/__tests__/ai/chat-stream-abort.test.tsx
+++ b/apps/mobile/__tests__/ai/chat-stream-abort.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * chat-stream-abort.test.tsx
+ * AbortController.abort() による stream 中断 / fetch ハングタイムアウトのテスト
+ */
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+
+// --- モック設定 (chat-stream.test.tsx と同パターン) ---
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+const mockDel = jest.fn();
+
+jest.mock('../../src/lib/api', () => ({
+  getApi: () => ({
+    get: mockGet,
+    post: mockPost,
+    del: mockDel,
+  }),
+  getApiBaseUrl: () => 'http://localhost:3000',
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ sessionId: 'test-session-id' }),
+  router: {
+    back: jest.fn(),
+    push: jest.fn(),
+  },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons',
+}));
+
+jest.mock('expo-image-picker', () => ({
+  requestMediaLibraryPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+  SafeAreaProvider: ({ children }: { children: React.ReactNode }) => children,
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// --- コンポーネント import (モック設定後) ---
+import React from 'react';
+import { Pressable } from 'react-native';
+import AiSessionPage from '../../app/ai/[sessionId]';
+import { supabase } from '../../src/lib/supabase';
+
+/** テキスト入力欄を見つけて文字を入力し、送信ボタンを押す */
+async function typeAndSend(inputText: string) {
+  const input = screen.getByPlaceholderText('相談内容を入力...');
+  fireEvent.changeText(input, inputText);
+  const pressables = screen.UNSAFE_getAllByType(Pressable);
+  await act(async () => {
+    fireEvent.press(pressables[pressables.length - 1]);
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  (supabase.auth.getSession as jest.Mock).mockResolvedValue({
+    data: { session: { access_token: 'test-token' } },
+  });
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('AiSessionPage — AbortController abort() による stream 中断', () => {
+  it('AbortController.abort() が呼ばれると AbortError が発生しタイムアウトメッセージが表示される', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+
+    // fetch が AbortError をスローするシミュレーション
+    (global.fetch as jest.Mock).mockImplementationOnce(
+      (_url: string, opts: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          // signal の abort イベントをリッスンして reject する
+          const signal = opts.signal as AbortSignal;
+          if (signal) {
+            signal.addEventListener('abort', () => {
+              const err = new DOMException('The operation was aborted.', 'AbortError');
+              reject(err);
+            });
+          }
+        })
+    );
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await typeAndSend('タイムアウトテスト');
+
+    // 楽観的メッセージが表示される
+    await waitFor(() => {
+      expect(screen.getByText('タイムアウトテスト')).toBeTruthy();
+    });
+
+    // 26秒タイムアウトを発火させる
+    await act(async () => {
+      jest.advanceTimersByTime(26000);
+    });
+
+    // タイムアウトエラーメッセージが表示される
+    await waitFor(() => {
+      expect(screen.getByText(/タイムアウト/)).toBeTruthy();
+    });
+  });
+
+  it('abort 後に楽観的メッセージが削除される', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+
+    (global.fetch as jest.Mock).mockImplementationOnce(
+      (_url: string, opts: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = opts.signal as AbortSignal;
+          if (signal) {
+            signal.addEventListener('abort', () => {
+              const err = new DOMException('The operation was aborted.', 'AbortError');
+              reject(err);
+            });
+          }
+        })
+    );
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await typeAndSend('削除確認テスト');
+
+    // 楽観的メッセージが一時的に表示される
+    await waitFor(() => {
+      expect(screen.getByText('削除確認テスト')).toBeTruthy();
+    });
+
+    // 26秒タイムアウトを発火させる
+    await act(async () => {
+      jest.advanceTimersByTime(26000);
+    });
+
+    // abort 後、楽観的メッセージが削除される
+    await waitFor(() => {
+      expect(screen.queryByText('削除確認テスト')).toBeNull();
+    });
+  });
+});
+
+describe('AiSessionPage — fetch ハングタイムアウト (26秒)', () => {
+  it('fetch が 26 秒応答しない場合、タイムアウト後にエラー状態になる', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+
+    // fetch が永久にハング (26秒タイムアウトで abort される)
+    (global.fetch as jest.Mock).mockImplementationOnce(
+      (_url: string, opts: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = opts.signal as AbortSignal;
+          if (signal) {
+            signal.addEventListener('abort', () => {
+              reject(new DOMException('The operation was aborted.', 'AbortError'));
+            });
+          }
+          // resolve しない = ハング状態
+        })
+    );
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await typeAndSend('ハングテスト');
+
+    // 25秒ではまだタイムアウトしていない
+    await act(async () => {
+      jest.advanceTimersByTime(25999);
+    });
+
+    // まだエラーは表示されていない（タイムアウトが発火していない）
+    // (楽観的メッセージが表示中)
+    expect(screen.queryByText(/タイムアウト/)).toBeNull();
+
+    // 26秒でタイムアウト発火
+    await act(async () => {
+      jest.advanceTimersByTime(1);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/タイムアウト/)).toBeTruthy();
+    });
+  });
+
+  it('fetch に signal が渡され、26秒タイムアウト設定が有効になっている', async () => {
+    mockGet.mockResolvedValueOnce({ messages: [] });
+
+    let capturedSignal: AbortSignal | undefined;
+    (global.fetch as jest.Mock).mockImplementationOnce(
+      (_url: string, opts: RequestInit) => {
+        capturedSignal = opts.signal as AbortSignal;
+        // すぐに成功レスポンスを返す
+        const text = 'data: [DONE]\n';
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode(text));
+            controller.close();
+          },
+        });
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          body: stream,
+          text: () => Promise.resolve(text),
+        } as unknown as Response);
+      }
+    );
+
+    render(<AiSessionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('相談内容を入力...')).toBeTruthy();
+    });
+
+    await typeAndSend('signal 確認テスト');
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    // signal が存在し、AbortSignal であることを確認
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    // タイムアウト前は abort されていない
+    expect(capturedSignal!.aborted).toBe(false);
+  });
+});

--- a/apps/mobile/__tests__/lib/push-notifications.test.ts
+++ b/apps/mobile/__tests__/lib/push-notifications.test.ts
@@ -1,0 +1,175 @@
+/**
+ * push-notifications.test.ts
+ * apps/mobile/src/lib/pushNotifications.ts のテスト
+ * - 権限拒否 → null 返却
+ * - Supabase upsert 成功 → トークン保存確認
+ * - Supabase upsert 失敗 → エラーをスローする
+ * - Android チャンネル作成パス
+ * - isDevice=false → null 返却
+ */
+
+// --- モック設定 ---
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+    from: jest.fn(() => ({ upsert: jest.fn().mockResolvedValue({ error: null }) })),
+  },
+}));
+
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn(),
+  requestPermissionsAsync: jest.fn(),
+  getExpoPushTokenAsync: jest.fn(),
+  setNotificationChannelAsync: jest.fn(),
+  AndroidImportance: { DEFAULT: 3 },
+}));
+
+jest.mock('expo-device', () => ({
+  __esModule: true,
+  isDevice: true,
+}));
+
+jest.mock('expo-constants', () => ({
+  default: {},
+}));
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+}));
+
+import * as Notifications from 'expo-notifications';
+import { supabase } from '../../src/lib/supabase';
+import { registerAndSaveExpoPushToken } from '../../src/lib/pushNotifications';
+
+// 型キャスト用
+const mockGetUser = supabase.auth.getUser as jest.Mock;
+const mockFrom = supabase.from as jest.Mock;
+const mockGetPermissionsAsync = Notifications.getPermissionsAsync as jest.Mock;
+const mockRequestPermissionsAsync = Notifications.requestPermissionsAsync as jest.Mock;
+const mockGetExpoPushTokenAsync = Notifications.getExpoPushTokenAsync as jest.Mock;
+const mockSetNotificationChannelAsync = Notifications.setNotificationChannelAsync as jest.Mock;
+
+/** upsert モックを作り直して from に設定するヘルパー */
+function setupUpsert(returnValue: { error: Error | null }) {
+  const mockUpsert = jest.fn().mockResolvedValue(returnValue);
+  mockFrom.mockReturnValue({ upsert: mockUpsert });
+  return mockUpsert;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // expo-device mock を物理端末状態にリセット
+  const DeviceMock = jest.requireMock('expo-device');
+  DeviceMock.isDevice = true;
+
+  // react-native Platform を iOS にリセット
+  const RNMock = jest.requireMock('react-native');
+  RNMock.Platform.OS = 'ios';
+
+  // デフォルト: 認証済みユーザー
+  mockGetUser.mockResolvedValue({
+    data: { user: { id: 'user-123' } },
+  });
+
+  // デフォルト: 既に権限付与済み
+  mockGetPermissionsAsync.mockResolvedValue({ status: 'granted' });
+
+  // デフォルト: トークン取得成功
+  mockGetExpoPushTokenAsync.mockResolvedValue({ data: 'ExponentPushToken[test-token]' });
+
+  // デフォルト: upsert 成功
+  setupUpsert({ error: null });
+});
+
+describe('registerAndSaveExpoPushToken — 権限拒否', () => {
+  it('権限が拒否された場合、null を返す', async () => {
+    mockGetPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    mockRequestPermissionsAsync.mockResolvedValue({ status: 'denied' });
+
+    const result = await registerAndSaveExpoPushToken();
+
+    expect(result).toBeNull();
+    // upsert は呼ばれない
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('初回権限未決定のとき requestPermissionsAsync を呼び、denied なら null を返す', async () => {
+    mockGetPermissionsAsync.mockResolvedValue({ status: 'undetermined' });
+    mockRequestPermissionsAsync.mockResolvedValue({ status: 'denied' });
+
+    const result = await registerAndSaveExpoPushToken();
+
+    expect(mockRequestPermissionsAsync).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+  });
+});
+
+describe('registerAndSaveExpoPushToken — Supabase upsert 成功', () => {
+  it('upsert が成功した場合、トークンを返す', async () => {
+    const mockUpsert = setupUpsert({ error: null });
+
+    const result = await registerAndSaveExpoPushToken();
+
+    expect(result).toBe('ExponentPushToken[test-token]');
+    expect(mockFrom).toHaveBeenCalledWith('user_push_tokens');
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-123',
+        expo_push_token: 'ExponentPushToken[test-token]',
+      }),
+      expect.objectContaining({ onConflict: 'user_id,expo_push_token' })
+    );
+  });
+
+  it('getExpoPushTokenAsync が呼ばれてトークンが取得される', async () => {
+    const result = await registerAndSaveExpoPushToken();
+
+    expect(mockGetExpoPushTokenAsync).toHaveBeenCalledTimes(1);
+    expect(result).toBe('ExponentPushToken[test-token]');
+  });
+});
+
+describe('registerAndSaveExpoPushToken — Supabase upsert 失敗', () => {
+  it('upsert が失敗した場合、エラーをスローする', async () => {
+    const upsertError = new Error('DB upsert failed');
+    setupUpsert({ error: upsertError });
+
+    await expect(registerAndSaveExpoPushToken()).rejects.toThrow('DB upsert failed');
+  });
+});
+
+describe('registerAndSaveExpoPushToken — Android チャンネル作成', () => {
+  it('Android の場合、setNotificationChannelAsync が呼ばれる', async () => {
+    jest.requireMock('react-native').Platform.OS = 'android';
+
+    await registerAndSaveExpoPushToken();
+
+    expect(mockSetNotificationChannelAsync).toHaveBeenCalledWith(
+      'default',
+      expect.objectContaining({ name: 'default' })
+    );
+  });
+
+  it('iOS の場合、setNotificationChannelAsync は呼ばれない', async () => {
+    // beforeEach で 'ios' に設定済み
+
+    await registerAndSaveExpoPushToken();
+
+    expect(mockSetNotificationChannelAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerAndSaveExpoPushToken — 物理端末チェック', () => {
+  it('isDevice が false のとき null を返す', async () => {
+    jest.requireMock('expo-device').isDevice = false;
+
+    const result = await registerAndSaveExpoPushToken();
+
+    expect(result).toBeNull();
+    expect(mockGetPermissionsAsync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- `apps/mobile/__tests__/ai/chat-stream-abort.test.tsx` 新規追加: AbortController.abort() によるストリーム中断と fetch ハング26秒タイムアウトのテスト (4ケース)
- `apps/mobile/__tests__/lib/push-notifications.test.ts` 新規追加: Push 通知トークン登録の権限拒否・upsert 成功失敗・Android チャンネル作成のテスト (8ケース)
- 既存 `chat-stream.test.tsx` のモックパターン (fetch, supabase, expo-router) を踏襲

## Test plan

- [ ] `cd apps/mobile && npm test -- --testPathPattern="chat-stream-abort|push-notifications"` で 12 件全 pass 確認済み
- [ ] 型エラーなし (既存エラーのみ、新規ファイルに型エラーなし)

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)