### PR TITLE
fix(e2e): /settings アカウント削除セレクタ修正 or 機能仕様確認

### DIFF
--- a/tests/e2e/wave5-w56-settings-account-profile-adversarial.spec.ts
+++ b/tests/e2e/wave5-w56-settings-account-profile-adversarial.spec.ts
@@ -225,8 +225,8 @@ test.describe("[account][adversarial] A. アカウント削除", () => {
     const cancelBtn = page.getByRole("button", { name: /キャンセル/ });
 
     await confirmBtn.click();
-    // 「削除中…」表示とキャンセルの disabled を確認
-    await expect(page.getByText("削除中")).toBeVisible({ timeout: 5_000 });
+    // 「削除中…」表示とキャンセルの disabled を確認 (実装は「削除中…」なので正規表現で部分一致)
+    await expect(page.getByText(/削除中/)).toBeVisible({ timeout: 5_000 });
     await expect(cancelBtn).toBeDisabled();
   });
 });
@@ -1335,8 +1335,8 @@ test.describe("[settings][adversarial] F. 追加シナリオ", () => {
       .getByRole("button", { name: /アカウントを完全に削除する/ })
       .click();
 
-    // 削除中の表示を確認
-    await expect(page.getByText("削除中")).toBeVisible({ timeout: 5_000 });
+    // 削除中の表示を確認 (実装は「削除中…」なので正規表現で部分一致)
+    await expect(page.getByText(/削除中/)).toBeVisible({ timeout: 5_000 });
 
     // モーダルがまだ表示されている
     await expect(page.getByText("アカウントを削除しますか？")).toBeVisible();


### PR DESCRIPTION
## Summary

- `wave5-w56-settings-account-profile-adversarial.spec.ts` の `getByText("削除中")` を `/削除中/` (正規表現) に修正
- 実装側のボタンテキストが `削除中…` (三点リーダー付き) のため、exact match では A-7 / F-7 が fail していた

## 調査結果

### 確認された実装状況

| 要素 | 実装状況 | 備考 |
|------|----------|------|
| 「アカウントを削除する」ボタン | 実装済み | `aria-label="アカウントを削除する"` あり |
| 削除確認モーダル | 実装済み | `アカウントを削除しますか？` ダイアログ |
| 削除確認テキスト入力 | 実装済み | `aria-label="削除確認テキスト入力"` あり |
| 「アカウントを完全に削除する」ボタン | 実装済み | `aria-label="アカウントを完全に削除する"` あり |
| `/api/account/delete` API | 実装済み | POST で `confirm: true` が必要 |
| `削除中…` テキスト | **不一致** | spec は `"削除中"` (exact)、実装は `削除中…` |

### 修正内容

- A-7 (line 229): `getByText("削除中")` → `getByText(/削除中/)` 
- F-7 (line 1339): `getByText("削除中")` → `getByText(/削除中/)`

### 未解決の問題 (要実行ログ確認)

27 件 fail のうち 2 件のみ修正。残り 25 件の失敗原因は実際のテスト実行ログなしでは特定できない。

考えられる原因:
1. CI 環境での認証セッション問題 (auth fixture の `login()` が 60s test timeout 内に完了しない)
2. 本番/ステージング環境でのページロード遅延
3. 他のセレクタ不一致 (実際のエラーログで確認が必要)

## Test plan

- [ ] CI で wave5-w56-settings-account-profile-adversarial.spec.ts を実行し、A-7 / F-7 がパスすることを確認
- [ ] 残り fail 件数が 25 件に減ったことを確認
- [ ] 残り fail のエラーログを取得して次の修正方針を決定