### PR TITLE
fix(test): coupons/plans の datetime 形式をテスト側で ISO 8601 full に統一

### DIFF
--- a/tests/integration/operator/super-admin-coupons.test.ts
+++ b/tests/integration/operator/super-admin-coupons.test.ts
@@ -71,8 +71,8 @@ describe('GET /api/super-admin/coupons', () => {
 describe('POST /api/super-admin/coupons', () => {
   it('201 for super_admin creating a coupon', async () => {
     const couponCode = `TEST${TS}`;
-    const tomorrow = new Date(Date.now() + 86400000).toISOString().split('T')[0];
-    const nextMonth = new Date(Date.now() + 30 * 86400000).toISOString().split('T')[0];
+    const tomorrow = new Date(Date.now() + 86400000).toISOString();
+    const nextMonth = new Date(Date.now() + 30 * 86400000).toISOString();
 
     const res = await apiCall('POST', '/api/super-admin/coupons', superAdminUser.jwt, {
       code: couponCode,
@@ -126,8 +126,8 @@ describe('GET /api/super-admin/coupons/[id]/redemptions', () => {
   beforeAll(async () => {
     // Create a coupon to test redemptions
     const couponCode = `REDEEM${TS}`;
-    const tomorrow = new Date(Date.now() + 86400000).toISOString().split('T')[0];
-    const nextMonth = new Date(Date.now() + 30 * 86400000).toISOString().split('T')[0];
+    const tomorrow = new Date(Date.now() + 86400000).toISOString();
+    const nextMonth = new Date(Date.now() + 30 * 86400000).toISOString();
 
     const res = await apiCall('POST', '/api/super-admin/coupons', superAdminUser.jwt, {
       code: couponCode,

--- a/tests/integration/operator/super-admin-plans-id.test.ts
+++ b/tests/integration/operator/super-admin-plans-id.test.ts
@@ -228,7 +228,7 @@ describe('POST /api/super-admin/plans/[id]/price-change', () => {
         new_yearly_price_jpy: 18000,
         applies_to: 'new_only',
         reason: 'Integration test price change',
-        effective_at: new Date().toISOString().split('T')[0],
+        effective_at: new Date().toISOString(),
       }
     );
     expect(res.status).toBe(200);
@@ -250,7 +250,7 @@ describe('POST /api/super-admin/plans/[id]/price-change', () => {
         new_monthly_price_jpy: 2000,
         applies_to: 'new_only',
         reason: 'Should fail',
-        effective_at: new Date().toISOString().split('T')[0],
+        effective_at: new Date().toISOString(),
       }
     );
     expect(res.status).toBe(422);
@@ -268,7 +268,7 @@ describe('POST /api/super-admin/plans/[id]/price-change', () => {
         new_monthly_price_jpy: 999,
         applies_to: 'new_only',
         reason: 'Admin should fail',
-        effective_at: new Date().toISOString().split('T')[0],
+        effective_at: new Date().toISOString(),
       }
     );
     expect(res.status).toBe(403);
@@ -280,7 +280,7 @@ describe('POST /api/super-admin/plans/[id]/price-change', () => {
       new_monthly_price_jpy: 999,
       applies_to: 'new_only',
       reason: 'No auth',
-      effective_at: new Date().toISOString().split('T')[0],
+      effective_at: new Date().toISOString(),
     });
     expect(res.status).toBe(401);
   });


### PR DESCRIPTION
## 概要

`z.string().datetime()` スキーマを持つフィールドに date-only 文字列 (`"2026-05-08"`) を送っていたため、API が 400 を返しテストが失敗していた。テスト側で `.toISOString()` の `.split('T')[0]` を削除し、full ISO 8601 datetime 形式に統一した。

## 修正ケース一覧

| ファイル | フィールド | 期待ステータス | 修正前 | 修正後 |
|---|---|---|---|---|
| `tests/integration/operator/super-admin-coupons.test.ts:74-75` | `valid_from`, `valid_until` | 201 | `...toISOString().split('T')[0]` | `...toISOString()` |
| `tests/integration/operator/super-admin-coupons.test.ts:129-130` | `valid_from`, `valid_until` | 201 (beforeAll) | 同上 | 同上 |
| `tests/integration/operator/super-admin-plans-id.test.ts:231` | `effective_at` | 200 | 同上 | 同上 |
| `tests/integration/operator/super-admin-plans-id.test.ts:253` | `effective_at` | 422 | 同上 | 同上 |
| `tests/integration/operator/super-admin-plans-id.test.ts:271` | `effective_at` | 403 | 同上 | 同上 |
| `tests/integration/operator/super-admin-plans-id.test.ts:283` | `effective_at` | 401 | 同上 | 同上 |

## 方針

- schema 側 (`z.string().datetime()`) はそのまま — full datetime の方が意味的に正しい
- テスト側のみ修正
- `super-admin-coupons-id.test.ts` の同パターンは Supabase admin client 直接 insert のため schema を通らず変更不要

## 検証

- `npm run typecheck` → 0 error