### PR TITLE
refactor(weekly): Phase B-1 zustand store 4 個を作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "recharts": "^3.6.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.4.0",
-        "zod": "^4.1.13"
+        "zod": "^4.1.13",
+        "zustand": "^5.0.13"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -22169,6 +22170,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "recharts": "^3.6.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.4.0",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/src/app/(main)/menus/weekly/_state/formDraftStore.ts
+++ b/src/app/(main)/menus/weekly/_state/formDraftStore.ts
@@ -1,0 +1,191 @@
+// Refactor B Phase B-1: モーダル内編集 state 集約 store
+import { create } from 'zustand';
+import type { MealMode, DishDetail, MealType } from '@/types/domain';
+import type { CatalogProductSummary } from '@/types/catalog';
+
+interface FormDraftState {
+  // 食事名・モード
+  editMealName: string;
+  editMealMode: MealMode;
+
+  // 手動入力
+  manualDishes: DishDetail[];
+  manualMode: MealMode;
+
+  // カタログ検索
+  catalogQuery: string;
+  catalogResults: CatalogProductSummary[];
+  selectedCatalogProduct: CatalogProductSummary | null;
+  isCatalogSearching: boolean;
+  catalogSearchError: string;
+
+  // 冷蔵庫追加フォーム
+  newFridgeName: string;
+  newFridgeAmount: string;
+  newFridgeExpiry: string;
+
+  // 買い物リスト追加フォーム
+  newShoppingName: string;
+  newShoppingAmount: string;
+  newShoppingCategory: string;
+
+  // AI チャット
+  aiChatInput: string;
+
+  // 条件選択
+  selectedConditions: string[];
+
+  // 食事追加
+  addMealKey: MealType | null;
+  addMealDayIndex: number;
+
+  // 画像生成
+  imageGenerationPrompt: string;
+  imageReferenceFiles: File[];
+  imageReferencePreviews: string[];
+
+  // 写真編集
+  photoFiles: File[];
+  photoPreviews: string[];
+}
+
+interface FormDraftActions {
+  setEditMealName: (name: string) => void;
+  setEditMealMode: (mode: MealMode) => void;
+  setManualDishes: (dishes: DishDetail[]) => void;
+  setManualMode: (mode: MealMode) => void;
+  setCatalogQuery: (query: string) => void;
+  setCatalogResults: (results: CatalogProductSummary[]) => void;
+  setSelectedCatalogProduct: (product: CatalogProductSummary | null) => void;
+  setIsCatalogSearching: (isSearching: boolean) => void;
+  setCatalogSearchError: (error: string) => void;
+  setNewFridgeName: (name: string) => void;
+  setNewFridgeAmount: (amount: string) => void;
+  setNewFridgeExpiry: (expiry: string) => void;
+  setNewShoppingName: (name: string) => void;
+  setNewShoppingAmount: (amount: string) => void;
+  setNewShoppingCategory: (category: string) => void;
+  setAiChatInput: (input: string) => void;
+  setSelectedConditions: (conditions: string[]) => void;
+  setAddMealKey: (key: MealType | null) => void;
+  setAddMealDayIndex: (index: number) => void;
+  setImageGenerationPrompt: (prompt: string) => void;
+  setImageReferenceFiles: (files: File[]) => void;
+  setImageReferencePreviews: (previews: string[]) => void;
+  setPhotoFiles: (files: File[]) => void;
+  setPhotoPreviews: (previews: string[]) => void;
+
+  resetEditMeal: () => void;
+  resetManual: () => void;
+  resetFridgeForm: () => void;
+  resetShoppingForm: () => void;
+  resetPhotoEdit: () => void;
+  resetImageGenerate: () => void;
+  resetAddMeal: () => void;
+}
+
+const initialState: FormDraftState = {
+  editMealName: '',
+  editMealMode: 'cook',
+  manualDishes: [],
+  manualMode: 'cook',
+  catalogQuery: '',
+  catalogResults: [],
+  selectedCatalogProduct: null,
+  isCatalogSearching: false,
+  catalogSearchError: '',
+  newFridgeName: '',
+  newFridgeAmount: '',
+  newFridgeExpiry: '',
+  newShoppingName: '',
+  newShoppingAmount: '',
+  newShoppingCategory: '',
+  aiChatInput: '',
+  selectedConditions: [],
+  addMealKey: null,
+  addMealDayIndex: 0,
+  imageGenerationPrompt: '',
+  imageReferenceFiles: [],
+  imageReferencePreviews: [],
+  photoFiles: [],
+  photoPreviews: [],
+};
+
+export const useFormDraftStore = create<FormDraftState & FormDraftActions>()((set) => ({
+  ...initialState,
+
+  setEditMealName: (name) => set({ editMealName: name }),
+  setEditMealMode: (mode) => set({ editMealMode: mode }),
+  setManualDishes: (dishes) => set({ manualDishes: dishes }),
+  setManualMode: (mode) => set({ manualMode: mode }),
+  setCatalogQuery: (query) => set({ catalogQuery: query }),
+  setCatalogResults: (results) => set({ catalogResults: results }),
+  setSelectedCatalogProduct: (product) => set({ selectedCatalogProduct: product }),
+  setIsCatalogSearching: (isSearching) => set({ isCatalogSearching: isSearching }),
+  setCatalogSearchError: (error) => set({ catalogSearchError: error }),
+  setNewFridgeName: (name) => set({ newFridgeName: name }),
+  setNewFridgeAmount: (amount) => set({ newFridgeAmount: amount }),
+  setNewFridgeExpiry: (expiry) => set({ newFridgeExpiry: expiry }),
+  setNewShoppingName: (name) => set({ newShoppingName: name }),
+  setNewShoppingAmount: (amount) => set({ newShoppingAmount: amount }),
+  setNewShoppingCategory: (category) => set({ newShoppingCategory: category }),
+  setAiChatInput: (input) => set({ aiChatInput: input }),
+  setSelectedConditions: (conditions) => set({ selectedConditions: conditions }),
+  setAddMealKey: (key) => set({ addMealKey: key }),
+  setAddMealDayIndex: (index) => set({ addMealDayIndex: index }),
+  setImageGenerationPrompt: (prompt) => set({ imageGenerationPrompt: prompt }),
+  setImageReferenceFiles: (files) => set({ imageReferenceFiles: files }),
+  setImageReferencePreviews: (previews) => set({ imageReferencePreviews: previews }),
+  setPhotoFiles: (files) => set({ photoFiles: files }),
+  setPhotoPreviews: (previews) => set({ photoPreviews: previews }),
+
+  resetEditMeal: () =>
+    set({
+      editMealName: initialState.editMealName,
+      editMealMode: initialState.editMealMode,
+    }),
+
+  resetManual: () =>
+    set({
+      manualDishes: initialState.manualDishes,
+      manualMode: initialState.manualMode,
+      catalogQuery: initialState.catalogQuery,
+      catalogResults: initialState.catalogResults,
+      selectedCatalogProduct: initialState.selectedCatalogProduct,
+      isCatalogSearching: initialState.isCatalogSearching,
+      catalogSearchError: initialState.catalogSearchError,
+    }),
+
+  resetFridgeForm: () =>
+    set({
+      newFridgeName: initialState.newFridgeName,
+      newFridgeAmount: initialState.newFridgeAmount,
+      newFridgeExpiry: initialState.newFridgeExpiry,
+    }),
+
+  resetShoppingForm: () =>
+    set({
+      newShoppingName: initialState.newShoppingName,
+      newShoppingAmount: initialState.newShoppingAmount,
+      newShoppingCategory: initialState.newShoppingCategory,
+    }),
+
+  resetPhotoEdit: () =>
+    set({
+      photoFiles: initialState.photoFiles,
+      photoPreviews: initialState.photoPreviews,
+    }),
+
+  resetImageGenerate: () =>
+    set({
+      imageGenerationPrompt: initialState.imageGenerationPrompt,
+      imageReferenceFiles: initialState.imageReferenceFiles,
+      imageReferencePreviews: initialState.imageReferencePreviews,
+    }),
+
+  resetAddMeal: () =>
+    set({
+      addMealKey: initialState.addMealKey,
+      addMealDayIndex: initialState.addMealDayIndex,
+    }),
+}));

