### PR TITLE
test(coverage): T06 bug-37 middleware skip 解消

### DIFF
--- a/tests/e2e/bug-37-auth-session-expired-redirect.spec.ts
+++ b/tests/e2e/bug-37-auth-session-expired-redirect.spec.ts
@@ -7,9 +7,10 @@
  *   3. ?next=/home パラメータが付与されていること (middleware がセット)
  *   4. ゲストモードのままホームが表示されないこと
  *
- * 注意: production では未認証でも /home がゲストモードで表示される実装のため、
- *       /login へのリダイレクトを前提とするテストは現状 skip。
- *       middleware でゲストモードを廃止し /login へ強制リダイレクトする修正後に有効化する。
+ * middleware (lib/supabase/middleware.ts) が公開ルート / ゲストルート / 認証必須ルートを正しく
+ * 分岐し、未認証アクセスを /login へリダイレクトすることを E2E で検証する。
+ *
+ * T06: Coverage Recovery — bug-37 middleware skip 解消 (Closes #848)
  */
 import { test, expect } from "@playwright/test";
 
@@ -23,24 +24,13 @@ async function clearSession(page: any) {
   });
 }
 
-/** middleware で !isPublicPath に Cache-Control: private, no-store を設定し CDN bypass を解消済み */
-const REDIRECT_EXPECTED = true;
-
 test("unauthenticated access to /home redirects to /login", async ({ page }) => {
-  if (!REDIRECT_EXPECTED) {
-    test.skip(true, '未認証アクセスがゲストモードで /home を表示する実装のため skip (middleware 修正待ち)');
-    return;
-  }
   await clearSession(page);
   await page.goto("/home");
   await expect(page).toHaveURL(/\/login/, { timeout: 15_000 });
 });
 
 test("redirect URL includes ?next= pointing back to the original protected route", async ({ page }) => {
-  if (!REDIRECT_EXPECTED) {
-    test.skip(true, '未認証アクセスがゲストモードで /home を表示する実装のため skip (middleware 修正待ち)');
-    return;
-  }
   await clearSession(page);
   await page.goto("/home");
   await page.waitForURL(/\/login/, { timeout: 15_000 });
@@ -50,10 +40,6 @@ test("redirect URL includes ?next= pointing back to the original protected route
 });
 
 test("unauthenticated access to /health redirects to /login with correct next param", async ({ page }) => {
-  if (!REDIRECT_EXPECTED) {
-    test.skip(true, '未認証アクセスがゲストモードで /home を表示する実装のため skip (middleware 修正待ち)');
-    return;
-  }
   await clearSession(page);
   await page.goto("/health");
   await page.waitForURL(/\/login/, { timeout: 15_000 });
@@ -63,10 +49,6 @@ test("unauthenticated access to /health redirects to /login with correct next pa
 });
 
 test("guest mode ('ゲスト') is not shown on home page when unauthenticated — login page shown instead", async ({ page }) => {
-  if (!REDIRECT_EXPECTED) {
-    test.skip(true, '未認証アクセスがゲストモードで /home を表示する実装のため skip (middleware 修正待ち)');
-    return;
-  }
   await clearSession(page);
   await page.goto("/home");
   await page.waitForURL(/\/login/, { timeout: 15_000 });


### PR DESCRIPTION
## Summary

- `tests/e2e/bug-37-auth-session-expired-redirect.spec.ts` の 4 テストを有効化
- dead code となっていた `REDIRECT_EXPECTED` フラグと `if (!REDIRECT_EXPECTED)` ガードを削除
- `lib/supabase/middleware.ts` が未認証アクセスを `/login?next=<path>` へ正しくリダイレクトすることを確認済み

## 変更内容

`REDIRECT_EXPECTED = true` が設定されていたため skip ガードは実際には機能していなかったが、
コードとして残っており混乱を招く状態だった。今回これを除去し、4 テストが明示的に実行されることを明確化した。

**middleware の動作確認**:
- 公開ルート (`/login`, `/signup`, `/`, `/pricing` 等): 未認証でもアクセス可
- 認証必須ルート (`/home`, `/health` 等): 未認証時 → `/login?next=<path>` にリダイレクト
- API ルート (`/api/*`): セッション更新のみ、リダイレクトなし

## Test plan

- [x] `npm run typecheck` — エラーなし
- [x] `npm run lint` (変更ファイルのみ) — エラーなし
- [x] E2E: 4 テスト全 pass、test.skip 0 件
  - `unauthenticated access to /home redirects to /login` ✓
  - `redirect URL includes ?next= pointing back to the original protected route` ✓
  - `unauthenticated access to /health redirects to /login with correct next param` ✓
  - `guest mode ('ゲスト') is not shown on home page when unauthenticated — login page shown instead` ✓

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)