### PR TITLE
fix(a11y): E2E カテゴリ F の ARIA/a11y 13 件対応

### DIFF
--- a/src/components/AIChatBubble.tsx
+++ b/src/components/AIChatBubble.tsx
@@ -930,7 +930,7 @@ export default function AIChatBubble() {
                 </button>
                 <button
                   onClick={() => { setIsOpen(false); setIsToggling(false); }}
-                  aria-label="閉じる"
+                  aria-label="AIチャットを閉じる"
                   className="p-2 rounded-full hover:bg-gray-100"
                 >
                   <X size={18} color={colors.textMuted} />


### PR DESCRIPTION
## Summary

- `AIChatBubble.tsx` の閉じるボタン `aria-label` を `"閉じる"` → `"AIチャットを閉じる"` に修正 (#204)
- 他 12 件 (#199/#207/#209/#210) は既に実装済みであることを確認済み

## 詳細調査結果

| テスト | 期待 | 実装状況 |
|--------|------|---------|
| #199 週間統計モーダル (3件) | `role=dialog`, `aria-modal`, `aria-labelledby`, Escape キー | 既に実装済み |
| #204 AIChatBubble 開くボタン | `data-testid="ai-chat-floating-button"`, `aria-label="AIアドバイザーを開く"` | 既に実装済み |
| #204 AIChatBubble 閉じるボタン | `aria-label="AIチャットを閉じる"` | 今回修正 ("閉じる" → "AIチャットを閉じる") |
| #204 AIChatBubble 送信ボタン | `aria-label="メッセージを送信"` | 既に実装済み |
| #207 通知スイッチ (3件) | `role=switch`, `aria-checked`, `aria-label="通知を有効化"` | 既に実装済み |
| #207 自動解析スイッチ | `aria-label="自動解析を有効化"` | 既に実装済み |
| #209 体重 input (2件) | `label[for="health-weight"]`, `input#health-weight` | 既に実装済み |
| #209 体脂肪率 input | `label[for="health-body-fat"]`, `input#health-body-fat` | 既に実装済み |
| #210 バッジモーダル (3件) | `data-testid="badge-detail-modal"`, `role=dialog`, Escape キー | 既に実装済み |

## Test plan

- [ ] `npm run typecheck` 通過確認済み
- [ ] E2E `wave2-f19-a11y-fixes.spec.ts` #204 「AI チャットを閉じるボタンに aria-label がある」が通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)