--- a/src/app/(main)/menus/weekly/_state/index.ts
+++ b/src/app/(main)/menus/weekly/_state/index.ts
@@ -1,0 +1,6 @@
+// Refactor B Phase B-1: _state barrel export
+export { useFormDraftStore } from './formDraftStore';
+export { usePantryStore } from './pantryStore';
+export { useShoppingStore } from './shoppingStore';
+export type { ShoppingRangeType, ShoppingRangeSelection } from './shoppingStore';
+export { useServingsConfigStore } from './servingsConfigStore';

--- a/src/app/(main)/menus/weekly/_state/pantryStore.ts
+++ b/src/app/(main)/menus/weekly/_state/pantryStore.ts
@@ -1,0 +1,35 @@
+// Refactor B Phase B-1: 冷蔵庫 state 集約 store
+import { create } from 'zustand';
+import type { PantryItem } from '@/types/domain';
+
+interface PantryState {
+  fridgeItems: PantryItem[];
+}
+
+interface PantryActions {
+  setFridgeItems: (items: PantryItem[]) => void;
+  addFridgeItem: (item: PantryItem) => void;
+  removeFridgeItem: (id: string) => void;
+  updateFridgeItem: (id: string, patch: Partial<PantryItem>) => void;
+}
+
+export const usePantryStore = create<PantryState & PantryActions>()((set) => ({
+  fridgeItems: [],
+
+  setFridgeItems: (items) => set({ fridgeItems: items }),
+
+  addFridgeItem: (item) =>
+    set((state) => ({ fridgeItems: [...state.fridgeItems, item] })),
+
+  removeFridgeItem: (id) =>
+    set((state) => ({
+      fridgeItems: state.fridgeItems.filter((item) => item.id !== id),
+    })),
+
+  updateFridgeItem: (id, patch) =>
+    set((state) => ({
+      fridgeItems: state.fridgeItems.map((item) =>
+        item.id === id ? { ...item, ...patch } : item
+      ),
+    })),
+}));

