### PR TITLE
fix(handson-tour): handleStart 内の analytics 発火が router.push をブロック

### DIFF
--- a/src/components/handson-tour/TourOverlay.tsx
+++ b/src/components/handson-tour/TourOverlay.tsx
@@ -106,6 +106,9 @@ export function TourOverlay(props: TourOverlayProps) {
           focusTrapOptions={{
             allowOutsideClick: true,
             escapeDeactivates: false,
+            // tabbable な要素がない auto-advance ステップでもエラーにならないよう
+            // オーバーレイ自体をフォールバックフォーカス先として指定する
+            fallbackFocus: '[data-testid="tour-overlay"]',
           }}
         >
           <motion.div
@@ -114,6 +117,7 @@ export function TourOverlay(props: TourOverlayProps) {
             aria-live="polite"
             aria-label={accessibilityLabel}
             data-testid="tour-overlay"
+            tabIndex={-1}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}


### PR DESCRIPTION
## 調査結果

旧 agent の分析では「`fireAnalytics` が `router.push` をブロック」の疑いがあったが、実際の原因は異なった。

### 根本原因

`/handson-tour/photo` (Step 1) に遷移した直後、`TourOverlay` コンポーネントが `FocusTrap` を初期化する際に例外が発生していた。

**エラー内容:**
```
Error: Your focus-trap must have at least one container with at least one tabbable node in it at all times
```

Step 1 の intro サブステップ (`1.1`) では `autoAdvanceMs` が設定されており、`primaryAction` のボタンが存在しない。そのため `TourOverlay` 内に tabbable な要素が一つもなく、`FocusTrap` が初期化失敗する。

この例外が Next.js のエラーバウンダリに捕捉されてエラーページが表示され、`tour-overlay` / `meal-camera-button` が表示されなくなっていた。

**なお `fireAnalytics` は同期的でブロックしない実装**のため、`router.push` 自体は正常に呼ばれていた。

### テスト環境の補足

ローカル `next dev` 環境では HMR タイムスタンプ競合により JS hydration が失敗するケースがあるため、**`next build && next start` を使った production サーバーでテストを実行した**。CI 環境は production build を使うため同条件になる。

## 修正内容

`src/components/handson-tour/TourOverlay.tsx` の `FocusTrap` に以下を追加:

1. `focusTrapOptions.fallbackFocus: '[data-testid="tour-overlay"]'` — tabbable 要素がない場合にオーバーレイ自体にフォーカスを当てる
2. `motion.div` に `tabIndex={-1}` — `fallbackFocus` のターゲットとして DOM フォーカス可能にする

## 影響範囲

- `src/components/handson-tour/TourOverlay.tsx` のみ変更
- Step 0, 1, 2, 3, 4 すべての auto-advance ステップで FocusTrap エラーが解消される
- 機能動作・UI の変更なし (`tabIndex={-1}` はキーボードフォーカス順序に影響しない)

## テスト確認

`PLAYWRIGHT_BASE_URL=http://localhost:3005 npx playwright test tests/e2e/tour/02-step0-welcome.spec.ts:48` → **1 passed**