### PR TITLE
chore(mobile): Maestro 期待の testID を実装に追加

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -77,6 +77,7 @@ export default function TabsLayout() {
               </View>
             ),
             tabBarLabel: () => null,
+            tabBarButtonTestID: "tab-meals",
           }}
         />
         <Tabs.Screen

--- a/apps/mobile/app/(tabs)/favorites.tsx
+++ b/apps/mobile/app/(tabs)/favorites.tsx
@@ -114,7 +114,7 @@ export default function FavoritesScreen() {
     }
   };
 
-  const renderItem = ({ item }: { item: FavoriteItem }) => (
+  const renderItem = ({ item, index }: { item: FavoriteItem; index: number }) => (
     <View
       testID={`favorites-item-${item.id}`}
       style={{
@@ -168,7 +168,7 @@ export default function FavoritesScreen() {
 
       {/* ハートボタン */}
       <Pressable
-        testID={`favorites-remove-${item.id}`}
+        testID={index === 0 ? "favorites-first-heart-button" : `favorites-remove-${item.id}`}
         onPress={() => handleRemove(item)}
         disabled={removingId === item.id}
         accessibilityLabel="お気に入りから削除"
@@ -382,6 +382,7 @@ export default function FavoritesScreen() {
         </View>
       ) : (
         <FlatList
+          testID="favorites-list"
           data={favorites}
           keyExtractor={(item) => item.id}
           renderItem={renderItem}

--- a/apps/mobile/app/meals/new.tsx
+++ b/apps/mobile/app/meals/new.tsx
@@ -812,14 +812,16 @@ export default function MealNewPage() {
 
       {/* ─── Step: mode-select ─── */}
       {step === "mode-select" && (
-        <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
+        <ScrollView testID="meal-mode-select-screen" contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
           <Text style={{ fontSize: 13, color: colors.textMuted, textAlign: "center" }}>撮影するものを選んでください</Text>
 
           <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 12 }}>
             {(Object.entries(PHOTO_MODES) as [PhotoMode, typeof PHOTO_MODES.auto][]).map(([mode, config]) => {
               const isSelected = photoMode === mode;
+              // Normalize testID: replace underscores with dashes, drop "select-" prefix for Maestro compatibility
+              const modeTestID = `meal-mode-${mode.replace(/_/g, "-")}`;
               return (
-                <Pressable key={mode} testID={`meal-mode-select-${mode}`} onPress={() => setPhotoMode(mode)} style={{
+                <Pressable key={mode} testID={modeTestID} onPress={() => setPhotoMode(mode)} style={{
                   width: "47%", padding: spacing.md, borderRadius: radius.lg, alignItems: "center", gap: spacing.sm,
                   backgroundColor: isSelected ? config.bg : colors.card,
                   borderWidth: isSelected ? 2 : 1, borderColor: isSelected ? config.color : colors.border,
@@ -839,7 +841,7 @@ export default function MealNewPage() {
           </Button>
 
           {/* 手動入力への導線 */}
-          <Pressable testID="meal-mode-manual-button" onPress={() => setStep("manual")} style={{
+          <Pressable testID="meal-mode-manual" onPress={() => setStep("manual")} style={{
             flexDirection: "row", alignItems: "center", justifyContent: "center", gap: spacing.sm,
             padding: spacing.md, borderRadius: radius.md, backgroundColor: colors.bg,
             borderWidth: 1, borderColor: colors.border,
@@ -852,7 +854,7 @@ export default function MealNewPage() {
 
       {/* ─── Step: manual ─── */}
       {step === "manual" && (
-        <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.md }} keyboardShouldPersistTaps="handled">
+        <ScrollView testID="meal-form-screen" contentContainerStyle={{ padding: spacing.lg, gap: spacing.md }} keyboardShouldPersistTaps="handled">
           {/* Date/meal type selector */}
           <Text style={{ fontSize: 13, fontWeight: "600", color: colors.text }}>記録日と食事タイプ</Text>
 
@@ -1013,7 +1015,7 @@ export default function MealNewPage() {
             <Text style={{ fontSize: 13, fontWeight: "600", color: colors.text }}>食事情報</Text>
 
             <TextInput
-              testID="meal-manual-name-input"
+              testID="meal-name-input"
               value={manualDishName}
               onChangeText={setManualDishName}
               placeholder="食事名（必須）"
@@ -1026,7 +1028,7 @@ export default function MealNewPage() {
 
             <View style={{ flexDirection: "row", gap: spacing.sm }}>
               <TextInput
-                testID="meal-manual-calorie-input"
+                testID="meal-calories-input"
                 value={manualCalories}
                 onChangeText={setManualCalories}
                 placeholder="カロリー (kcal)"
@@ -1088,7 +1090,7 @@ export default function MealNewPage() {
 
       {/* ─── Step: capture ─── */}
       {step === "capture" && (
-        <ScrollView contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
+        <ScrollView testID="camera-screen" contentContainerStyle={{ padding: spacing.lg, gap: spacing.lg }}>
           <Text style={{ fontSize: 13, color: colors.textMuted, textAlign: "center" }}>{modeCopy.captureDescription}</Text>
 
           {photos.length > 0 ? (
@@ -1110,7 +1112,7 @@ export default function MealNewPage() {
             </View>
           ) : (
             <View style={{ flexDirection: "row", gap: spacing.md }}>
-              <Pressable testID="meal-camera-button" onPress={takePhoto} style={({ pressed }) => ({
+              <Pressable testID="camera-capture-button" onPress={takePhoto} style={({ pressed }) => ({
                 flex: 1, padding: spacing.xl, borderRadius: radius.lg, alignItems: "center", gap: spacing.sm,
                 backgroundColor: colors.card, borderWidth: 2, borderStyle: "dashed", borderColor: colors.border, opacity: pressed ? 0.9 : 1,
               })}>
@@ -1119,7 +1121,7 @@ export default function MealNewPage() {
                 </View>
                 <Text style={{ fontSize: 14, fontWeight: "500", color: colors.text }}>{modeCopy.cameraLabel}</Text>
               </Pressable>
-              <Pressable testID="meal-gallery-button" onPress={pickFromLibrary} style={({ pressed }) => ({
+              <Pressable testID="camera-gallery-button" onPress={pickFromLibrary} style={({ pressed }) => ({
                 flex: 1, padding: spacing.xl, borderRadius: radius.lg, alignItems: "center", gap: spacing.sm,
                 backgroundColor: colors.card, borderWidth: 2, borderStyle: "dashed", borderColor: colors.border, opacity: pressed ? 0.9 : 1,
               })}>
@@ -1145,7 +1147,7 @@ export default function MealNewPage() {
 
       {/* ─── Step: analyzing ─── */}
       {step === "analyzing" && (
-        <View testID="meal-analyzing-view" style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: spacing.lg, gap: spacing.lg }}>
+        <View testID="ai-analyzing-indicator" style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: spacing.lg, gap: spacing.lg }}>
           {photos.length > 0 && (
             <View style={{ position: "relative" }}>
               <Image source={{ uri: photos[0].uri }} style={{ width: 220, height: 220, borderRadius: radius.lg, opacity: 0.8 }} />
@@ -1164,7 +1166,7 @@ export default function MealNewPage() {
 
       {/* ─── Step: result (meal) ─── */}
       {step === "result" && (
-        <ScrollView testID="meal-result-screen" contentContainerStyle={{ padding: spacing.lg, gap: spacing.md }}>
+        <ScrollView testID="meal-form-screen" contentContainerStyle={{ padding: spacing.lg, gap: spacing.md }}>
           {/* Score */}
           <View style={{ flexDirection: "row", alignItems: "center", gap: spacing.md, padding: spacing.md, borderRadius: radius.lg, backgroundColor: colors.successLight }}>
             <View style={{ width: 56, height: 56, borderRadius: radius.lg, alignItems: "center", justifyContent: "center", backgroundColor: overallScore >= 85 ? colors.success : overallScore >= 70 ? colors.warning : colors.accent }}>

--- a/apps/mobile/src/components/web/WebViewScreen.tsx
+++ b/apps/mobile/src/components/web/WebViewScreen.tsx
@@ -282,7 +282,7 @@ export const WebViewScreen: React.FC<Props> = ({ path, testID }) => {
           }
         }}
         renderLoading={() => (
-          <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+          <View testID="webview-loading" style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
             <ActivityIndicator size="large" color={colors.accent} />
           </View>
         )}


### PR DESCRIPTION
## Summary

T11 #862 で指摘された「meals タブに tabBarButtonTestID がない」問題を修正し、Maestro flow が参照する testID と実装の整合性を取りました。

## 不在 testID リスト (Maestro 期待 vs 実装)

| Maestro 期待 testID | 実装側の状況 | 対処 |
|---|---|---|
| `tab-meals` | `tabBarButtonTestID` なし | 追加 |
| `webview-loading` | `renderLoading` の View に testID なし | 追加 |
| `favorites-list` | FlatList に testID なし | 追加 |
| `favorites-first-heart-button` | 動的 `favorites-remove-${id}` のみ | 先頭アイテム (index=0) に追加 |
| `meal-mode-select-screen` | mode-select ScrollView に testID なし | 追加 |
| `meal-mode-meal` / `meal-mode-auto` 等 | `meal-mode-select-${mode}` (旧 prefix) | `meal-mode-${mode}` に統一 |
| `meal-mode-manual` | `meal-mode-manual-button` | 修正 |
| `meal-form-screen` | なし (result/manual 両ステップ) | 追加 |
| `camera-screen` | capture ScrollView に testID なし | 追加 |
| `camera-capture-button` | `meal-camera-button` (capture ステップ) | 修正 |
| `camera-gallery-button` | `meal-gallery-button` | 修正 |
| `ai-analyzing-indicator` | `meal-analyzing-view` | 修正 |
| `meal-name-input` | `meal-manual-name-input` | 修正 |
| `meal-calories-input` | `meal-manual-calorie-input` | 修正 |

## 追加した testID 一覧

| ファイル | 追加 testID |
|---|---|
| `(tabs)/_layout.tsx` | `tab-meals` (tabBarButtonTestID) |
| `WebViewScreen.tsx` | `webview-loading` |
| `(tabs)/favorites.tsx` | `favorites-list`, `favorites-first-heart-button` |
| `meals/new.tsx` | `meal-mode-select-screen`, `meal-mode-*`, `meal-mode-manual`, `meal-form-screen` (×2), `camera-screen`, `camera-capture-button`, `camera-gallery-button`, `ai-analyzing-indicator`, `meal-name-input`, `meal-calories-input` |

## 注意点

- `home-screen`, `meals-screen`, `comparison-screen` 等の多くのスクリーン testID は、Phase B-1/B-2 でタブが WebViewScreen に移行済みのため、Maestro から直接参照できない状態が続く。これらは別 PR (Maestro YAML 更新または native タブ復帰) が必要。
- `meal-camera-button` は handson-tour サンドボックス用の View (line 719) に保持。tour 用 Maestro flow との互換性を維持。
- `meal-result-screen` は flow 28 (`28-photo-meal-analysis.yaml`) が参照するが、同 flow は `tab-meals` 経由 (WebView) で開始するため既に動作しない。今回の変更による追加の影響はなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)