--- a/src/app/(main)/menus/weekly/_state/servingsConfigStore.ts
+++ b/src/app/(main)/menus/weekly/_state/servingsConfigStore.ts
@@ -1,0 +1,23 @@
+// Refactor B Phase B-1: 配膳設定 state 集約 store
+import { create } from 'zustand';
+import type { ServingsConfig } from '@/types/domain';
+
+interface ServingsConfigState {
+  servingsConfig: ServingsConfig | null;
+  isLoadingServingsConfig: boolean;
+}
+
+interface ServingsConfigActions {
+  setServingsConfig: (config: ServingsConfig | null) => void;
+  setIsLoadingServingsConfig: (isLoading: boolean) => void;
+}
+
+export const useServingsConfigStore = create<ServingsConfigState & ServingsConfigActions>()(
+  (set) => ({
+    servingsConfig: null,
+    isLoadingServingsConfig: false,
+
+    setServingsConfig: (config) => set({ servingsConfig: config }),
+    setIsLoadingServingsConfig: (isLoading) => set({ isLoadingServingsConfig: isLoading }),
+  })
+);

--- a/src/app/(main)/menus/weekly/_state/shoppingStore.ts
+++ b/src/app/(main)/menus/weekly/_state/shoppingStore.ts
@@ -1,0 +1,79 @@
+// Refactor B Phase B-1: 買い物リスト state 集約 store
+import { create } from 'zustand';
+import type { ShoppingListItem, ShoppingList } from '@/types/domain';
+
+export type ShoppingRangeType = 'today' | 'tomorrow' | 'dayAfterTomorrow' | 'week' | 'days' | 'custom';
+
+export interface ShoppingRangeSelection {
+  type: ShoppingRangeType;
+  /** today 選択時の食事タイプ */
+  todayMeals: ('breakfast' | 'lunch' | 'dinner')[];
+  /** days 選択時の日数 */
+  daysCount: number;
+  /** custom 選択時の開始日 */
+  customStartDate?: string;
+  /** custom 選択時の終了日 */
+  customEndDate?: string;
+}
+
+interface ShoppingListProgress {
+  phase: string;
+  message: string;
+  percentage: number;
+}
+
+const defaultShoppingRange: ShoppingRangeSelection = {
+  type: 'week',
+  todayMeals: ['breakfast', 'lunch', 'dinner'],
+  daysCount: 3,
+};
+
+interface ShoppingState {
+  shoppingList: ShoppingListItem[];
+  activeShoppingList: ShoppingList | null;
+  isRegeneratingShoppingList: boolean;
+  shoppingListProgress: ShoppingListProgress | null;
+  shoppingListRequestId: string | null;
+  shoppingListTotalServings: number | null;
+  shoppingRange: ShoppingRangeSelection;
+  shoppingRangeStep: 'range' | 'servings';
+}
+
+interface ShoppingActions {
+  setShoppingList: (list: ShoppingListItem[]) => void;
+  setActiveShoppingList: (list: ShoppingList | null) => void;
+  setIsRegeneratingShoppingList: (isRegenerating: boolean) => void;
+  setShoppingListProgress: (progress: ShoppingListProgress | null) => void;
+  setShoppingListRequestId: (id: string | null) => void;
+  setShoppingListTotalServings: (servings: number | null) => void;
+  setShoppingRange: (range: ShoppingRangeSelection) => void;
+  setShoppingRangeStep: (step: 'range' | 'servings') => void;
+  resetShoppingState: () => void;
+}
+
+const initialState: ShoppingState = {
+  shoppingList: [],
+  activeShoppingList: null,
+  isRegeneratingShoppingList: false,
+  shoppingListProgress: null,
+  shoppingListRequestId: null,
+  shoppingListTotalServings: null,
+  shoppingRange: defaultShoppingRange,
+  shoppingRangeStep: 'range',
+};
+
+export const useShoppingStore = create<ShoppingState & ShoppingActions>()((set) => ({
+  ...initialState,
+
+  setShoppingList: (list) => set({ shoppingList: list }),
+  setActiveShoppingList: (list) => set({ activeShoppingList: list }),
+  setIsRegeneratingShoppingList: (isRegenerating) =>
+    set({ isRegeneratingShoppingList: isRegenerating }),
+  setShoppingListProgress: (progress) => set({ shoppingListProgress: progress }),
+  setShoppingListRequestId: (id) => set({ shoppingListRequestId: id }),
+  setShoppingListTotalServings: (servings) => set({ shoppingListTotalServings: servings }),
+  setShoppingRange: (range) => set({ shoppingRange: range }),
+  setShoppingRangeStep: (step) => set({ shoppingRangeStep: step }),
+
+  resetShoppingState: () => set(initialState),
+}));


### PR DESCRIPTION
## Summary

- `_state/formDraftStore.ts`: モーダル内編集 state (~25 fields) を集約する zustand store
- `_state/pantryStore.ts`: 冷蔵庫アイテム管理 store
- `_state/shoppingStore.ts`: 買い物リスト + range 選択 store (ShoppingRangeSelection 型定義含む)
- `_state/servingsConfigStore.ts`: 配膳設定 store
- `_state/index.ts`: 4 store + shared 型を barrel re-export
- `zustand@^5.0.13` を package.json に追加

page.tsx への統合は Phase B-2/B-3 で実施。本 PR は store 単体追加のみ。

## Test plan

- [ ] typecheck pass (`npm run typecheck` エラー 0)
- [ ] lint pass (対象ファイルの error 0)
- [ ] store 単体追加のみで page.tsx は未変更 — 既存 E2E への影響なし

関連: docs/refactor/2026-05-08-refactor-b-state-aggregation.md