### PR TITLE
fix(e2e): handson-tour signup 失敗の修正

### DIFF
--- a/tests/e2e/tour/01-eligibility.spec.ts
+++ b/tests/e2e/tour/01-eligibility.spec.ts
@@ -41,7 +41,7 @@ async function getUserToken(email: string, password: string): Promise<string | n
 /** service_role 経由でユーザーの onboarding_completed_at を設定する */
 async function setOnboardingCompleted(userId: string, value: string | null): Promise<void> {
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) return;
-  await fetch(`${SUPABASE_URL}/rest/v1/user_profiles?user_id=eq.${userId}`, {
+  await fetch(`${SUPABASE_URL}/rest/v1/user_profiles?id=eq.${userId}`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
@@ -56,7 +56,7 @@ async function setOnboardingCompleted(userId: string, value: string | null): Pro
 /** service_role 経由でユーザーの handson_tour_skipped_at を設定する */
 async function setTourSkipped(userId: string, value: string | null): Promise<void> {
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) return;
-  await fetch(`${SUPABASE_URL}/rest/v1/user_profiles?user_id=eq.${userId}`, {
+  await fetch(`${SUPABASE_URL}/rest/v1/user_profiles?id=eq.${userId}`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
@@ -71,7 +71,7 @@ async function setTourSkipped(userId: string, value: string | null): Promise<voi
 /** service_role 経由でユーザーの handson_tour_completed_at を設定する */
 async function setTourCompleted(userId: string, value: string | null): Promise<void> {
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) return;
-  await fetch(`${SUPABASE_URL}/rest/v1/user_profiles?user_id=eq.${userId}`, {
+  await fetch(`${SUPABASE_URL}/rest/v1/user_profiles?id=eq.${userId}`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
@@ -86,7 +86,7 @@ async function setTourCompleted(userId: string, value: string | null): Promise<v
 /** service_role 経由でユーザーの roles を設定する */
 async function setUserRoles(userId: string, roles: string[]): Promise<void> {
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) return;
-  await fetch(`${SUPABASE_URL}/rest/v1/user_profiles?user_id=eq.${userId}`, {
+  await fetch(`${SUPABASE_URL}/rest/v1/user_profiles?id=eq.${userId}`, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",

--- a/tests/e2e/tour/helpers.ts
+++ b/tests/e2e/tour/helpers.ts
@@ -42,33 +42,66 @@ export async function cleanupTestUser(userId: string): Promise<void> {
 }
 
 /**
- * Supabase Auth API で新規 signup する。
- * email_confirm が disabled 想定の E2E 環境用。
+ * Supabase service_role admin API で新規ユーザーを作成し、
+ * user_profiles に初期レコードを insert する。
+ * anon key の signup ではなく admin API を使うことで
+ * email_confirm (メール確認) を強制的にバイパスする。
  * 成功した場合は user_id を返す。
  */
 export async function signupViaApi(email: string, password: string): Promise<string | null> {
-  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-    console.warn("[tour/helpers] Supabase 環境変数が未設定");
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    console.warn("[tour/helpers] SUPABASE_SERVICE_ROLE_KEY が未設定 — admin API でのユーザー作成不可");
     return null;
   }
   try {
-    const resp = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    // service_role admin API: email_confirm をバイパスしてユーザー作成
+    const resp = await fetch(`${SUPABASE_URL}/auth/v1/admin/users`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        apikey: SUPABASE_ANON_KEY,
+        apikey: SUPABASE_SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
       },
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({
+        email,
+        password,
+        email_confirm: true, // メール確認をスキップして即時有効化
+      }),
     });
     if (!resp.ok) {
       const body = await resp.text();
-      console.warn(`[tour/helpers] signup API 失敗 (${resp.status}): ${body.substring(0, 200)}`);
+      console.warn(`[tour/helpers] admin/users 作成失敗 (${resp.status}): ${body.substring(0, 200)}`);
       return null;
     }
     const data = await resp.json() as Record<string, unknown>;
-    // signup レスポンスは { user: { id: ... }, session: { ... } } 形式
-    const user = data.user as { id?: string } | undefined;
-    return user?.id ?? null;
+    // admin API のレスポンスは { id: "...", email: "...", ... } 形式
+    const userId = (data.id as string | undefined) ?? null;
+    if (!userId) return null;
+
+    // user_profiles に最低限の初期レコードを insert する。
+    // オンボーディング未完了のテスト用途なので onboarding_completed_at は null のまま。
+    const profileResp = await fetch(`${SUPABASE_URL}/rest/v1/user_profiles`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        apikey: SUPABASE_SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+        Prefer: "return=minimal",
+      },
+      body: JSON.stringify({
+        id: userId,
+        nickname: "E2E Test User",
+        age_group: "30s",
+        gender: "unspecified",
+      }),
+    });
+    if (!profileResp.ok) {
+      const profileBody = await profileResp.text();
+      console.warn(`[tour/helpers] user_profiles 初期レコード作成失敗 (${profileResp.status}): ${profileBody.substring(0, 200)}`);
+      // profile 作成失敗でもユーザー自体は作成されているので userId を返す
+    }
+
+    return userId;
   } catch (err) {
     console.warn(`[tour/helpers] signupViaApi error: ${err}`);
     return null;


### PR DESCRIPTION
## 根本原因

handson-tour E2E テスト (`01-07.spec.ts`) が全件 skip / fail していた原因は 3 つ:

### 原因 1: signupViaApi が anon key を使っていた
- **Before**: `/auth/v1/signup` + anon key → email confirmation が必要な場合にユーザーが未確認状態になり、パスワード認証できない
- **After**: `/auth/v1/admin/users` + service_role key → `email_confirm: true` で即時有効化

### 原因 2: user_profiles レコードが存在しない
- admin API でユーザーを作成しても `user_profiles` テーブルに自動レコード作成されない
- `/api/handson-tour/status` は `user_profiles` を `.single()` で取得し、レコードがなければ `profile_not_found=404` を返す
- `fetchTourStatus` は `!resp.ok` で null を返し → `test.skip` になっていた
- **Fix**: `signupViaApi` 内で service_role 経由で `user_profiles` 初期レコード (nickname/age_group/gender) を INSERT

### 原因 3: user_profiles PATCH フィルタが誤り
- `user_profiles?user_id=eq.{id}` → `user_profiles` に `user_id` カラムは存在しない (PK は `id`)
- `setOnboardingCompleted` / `setTourSkipped` / `setTourCompleted` / `setUserRoles` が全て no-op になっていた
- **Fix**: `id=eq.{userId}` に修正

## 修正内容

- `tests/e2e/tour/helpers.ts`: `signupViaApi` を service_role admin API に変更し `user_profiles` 初期レコード作成を追加
- `tests/e2e/tour/01-eligibility.spec.ts`: PATCH フィルタを `user_id` → `id` に修正

## 検証結果

```
01-eligibility.spec.ts:
  ✓ onboarding 未完のユーザーは reason=onboarding_not_completed
  ✓ onboarding 完了済のユーザーは reason=eligible (通常新規)
  ✓ ハンズオンツアー完了済ユーザーは reason=already_completed
  ✓ スキップ済ユーザーは reason=already_skipped
  ✓ admin ロールユーザーは reason=admin_role
  - 既存活動有りユーザーは reason=existing_user_auto_skip (明示的 test.skip)

5 passed, 1 skipped (明示的 skip)
```

Before: 全件 skip/fail (signup 失敗 or profile_not_found)
After: 5件 pass

## フォローアップ

残り 14件 fail (02-07 spec) はボタン操作・UI 遷移の問題で別 issue にて対応:
- Step 0「はじめる」→ Step 1 遷移しない
- 「あとで」→ /home 遷移しない
- settings-restart-handson-tour が存在しない

これらは今回の signup インフラ修正とは独立した UI 実装の問題。