### PR TITLE
fix(api): createClient() の await 欠落を全件修正 (RLS 誤発動防止)

### DIFF
--- a/src/app/api/admin/finance/dashboard/route.ts
+++ b/src/app/api/admin/finance/dashboard/route.ts
@@ -14,7 +14,7 @@ export const dynamic = 'force-dynamic';
 export async function GET() {
   try {
     const user = await requireRole(['admin', 'super_admin', 'finance']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     // 最新スナップショット (今月と先月) を revenue_snapshots から取得
     const today = new Date();

--- a/src/app/api/admin/finance/exports/route.ts
+++ b/src/app/api/admin/finance/exports/route.ts
@@ -27,7 +27,7 @@ function toCsv(headers: string[], rows: Record<string, unknown>[]): string {
 export async function POST(request: NextRequest) {
   try {
     const user = await requireRole(['admin', 'super_admin', 'finance']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const body = await request.json() as unknown;
     const req = ExportRequestSchema.parse(body);

--- a/src/app/api/admin/finance/invoices/[id]/route.ts
+++ b/src/app/api/admin/finance/invoices/[id]/route.ts
@@ -17,7 +17,7 @@ export async function GET(
 ) {
   try {
     await requireRole(['admin', 'super_admin', 'finance']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { data: evt, error } = await supabase
       .from('stripe_webhook_events')

--- a/src/app/api/admin/finance/invoices/route.ts
+++ b/src/app/api/admin/finance/invoices/route.ts
@@ -15,7 +15,7 @@ export const dynamic = 'force-dynamic';
 export async function GET(request: NextRequest) {
   try {
     await requireRole(['admin', 'super_admin', 'finance']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { searchParams } = new URL(request.url);
     const query = InvoiceQuerySchema.parse({

--- a/src/app/api/admin/finance/nps/route.ts
+++ b/src/app/api/admin/finance/nps/route.ts
@@ -15,7 +15,7 @@ export const dynamic = 'force-dynamic';
 export async function GET(request: NextRequest) {
   try {
     await requireRole(['admin', 'super_admin', 'finance']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { searchParams } = new URL(request.url);
     const query = NpsQuerySchema.parse({

--- a/src/app/api/admin/finance/reconciliation/route.ts
+++ b/src/app/api/admin/finance/reconciliation/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
     const user = await requireRole(['admin', 'super_admin', 'finance']);
     const isAdminOrSuperAdmin = user.roles.some((r) => ['admin', 'super_admin'].includes(r));
 
-    const supabase = createClient();
+    const supabase = await createClient();
 
     // admin_audit_logs から reconciliation discrepancy を取得
     const { searchParams } = new URL(request.url);

--- a/src/app/api/admin/finance/revenue/route.ts
+++ b/src/app/api/admin/finance/revenue/route.ts
@@ -15,7 +15,7 @@ export const dynamic = 'force-dynamic';
 export async function GET(request: NextRequest) {
   try {
     await requireRole(['admin', 'super_admin', 'finance']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { searchParams } = new URL(request.url);
     const query = RevenueQuerySchema.parse({

--- a/src/app/api/admin/sales/leads/[id]/activities/route.ts
+++ b/src/app/api/admin/sales/leads/[id]/activities/route.ts
@@ -16,7 +16,7 @@ type RouteContext = { params: { id: string } };
 export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     await requireRole(['sales', 'admin', 'super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { data, error } = await supabase
       .from('sales_lead_activities')
@@ -67,7 +67,7 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
     }
 
     const { activity_type, details } = parseResult.data;
-    const supabase = createClient();
+    const supabase = await createClient();
 
     // リード存在確認
     const { data: lead, error: leadError } = await supabase

--- a/src/app/api/admin/sales/leads/[id]/route.ts
+++ b/src/app/api/admin/sales/leads/[id]/route.ts
@@ -16,7 +16,7 @@ type RouteContext = { params: { id: string } };
 export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     await requireRole(['sales', 'admin', 'super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { data: lead, error } = await supabase
       .from('sales_leads')
@@ -91,7 +91,7 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
       );
     }
 
-    const supabase = createClient();
+    const supabase = await createClient();
     const updates = parseResult.data;
 
     // 現在のステージを取得 (ステージ変更の監査用)

--- a/src/app/api/admin/sales/leads/route.ts
+++ b/src/app/api/admin/sales/leads/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
     }
 
     const { stage, assigned_to, page, per_page } = queryResult.data;
-    const supabase = createClient();
+    const supabase = await createClient();
 
     let query = supabase
       .from('sales_leads')
@@ -108,7 +108,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const supabase = createClient();
+    const supabase = await createClient();
     const inputData = parseResult.data;
 
     // assigned_to が未指定の場合は作成者を割り当て

--- a/src/app/api/admin/support/tickets/[id]/assign/route.ts
+++ b/src/app/api/admin/support/tickets/[id]/assign/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
     }
 
     const { assignee_id } = parseResult.data;
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { data: ticket, error } = await supabase
       .from('support_tickets')

--- a/src/app/api/admin/support/tickets/[id]/messages/route.ts
+++ b/src/app/api/admin/support/tickets/[id]/messages/route.ts
@@ -16,7 +16,7 @@ type RouteContext = { params: { id: string } };
 export async function GET(request: NextRequest, { params }: RouteContext) {
   try {
     const currentUser = await requireRole(['support', 'admin', 'super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const isInternalAllowed = currentUser.roles.some((r) =>
       ['support', 'admin', 'super_admin'].includes(r),
@@ -90,7 +90,7 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
       }
     }
 
-    const supabase = createClient();
+    const supabase = await createClient();
 
     // チケット存在確認
     const { data: ticket, error: ticketError } = await supabase
@@ -179,7 +179,7 @@ async function sendEmailToUser(
   }
 
   try {
-    const supabase = createClient();
+    const supabase = await createClient();
     const { data: profile } = await supabase
       .from('user_profiles')
       .select('id')

--- a/src/app/api/admin/support/tickets/[id]/route.ts
+++ b/src/app/api/admin/support/tickets/[id]/route.ts
@@ -16,7 +16,7 @@ type RouteContext = { params: { id: string } };
 export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     const currentUser = await requireRole(['support', 'admin', 'super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { data: ticket, error } = await supabase
       .from('support_tickets')
@@ -99,7 +99,7 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
       );
     }
 
-    const supabase = createClient();
+    const supabase = await createClient();
     const updates = parseResult.data;
 
     // resolved 状態に変更する場合は resolved_at を設定

--- a/src/app/api/admin/support/tickets/route.ts
+++ b/src/app/api/admin/support/tickets/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
     }
 
     const { status, priority, assignee_id, page, per_page } = queryResult.data;
-    const supabase = createClient();
+    const supabase = await createClient();
 
     let query = supabase
       .from('support_tickets')
@@ -109,7 +109,7 @@ export async function POST(request: NextRequest) {
     }
 
     const { user_id, subject, category, priority, body: messageBody } = parseResult.data;
-    const supabase = createClient();
+    const supabase = await createClient();
 
     // トランザクション的に ticket + 最初のメッセージを作成
     const { data: ticket, error: ticketError } = await supabase

--- a/src/app/api/catalog/products/[id]/route.ts
+++ b/src/app/api/catalog/products/[id]/route.ts
@@ -13,7 +13,7 @@ export async function GET(
     return NextResponse.json({ error: "invalid_id" }, { status: 400 });
   }
 
-  const supabase = createClient();
+  const supabase = await createClient();
 
   try {
     const {

--- a/src/app/api/catalog/products/route.ts
+++ b/src/app/api/catalog/products/route.ts
@@ -6,7 +6,7 @@ const DEFAULT_LIMIT = 8;
 const MAX_LIMIT = 20;
 
 export async function GET(request: Request) {
-  const supabase = createClient();
+  const supabase = await createClient();
 
   try {
     const {

--- a/src/app/api/super-admin/coupons/[id]/redemptions/route.ts
+++ b/src/app/api/super-admin/coupons/[id]/redemptions/route.ts
@@ -16,7 +16,7 @@ type RouteContext = { params: { id: string } };
 export async function GET(request: NextRequest, { params }: RouteContext) {
   try {
     await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     // クーポン ID(UUID)で取得
     const { data: coupon, error: couponErr } = await supabase

--- a/src/app/api/super-admin/coupons/[id]/route.ts
+++ b/src/app/api/super-admin/coupons/[id]/route.ts
@@ -18,7 +18,7 @@ type RouteContext = { params: { id: string } };
 export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { data: coupon, error } = await supabase
       .from('coupons')
@@ -49,7 +49,7 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
 export async function PATCH(request: NextRequest, { params }: RouteContext) {
   try {
     const user = await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const body = await request.json();
     const parseResult = CouponUpdateSchema.safeParse(body);
@@ -138,7 +138,7 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
 export async function DELETE(request: NextRequest, { params }: RouteContext) {
   try {
     const user = await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { data: existing, error: fetchErr } = await supabase
       .from('coupons')

--- a/src/app/api/super-admin/coupons/route.ts
+++ b/src/app/api/super-admin/coupons/route.ts
@@ -18,7 +18,7 @@ import {
 export async function GET(request: NextRequest) {
   try {
     await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { searchParams } = request.nextUrl;
     const queryResult = CouponsQuerySchema.safeParse({
@@ -76,7 +76,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const user = await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const body = await request.json();
     const parseResult = CouponCreateSchema.safeParse(body);

--- a/src/app/api/super-admin/feature-packages/[id]/route.ts
+++ b/src/app/api/super-admin/feature-packages/[id]/route.ts
@@ -18,7 +18,7 @@ type RouteContext = { params: { id: string } };
 export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { data: pkg, error } = await supabase
       .from('feature_packages')
@@ -49,7 +49,7 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
 export async function PATCH(request: NextRequest, { params }: RouteContext) {
   try {
     const user = await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const body = await request.json();
     const parseResult = FeaturePackageUpdateSchema.safeParse(body);
@@ -122,7 +122,7 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
 export async function DELETE(request: NextRequest, { params }: RouteContext) {
   try {
     const user = await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { data: existing, error: fetchErr } = await supabase
       .from('feature_packages')

--- a/src/app/api/super-admin/feature-packages/route.ts
+++ b/src/app/api/super-admin/feature-packages/route.ts
@@ -18,7 +18,7 @@ import {
 export async function GET(request: NextRequest) {
   try {
     await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { searchParams } = request.nextUrl;
     const queryResult = FeaturePackagesQuerySchema.safeParse({
@@ -74,7 +74,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const user = await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const body = await request.json();
     const parseResult = FeaturePackageCreateSchema.safeParse(body);

--- a/src/app/api/super-admin/plans/[id]/price-change/route.ts
+++ b/src/app/api/super-admin/plans/[id]/price-change/route.ts
@@ -20,7 +20,7 @@ type RouteContext = { params: { id: string } };
 export async function POST(request: NextRequest, { params }: RouteContext) {
   try {
     const user = await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const body = await request.json();
     const parseResult = PriceChangeSchema.safeParse(body);

--- a/src/app/api/super-admin/plans/[id]/price-impact/route.ts
+++ b/src/app/api/super-admin/plans/[id]/price-impact/route.ts
@@ -16,7 +16,7 @@ type RouteContext = { params: { id: string } };
 export async function GET(request: NextRequest, { params }: RouteContext) {
   try {
     await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { searchParams } = request.nextUrl;
     const queryResult = PriceImpactQuerySchema.safeParse({

--- a/src/app/api/super-admin/plans/[id]/route.ts
+++ b/src/app/api/super-admin/plans/[id]/route.ts
@@ -18,7 +18,7 @@ type RouteContext = { params: { id: string } };
 export async function GET(_request: NextRequest, { params }: RouteContext) {
   try {
     await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { data: plan, error } = await supabase
       .from('subscription_plans')
@@ -57,7 +57,7 @@ export async function GET(_request: NextRequest, { params }: RouteContext) {
 export async function PATCH(request: NextRequest, { params }: RouteContext) {
   try {
     const user = await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     // 既存プランを取得
     const { data: existing, error: fetchErr } = await supabase
@@ -179,7 +179,7 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
 export async function DELETE(request: NextRequest, { params }: RouteContext) {
   try {
     const user = await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { data: existing, error: fetchErr } = await supabase
       .from('subscription_plans')

--- a/src/app/api/super-admin/plans/route.ts
+++ b/src/app/api/super-admin/plans/route.ts
@@ -18,7 +18,7 @@ import {
 export async function GET(request: NextRequest) {
   try {
     const user = await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const { searchParams } = request.nextUrl;
     const queryResult = PlansQuerySchema.safeParse({
@@ -76,7 +76,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const user = await requireRole(['super_admin']);
-    const supabase = createClient();
+    const supabase = await createClient();
 
     const body = await request.json();
     const parseResult = PlanCreateSchema.safeParse(body);


### PR DESCRIPTION
## 概要

25 ファイル・41 箇所で `const supabase = createClient()` が `await` なしで
呼ばれていた問題を全件修正した。

## 根本原因

`@supabase/ssr` の `createClient()` は同期関数だが、コードベースの正しい実装
(meal-plans / pantry / org など) は `await createClient()` で統一されていた。
`await` なしの場合、Next.js の動的 cookie/headers コンテキストが未解決のまま
Supabase クライアントが生成されるケースがあり、JWT が注入されず anonymous
アクセスになる → RLS が user_id フィルタを適用しない → 認証バイパス。

## 修正内容

`const supabase = createClient()` → `const supabase = await createClient()` への
一括置換 (全 25 ファイル / 41 箇所)

### 修正ファイル一覧

**admin/finance (7 ファイル)**
- `src/app/api/admin/finance/dashboard/route.ts`
- `src/app/api/admin/finance/exports/route.ts`
- `src/app/api/admin/finance/invoices/route.ts`
- `src/app/api/admin/finance/invoices/[id]/route.ts`
- `src/app/api/admin/finance/nps/route.ts`
- `src/app/api/admin/finance/reconciliation/route.ts`
- `src/app/api/admin/finance/revenue/route.ts`

**admin/sales (3 ファイル)**
- `src/app/api/admin/sales/leads/route.ts`
- `src/app/api/admin/sales/leads/[id]/route.ts`
- `src/app/api/admin/sales/leads/[id]/activities/route.ts`

**admin/support (4 ファイル)**
- `src/app/api/admin/support/tickets/route.ts`
- `src/app/api/admin/support/tickets/[id]/route.ts`
- `src/app/api/admin/support/tickets/[id]/messages/route.ts`
- `src/app/api/admin/support/tickets/[id]/assign/route.ts`

**catalog (2 ファイル)**
- `src/app/api/catalog/products/route.ts`
- `src/app/api/catalog/products/[id]/route.ts`

**super-admin/coupons (3 ファイル)**
- `src/app/api/super-admin/coupons/route.ts`
- `src/app/api/super-admin/coupons/[id]/route.ts`
- `src/app/api/super-admin/coupons/[id]/redemptions/route.ts`

**super-admin/feature-packages (2 ファイル)**
- `src/app/api/super-admin/feature-packages/route.ts`
- `src/app/api/super-admin/feature-packages/[id]/route.ts`

**super-admin/plans (4 ファイル)**
- `src/app/api/super-admin/plans/route.ts`
- `src/app/api/super-admin/plans/[id]/route.ts`
- `src/app/api/super-admin/plans/[id]/price-impact/route.ts`
- `src/app/api/super-admin/plans/[id]/price-change/route.ts`

## 検証

- `npm run typecheck`: 0 error
- 修正後の残件: `grep -rn "const supabase = createClient()" src/app/api/` → 0 件
- 全 `await createClient()` 使用箇所: 212 件

## 影響を受ける症状 (修正前)

- Integration test 5+ 件 fail (support role POST 500, stage filter で自分の lead 見えない等)
- super-admin feature-packages の duplicate 検知失敗 (409 が 400 に変わる)
- 認証バイパスによる RLS 誤発動 (anonymous key で RLS の user_id フィルタが効かない)