### PR TITLE
refactor(packages): shared/core の境界明確化 + Web/Mobile 重複統合

### DIFF
--- a/apps/mobile/app/onboarding/complete/index.tsx
+++ b/apps/mobile/app/onboarding/complete/index.tsx
@@ -17,6 +17,7 @@ import { Card, SectionHeader } from "../../../src/components/ui";
 import { getApi } from "../../../src/lib/api";
 import { supabase } from "../../../src/lib/supabase";
 import { colors, radius, shadows, spacing } from "../../../src/theme";
+import { deriveMacroTargets } from "@homegohan/shared";
 
 // ------------------------------------------------------------
 // 型定義
@@ -45,19 +46,6 @@ interface CalculationBasis {
   macros?: {
     ratios?: { protein: number; fat: number; carbs: number };
   };
-}
-
-// PFC 比率から g を再計算するミニ関数（web 版 deriveMacroTargets と同等）
-function deriveMacros(
-  dailyCalories: number,
-  ratios: { protein: number; fat: number; carbs: number },
-): { proteinG: number; fatG: number; carbsG: number } {
-  const r1 = (v: number) => Math.round(v * 10) / 10;
-  const total = Math.max(0, dailyCalories);
-  const proteinG = r1((total * ratios.protein) / 4);
-  const fatG = r1((total * ratios.fat) / 9);
-  const carbsG = r1(Math.max(0, total - proteinG * 4 - fatG * 9) / 4);
-  return { proteinG, fatG, carbsG };
 }
 
 function getRatios(targets: NutritionTargets): { protein: number; fat: number; carbs: number } {
@@ -125,7 +113,7 @@ export default function OnboardingComplete() {
   // PFC プレビュー
   const previewMacros = useMemo(() => {
     if (!targets) return null;
-    return deriveMacros(previewCalories, getRatios(targets));
+    return deriveMacroTargets({ dailyCalories: previewCalories, ratios: getRatios(targets) });
   }, [previewCalories, targets]);
 
   // BMR / TDEE 情報

--- a/apps/mobile/src/lib/mealPlan.ts
+++ b/apps/mobile/src/lib/mealPlan.ts
@@ -1,11 +1,5 @@
 import { supabase } from "./supabase";
-
-const formatLocalDate = (date: Date): string => {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-};
+import { formatLocalDate } from "@homegohan/shared";
 
 /**
  * Get or create user_daily_meals for a specific date

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -6,7 +6,9 @@
       "@homegohan/handson-tour-shared": ["../../packages/handson-tour-shared/src/index.ts"],
       "@homegohan/handson-tour-shared/*": ["../../packages/handson-tour-shared/src/*"],
       "@homegohan/shared": ["../../packages/shared/src/index.ts"],
-      "@homegohan/shared/*": ["../../packages/shared/src/*"]
+      "@homegohan/shared/*": ["../../packages/shared/src/*"],
+      "@homegohan/core": ["../../packages/core/src/index.ts"],
+      "@homegohan/core/*": ["../../packages/core/src/*"]
     }
   },
   "include": [

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,44 @@
+# @homegohan/core
+
+Web / Mobile 共通の **API クライアント・計算エンジン** パッケージ。
+純粋ロジック・定数は `@homegohan/shared` に置く。
+
+## 境界定義
+
+| カテゴリ | 内容 | 例 |
+|--------|------|-----|
+| HTTP client | fetch ラッパー・認証トークン付与 | `createHttpClient`, `HttpClient` |
+| 栄養計算エンジン | DRI2020 準拠の栄養目標計算 | `calculateNutritionTargets` |
+| 型定義 | API・プロフィール型 | `UserProfileLite`, `NutritionCalculatorInput` |
+| Zod スキーマ | API レスポンス検証 | `DishSchema`, `MenuResponseSchema` |
+| 週計算 | 週範囲・日付操作 | `getWeekRange`, `shiftWeek` |
+| アダプティブループ | チェックイン分析・推奨調整 | `analyzeCheckinLoop`, `applyRecommendations` |
+
+## 含めないもの
+
+- 純粋定数・ラベル → `@homegohan/shared`
+- UI コンポーネント → 各プラットフォームの `src/components`
+- Supabase client インスタンス → 各プラットフォームで初期化 (環境変数が異なるため)
+- プラットフォーム固有のストレージ → 各プラットフォームの `src/lib`
+
+## インポート方法
+
+```ts
+import { createHttpClient, calculateNutritionTargets } from '@homegohan/core';
+```
+
+## モジュール一覧
+
+| ファイル | エクスポート |
+|---------|------------|
+| `api/httpClient.ts` | `createHttpClient`, `HttpClient`, `GetAccessToken` |
+| `nutrition/calculate.ts` | `calculateNutritionTargets` |
+| `nutrition/types.ts` | `NutritionCalculatorInput`, `NutritionCalculationResult`, etc. |
+| `nutrition/dri-tables.ts` | DRI2020 参照テーブル |
+| `nutrition/adaptive-loop.ts` | `analyzeCheckinLoop`, `applyRecommendations` |
+| `schemas/dish.ts` | `DishSchema`, `DishRole`, `Dish` |
+| `schemas/menu-response.ts` | `MenuResponseSchema` |
+| `schemas/generation-config.ts` | `GenerationConfigSchema` |
+| `types/userProfile.ts` | `UserProfileLite`, `DbUserProfileLite` |
+| `converters/userProfile.ts` | `toUserProfileLite` |
+| `utils/week-utils.ts` | `getWeekRange`, `shiftWeek`, `formatLocalDate`, `getDaysBetween` |

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,39 @@
+# @homegohan/shared
+
+Web / Mobile 共通の **純粋ロジック** パッケージ。
+DOM、React Native、Supabase など、実行環境に依存するコードは含まない。
+
+## 境界定義
+
+| カテゴリ | 内容 | 例 |
+|--------|------|-----|
+| 型 | ドメイン定数型 | `DishRole`, `MealType`, `ModeKey` |
+| 定数 | 表示ラベル・フェーズ定義 | `MEAL_LABELS`, `PROGRESS_PHASES`, `NUTRIENT_DEFINITIONS` |
+| util | 純粋関数（副作用なし） | `formatLocalDate`, `todayLocal`, `getDishConfig` |
+| 栄養プランナー | PFC 計算・目標予測 | `deriveMacroTargets`, `estimateGoalProjection` |
+
+## 含めないもの
+
+- HTTP client・fetch ラッパー → `@homegohan/core`
+- Supabase client → `@homegohan/core`
+- ストレージ抽象 (localStorage / AsyncStorage) → 各プラットフォームの実装
+- UI コンポーネント → 各プラットフォームの `src/components`
+
+## インポート方法
+
+```ts
+import { formatLocalDate, getDishConfig, MEAL_LABELS } from '@homegohan/shared';
+```
+
+## モジュール一覧
+
+| ファイル | エクスポート |
+|---------|------------|
+| `date-utils.ts` | `formatLocalDate`, `todayLocal`, `parseLocalDate`, `addDays` |
+| `nutrition-planner.ts` | `deriveMacroTargets`, `estimateGoalProjection` |
+| `dish-roles.ts` | `DishRole`, `DishConfig`, `getDishConfig` |
+| `meal-types.ts` | `MealType`, `MEAL_LABELS`, `MEAL_ORDER` |
+| `mode-config.ts` | `ModeKey`, `ModeConfig`, `MODE_CONFIG` |
+| `nutrition-constants.ts` | `NUTRIENT_DEFINITIONS`, `getNutrientDefinition`, `calculateDriPercentage` |
+| `theme-labels.ts` | `THEME_LABELS_REQUEST`, `AI_CONDITIONS` |
+| `progress-phases.ts` | `PROGRESS_PHASES`, `ULTIMATE_PROGRESS_PHASES`, `SHOPPING_LIST_PHASES` |

--- a/packages/shared/src/date-utils.ts
+++ b/packages/shared/src/date-utils.ts
@@ -1,0 +1,38 @@
+/**
+ * 日付ユーティリティ（純粋関数）
+ *
+ * Web / Mobile 共通で使用するタイムゾーン対応の日付ヘルパー。
+ * DOM / React Native に依存しない純粋関数のみを置く。
+ */
+
+/**
+ * 現地時刻（デフォルト Asia/Tokyo）の YYYY-MM-DD を返す。
+ * UTC 偏移によるズレを防ぐためにロケール 'sv-SE' を使用する。
+ */
+export function formatLocalDate(date: Date = new Date(), timeZone = 'Asia/Tokyo'): string {
+  return date.toLocaleDateString('sv-SE', { timeZone });
+}
+
+/**
+ * 現地時刻の今日（YYYY-MM-DD）を返す。
+ */
+export function todayLocal(timeZone = 'Asia/Tokyo'): string {
+  return formatLocalDate(new Date(), timeZone);
+}
+
+/**
+ * YYYY-MM-DD 形式の文字列を Date に変換する（ローカルタイムとして解釈）。
+ */
+export function parseLocalDate(dateStr: string): Date {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+/**
+ * 指定した日付に days 日加算した Date を返す。
+ */
+export function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,3 +4,5 @@ export * from './dish-roles';
 export * from './meal-types';
 export * from './mode-config';
 export * from './progress-phases';
+export * from './date-utils';
+export * from './nutrition-planner';

--- a/packages/shared/src/nutrition-planner.ts
+++ b/packages/shared/src/nutrition-planner.ts
@@ -1,0 +1,133 @@
+/**
+ * 栄養目標プランナー（純粋関数）
+ *
+ * PFC 比率からマクロ栄養素の g 数を導出する関数と
+ * 目標体重の到達予想日を計算する関数。
+ * Web / Mobile 共通で使用する。
+ */
+
+export type MacroRatios = {
+  protein: number;
+  fat: number;
+  carbs: number;
+};
+
+export type DerivedMacroTargets = {
+  proteinG: number;
+  fatG: number;
+  carbsG: number;
+};
+
+export type GoalProjection =
+  | {
+      reachable: true;
+      estimatedDate: string;
+      estimatedDays: number;
+      dailyEnergyGapKcal: number;
+      weeklyWeightChangeKg: number;
+      direction: 'lose' | 'gain';
+    }
+  | {
+      reachable: false;
+      reason: string;
+    };
+
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/**
+ * PFC 比率とカロリーからマクロ栄養素グラム数を導出する。
+ * 体重・目標に応じたタンパク質フロアを適用する。
+ */
+export function deriveMacroTargets(input: {
+  dailyCalories: number;
+  ratios: MacroRatios;
+  currentWeightKg?: number | null;
+  nutritionGoal?: string | null;
+}): DerivedMacroTargets {
+  const dailyCalories = Math.max(0, input.dailyCalories);
+  const ratios = input.ratios;
+  const proteinFloor =
+    input.currentWeightKg &&
+    ['lose_weight', 'gain_muscle', 'athlete_performance'].includes(String(input.nutritionGoal))
+      ? input.currentWeightKg * 1.2
+      : 0;
+
+  let proteinG = Math.max((dailyCalories * ratios.protein) / 4, proteinFloor);
+  proteinG = Math.min(proteinG, dailyCalories / 4);
+
+  const remainingAfterProtein = Math.max(dailyCalories - proteinG * 4, 0);
+  const fatG = Math.min((dailyCalories * ratios.fat) / 9, remainingAfterProtein / 9);
+
+  const remainingAfterFat = Math.max(remainingAfterProtein - fatG * 9, 0);
+  const carbsG = remainingAfterFat / 4;
+
+  return {
+    proteinG: round1(proteinG),
+    fatG: round1(fatG),
+    carbsG: round1(carbsG),
+  };
+}
+
+/**
+ * 目標体重への到達予想日を計算する（7700 kcal/kg の法則に基づく）。
+ */
+export function estimateGoalProjection(input: {
+  currentWeightKg?: number | null;
+  targetWeightKg?: number | null;
+  dailyCalories?: number | null;
+  tdeeKcal?: number | null;
+  startDate?: Date;
+}): GoalProjection {
+  const currentWeightKg = Number(input.currentWeightKg);
+  const targetWeightKg = Number(input.targetWeightKg);
+  const dailyCalories = Number(input.dailyCalories);
+  const tdeeKcal = Number(input.tdeeKcal);
+
+  if (
+    !Number.isFinite(currentWeightKg) ||
+    !Number.isFinite(targetWeightKg) ||
+    !Number.isFinite(dailyCalories) ||
+    !Number.isFinite(tdeeKcal)
+  ) {
+    return { reachable: false, reason: '目標体重と目標カロリーを入れると到達予想日を表示できます。' };
+  }
+
+  const weightDiffKg = round1(targetWeightKg - currentWeightKg);
+  if (weightDiffKg === 0) {
+    return { reachable: false, reason: '現在体重と目標体重が同じです。' };
+  }
+
+  const dailyEnergyGapKcal = round1(dailyCalories - tdeeKcal);
+  const wantsToLose = weightDiffKg < 0;
+
+  if (wantsToLose && dailyEnergyGapKcal >= 0) {
+    return { reachable: false, reason: 'この目標カロリーだと減量方向になりません。' };
+  }
+
+  if (!wantsToLose && dailyEnergyGapKcal <= 0) {
+    return { reachable: false, reason: 'この目標カロリーだと増量方向になりません。' };
+  }
+
+  const effectiveGap = Math.abs(dailyEnergyGapKcal);
+  if (effectiveGap < 1) {
+    return { reachable: false, reason: '差が小さすぎて到達予想日を計算できません。' };
+  }
+
+  const estimatedDays = Math.ceil((Math.abs(weightDiffKg) * 7700) / effectiveGap);
+  const baseDate = input.startDate ?? new Date();
+  const estimatedDate = new Date(baseDate);
+  estimatedDate.setDate(baseDate.getDate() + estimatedDays);
+
+  const weeklyWeightChangeKg = round1((effectiveGap * 7) / 7700);
+
+  return {
+    reachable: true,
+    estimatedDate: estimatedDate.toISOString(),
+    estimatedDays,
+    dailyEnergyGapKcal,
+    weeklyWeightChangeKg,
+    direction: wantsToLose ? 'lose' : 'gain',
+  };
+}

--- a/src/app/(main)/meals/new/page.tsx
+++ b/src/app/(main)/meals/new/page.tsx
@@ -5,6 +5,7 @@ import { useState, useRef, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { resolveClassifyPhotoType } from "@/lib/ai/image-recognition";
 import { logToServer } from "@/lib/db-logger";
+import { formatLocalDate } from "@homegohan/shared";
 import type { CatalogDishMatch, CatalogProductSummary } from "@/types/catalog";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -193,14 +194,6 @@ const IMAGE_PAYLOAD_CONFIG: Record<PhotoMode | 'classify', ImagePayloadConfig> =
   fridge: { maxWidth: 1600, maxHeight: 1600, quality: 0.8, maxBytes: 900 * 1024 },
   health_checkup: { maxWidth: 1800, maxHeight: 2400, quality: 0.88, maxBytes: 1400 * 1024 },
   weight_scale: { maxWidth: 1600, maxHeight: 1600, quality: 0.86, maxBytes: 900 * 1024 },
-};
-
-// Helper: ローカル日付文字列
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
 };
 
 // Helper: 週の日付を取得

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -13,7 +13,7 @@ import type { CatalogProductSummary } from "@/types/catalog";
 import ReactMarkdown from "react-markdown";
 import { useV4MenuGeneration } from "@/hooks/useV4MenuGeneration";
 import { notifyMenuGenerated } from "@/lib/local-notification";
-import { DEFAULT_RADAR_NUTRIENTS, getNutrientDefinition, calculateDriPercentage, NUTRIENT_DEFINITIONS, NUTRIENT_BY_CATEGORY, CATEGORY_LABELS, THEME_LABELS_REQUEST, AI_CONDITIONS, getDishConfig as getDishConfigShared, type DishConfig, MEAL_LABELS, MEAL_ORDER as MEAL_ORDER_SHARED, PROGRESS_PHASES, ULTIMATE_PROGRESS_PHASES, SHOPPING_LIST_PHASES, type PhaseDefinition, MODE_CONFIG as MODE_CONFIG_SHARED } from "@homegohan/shared";
+import { DEFAULT_RADAR_NUTRIENTS, getNutrientDefinition, calculateDriPercentage, NUTRIENT_DEFINITIONS, NUTRIENT_BY_CATEGORY, CATEGORY_LABELS, THEME_LABELS_REQUEST, AI_CONDITIONS, getDishConfig as getDishConfigShared, type DishConfig, MEAL_LABELS, MEAL_ORDER as MEAL_ORDER_SHARED, PROGRESS_PHASES, ULTIMATE_PROGRESS_PHASES, SHOPPING_LIST_PHASES, type PhaseDefinition, MODE_CONFIG as MODE_CONFIG_SHARED, formatLocalDate } from "@homegohan/shared";
 import { MOCK_MENU_RESPONSE, HANDSON_TOUR_CONSTANTS } from "@homegohan/handson-tour-shared";
 import remarkGfm from "remark-gfm";
 // #fix/e2e-profile-reminder-banner-chunk: chunk 404 防止のため静的 import に変更
@@ -462,12 +462,7 @@ const formatRecipeStepsToMarkdown = (recipeStepsText: string | null | undefined,
 // AI_CONDITIONS は @homegohan/shared からインポート
 
 // Helper functions
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
+// formatLocalDate は @homegohan/shared からインポート済み
 
 const getWeekDates = (startDate: Date): { date: Date; dayOfWeek: string; dateStr: string }[] => {
   const days = [];

--- a/src/hooks/useHomeData.ts
+++ b/src/hooks/useHomeData.ts
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { toAnnouncement, toPlannedMeal } from "@/lib/converter";
 import { resolveDisplayName } from "@/lib/user-display";
+import { formatLocalDate } from "@homegohan/shared";
 import type { Announcement, PlannedMeal, PantryItem, Badge } from "@/types/domain";
 
 // 今日の献立データ
@@ -36,14 +37,6 @@ interface MonthlyStats {
   totalMeals: number;
   cookRate: number;
 }
-
-// Helper: ローカル日付文字列
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
 
 // Helper: 曜日を取得
 const getDayOfWeek = (dateStr: string): string => {

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,14 +1,7 @@
 /**
- * 現地時刻(Asia/Tokyo)の YYYY-MM-DD を返す。
- * UTC 偏移によるズレを防ぐ。
+ * 日付ユーティリティ — @homegohan/shared からの再エクスポート。
+ *
+ * 既存のインポートパス "@/lib/date-utils" を維持しつつ、
+ * 実装の canonical ソースを packages/shared に一本化する。
  */
-export function formatLocalDate(date: Date = new Date(), timeZone = 'Asia/Tokyo'): string {
-  return date.toLocaleDateString('sv-SE', { timeZone });
-}
-
-/**
- * 現地時刻の今日(YYYY-MM-DD)
- */
-export function todayLocal(timeZone = 'Asia/Tokyo'): string {
-  return formatLocalDate(new Date(), timeZone);
-}
+export { formatLocalDate, todayLocal, parseLocalDate, addDays } from '@homegohan/shared';

--- a/src/lib/nutrition-target-planner.ts
+++ b/src/lib/nutrition-target-planner.ts
@@ -1,112 +1,16 @@
-export type MacroRatios = {
-  protein: number;
-  fat: number;
-  carbs: number;
-};
+/**
+ * 栄養目標プランナー — @homegohan/shared からの再エクスポート。
+ *
+ * 既存のインポートパス "@/lib/nutrition-target-planner" を維持しつつ、
+ * 実装の canonical ソースを packages/shared に一本化する。
+ */
+export type {
+  MacroRatios,
+  DerivedMacroTargets,
+  GoalProjection,
+} from '@homegohan/shared';
 
-export type DerivedMacroTargets = {
-  proteinG: number;
-  fatG: number;
-  carbsG: number;
-};
-
-export type GoalProjection =
-  | {
-      reachable: true;
-      estimatedDate: string;
-      estimatedDays: number;
-      dailyEnergyGapKcal: number;
-      weeklyWeightChangeKg: number;
-      direction: "lose" | "gain";
-    }
-  | {
-      reachable: false;
-      reason: string;
-    };
-
-function round1(value: number): number {
-  return Math.round(value * 10) / 10;
-}
-
-export function deriveMacroTargets(input: {
-  dailyCalories: number;
-  ratios: MacroRatios;
-  currentWeightKg?: number | null;
-  nutritionGoal?: string | null;
-}): DerivedMacroTargets {
-  const dailyCalories = Math.max(0, input.dailyCalories);
-  const ratios = input.ratios;
-  const proteinFloor =
-    input.currentWeightKg && ["lose_weight", "gain_muscle", "athlete_performance"].includes(String(input.nutritionGoal))
-      ? input.currentWeightKg * 1.2
-      : 0;
-
-  let proteinG = Math.max((dailyCalories * ratios.protein) / 4, proteinFloor);
-  proteinG = Math.min(proteinG, dailyCalories / 4);
-
-  const remainingAfterProtein = Math.max(dailyCalories - proteinG * 4, 0);
-  let fatG = Math.min((dailyCalories * ratios.fat) / 9, remainingAfterProtein / 9);
-
-  const remainingAfterFat = Math.max(remainingAfterProtein - fatG * 9, 0);
-  const carbsG = remainingAfterFat / 4;
-
-  return {
-    proteinG: round1(proteinG),
-    fatG: round1(fatG),
-    carbsG: round1(carbsG),
-  };
-}
-
-export function estimateGoalProjection(input: {
-  currentWeightKg?: number | null;
-  targetWeightKg?: number | null;
-  dailyCalories?: number | null;
-  tdeeKcal?: number | null;
-  startDate?: Date;
-}): GoalProjection {
-  const currentWeightKg = Number(input.currentWeightKg);
-  const targetWeightKg = Number(input.targetWeightKg);
-  const dailyCalories = Number(input.dailyCalories);
-  const tdeeKcal = Number(input.tdeeKcal);
-
-  if (!Number.isFinite(currentWeightKg) || !Number.isFinite(targetWeightKg) || !Number.isFinite(dailyCalories) || !Number.isFinite(tdeeKcal)) {
-    return { reachable: false, reason: "目標体重と目標カロリーを入れると到達予想日を表示できます。" };
-  }
-
-  const weightDiffKg = round1(targetWeightKg - currentWeightKg);
-  if (weightDiffKg === 0) {
-    return { reachable: false, reason: "現在体重と目標体重が同じです。" };
-  }
-
-  const dailyEnergyGapKcal = round1(dailyCalories - tdeeKcal);
-  const wantsToLose = weightDiffKg < 0;
-
-  if (wantsToLose && dailyEnergyGapKcal >= 0) {
-    return { reachable: false, reason: "この目標カロリーだと減量方向になりません。" };
-  }
-
-  if (!wantsToLose && dailyEnergyGapKcal <= 0) {
-    return { reachable: false, reason: "この目標カロリーだと増量方向になりません。" };
-  }
-
-  const effectiveGap = Math.abs(dailyEnergyGapKcal);
-  if (effectiveGap < 1) {
-    return { reachable: false, reason: "差が小さすぎて到達予想日を計算できません。" };
-  }
-
-  const estimatedDays = Math.ceil((Math.abs(weightDiffKg) * 7700) / effectiveGap);
-  const baseDate = input.startDate ?? new Date();
-  const estimatedDate = new Date(baseDate);
-  estimatedDate.setDate(baseDate.getDate() + estimatedDays);
-
-  const weeklyWeightChangeKg = round1((effectiveGap * 7) / 7700);
-
-  return {
-    reachable: true,
-    estimatedDate: estimatedDate.toISOString(),
-    estimatedDays,
-    dailyEnergyGapKcal,
-    weeklyWeightChangeKg,
-    direction: wantsToLose ? "lose" : "gain",
-  };
-}
+export {
+  deriveMacroTargets,
+  estimateGoalProjection,
+} from '@homegohan/shared';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,12 @@
       "@homegohan/shared/*": [
         "./packages/shared/src/*"
       ],
+      "@homegohan/core": [
+        "./packages/core/src/index.ts"
+      ],
+      "@homegohan/core/*": [
+        "./packages/core/src/*"
+      ],
       "@homegohan/handson-tour-shared": [
         "./packages/handson-tour-shared/src/index.ts"
       ],


### PR DESCRIPTION
## 概要

`packages/shared` と `packages/core` の境界を明確化し、Web/Mobile 間で重複していた関数・型を共通化する。

## 境界定義

### `@homegohan/shared` — 純粋ロジック
- 型・定数（`DishRole`, `MealType`, `ModeKey` など）
- util（純粋関数: format, calc, validation）
- i18n（ラベル文字列）
- **新規**: `date-utils.ts` — 日付フォーマット・操作
- **新規**: `nutrition-planner.ts` — PFC 計算・目標予測

### `@homegohan/core` — API client + 計算エンジン
- HTTP client（fetch ラッパー）
- 栄養目標計算エンジン（DRI2020 準拠）
- Zod スキーマ（API レスポンス検証）
- 週計算ユーティリティ

## 統合した関数・型一覧（7 件）

| # | 関数/型 | 移動前 | 移動後 |
|---|---------|--------|--------|
| 1 | `formatLocalDate` | Web: `src/lib/date-utils.ts` (inline × 3 箇所) | `@homegohan/shared` |
| 2 | `todayLocal` | Web: `src/lib/date-utils.ts` | `@homegohan/shared` |
| 3 | `parseLocalDate` | Web: なし / Core: `week-utils.ts` | `@homegohan/shared` |
| 4 | `addDays` | Web: なし | `@homegohan/shared` |
| 5 | `deriveMacroTargets` | Web: `src/lib/nutrition-target-planner.ts` / Mobile: inline `deriveMacros` | `@homegohan/shared` |
| 6 | `estimateGoalProjection` | Web: `src/lib/nutrition-target-planner.ts` | `@homegohan/shared` |
| 7 | `MacroRatios` / `GoalProjection` 型 | Web: `src/lib/nutrition-target-planner.ts` | `@homegohan/shared` |

## import path の統一

```ts
// 日付ユーティリティ（Web / Mobile 共通）
import { formatLocalDate, todayLocal } from '@homegohan/shared';

// PFC 計算（Web / Mobile 共通）
import { deriveMacroTargets, estimateGoalProjection } from '@homegohan/shared';

// API クライアント（Mobile）
import { createHttpClient } from '@homegohan/core';

// 栄養目標計算（Web / Mobile 共通）
import { calculateNutritionTargets } from '@homegohan/core';
```

## 変更ファイル一覧

- `packages/shared/src/date-utils.ts` — **新規作成**
- `packages/shared/src/nutrition-planner.ts` — **新規作成**
- `packages/shared/README.md` — **新規作成** (境界定義)
- `packages/core/README.md` — **新規作成** (境界定義)
- `packages/shared/src/index.ts` — 新モジュールを re-export
- `src/lib/date-utils.ts` — `@homegohan/shared` からの re-export に変更
- `src/lib/nutrition-target-planner.ts` — `@homegohan/shared` からの re-export に変更
- `src/hooks/useHomeData.ts` — インライン `formatLocalDate` を削除、`@homegohan/shared` に統一
- `src/app/(main)/meals/new/page.tsx` — インライン `formatLocalDate` を削除
- `src/app/(main)/menus/weekly/page.tsx` — インライン `formatLocalDate` を削除
- `apps/mobile/src/lib/mealPlan.ts` — インライン `formatLocalDate` → `@homegohan/shared`
- `apps/mobile/app/onboarding/complete/index.tsx` — インライン `deriveMacros` → `@homegohan/shared`
- `apps/mobile/tsconfig.json` — `@homegohan/core` パスエイリアスを追加
- `tsconfig.json` — `@homegohan/core` パスエイリアスを追加

## 検証

- `npm run typecheck` — 0 error
- `npm run lint` — 0 error
- `next build` — Compiled successfully (Supabase env なし環境での静的生成エラーは既存の事象)