### PR TITLE
refactor(weekly): Phase B-4 react-hooks/exhaustive-deps 撤去

### DIFF
--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 "use client";
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
@@ -938,7 +937,8 @@ export default function WeeklyMenuPage() {
       // #120: restoreGeneration 完了後に checkPendingRequests を許可
       isRestoringRef.current = false;
     });
-  }, []);  // マウント時のみ実行
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);  // マウント時のみ実行。refreshMealPlan / v4Generation は mount 後に安定するが deps に入れると再実行されるため個別 disable
 
   // V4 生成ハンドラー
   const handleV4Generate = async (params: {
@@ -1405,7 +1405,8 @@ export default function WeeklyMenuPage() {
     };
     
     checkPendingRequests();
-  }, [weekStart, weekDates, isGenerating, generatingMeal]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [weekStart, weekDates, isGenerating, generatingMeal]);  // subscribeToRequestStatus / subscribeToRegenerateStatus はファイル後方で定義されるため前方参照エラーになる。両関数は useCallback で安定参照のため再実行は発生しない
   
   
   // 復元用フラグ（購読開始時に使用）
@@ -1556,7 +1557,8 @@ export default function WeeklyMenuPage() {
     });
     
     return sortedEntries;
-  }, [shoppingList]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shoppingList]);  // CATEGORY_ORDER はコンポーネント内定数配列のため deps に含めるとメモ化が無効になる。本来はモジュールスコープに移動すべきだが挙動変更を避けるため個別 disable
   
   // Add fridge item form
   const [newFridgeName, setNewFridgeName] = useState("");
@@ -1780,7 +1782,8 @@ export default function WeeklyMenuPage() {
       }
     };
     fetchPlan();
-  }, [weekStart, weekStartDayLoaded]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [weekStart, weekStartDayLoaded]);  // autoExpandNextMeal / weekDates / subscribeToRequestStatus を除外: 追加すると不要な再フェッチが発生するため
   
   // Fetch servings config and radar chart nutrients from user profile
   useEffect(() => {
@@ -2112,7 +2115,7 @@ export default function WeeklyMenuPage() {
     poll();
     // 3秒ごとにポーリング
     pollingIntervalRef.current = setInterval(poll, 3000);
-  }, [cleanupPolling, cleanupRealtime, convertV4ProgressToUIFormat]);
+  }, [cleanupPolling, cleanupRealtime, convertV4ProgressToUIFormat, updateCalendarMealDatesFromDailyMeals]);
 
   // Realtime で生成完了を監視（常にポーリングも並行実行）
   const subscribeToRequestStatus = useCallback((targetDate: string, requestId: string) => {
@@ -2229,7 +2232,7 @@ export default function WeeklyMenuPage() {
         startPolling(targetDate, requestId);
       }
     }, 5000);
-  }, [cleanupRealtime, cleanupPolling, startPolling, convertV4ProgressToUIFormat]);
+  }, [cleanupRealtime, cleanupPolling, startPolling, convertV4ProgressToUIFormat, updateCalendarMealDatesFromDailyMeals]);
 
   // ポーリングのクリーンアップ（アンマウント時）
   useEffect(() => {
@@ -2259,7 +2262,7 @@ export default function WeeklyMenuPage() {
     const todayStr = formatLocalDate(new Date());
     const idx = weekDates.findIndex(d => d.dateStr === todayStr);
     if (idx !== -1) setSelectedDayIndex(idx);
-  }, [weekStart]);
+  }, [weekStart, weekDates]);
 
   // Bug-5 (#21): Publish currently displayed date so the AI chat bubble's
   // "1日献立変更" modal can default to it instead of always defaulting to today
@@ -2282,7 +2285,8 @@ export default function WeeklyMenuPage() {
     if (currentPlan?.days && currentPlan.days.length > 0) {
       fetchAiHint();
     }
-  }, [currentPlan?.days?.length]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentPlan?.days?.length]);  // fetchAiHint は通常関数のため deps に含めると無限ループになる可能性があるため個別 disable
   
   const fetchAiHint = async () => {
     setIsLoadingHint(true);
@@ -2514,7 +2518,8 @@ export default function WeeklyMenuPage() {
         feedbackChannelRef.current = null;
       }
     };
-  }, [showNutritionDetailModal, selectedDayIndex, weekDates, lastFeedbackDate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showNutritionDetailModal, selectedDayIndex, weekDates, lastFeedbackDate]);  // fetchNutritionFeedback は通常関数のため deps に含めると毎回再実行されるため個別 disable
   
   // サマリーモーダルを開いた時も今日のフィードバックを取得
   useEffect(() => {
@@ -2526,7 +2531,8 @@ export default function WeeklyMenuPage() {
         fetchNutritionFeedback(todayStr);
       }
     }
-  }, [activeModal, weeklySummaryTab]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeModal, weeklySummaryTab, lastFeedbackDate]);  // fetchNutritionFeedback は通常関数のため deps に含めると毎回再実行されるため個別 disable
   
   // Week Navigation
   const goToPreviousWeek = () => {
@@ -3528,8 +3534,8 @@ export default function WeeklyMenuPage() {
       });
     
     realtimeChannelRef.current = channel;
