### PR TITLE
fix(test): Vitest integration の env ロード + Node 20 ws polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,11 +40,14 @@
         "@types/node": "^20.19.25",
         "@types/react": "~19.0.10",
         "@types/react-dom": "~19.0.4",
+        "@types/ws": "^8.18.1",
+        "dotenv": "^17.4.2",
         "eslint": "^8.57.0",
         "eslint-config-next": "^14.2.3",
         "tailwindcss": "^4.1.17",
         "typescript": "^5.9.3",
-        "vitest": "^4.0.16"
+        "vitest": "^4.0.16",
+        "ws": "^8.20.0"
       },
       "engines": {
         "node": "20.x"
@@ -2259,6 +2262,18 @@
         "getenv": "^2.0.0"
       }
     },
+    "node_modules/@expo/env/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@expo/fingerprint": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.13.4.tgz",
@@ -2415,6 +2430,18 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@expo/metro-config/node_modules/glob": {
@@ -9486,9 +9513,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -9505,6 +9533,18 @@
       "dependencies": {
         "dotenv": "^16.4.5"
       },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -58,11 +58,14 @@
     "@types/node": "^20.19.25",
     "@types/react": "~19.0.10",
     "@types/react-dom": "~19.0.4",
+    "@types/ws": "^8.18.1",
+    "dotenv": "^17.4.2",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.3",
     "tailwindcss": "^4.1.17",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.16"
+    "vitest": "^4.0.16",
+    "ws": "^8.20.0"
   },
   "overrides": {
     "react-native": {

--- a/tests/integration/helpers/supabase.ts
+++ b/tests/integration/helpers/supabase.ts
@@ -15,6 +15,7 @@
  */
 
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import ws from 'ws';
 
 // ---------------------------------------------------------------
 // 関数形式 (PR #839 由来) — 各呼び出し時に env を読む。lazy 評価。
@@ -29,6 +30,7 @@ export function adminClient(): SupabaseClient {
   }
   return createClient(url, key, {
     auth: { autoRefreshToken: false, persistSession: false },
+    realtime: { transport: ws as unknown as typeof WebSocket },
   });
 }
 
@@ -56,6 +58,7 @@ export const supabaseAdmin = new Proxy({} as SupabaseClient, {
       }
       _supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
         auth: { autoRefreshToken: false, persistSession: false },
+        realtime: { transport: ws as unknown as typeof WebSocket },
       });
     }
     return _supabaseAdmin[prop as keyof SupabaseClient];
@@ -74,6 +77,7 @@ export const supabaseAnon = new Proxy({} as SupabaseClient, {
       }
       _supabaseAnon = createClient(supabaseUrl, anonKey, {
         auth: { autoRefreshToken: false, persistSession: false },
+        realtime: { transport: ws as unknown as typeof WebSocket },
       });
     }
     return _supabaseAnon[prop as keyof SupabaseClient];

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,0 +1,10 @@
+/**
+ * Integration test global setup.
+ * dotenv で .env.local を明示的に読み込む。
+ * vitest.integration.config.ts の loadEnv と二重になるが、
+ * fork worker 内で process.env が欠落するケースへの保険として維持する。
+ */
+import { config as dotenvConfig } from 'dotenv';
+import path from 'node:path';
+
+dotenvConfig({ path: path.resolve(process.cwd(), '.env.local') });

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -13,33 +13,40 @@
  *   API_BASE_URL or PLAYWRIGHT_BASE_URL (default: http://localhost:3000)
  */
 import { defineConfig } from 'vitest/config';
+import { loadEnv } from 'vite';
 import path from 'node:path';
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ mode }) => {
+  // .env.local を明示的に読み込む (prefix '' = 全変数対象)
+  const env = loadEnv(mode ?? 'test', process.cwd(), '');
+  return {
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-  test: {
-    include: ['tests/integration/**/*.test.ts'],
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/.next/**',
-      'tests/e2e/**',
-      'homegohan-app/**',
-      '.claude/**',
-    ],
-    // Integration tests hit real Supabase — allow longer timeouts
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
-    // Run sequentially to avoid auth rate limits and DB conflicts
-    pool: 'forks',
-    maxConcurrency: 1,
-    maxWorkers: 1,
-    env: {
-      NODE_ENV: 'test',
+    test: {
+      include: ['tests/integration/**/*.test.ts'],
+      exclude: [
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/.next/**',
+        'tests/e2e/**',
+        'homegohan-app/**',
+        '.claude/**',
+      ],
+      // Integration tests hit real Supabase — allow longer timeouts
+      testTimeout: 30_000,
+      hookTimeout: 30_000,
+      // Run sequentially to avoid auth rate limits and DB conflicts
+      pool: 'forks',
+      maxConcurrency: 1,
+      maxWorkers: 1,
+      env: {
+        NODE_ENV: 'test',
+        ...env,
+      },
+      setupFiles: ['./tests/integration/setup.ts'],
     },
-  },
+  };
 });


### PR DESCRIPTION
## 概要

operator suite 全 314 件が beforeAll クラッシュで skip 状態になっていた root cause 2 件を修正する。

## Root Cause A: `.env.local` が読まれない

**現状**: `vitest.integration.config.ts` に `env: { NODE_ENV: 'test' }` のみ  
**結果**: `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` 等が `undefined` → beforeAll で throw

**修正**:
- `vitest.integration.config.ts` を関数形式に変更し、`loadEnv` (vite) で `.env.local` を全変数読み込み
- `tests/integration/setup.ts` を新規作成し、fork worker 内でも `dotenv` フォールバックで確実に env を展開

## Root Cause B: Node 20 WebSocket throw

**現状**: `createClient(url, key, { auth: {...} })` のみ  
**結果**: `@supabase/realtime-js` が Node 20 でネイティブ `WebSocket` を要求 → `websocket-factory.ts:178` で throw

**修正**:
- `tests/integration/helpers/supabase.ts` の `adminClient()` / `supabaseAdmin` / `supabaseAnon` 全箇所に `realtime: { transport: ws }` を追加
- `ws` パッケージ (v8) を devDependencies に追加

## 依存パッケージ追加

```
ws@^8.20.0, @types/ws@^8.18.1, dotenv@^17.4.2 (devDependencies のみ)
```

## 期待される効果

- operator suite 全 314 件の beforeAll クラッシュ skip が解消
- 22 fail の真の状態が可視化される (db schema 等の独立した失敗が露出)

## 検証

- `npm run typecheck` パス (型エラーなし)
- `SUPABASE_INTEGRATION_TEST=1 npm run test:integration -- tests/integration/handson-tour/status.test.ts` で beforeAll 通過確認済み (WebSocket エラーなし、env 読み込み成功、7 テスト実行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)