### PR TITLE
fix(test): Mobile Jest 残 fail の修復 - @homegohan package moduleNameMapper 追加

### DIFF
--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -6,6 +6,7 @@ const path = require('path');
 const repoRoot = path.resolve(__dirname, '../..');
 const worktreeNodeModules = path.join(repoRoot, 'node_modules');
 const mobileNodeModules = path.join(__dirname, 'node_modules');
+const packagesDir = path.join(repoRoot, 'packages');
 
 /** @type {import('jest-expo').JestExpoConfig} */
 module.exports = {
@@ -16,7 +17,13 @@ module.exports = {
   ],
   // react 系モジュールを apps/mobile/node_modules から優先解決し、
   // モノレポルートの react@18 が react-test-renderer 経由で漏れ込むのを防ぐ。
+  // @homegohan/* は tsconfig の paths 設定が <rootDir>/../../... を展開するとき
+  // jest が .. を解釈しないため絶対パスで上書きする。
   moduleNameMapper: {
+    '^@homegohan/handson-tour-shared$': path.join(packagesDir, 'handson-tour-shared', 'src', 'index.ts'),
+    '^@homegohan/handson-tour-shared/(.*)$': path.join(packagesDir, 'handson-tour-shared', 'src', '$1'),
+    '^@homegohan/shared$': path.join(packagesDir, 'shared', 'src', 'index.ts'),
+    '^@homegohan/shared/(.*)$': path.join(packagesDir, 'shared', 'src', '$1'),
     '^react$': path.join(mobileNodeModules, 'react'),
     '^react/(.*)$': path.join(mobileNodeModules, 'react', '$1'),
     '^react-native$': path.join(worktreeNodeModules, 'react-native'),


### PR DESCRIPTION
## Summary

- `apps/mobile/jest.config.js` の `moduleNameMapper` に `@homegohan/handson-tour-shared` と `@homegohan/shared` の絶対パスマッピングを追加
- `jest-expo` preset が `tsconfig.json` の `paths` を変換する際、`<rootDir>/../../packages/...` を文字列結合で処理するため `..` が解決されず `apps/mobile/packages/` という誤ったパスを生成するバグを回避
- `meals/new.tsx` が `@homegohan/handson-tour-shared` を直接 import しており、このモジュール解決失敗が `__tests__/meals/new.test.tsx` のスイート全体 (15 tests) を `Test suite failed to run` で落としていた

## Before / After

| | Before (#880) | After (this PR) |
|---|---|---|
| Test Suites | 42 passed, 1 failed | **43 passed, 0 failed** |
| Tests | 336 passed | **351 passed**, 1 skipped |
| 連続 PASS | N/A | 2 回連続確認済み |

## Root Cause

`jest-expo` の `withTypescriptMapping` は `tsconfig.json` の `paths` を読んで `moduleNameMapper` を生成する。変換時に target パスの `..` を文字列連結でそのまま返す (`[prefix, ...segments].join('/')`) ため、jest が `<rootDir>` を展開した後の文字列が:

```
/abs/path/to/apps/mobile/../../packages/handson-tour-shared/src/index.ts
```

となる。jest はこの文字列を `path.resolve()` せず `fs.statSync()` に渡すため `ENOENT` でモジュールが見つからない。

## Fix

`jest.config.js` 内で `@homegohan/*` に対して `path.resolve()` 済みの絶対パスを事前に `moduleNameMapper` に追加し、jest-expo の自動生成エントリを上書き。

## Test plan

- [x] `cd apps/mobile && jest` (43 suite, 0 failed) — 1 回目
- [x] `cd apps/mobile && jest` (43 suite, 0 failed) — 2 回目 (timer pollution 根絶確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)