### PR TITLE
fix(handson-tour): skip 後 /handson-tour URL ガード

### DIFF
--- a/src/app/handson-tour/layout.tsx
+++ b/src/app/handson-tour/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { TourProvider } from '@/contexts/TourContext';
+import { getHandsonTourStatusInternal } from '@/lib/handson-tour/getStatus';
 
 interface HandsonTourLayoutProps {
   children: React.ReactNode;
@@ -28,24 +29,12 @@ export default async function HandsonTourLayout({
 
   if (!isForce) {
     try {
-      const baseUrl =
-        process.env.NEXT_PUBLIC_APP_URL ??
-        (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
-      const res = await fetch(`${baseUrl}/api/handson-tour/status`, {
-        headers: {
-          Cookie: (await import('next/headers')).cookies().toString(),
-        },
-        cache: 'no-store',
-      });
-
-      if (res.ok) {
-        const status = (await res.json()) as { should_show: boolean };
-        if (!status.should_show) {
-          redirect('/home');
-        }
+      const status = await getHandsonTourStatusInternal(user.id);
+      if (!status.should_show) {
+        redirect('/home');
       }
     } catch {
-      // ネットワークエラー時はそのまま表示する
+      // プロファイル未取得時はそのまま表示する
     }
   }
 


### PR DESCRIPTION
## 修正内容

`src/app/handson-tour/layout.tsx` の URL ガードロジックを修正。

### 問題

self-fetch 経由（`fetch('/api/handson-tour/status')` + Cookie 転送）でステータスチェックを行っていたが、Next.js 15 では `cookies()` が非同期 API となっており、`cookies().toString()` という同期呼び出しでは Cookie が正しく転送されていなかった。

その結果、`handson_tour_skipped_at` が設定済みのユーザーが `/handson-tour` に直接アクセスしても `/home` にリダイレクトされず、`tour-step-0` が再表示されていた。

### 修正

self-fetch を廃止し、Server Component から `getHandsonTourStatusInternal(user.id)` を直接呼び出すように変更。

- 不要な HTTP ラウンドトリップがなくなる
- Cookie 転送の問題が解消される
- `already_skipped` の場合に確実に `/home` へリダイレクトされる

### 受け入れ条件

- `tests/e2e/tour/07-skip-and-replay.spec.ts:50` のケース（「あとで」後に /handson-tour に戻っても tour-step-0 が表示されない）が pass

## 変更ファイル

- `src/app/handson-tour/layout.tsx`