### PR TITLE
fix(hotfix): web-vitals v4 対応 (onFID → onINP)

### DIFF
--- a/packages/handson-tour-shared/src/analytics.ts
+++ b/packages/handson-tour-shared/src/analytics.ts
@@ -88,7 +88,8 @@ export const HandsonTourEventSchemas = {
     page: z.string(),
   }),
 
-  web_vitals_fid: CommonPropertiesSchema.extend({
+  // web-vitals v4+ で onFID → onINP に変更 (INP = Interaction to Next Paint)
+  web_vitals_inp: CommonPropertiesSchema.extend({
     value_ms: z.number(),
     page: z.string(),
   }),

--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -63,7 +63,8 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
           }
 
           // Web Vitals 計測 (handson-tour 専用 analytics schema)
-          import('web-vitals').then(({ onLCP, onCLS, onFID }) => {
+          // web-vitals v4+ では onFID は削除され onINP (Interaction to Next Paint) に置き換わった
+          import('web-vitals').then(({ onLCP, onCLS, onINP }) => {
             const page = typeof window !== 'undefined' ? window.location.pathname : '/';
             const common = {
               user_id: userId,
@@ -78,8 +79,8 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
             onCLS((metric) => {
               fireAnalytics('web_vitals_cls', { ...common, value: metric.value });
             });
-            onFID((metric) => {
-              fireAnalytics('web_vitals_fid', { ...common, value_ms: metric.value });
+            onINP((metric) => {
+              fireAnalytics('web_vitals_inp', { ...common, value_ms: metric.value });
             });
           }).catch(() => {
             // web-vitals unavailable — ignore

--- a/tests/integration/handson-tour/analytics-wiring.test.ts
+++ b/tests/integration/handson-tour/analytics-wiring.test.ts
@@ -16,7 +16,7 @@
  *   handson_tour_force_replayed
  *   web_vitals_lcp
  *   web_vitals_cls
- *   web_vitals_fid
+ *   web_vitals_inp
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -194,9 +194,9 @@ describe('HandsonTourEventSchemas — Zod schema 全件 pass', () => {
     expect(result.success).toBe(true);
   });
 
-  it('web_vitals_fid — valid', () => {
+  it('web_vitals_inp — valid', () => {
     const payload = { ...baseCommon(), value_ms: 50, page: '/handson-tour' };
-    const result = HandsonTourEventSchemas.web_vitals_fid.safeParse(payload);
+    const result = HandsonTourEventSchemas.web_vitals_inp.safeParse(payload);
     expect(result.success).toBe(true);
   });
 });
@@ -326,10 +326,10 @@ describe('fireAnalytics — AnalyticsAdapter への委譲確認', () => {
     expect(captureMock).toHaveBeenCalledWith('web_vitals_cls', expect.objectContaining({ value: 0.1 }));
   });
 
-  it('web_vitals_fid — adapter.capture が呼ばれる', () => {
-    fireAnalytics('web_vitals_fid', { ...baseCommon(), value_ms: 50, page: '/handson-tour' });
+  it('web_vitals_inp — adapter.capture が呼ばれる', () => {
+    fireAnalytics('web_vitals_inp', { ...baseCommon(), value_ms: 50, page: '/handson-tour' });
     expect(captureMock).toHaveBeenCalledOnce();
-    expect(captureMock).toHaveBeenCalledWith('web_vitals_fid', expect.objectContaining({ value_ms: 50 }));
+    expect(captureMock).toHaveBeenCalledWith('web_vitals_inp', expect.objectContaining({ value_ms: 50 }));
   });
 });
 
@@ -465,15 +465,15 @@ describe('Step 0-4 全分岐 + skip/replay/eligibility', () => {
     expect(result.success).toBe(true);
   });
 
-  it('web_vitals_lcp/cls/fid — 3 つのイベントが連続して捕捉できる', () => {
+  it('web_vitals_lcp/cls/inp — 3 つのイベントが連続して捕捉できる', () => {
     fireAnalytics('web_vitals_lcp', { ...baseCommon(), value_ms: 1200, page: '/handson-tour' });
     fireAnalytics('web_vitals_cls', { ...baseCommon(), value: 0.05, page: '/handson-tour' });
-    fireAnalytics('web_vitals_fid', { ...baseCommon(), value_ms: 30, page: '/handson-tour' });
+    fireAnalytics('web_vitals_inp', { ...baseCommon(), value_ms: 30, page: '/handson-tour' });
 
     expect(captured).toHaveLength(3);
     expect(captured[0].name).toBe('web_vitals_lcp');
     expect(captured[1].name).toBe('web_vitals_cls');
-    expect(captured[2].name).toBe('web_vitals_fid');
+    expect(captured[2].name).toBe('web_vitals_inp');
   });
 
   it('Mobile platform (ios) — adapter が ios プラットフォームで呼ばれる', () => {


### PR DESCRIPTION
## Vercel build エラー

commit `6f5fd44` で Vercel production build が以下のエラーで失敗:

```
./src/components/PostHogProvider.tsx:66:54
Type error: Property 'onFID' does not exist on type 'typeof web-vitals'.
import('web-vitals').then(({ onLCP, onCLS, onFID }) => {
                                                ^
```

`web-vitals` は現在 v5.x (`^5.1.0`) が lock されており、v4 以降 `onFID` (First Input Delay) は削除され `onINP` (Interaction to Next Paint) に置き換えられた。

## 修正内容

- `src/components/PostHogProvider.tsx`: `onFID` → `onINP`、`fireAnalytics('web_vitals_fid')` → `fireAnalytics('web_vitals_inp')` に変更
- `packages/handson-tour-shared/src/analytics.ts`: `HandsonTourEventSchemas` の `web_vitals_fid` キーを `web_vitals_inp` にリネーム (Zod schema + 型)
- `tests/integration/handson-tour/analytics-wiring.test.ts`: `web_vitals_fid` 参照を `web_vitals_inp` に更新

## 検証

- `npm run typecheck` → エラー 0
- `npm run test tests/integration/handson-tour/analytics-wiring.test.ts` → 144 tests all passed
- Mobile 側 `apps/mobile/src/providers/PostHogProvider.tsx` に `onFID` 参照なし (変更不要を確認)