### PR TITLE
fix(auth): wrong password / 重複メールエラーを日本語化

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -78,26 +78,29 @@ function LoginContent() {
 
       if (error) {
         // エラーコードに応じたメッセージ
-        if (
-          error.message.includes('Invalid login credentials') ||
+        const isRateLimit =
+          error.code === 'over_email_send_rate_limit' ||
+          error.code === 'over_request_rate_limit' ||
+          error.status === 429 ||
           error.message.includes('over_email_send_rate_limit') ||
           error.message.includes('For security purposes') ||
-          error.message.includes('too many requests') ||
-          error.status === 429
-        ) {
+          error.message.includes('too many requests');
+        const isInvalidCredentials =
+          error.code === 'invalid_credentials' ||
+          error.message.includes('Invalid login credentials');
+        const isEmailNotConfirmed =
+          error.code === 'email_not_confirmed' ||
+          error.message.includes('Email not confirmed');
+
+        if (isRateLimit || isInvalidCredentials) {
           // #287: rate limit または認証失敗 → 最終失敗時刻を記録
           localStorage.setItem(RATE_LIMIT_KEY, String(Date.now()));
-          if (
-            error.status === 429 ||
-            error.message.includes('over_email_send_rate_limit') ||
-            error.message.includes('For security purposes') ||
-            error.message.includes('too many requests')
-          ) {
+          if (isRateLimit) {
             setError('しばらくしてから再度お試しください。');
           } else {
             setError('メールアドレスまたはパスワードが正しくありません。');
           }
-        } else if (error.message.includes('Email not confirmed')) {
+        } else if (isEmailNotConfirmed) {
           setError('メールアドレスが確認されていません。確認メールをご確認ください。');
         } else {
           setError('ログインに失敗しました。入力内容をご確認ください。');
@@ -156,7 +159,7 @@ function LoginContent() {
 
       {/* エラーメッセージ表示 */}
       {error && (
-        <div className="flex items-start gap-3 p-4 rounded-xl bg-red-50 border border-red-200 animate-shake">
+        <div role="alert" className="flex items-start gap-3 p-4 rounded-xl bg-red-50 border border-red-200 animate-shake">
           <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
           <div className="flex-1">
             <p className="text-sm font-medium text-red-800">{error}</p>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -80,12 +80,23 @@ export default function SignupPage() {
 
       if (error) {
         console.error('Signup error:', error);
-        // Supabase エラーを日本語化してインライン表示
-        const messages: Record<string, string> = {
-          'Password should be at least 6 characters.': 'パスワードは8文字以上で入力してください',
-          'User already registered': 'このメールアドレスは既に登録されています',
-        };
-        setFormError(messages[error.message] ?? `登録に失敗しました: ${error.message}`);
+        // Supabase エラーコードおよびメッセージで日本語化
+        const isDuplicateEmail =
+          error.code === 'user_already_exists' ||
+          error.code === 'email_exists' ||
+          error.message === 'User already registered' ||
+          error.message.includes('already registered') ||
+          error.message.includes('already been registered');
+        const isWeakPassword =
+          error.code === 'weak_password' ||
+          error.message.includes('Password should be at least');
+        if (isDuplicateEmail) {
+          setFormError('このメールアドレスは既に登録されています。ログインへ進んでください。');
+        } else if (isWeakPassword) {
+          setFormError('パスワードは8文字以上で入力してください');
+        } else {
+          setFormError(`登録に失敗しました: ${error.message}`);
+        }
         // #286: エラー確定後に即座にローディングを解除（finally でも解除されるが明示的に）
         setIsLoading(false);
         return;


### PR DESCRIPTION
## Summary

- `login/page.tsx` のエラー表示 `<div>` に `role="alert"` を追加 (E2E テスト 1-3 が `[role="alert"]` を優先検索するため)
- `login/page.tsx` で `error.code === 'invalid_credentials'` による判定を優先し、`message.includes()` をフォールバックとして整理
- `signup/page.tsx` で重複メール判定を `error.code === 'user_already_exists' || 'email_exists'` に対応させ、メッセージのフォールバック比較も拡充
- `signup/page.tsx` で弱パスワード判定を `error.code === 'weak_password'` にも対応

## 背景

E2E カテゴリ H の 2 件が失敗していた:
- `1-3: wrong password → 日本語エラーメッセージ`: login の `<div>` に `role="alert"` がなく、テストのセレクタが空文字列しか取得できなかった
- `2-2: 重複メール → 日本語エラー`: signup のエラーハンドリングは実装済みだが、Supabase が返すエラーコード (`user_already_exists`) でも確実にキャッチできるよう補強

## Test plan

- [ ] `PLAYWRIGHT_BASE_URL=https://homegohan-app.vercel.app npx playwright test tests/e2e/.exploration/auth-explore.spec.ts` で 1-3 / 2-2 が pass
- [ ] `npm run typecheck` が通ること (確認済み)
- [ ] ログイン失敗時に日本語エラーが表示されること (手動確認)
- [ ] 重複メールでサインアップ時に日本語エラーが表示されること (手動確認)