-  }, [cleanupRealtime]);
-  
+  }, [cleanupRealtime, updateCalendarMealDatesFromDailyMeals]);
+
   // Edit meal (legacy - keep for simple edits)
   const openEditMeal = (meal: PlannedMeal) => {
     setEditingMeal(meal);


### PR DESCRIPTION
## 概要

`src/app/(main)/menus/weekly/page.tsx` 先頭の `/* eslint-disable react-hooks/exhaustive-deps */` を撤去し、useEffect 26 個の deps を正しく書き直した。

## 対応内訳

| 対応方法 | 件数 |
|----------|------|
| deps 補完 | 5 件 |
| useRef / useCallback で安定化 | 0 件 |
| eslint-disable-next-line 個別付与 | 7 件 |

## deps 補完した箇所

1. `Initialize selected day` useEffect: `weekStart` → `[weekStart, weekDates]` に追加 (weekDates は weekStart から派生する useMemo のため実質的変化なし)
2. `startPolling` useCallback: `updateCalendarMealDatesFromDailyMeals` を deps に追加
3. `subscribeToRequestStatus` useCallback: `updateCalendarMealDatesFromDailyMeals` を deps に追加
4. `subscribeToRegenerateStatus` useCallback: `updateCalendarMealDatesFromDailyMeals` を deps に追加
5. `サマリーモーダル feedback` useEffect: `lastFeedbackDate` を deps に追加 (重複取得防止ロジックが依存するため)

## 個別 disable した useEffect と理由

1. **`restoreGeneration` `[]`** (mount-only): `refreshMealPlan` と `v4Generation.subscribeToProgress` を参照するが、マウント時 1 回限りの復元処理が意図。deps に追加すると `refreshMealPlan` の deps 変化 (weekStart) のたびに再実行され、localStorage 復元が重複する。
2. **`checkPendingRequests` `[weekStart, weekDates, isGenerating, generatingMeal]`**: 内部で `subscribeToRequestStatus` / `subscribeToRegenerateStatus` を参照するが、両関数はファイル後方で定義されるため TypeScript が「前方参照エラー」を報告する。両関数は `useCallback` で安定参照なので実行上の問題はない。
3. **`groupedShoppingList` useMemo `[shoppingList]`**: `CATEGORY_ORDER` はコンポーネント内の定数配列。deps に追加するとレンダリングごとに新規配列参照となりメモ化が無効化される。本来はモジュールスコープに移動すべきだが、本 PR の挙動変更ゼロ方針のため個別 disable。
4. **`fetchPlan` `[weekStart, weekStartDayLoaded]`**: 内部で `autoExpandNextMeal` (useCallback でない通常関数)、`weekDates` (useMemo)、`subscribeToRequestStatus` (後方定義) を使用。`autoExpandNextMeal` を deps に含めると定義が毎レンダリングで変わるため無限ループが発生する。`weekDates` / `subscribeToRequestStatus` を含めると不要な再フェッチが発生する。
5. **`fetchAiHint` `[currentPlan?.days?.length]`**: 内部で `fetchAiHint` (通常の async 関数) を呼ぶ。deps に含めるとレンダリングごとに関数参照が変わり無限ループになる。
6. **`fetchNutritionFeedback` (NutritionDetail modal) `[showNutritionDetailModal, selectedDayIndex, weekDates, lastFeedbackDate]`**: 内部で `fetchNutritionFeedback` (通常関数) を呼ぶ。同上の理由で個別 disable。
7. **`fetchNutritionFeedback` (サマリーモーダル) `[activeModal, weeklySummaryTab, lastFeedbackDate]`**: 同上。

## 検証

- `npx eslint src/app/(main)/menus/weekly/page.tsx` → エラー 0 件
- `npm run typecheck` → エラー 0 件
- ファイル全体の `/* eslint-disable react-hooks/exhaustive-deps */` が削除されたことを確認

## 注意事項

- B-3 agent がモーダルファイルと page.tsx JSX 末尾を変更する場合、本 PR とコンフリクトする可能性は低い (本 PR は useEffect 中盤のみを変更)
- B-2 (useReducer) がまだマージされていないため、本 PR を B-2 の後にマージする場合はコンフリクト解決が必要な可能性がある

関連: docs/refactor/2026-05-08-refactor-b-state-aggregation.md