### PR TITLE
fix(db): plan_key seed を設計書 canonical 9 種に更新

### DIFF
--- a/tests/integration/operator/super-admin-plans.test.ts
+++ b/tests/integration/operator/super-admin-plans.test.ts
@@ -57,16 +57,16 @@ describe('GET /api/super-admin/plans', () => {
     expect(body).toHaveProperty('meta');
     expect(Array.isArray(body.data)).toBe(true);
 
-    // Canonical 9 plan_keys (cross/09 design)
+    // Canonical 9 plan_keys (operator/01-data-model.md §3.2 seed)
     const canonicalPlanKeys = [
       'free',
-      'personal_lite',
-      'personal_standard',
-      'personal_pro',
-      'family_standard',
+      'pro',
+      'family_basic',
       'family_pro',
+      'family_addon',
       'org_starter',
-      'org_growth',
+      'org_standard',
+      'org_pro',
       'org_enterprise',
     ];
 


### PR DESCRIPTION
## 調査結果

調査した結果、**migration seed は正しく、テストが誤っていた**ことが判明した。

### Canonical 単一ソース

`docs/design/operator/01-data-model.md` §3.2 が canonical。`docs/design/cross/09-testing.md` §8 でも「operator/01-data-model.md §3.2 seed と同一」と明記。

### 旧 plan_key (テストが誤って期待していた値)

| # | plan_key (誤) |
|---|---|
| 1 | free |
| 2 | personal_lite |
| 3 | personal_standard |
| 4 | personal_pro |
| 5 | family_standard |
| 6 | family_pro |
| 7 | org_starter |
| 8 | org_growth |
| 9 | org_enterprise |

### 新 plan_key (設計書 canonical / migration seed と一致)

| # | plan_key | plan_type | price (月) |
|---|---|---|---|
| 1 | free | personal | ¥0 |
| 2 | pro | personal | ¥980 |
| 3 | family_basic | family | ¥1,480 |
| 4 | family_pro | family | ¥2,480 |
| 5 | family_addon | family | ¥280 (private) |
| 6 | org_starter | org | ¥580 |
| 7 | org_standard | org | ¥980 |
| 8 | org_pro | org | ¥1,980 |
| 9 | org_enterprise | org | カスタム |

## 変更内容

- `tests/integration/operator/super-admin-plans.test.ts`: `canonicalPlanKeys` 配列を設計書 canonical の 9 種に修正

## 変更しなかったもの

- `supabase/migrations/20260508120000_operator_phase_4_5_foundation.sql`: 設計書と一致済み (変更不要)
- `src/lib/super-admin/plans-schemas.ts` の `OFFICIAL_PLAN_KEYS`: 設計書と一致済み (変更不要)

## DB 影響範囲

migration seed は既に正しいため、prod data migration は不要。

## Test plan

- [ ] `tests/integration/operator/super-admin-plans.test.ts` の `GET /api/super-admin/plans 200` ケースが PASS することを確認
- [ ] `OFFICIAL_PLAN_KEYS` (plans-schemas.ts) が migration seed と一致していることを確認