### PR TITLE
fix(e2e): /tmp/classify-test 画像 fixture を整備 (カテゴリ A 9 件解消)

### DIFF
--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -16,6 +16,7 @@
 import { chromium, type FullConfig } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
+import { seedClassifyFixtures } from "./setup/seed-classify-fixtures";
 
 const STORAGE_STATE_PATH = "tests/e2e/.auth/user.json";
 const MAX_RETRIES = 3;
@@ -61,6 +62,9 @@ async function fetchSupabaseSession(
 }
 
 async function globalSetup(config: FullConfig): Promise<void> {
+  // classify-test fixture を /tmp/classify-test/ に生成 (存在しない場合のみ)
+  seedClassifyFixtures();
+
   const baseURL =
     config.projects[0]?.use?.baseURL ??
     process.env.PLAYWRIGHT_BASE_URL ??

--- a/tests/e2e/setup/seed-classify-fixtures.ts
+++ b/tests/e2e/setup/seed-classify-fixtures.ts
@@ -1,0 +1,76 @@
+/**
+ * seed-classify-fixtures.ts
+ *
+ * /tmp/classify-test/ に最小 JPEG ファイルを生成する。
+ * ImageMagick 等の外部依存なしに Node.js Buffer だけで有効な JPEG を作成する。
+ *
+ * 生成ファイル:
+ *   meal-1.jpg, meal-2.jpg
+ *   fridge-1.jpg, fridge-2.jpg
+ *   health-1.jpg, health-2.jpg
+ *   weight-1.jpg, weight-2.jpg
+ *   unknown-blank.jpg
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const CLASSIFY_TEST_DIR = "/tmp/classify-test";
+
+/**
+ * 1x1 ピクセルの最小有効 JPEG バイナリ (Base64 エンコード済み)
+ * SOI + APP0(JFIF) + DQT + SOF0 + DHT + SOS + EOI の完全な構造を持つ
+ * Node.js で生成・検証済み (SOI=FF D8, EOI=FF D9)
+ */
+const MINIMAL_JPEG_BASE64 =
+  "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABALChAYKDM9DAwOExo6PDcODRAYKDlFOA4R" +
+  "Fh0zV1A+EhYlOERtZ00YIzdAUWhxXDFATldneXhlSFxfYnBkZ2P/wAALCAABAAEBAREA" +
+  "/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/9oACAEBAAA/AH///9k=";
+
+/**
+ * 最小 JPEG バイナリを生成する
+ */
+function makeMinimalJpeg(): Buffer {
+  return Buffer.from(MINIMAL_JPEG_BASE64, "base64");
+}
+
+/**
+ * classify-test ディレクトリと必要な JPEG ファイルを生成する。
+ * 既存ファイルはスキップする。
+ */
+export function seedClassifyFixtures(): void {
+  if (!fs.existsSync(CLASSIFY_TEST_DIR)) {
+    fs.mkdirSync(CLASSIFY_TEST_DIR, { recursive: true });
+    console.log(`[seed-classify-fixtures] ディレクトリ作成: ${CLASSIFY_TEST_DIR}`);
+  }
+
+  const files = [
+    "meal-1.jpg",
+    "meal-2.jpg",
+    "fridge-1.jpg",
+    "fridge-2.jpg",
+    "health-1.jpg",
+    "health-2.jpg",
+    "weight-1.jpg",
+    "weight-2.jpg",
+    "unknown-blank.jpg",
+  ];
+
+  const jpegBuf = makeMinimalJpeg();
+
+  for (const file of files) {
+    const filePath = path.join(CLASSIFY_TEST_DIR, file);
+    if (!fs.existsSync(filePath)) {
+      fs.writeFileSync(filePath, jpegBuf);
+      console.log(`[seed-classify-fixtures] 生成: ${filePath} (${jpegBuf.length} bytes)`);
+    } else {
+      console.log(`[seed-classify-fixtures] スキップ (既存): ${filePath}`);
+    }
+  }
+}
+
+// スクリプトとして直接実行された場合
+if (require.main === module) {
+  seedClassifyFixtures();
+  console.log("[seed-classify-fixtures] 完了");
+}


### PR DESCRIPTION
## 修正方針

`global-setup.ts` (Playwright グローバルセットアップ) から `seedClassifyFixtures()` を呼び出し、テスト実行前に `/tmp/classify-test/` へ最小 JPEG を自動生成する方式を採用。

- ImageMagick / Sharp 等の外部依存なし
- リポジトリにバイナリを含めない (生成スクリプトのみコミット)
- 既存ファイルがある場合はスキップ (冪等)

## 追加ファイル

| ファイル | 内容 |
|---|---|
| `tests/e2e/setup/seed-classify-fixtures.ts` | `/tmp/classify-test/` に 1x1px JPEG (149 bytes) を生成するセットアップスクリプト |
| `tests/e2e/global-setup.ts` | `seedClassifyFixtures()` 呼び出しを追加 (import 1行 + 呼び出し 1行) |

## 生成される fixture ファイル

```
/tmp/classify-test/
  meal-1.jpg    (149 bytes, 1x1px JPEG, SOI=FF D8, EOI=FF D9)
  meal-2.jpg
  fridge-1.jpg
  fridge-2.jpg
  health-1.jpg
  health-2.jpg
  weight-1.jpg
  weight-2.jpg
  unknown-blank.jpg
```

## 影響 spec (9 件 ENOENT 解消)

| spec | テスト |
|---|---|
| `tests/e2e/.exploration/aichat-image-explore.spec.ts:281` | `2-2: capture ステップで解析ボタンが表示される` |
| `tests/e2e/.exploration/aichat-image-explore.spec.ts:321` | `3-auto: meal/fridge/health/weight 各 2 枚 → classify` (8 件) |

`image-classification-validation.spec.ts` および `bug-64-65-image-classify.spec.ts` も同じ `SAMPLE_DIR = "/tmp/classify-test"` を参照しているが、後者は `test.skip(true, ...)` のため影響なし。前者は本 PR で ENOENT が解消される。

## 検証

- `npm run typecheck` 0 error 確認済み
- Node.js で JPEG バイナリの SOI/EOI マーカーを検証済み