### PR TITLE
refactor(weekly): Phase B-3 モーダル 20 個の props 削減

### DIFF
--- a/src/app/(main)/menus/weekly/_components/modals/AddFridgeModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/AddFridgeModal.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { motion } from "framer-motion";
 import { X } from "lucide-react";
+import { useFormDraftStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -15,26 +16,21 @@ const colors = {
 };
 
 interface AddFridgeModalProps {
-  newFridgeName: string;
-  newFridgeAmount: string;
-  newFridgeExpiry: string;
-  onChangeName: (value: string) => void;
-  onChangeAmount: (value: string) => void;
-  onChangeExpiry: (value: string) => void;
   onAdd: () => void;
   onClose: () => void;
 }
 
 export function AddFridgeModal({
-  newFridgeName,
-  newFridgeAmount,
-  newFridgeExpiry,
-  onChangeName,
-  onChangeAmount,
-  onChangeExpiry,
   onAdd,
   onClose,
 }: AddFridgeModalProps) {
+  const newFridgeName = useFormDraftStore((s) => s.newFridgeName);
+  const newFridgeAmount = useFormDraftStore((s) => s.newFridgeAmount);
+  const newFridgeExpiry = useFormDraftStore((s) => s.newFridgeExpiry);
+  const setNewFridgeName = useFormDraftStore((s) => s.setNewFridgeName);
+  const setNewFridgeAmount = useFormDraftStore((s) => s.setNewFridgeAmount);
+  const setNewFridgeExpiry = useFormDraftStore((s) => s.setNewFridgeExpiry);
+
   return (
     <motion.div
       initial={{ y: "100%" }} animate={{ y: 0 }} exit={{ y: "100%" }}
@@ -53,7 +49,7 @@ export function AddFridgeModal({
         <input
           type="text"
           value={newFridgeName}
-          onChange={(e) => onChangeName(e.target.value)}
+          onChange={(e) => setNewFridgeName(e.target.value)}
           placeholder="食材名（例: 鶏もも肉）"
           className="w-full p-3 rounded-xl text-[14px] outline-none"
           style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
@@ -61,7 +57,7 @@ export function AddFridgeModal({
         <input
           type="text"
           value={newFridgeAmount}
-          onChange={(e) => onChangeAmount(e.target.value)}
+          onChange={(e) => setNewFridgeAmount(e.target.value)}
           placeholder="量（例: 300g）"
           className="w-full p-3 rounded-xl text-[14px] outline-none"
           style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
@@ -69,7 +65,7 @@ export function AddFridgeModal({
         <input
           type="date"
           value={newFridgeExpiry}
-          onChange={(e) => onChangeExpiry(e.target.value)}
+          onChange={(e) => setNewFridgeExpiry(e.target.value)}
           className="w-full p-3 rounded-xl text-[14px] outline-none"
           style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
         />

--- a/src/app/(main)/menus/weekly/_components/modals/AddMealModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/AddMealModal.tsx
@@ -4,8 +4,8 @@ import React from "react";
 import { motion } from "framer-motion";
 import { X, Sparkles } from "lucide-react";
 import type { MealMode } from "@/types/domain";
-import type { CatalogProductSummary } from "@/types/catalog";
 import { MEAL_LABELS } from "@homegohan/shared";
+import { useFormDraftStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -44,34 +44,27 @@ const formatNutrition = (value: number | null | undefined, decimals = 1): string
 };
 
 interface AddMealModalProps {
-  addMealKey: MealType | null;
   modeConfig: Record<string, ModeConfig>;
-  catalogQuery: string;
-  catalogResults: CatalogProductSummary[];
-  selectedCatalogProduct: CatalogProductSummary | null;
-  isCatalogSearching: boolean;
-  catalogSearchError: string;
   onClose: () => void;
   onOpenAiMeal: () => void;
-  onChangeCatalogQuery: (query: string) => void;
-  onSelectCatalogProduct: (product: CatalogProductSummary | null) => void;
   onAddMealWithMode: (mode: MealMode) => void;
 }
 
 export function AddMealModal({
-  addMealKey,
   modeConfig,
-  catalogQuery,
-  catalogResults,
-  selectedCatalogProduct,
-  isCatalogSearching,
-  catalogSearchError,
   onClose,
   onOpenAiMeal,
-  onChangeCatalogQuery,
-  onSelectCatalogProduct,
   onAddMealWithMode,
 }: AddMealModalProps) {
+  const addMealKey = useFormDraftStore((s) => s.addMealKey);
+  const catalogQuery = useFormDraftStore((s) => s.catalogQuery);
+  const catalogResults = useFormDraftStore((s) => s.catalogResults);
+  const selectedCatalogProduct = useFormDraftStore((s) => s.selectedCatalogProduct);
+  const isCatalogSearching = useFormDraftStore((s) => s.isCatalogSearching);
+  const catalogSearchError = useFormDraftStore((s) => s.catalogSearchError);
+  const setCatalogQuery = useFormDraftStore((s) => s.setCatalogQuery);
+  const setSelectedCatalogProduct = useFormDraftStore((s) => s.setSelectedCatalogProduct);
+
   return (
     <motion.div
       initial={{ y: "100%" }} animate={{ y: 0 }} exit={{ y: "100%" }}
@@ -93,8 +86,8 @@ export function AddMealModal({
             {selectedCatalogProduct && (
               <button
                 onClick={() => {
-                  onSelectCatalogProduct(null);
-                  onChangeCatalogQuery('');
+                  setSelectedCatalogProduct(null);
+                  setCatalogQuery('');
                 }}
                 className="text-[12px]"
                 style={{ color: colors.textLight }}
@@ -107,9 +100,9 @@ export function AddMealModal({
             type="text"
             value={catalogQuery}
             onChange={(e) => {
-              onChangeCatalogQuery(e.target.value);
+              setCatalogQuery(e.target.value);
               if (!e.target.value.trim()) {
-                onSelectCatalogProduct(null);
+                setSelectedCatalogProduct(null);
               }
             }}
             placeholder="商品名で検索"
@@ -161,7 +154,7 @@ export function AddMealModal({
                 return (
                   <button
                     key={product.id}
-                    onClick={() => onSelectCatalogProduct(product)}
+                    onClick={() => setSelectedCatalogProduct(product)}
                     className="w-full p-3 rounded-2xl text-left"
                     style={{
                       background: isSelected ? colors.purpleLight : colors.bg,

--- a/src/app/(main)/menus/weekly/_components/modals/AddShoppingModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/AddShoppingModal.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { motion } from "framer-motion";
 import { X } from "lucide-react";
+import { useFormDraftStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -13,26 +14,21 @@ const colors = {
 };
 
 interface AddShoppingModalProps {
-  newShoppingName: string;
-  newShoppingAmount: string;
-  newShoppingCategory: string;
-  onChangeName: (value: string) => void;
-  onChangeAmount: (value: string) => void;
-  onChangeCategory: (value: string) => void;
   onAdd: () => void;
   onClose: () => void;
 }
 
 export function AddShoppingModal({
-  newShoppingName,
-  newShoppingAmount,
-  newShoppingCategory,
-  onChangeName,
-  onChangeAmount,
-  onChangeCategory,
   onAdd,
   onClose,
 }: AddShoppingModalProps) {
+  const newShoppingName = useFormDraftStore((s) => s.newShoppingName);
+  const newShoppingAmount = useFormDraftStore((s) => s.newShoppingAmount);
+  const newShoppingCategory = useFormDraftStore((s) => s.newShoppingCategory);
+  const setNewShoppingName = useFormDraftStore((s) => s.setNewShoppingName);
+  const setNewShoppingAmount = useFormDraftStore((s) => s.setNewShoppingAmount);
+  const setNewShoppingCategory = useFormDraftStore((s) => s.setNewShoppingCategory);
+
   return (
     <motion.div
       initial={{ y: "100%" }} animate={{ y: 0 }} exit={{ y: "100%" }}
@@ -51,7 +47,7 @@ export function AddShoppingModal({
         <input
           type="text"
           value={newShoppingName}
-          onChange={(e) => onChangeName(e.target.value)}
+          onChange={(e) => setNewShoppingName(e.target.value)}
           placeholder="品名（例: もやし）"
           className="w-full p-3 rounded-xl text-[14px] outline-none"
           style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
@@ -59,14 +55,14 @@ export function AddShoppingModal({
         <input
           type="text"
           value={newShoppingAmount}
-          onChange={(e) => onChangeAmount(e.target.value)}
+          onChange={(e) => setNewShoppingAmount(e.target.value)}
           placeholder="量（例: 2袋）"
           className="w-full p-3 rounded-xl text-[14px] outline-none"
           style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
         />
         <select
           value={newShoppingCategory}
-          onChange={(e) => onChangeCategory(e.target.value)}
+          onChange={(e) => setNewShoppingCategory(e.target.value)}
           className="w-full p-3 rounded-xl text-[14px] outline-none"
           style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
         >

--- a/src/app/(main)/menus/weekly/_components/modals/AiAssistantModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/AiAssistantModal.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { Sparkles, X, Check, Send } from "lucide-react";
 import { AI_CONDITIONS } from "@homegohan/shared";
+import { useFormDraftStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -19,24 +20,21 @@ const colors = {
 interface AiAssistantModalProps {
   isGenerating: boolean;
   emptySlotCount: number;
-  selectedConditions: string[];
-  aiChatInput: string;
   onClose: () => void;
-  onChangeConditions: (conditions: string[]) => void;
-  onChangeAiChatInput: (value: string) => void;
   onGenerateWeekly: () => void;
 }
 
 export function AiAssistantModal({
   isGenerating,
   emptySlotCount,
-  selectedConditions,
-  aiChatInput,
   onClose,
-  onChangeConditions,
-  onChangeAiChatInput,
   onGenerateWeekly,
 }: AiAssistantModalProps) {
+  const selectedConditions = useFormDraftStore((s) => s.selectedConditions);
+  const aiChatInput = useFormDraftStore((s) => s.aiChatInput);
+  const setSelectedConditions = useFormDraftStore((s) => s.setSelectedConditions);
+  const setAiChatInput = useFormDraftStore((s) => s.setAiChatInput);
+
   return (
     <motion.div
       initial={{ y: "100%" }} animate={{ y: 0 }} exit={{ y: "100%" }}
@@ -89,7 +87,7 @@ export function AiAssistantModal({
             <button
               key={i}
               data-testid={`ai-condition-${text}`}
-              onClick={() => onChangeConditions(
+              onClick={() => setSelectedConditions(
                 isSelected ? selectedConditions.filter(c => c !== text) : [...selectedConditions, text]
               )}
               className="w-full p-3 mb-1.5 rounded-[10px] text-left text-[13px] flex items-center justify-between transition-all"
@@ -109,7 +107,7 @@ export function AiAssistantModal({
         <input
           type="text"
           value={aiChatInput}
-          onChange={(e) => onChangeAiChatInput(e.target.value)}
+          onChange={(e) => setAiChatInput(e.target.value)}
           placeholder="例: 木金は簡単に..."
           className="flex-1 px-3.5 py-2.5 rounded-full text-[13px] outline-none"
           style={{ background: colors.bg }}

--- a/src/app/(main)/menus/weekly/_components/modals/AiMealModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/AiMealModal.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { Sparkles, X, Check } from "lucide-react";
 import { AI_CONDITIONS, MEAL_LABELS } from "@homegohan/shared";
+import { useFormDraftStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -23,28 +24,23 @@ interface WeekDate {
 }
 
 interface AiMealModalProps {
-  addMealKey: string | null;
-  addMealDayIndex: number;
   weekDates: WeekDate[];
-  selectedConditions: string[];
-  aiChatInput: string;
   onClose: () => void;
-  onChangeConditions: (conditions: string[]) => void;
-  onChangeAiChatInput: (value: string) => void;
   onGenerateSingleMeal: () => void;
 }
 
 export function AiMealModal({
-  addMealKey,
-  addMealDayIndex,
   weekDates,
-  selectedConditions,
-  aiChatInput,
   onClose,
-  onChangeConditions,
-  onChangeAiChatInput,
   onGenerateSingleMeal,
 }: AiMealModalProps) {
+  const addMealKey = useFormDraftStore((s) => s.addMealKey);
+  const addMealDayIndex = useFormDraftStore((s) => s.addMealDayIndex);
+  const selectedConditions = useFormDraftStore((s) => s.selectedConditions);
+  const aiChatInput = useFormDraftStore((s) => s.aiChatInput);
+  const setSelectedConditions = useFormDraftStore((s) => s.setSelectedConditions);
+  const setAiChatInput = useFormDraftStore((s) => s.setAiChatInput);
+
   const dayInfo = weekDates[addMealDayIndex];
   const mealLabel = addMealKey ? MEAL_LABELS[addMealKey as keyof typeof MEAL_LABELS] : '';
 
@@ -74,7 +70,7 @@ export function AiMealModal({
             <button
               key={i}
               data-testid={`weekly-condition-${text}`}
-              onClick={() => onChangeConditions(
+              onClick={() => setSelectedConditions(
                 isSelected ? selectedConditions.filter(c => c !== text) : [...selectedConditions, text]
               )}
               className="w-full p-3 mb-1.5 rounded-[10px] text-left text-[13px] flex items-center justify-between transition-all"
@@ -93,7 +89,7 @@ export function AiMealModal({
           <p style={{ fontSize: 13, color: colors.textMuted, marginBottom: 8 }}>リクエスト（任意）</p>
           <textarea
             value={aiChatInput}
-            onChange={(e) => onChangeAiChatInput(e.target.value)}
+            onChange={(e) => setAiChatInput(e.target.value)}
             placeholder="例: 昨日カレーだったので違うものがいい、野菜多めで..."
             className="w-full p-3 rounded-[10px] text-[13px] outline-none resize-none"
             style={{ background: colors.bg, minHeight: 80 }}

--- a/src/app/(main)/menus/weekly/_components/modals/EditMealModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/EditMealModal.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { X } from "lucide-react";
 import type { MealMode } from "@/types/domain";
+import { useFormDraftStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -23,24 +24,21 @@ interface ModeConfig {
 }
 
 interface EditMealModalProps {
-  editMealName: string;
-  editMealMode: MealMode;
   modeConfig: Record<string, ModeConfig>;
   onClose: () => void;
-  onChangeName: (value: string) => void;
-  onChangeMode: (mode: MealMode) => void;
   onSave: () => void;
 }
 
 export function EditMealModal({
-  editMealName,
-  editMealMode,
   modeConfig,
   onClose,
-  onChangeName,
-  onChangeMode,
   onSave,
 }: EditMealModalProps) {
+  const editMealName = useFormDraftStore((s) => s.editMealName);
+  const editMealMode = useFormDraftStore((s) => s.editMealMode);
+  const setEditMealName = useFormDraftStore((s) => s.setEditMealName);
+  const setEditMealMode = useFormDraftStore((s) => s.setEditMealMode);
+
   return (
     <motion.div
       initial={{ y: "100%" }} animate={{ y: 0 }} exit={{ y: "100%" }}
@@ -61,7 +59,7 @@ export function EditMealModal({
           <input
             type="text"
             value={editMealName}
-            onChange={(e) => onChangeName(e.target.value)}
+            onChange={(e) => setEditMealName(e.target.value)}
             className="w-full p-3 rounded-xl text-[14px] outline-none"
             style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
           />
@@ -75,7 +73,7 @@ export function EditMealModal({
               return (
                 <button
                   key={key}
-                  onClick={() => onChangeMode(key)}
+                  onClick={() => setEditMealMode(key)}
                   className="flex items-center gap-1.5 px-3 py-2 rounded-lg"
                   style={{
                     background: isSelected ? mode.bg : colors.bg,

--- a/src/app/(main)/menus/weekly/_components/modals/FridgeModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/FridgeModal.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { motion } from "framer-motion";
 import { Refrigerator, X, Trash2, Plus } from "lucide-react";
-import type { PantryItem } from "@/types/domain";
+import { usePantryStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -35,18 +35,18 @@ const getDaysUntil = (dateStr: string | null | undefined): number | null => {
 };
 
 interface FridgeModalProps {
-  fridgeItems: PantryItem[];
   onClose: () => void;
   onOpenAddFridge: () => void;
   onDeleteItem: (id: string) => void;
 }
 
 export function FridgeModal({
-  fridgeItems,
   onClose,
   onOpenAddFridge,
   onDeleteItem,
 }: FridgeModalProps) {
+  const fridgeItems = usePantryStore((s) => s.fridgeItems);
+
   return (
     <motion.div
       initial={{ y: "100%" }} animate={{ y: 0 }} exit={{ y: "100%" }}

--- a/src/app/(main)/menus/weekly/_components/modals/ImageGenerateModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/ImageGenerateModal.tsx
@@ -4,6 +4,7 @@ import React, { useRef } from "react";
 import { motion } from "framer-motion";
 import { X, Plus, Sparkles, Image as ImageIcon } from "lucide-react";
 import Image from "next/image";
+import { useFormDraftStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -23,11 +24,8 @@ interface ImageGenerateMeal {
 
 interface ImageGenerateModalProps {
   imageGenerateMeal: ImageGenerateMeal;
-  imageGenerationPrompt: string;
-  imageReferencePreviews: string[];
   isGeneratingMealImage: boolean;
   onClose: () => void;
-  onChangePrompt: (value: string) => void;
   onAddReferenceImages: (files: FileList) => void;
   onRemoveReferenceImage: (idx: number) => void;
   onGenerate: () => void;
@@ -35,16 +33,17 @@ interface ImageGenerateModalProps {
 
 export function ImageGenerateModal({
   imageGenerateMeal,
-  imageGenerationPrompt,
-  imageReferencePreviews,
   isGeneratingMealImage,
   onClose,
-  onChangePrompt,
   onAddReferenceImages,
   onRemoveReferenceImage,
   onGenerate,
 }: ImageGenerateModalProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const imageGenerationPrompt = useFormDraftStore((s) => s.imageGenerationPrompt);
+  const imageReferencePreviews = useFormDraftStore((s) => s.imageReferencePreviews);
+  const setImageGenerationPrompt = useFormDraftStore((s) => s.setImageGenerationPrompt);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
@@ -112,7 +111,7 @@ export function ImageGenerateModal({
           <label style={{ fontSize: 12, color: colors.textMuted, display: 'block', marginBottom: 8 }}>生成したい画像の説明</label>
           <textarea
             value={imageGenerationPrompt}
-            onChange={(e) => onChangePrompt(e.target.value)}
+            onChange={(e) => setImageGenerationPrompt(e.target.value)}
             placeholder="例: 彩りの良い和風ハンバーグ定食、湯気のある自然光、木のテーブル"
             rows={4}
             className="w-full p-3 rounded-2xl text-[13px] outline-none resize-none"

--- a/src/app/(main)/menus/weekly/_components/modals/ManualEditModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/ManualEditModal.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { X, Check, Trash2, Plus, Pencil, Camera, Image as ImageIcon } from "lucide-react";
 import type { MealMode, PlannedMeal, DishDetail } from "@/types/domain";
 import type { CatalogProductSummary } from "@/types/catalog";
+import { useFormDraftStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -46,18 +47,8 @@ interface ModeConfig {
 
 interface ManualEditModalProps {
   manualEditMeal: PlannedMeal;
-  manualDishes: DishDetail[];
-  manualMode: MealMode;
   modeConfig: Record<string, ModeConfig>;
-  catalogQuery: string;
-  catalogResults: CatalogProductSummary[];
-  selectedCatalogProduct: CatalogProductSummary | null;
-  isCatalogSearching: boolean;
-  catalogSearchError: string;
   onClose: () => void;
-  onChangeMode: (mode: MealMode) => void;
-  onChangeCatalogQuery: (query: string) => void;
-  onSelectCatalogProduct: (product: CatalogProductSummary | null) => void;
   onApplyCatalogProduct: (product: CatalogProductSummary) => void;
   onAddDish: () => void;
   onRemoveDish: (index: number) => void;
@@ -69,18 +60,8 @@ interface ManualEditModalProps {
 
 export function ManualEditModal({
   manualEditMeal,
-  manualDishes,
-  manualMode,
   modeConfig,
-  catalogQuery,
-  catalogResults,
-  selectedCatalogProduct,
-  isCatalogSearching,
-  catalogSearchError,
   onClose,
-  onChangeMode,
-  onChangeCatalogQuery,
-  onSelectCatalogProduct,
   onApplyCatalogProduct,
   onAddDish,
   onRemoveDish,
@@ -89,6 +70,17 @@ export function ManualEditModal({
   onOpenImageGenerate,
   onSave,
 }: ManualEditModalProps) {
+  const manualDishes = useFormDraftStore((s) => s.manualDishes);
+  const manualMode = useFormDraftStore((s) => s.manualMode);
+  const catalogQuery = useFormDraftStore((s) => s.catalogQuery);
+  const catalogResults = useFormDraftStore((s) => s.catalogResults);
+  const selectedCatalogProduct = useFormDraftStore((s) => s.selectedCatalogProduct);
+  const isCatalogSearching = useFormDraftStore((s) => s.isCatalogSearching);
+  const catalogSearchError = useFormDraftStore((s) => s.catalogSearchError);
+  const setManualMode = useFormDraftStore((s) => s.setManualMode);
+  const setCatalogQuery = useFormDraftStore((s) => s.setCatalogQuery);
+  const setSelectedCatalogProduct = useFormDraftStore((s) => s.setSelectedCatalogProduct);
+
   return (
     <motion.div
       initial={{ y: "100%" }} animate={{ y: 0 }} exit={{ y: "100%" }}
@@ -116,7 +108,7 @@ export function ManualEditModal({
               return (
                 <button
                   key={key}
-                  onClick={() => onChangeMode(key)}
+                  onClick={() => setManualMode(key)}
                   className="flex items-center gap-1.5 px-3 py-2 rounded-lg"
                   style={{
                     background: isSelected ? mode.bg : colors.bg,
@@ -137,8 +129,8 @@ export function ManualEditModal({
             {selectedCatalogProduct && (
               <button
                 onClick={() => {
-                  onSelectCatalogProduct(null);
-                  onChangeCatalogQuery('');
+                  setSelectedCatalogProduct(null);
+                  setCatalogQuery('');
                 }}
                 className="text-[12px]"
                 style={{ color: colors.textLight }}
@@ -151,9 +143,9 @@ export function ManualEditModal({
             type="text"
             value={catalogQuery}
             onChange={(e) => {
-              onChangeCatalogQuery(e.target.value);
+              setCatalogQuery(e.target.value);
               if (!e.target.value.trim()) {
-                onSelectCatalogProduct(null);
+                setSelectedCatalogProduct(null);
               }
             }}
             placeholder="商品名で検索"

--- a/src/app/(main)/menus/weekly/_components/modals/PhotoEditModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/PhotoEditModal.tsx
@@ -4,6 +4,7 @@ import React, { useRef } from "react";
 import { motion } from "framer-motion";
 import { X, Plus, Sparkles, Camera, Image as ImageIcon } from "lucide-react";
 import Image from "next/image";
+import { useFormDraftStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -19,8 +20,6 @@ const colors = {
 };
 
 interface PhotoEditModalProps {
-  photoPreviews: string[];
-  photoFilesCount: number;
   isAnalyzingPhoto: boolean;
   onClose: () => void;
   onPhotoSelect: (files: FileList) => void;
@@ -29,8 +28,6 @@ interface PhotoEditModalProps {
 }
 
 export function PhotoEditModal({
-  photoPreviews,
-  photoFilesCount,
   isAnalyzingPhoto,
   onClose,
   onPhotoSelect,
@@ -38,6 +35,9 @@ export function PhotoEditModal({
   onAnalyze,
 }: PhotoEditModalProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const photoPreviews = useFormDraftStore((s) => s.photoPreviews);
+  const photoFiles = useFormDraftStore((s) => s.photoFiles);
 
   const handleCaptureChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
@@ -163,7 +163,7 @@ export function PhotoEditModal({
       <div className="px-4 py-4 pb-4 lg:pb-6 flex-shrink-0" style={{ borderTop: `1px solid ${colors.border}`, background: colors.card }}>
         <button
           onClick={onAnalyze}
-          disabled={photoFilesCount === 0 || isAnalyzingPhoto}
+          disabled={photoFiles.length === 0 || isAnalyzingPhoto}
           className="w-full py-3.5 rounded-xl flex items-center justify-center gap-2 disabled:opacity-50"
           style={{ background: colors.blue }}
         >
@@ -176,7 +176,7 @@ export function PhotoEditModal({
             <>
               <Sparkles size={16} color="#fff" />
               <span style={{ fontSize: 14, fontWeight: 600, color: '#fff' }}>
-                {photoFilesCount > 1 ? `${photoFilesCount}枚をAIで解析` : 'AIで解析する'}
+                {photoFiles.length > 1 ? `${photoFiles.length}枚をAIで解析` : 'AIで解析する'}
               </span>
             </>
           )}

--- a/src/app/(main)/menus/weekly/_components/modals/RegenerateMealModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/RegenerateMealModal.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { Sparkles, X, Check } from "lucide-react";
 import { AI_CONDITIONS, MEAL_LABELS } from "@homegohan/shared";
+import { useFormDraftStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -25,25 +26,22 @@ interface RegeneratingMeal {
 
 interface RegenerateMealModalProps {
   regeneratingMeal: RegeneratingMeal;
-  selectedConditions: string[];
-  aiChatInput: string;
   isRegenerating: boolean;
   onClose: () => void;
-  onChangeConditions: (conditions: string[]) => void;
-  onChangeAiChatInput: (value: string) => void;
   onRegenerateMeal: () => void;
 }
 
 export function RegenerateMealModal({
   regeneratingMeal,
-  selectedConditions,
-  aiChatInput,
   isRegenerating,
   onClose,
-  onChangeConditions,
-  onChangeAiChatInput,
   onRegenerateMeal,
 }: RegenerateMealModalProps) {
+  const selectedConditions = useFormDraftStore((s) => s.selectedConditions);
+  const aiChatInput = useFormDraftStore((s) => s.aiChatInput);
+  const setSelectedConditions = useFormDraftStore((s) => s.setSelectedConditions);
+  const setAiChatInput = useFormDraftStore((s) => s.setAiChatInput);
+
   return (
     <motion.div
       initial={{ y: "100%" }} animate={{ y: 0 }} exit={{ y: "100%" }}
@@ -75,7 +73,7 @@ export function RegenerateMealModal({
             <button
               key={i}
               data-testid={`regen-condition-${text}`}
-              onClick={() => onChangeConditions(
+              onClick={() => setSelectedConditions(
                 isSelected ? selectedConditions.filter(c => c !== text) : [...selectedConditions, text]
               )}
               className="w-full p-3 mb-1.5 rounded-[10px] text-left text-[13px] flex items-center justify-between transition-all"
@@ -94,7 +92,7 @@ export function RegenerateMealModal({
           <p style={{ fontSize: 13, color: colors.textMuted, marginBottom: 8 }}>リクエスト（任意）</p>
           <textarea
             value={aiChatInput}
-            onChange={(e) => onChangeAiChatInput(e.target.value)}
+            onChange={(e) => setAiChatInput(e.target.value)}
             placeholder="例: もっとヘルシーに、魚料理がいい..."
             className="w-full p-3 rounded-[10px] text-[13px] outline-none resize-none"
             style={{ background: colors.bg, minHeight: 80 }}

--- a/src/app/(main)/menus/weekly/_components/modals/ServingsModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/ServingsModal.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { X } from "lucide-react";
 import type { ServingsConfig } from "@/types/domain";
+import { useServingsConfigStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -21,18 +22,17 @@ type DayOfWeekKey = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' |
 type MealTimeKey = 'breakfast' | 'lunch' | 'dinner';
 
 interface ServingsModalProps {
-  servingsConfig: ServingsConfig | null;
   onClose: () => void;
-  onUpdateServingsConfig: (config: ServingsConfig) => void;
   onSave: () => void;
 }
 
 export function ServingsModal({
-  servingsConfig,
   onClose,
-  onUpdateServingsConfig,
   onSave,
 }: ServingsModalProps) {
+  const servingsConfig = useServingsConfigStore((s) => s.servingsConfig);
+  const setServingsConfig = useServingsConfigStore((s) => s.setServingsConfig);
+
   const days: DayOfWeekKey[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
   const dayLabels: Record<DayOfWeekKey, string> = {
     monday: '月', tuesday: '火', wednesday: '水', thursday: '木',
@@ -46,7 +46,7 @@ export function ServingsModal({
     };
     if (!updated.byDayMeal[day]) updated.byDayMeal[day] = {};
     updated.byDayMeal[day]![meal] = Math.max(0, Math.min(10, newValue));
-    onUpdateServingsConfig(updated);
+    setServingsConfig(updated);
   };
 
   return (

--- a/src/app/(main)/menus/weekly/_components/modals/ShoppingModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/ShoppingModal.tsx
@@ -8,6 +8,7 @@ import {
 import type { ShoppingListItem } from "@/types/domain";
 import { SHOPPING_LIST_PHASES } from "@homegohan/shared";
 import { ProgressTodoCard } from "../ProgressTodoCard";
+import { useShoppingStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -24,11 +25,7 @@ const colors = {
 };
 
 interface ShoppingModalProps {
-  shoppingList: ShoppingListItem[];
   groupedShoppingList: [string, ShoppingListItem[]][];
-  shoppingListTotalServings: number | null;
-  isRegeneratingShoppingList: boolean;
-  shoppingListProgress: { phase: string; message: string; percentage: number } | null;
   hasAnyMealsThisWeek: boolean;
   onClose: () => void;
   onOpenAddShopping: () => void;
@@ -43,11 +40,7 @@ interface ShoppingModalProps {
 }
 
 export function ShoppingModal({
-  shoppingList,
   groupedShoppingList,
-  shoppingListTotalServings,
-  isRegeneratingShoppingList,
-  shoppingListProgress,
   hasAnyMealsThisWeek,
   onClose,
   onOpenAddShopping,
@@ -60,6 +53,11 @@ export function ShoppingModal({
   onDismissProgress,
   onSetSuccessMessage,
 }: ShoppingModalProps) {
+  const shoppingList = useShoppingStore((s) => s.shoppingList);
+  const shoppingListTotalServings = useShoppingStore((s) => s.shoppingListTotalServings);
+  const isRegeneratingShoppingList = useShoppingStore((s) => s.isRegeneratingShoppingList);
+  const shoppingListProgress = useShoppingStore((s) => s.shoppingListProgress);
+
   return (
     <div className="fixed inset-0 z-[201] pointer-events-none">
       {/* backdrop: 背後ナビを遮断しモーダルを閉じる (#76) */}

--- a/src/app/(main)/menus/weekly/_components/modals/ShoppingRangeModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/ShoppingRangeModal.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, ChevronDown, ChevronRight, ChevronLeft, Check, Sparkles } from "lucide-react";
 import type { ServingsConfig } from "@/types/domain";
+import { useShoppingStore, useServingsConfigStore } from "../../_state";
 
 const colors = {
   bg: '#F7F6F3',
@@ -18,41 +19,26 @@ const colors = {
   border: '#E8E8E8',
 };
 
-type ShoppingRangeType = 'today' | 'tomorrow' | 'dayAfterTomorrow' | 'week' | 'days' | 'custom';
-
-interface ShoppingRangeSelection {
-  type: ShoppingRangeType;
-  todayMeals: ('breakfast' | 'lunch' | 'dinner')[];
-  daysCount: number;
-  customStartDate?: string;
-  customEndDate?: string;
-}
-
 interface ShoppingRangeModalProps {
-  shoppingRange: ShoppingRangeSelection;
-  shoppingRangeStep: 'range' | 'servings';
   isTodayExpanded: boolean;
-  servingsConfig: ServingsConfig | null;
   onClose: () => void;
-  onChangeRange: (range: ShoppingRangeSelection) => void;
-  onChangeStep: (step: 'range' | 'servings') => void;
   onToggleTodayExpanded: (expanded: boolean) => void;
-  onUpdateServingsConfig: (config: ServingsConfig) => void;
   onGenerate: (servingsConfig: ServingsConfig | null) => Promise<void>;
 }
 
 export function ShoppingRangeModal({
-  shoppingRange,
-  shoppingRangeStep,
   isTodayExpanded,
-  servingsConfig,
   onClose,
-  onChangeRange,
-  onChangeStep,
   onToggleTodayExpanded,
-  onUpdateServingsConfig,
   onGenerate,
 }: ShoppingRangeModalProps) {
+  const shoppingRange = useShoppingStore((s) => s.shoppingRange);
+  const shoppingRangeStep = useShoppingStore((s) => s.shoppingRangeStep);
+  const setShoppingRange = useShoppingStore((s) => s.setShoppingRange);
+  const setShoppingRangeStep = useShoppingStore((s) => s.setShoppingRangeStep);
+  const servingsConfig = useServingsConfigStore((s) => s.servingsConfig);
+  const setServingsConfig = useServingsConfigStore((s) => s.setServingsConfig);
+
   return (
     <motion.div
       initial={{ y: "100%" }} animate={{ y: 0 }} exit={{ y: "100%" }}
@@ -82,7 +68,7 @@ export function ShoppingRangeModal({
                   if (shoppingRange.type === 'today') {
                     onToggleTodayExpanded(!isTodayExpanded);
                   } else {
-                    onChangeRange({ ...shoppingRange, type: 'today' });
+                    setShoppingRange({ ...shoppingRange, type: 'today' });
                     onToggleTodayExpanded(true);
                   }
                 }}
@@ -125,7 +111,7 @@ export function ShoppingRangeModal({
                               const newMeals = isSelected
                                 ? shoppingRange.todayMeals.filter(m => m !== mealType)
                                 : [...shoppingRange.todayMeals, mealType];
-                              onChangeRange({ ...shoppingRange, todayMeals: newMeals });
+                              setShoppingRange({ ...shoppingRange, todayMeals: newMeals });
                             }}
                             className="w-full p-2.5 rounded-lg flex items-center gap-2"
                             style={{ background: isSelected ? `${colors.accent}15` : 'transparent' }}
@@ -151,7 +137,7 @@ export function ShoppingRangeModal({
 
             {/* 明日の分 */}
             <button
-              onClick={() => onChangeRange({ ...shoppingRange, type: 'tomorrow' })}
+              onClick={() => setShoppingRange({ ...shoppingRange, type: 'tomorrow' })}
               className="w-full p-3 rounded-xl flex items-center justify-between transition-colors"
               style={{
                 background: shoppingRange.type === 'tomorrow' ? colors.accent : colors.bg,
@@ -165,7 +151,7 @@ export function ShoppingRangeModal({
 
             {/* 明後日の分 */}
             <button
-              onClick={() => onChangeRange({ ...shoppingRange, type: 'dayAfterTomorrow' })}
+              onClick={() => setShoppingRange({ ...shoppingRange, type: 'dayAfterTomorrow' })}
               className="w-full p-3 rounded-xl flex items-center justify-between transition-colors"
               style={{
                 background: shoppingRange.type === 'dayAfterTomorrow' ? colors.accent : colors.bg,
@@ -180,7 +166,7 @@ export function ShoppingRangeModal({
             {/* ○○日分 */}
             <div>
               <button
-                onClick={() => onChangeRange({ ...shoppingRange, type: 'days' })}
+                onClick={() => setShoppingRange({ ...shoppingRange, type: 'days' })}
                 className="w-full p-3 rounded-xl flex items-center justify-between transition-colors"
                 style={{
                   background: shoppingRange.type === 'days' ? colors.accent : colors.bg,
@@ -199,7 +185,7 @@ export function ShoppingRangeModal({
                     min={1}
                     max={14}
                     value={shoppingRange.daysCount}
-                    onChange={(e) => onChangeRange({ ...shoppingRange, daysCount: parseInt(e.target.value) || 1 })}
+                    onChange={(e) => setShoppingRange({ ...shoppingRange, daysCount: parseInt(e.target.value) || 1 })}
                     className="w-20 p-2 rounded-lg text-center text-[14px] outline-none"
                     style={{ background: colors.bg, border: `1px solid ${colors.border}` }}
                   />
@@ -210,7 +196,7 @@ export function ShoppingRangeModal({
 
             {/* 1週間分 */}
             <button
-              onClick={() => onChangeRange({ ...shoppingRange, type: 'week' })}
+              onClick={() => setShoppingRange({ ...shoppingRange, type: 'week' })}
               className="w-full p-3 rounded-xl flex items-center justify-between transition-colors"
               style={{
                 background: shoppingRange.type === 'week' ? colors.accent : colors.bg,
@@ -225,7 +211,7 @@ export function ShoppingRangeModal({
 
           {/* 次へボタン */}
           <button
-            onClick={() => onChangeStep('servings')}
+            onClick={() => setShoppingRangeStep('servings')}
             disabled={shoppingRange.type === 'today' && shoppingRange.todayMeals.length === 0}
             className="w-full mt-4 p-3.5 rounded-xl font-semibold text-[14px] disabled:opacity-50 flex items-center justify-center gap-2"
             style={{ background: colors.accent, color: '#fff' }}
@@ -242,7 +228,7 @@ export function ShoppingRangeModal({
           <div className="flex justify-between items-center mb-4">
             <div className="flex items-center gap-2">
               <button
-                onClick={() => onChangeStep('range')}
+                onClick={() => setShoppingRangeStep('range')}
                 className="w-7 h-7 rounded-full flex items-center justify-center"
                 style={{ background: colors.bg }}
               >
@@ -289,7 +275,7 @@ export function ShoppingRangeModal({
                     };
                     if (!updated.byDayMeal[day]) updated.byDayMeal[day] = {};
                     updated.byDayMeal[day][meal] = Math.max(0, Math.min(10, newValue));
-                    onUpdateServingsConfig(updated);
+                    setServingsConfig(updated);
                   };
 
                   return (

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -8,6 +8,7 @@ import {
   nutritionReducer, initialNutritionState,
   recipeReducer, initialRecipeState,
   uiFlagReducer, initialUiFlagState,
+  useServingsConfigStore,
 } from './_state';
 import dynamic from "next/dynamic";
 import { motion, AnimatePresence } from "framer-motion";
@@ -5534,11 +5535,7 @@ export default function WeeklyMenuPage() {
               <AiAssistantModal
                 isGenerating={isGenerating}
                 emptySlotCount={emptySlotCount}
-                selectedConditions={selectedConditions}
-                aiChatInput={aiChatInput}
                 onClose={() => setActiveModal(null)}
-                onChangeConditions={setSelectedConditions}
-                onChangeAiChatInput={setAiChatInput}
                 onGenerateWeekly={handleGenerateWeekly}
               />
             )}
@@ -5575,7 +5572,6 @@ export default function WeeklyMenuPage() {
             {/* Fridge Modal */}
             {activeModal === 'fridge' && (
               <FridgeModal
-                fridgeItems={fridgeItems}
                 onClose={() => setActiveModal(null)}
                 onOpenAddFridge={() => setActiveModal('addFridge')}
                 onDeleteItem={deletePantryItem}
@@ -5585,12 +5581,6 @@ export default function WeeklyMenuPage() {
             {/* Add Fridge Item Modal */}
             {activeModal === 'addFridge' && (
               <AddFridgeModal
-                newFridgeName={newFridgeName}
-                newFridgeAmount={newFridgeAmount}
-                newFridgeExpiry={newFridgeExpiry}
-                onChangeName={setNewFridgeName}
-                onChangeAmount={setNewFridgeAmount}
-                onChangeExpiry={setNewFridgeExpiry}
                 onAdd={addPantryItem}
                 onClose={() => setActiveModal('fridge')}
               />
@@ -5599,11 +5589,7 @@ export default function WeeklyMenuPage() {
             {/* Shopping List Modal */}
             {activeModal === 'shopping' && (
               <ShoppingModal
-                shoppingList={shoppingList}
                 groupedShoppingList={groupedShoppingList}
-                shoppingListTotalServings={shoppingListTotalServings}
-                isRegeneratingShoppingList={isRegeneratingShoppingList}
-                shoppingListProgress={shoppingListProgress}
                 hasAnyMealsThisWeek={hasAnyMealsThisWeek}
                 onClose={() => setActiveModal(null)}
                 onOpenAddShopping={() => setActiveModal('addShopping')}
@@ -5621,12 +5607,6 @@ export default function WeeklyMenuPage() {
             {/* Add Shopping Item Modal */}
             {activeModal === 'addShopping' && (
               <AddShoppingModal
-                newShoppingName={newShoppingName}
-                newShoppingAmount={newShoppingAmount}
-                newShoppingCategory={newShoppingCategory}
-                onChangeName={setNewShoppingName}
-                onChangeAmount={setNewShoppingAmount}
-                onChangeCategory={setNewShoppingCategory}
                 onAdd={addShoppingItem}
                 onClose={() => setActiveModal('shopping')}
               />
@@ -5635,15 +5615,9 @@ export default function WeeklyMenuPage() {
             {/* Shopping Range Selection Modal (2-step) */}
             {activeModal === 'shoppingRange' && (
               <ShoppingRangeModal
-                shoppingRange={shoppingRange}
-                shoppingRangeStep={shoppingRangeStep}
                 isTodayExpanded={isTodayExpanded}
-                servingsConfig={servingsConfig}
                 onClose={() => { setActiveModal('shopping'); setShoppingRangeStep('range'); }}
-                onChangeRange={setShoppingRange}
-                onChangeStep={setShoppingRangeStep}
                 onToggleTodayExpanded={setIsTodayExpanded}
-                onUpdateServingsConfig={setServingsConfig}
                 onGenerate={async (cfg) => {
                   if (cfg) {
                     try {
@@ -5679,16 +5653,15 @@ export default function WeeklyMenuPage() {
             {/* Servings Config Modal */}
             {showServingsModal && (
               <ServingsModal
-                servingsConfig={servingsConfig}
                 onClose={() => setShowServingsModal(false)}
-                onUpdateServingsConfig={setServingsConfig}
                 onSave={async () => {
-                  if (!servingsConfig) return;
+                  const currentServingsConfig = useServingsConfigStore.getState().servingsConfig;
+                  if (!currentServingsConfig) return;
                   try {
                     const res = await fetch('/api/profile', {
                       method: 'POST',
                       headers: { 'Content-Type': 'application/json' },
-                      body: JSON.stringify({ servingsConfig })
+                      body: JSON.stringify({ servingsConfig: currentServingsConfig })
                     });
                     if (res.ok) {
                       setSuccessMessage({ title: '保存しました', message: '人数設定を更新しました' });
@@ -5704,17 +5677,9 @@ export default function WeeklyMenuPage() {
             {/* Add Meal Modal */}
             {activeModal === 'add' && (
               <AddMealModal
-                addMealKey={addMealKey}
                 modeConfig={MODE_CONFIG}
-                catalogQuery={catalogQuery}
-                catalogResults={catalogResults}
-                selectedCatalogProduct={selectedCatalogProduct}
-                isCatalogSearching={isCatalogSearching}
-                catalogSearchError={catalogSearchError}
                 onClose={() => setActiveModal(null)}
                 onOpenAiMeal={() => setActiveModal('aiMeal')}
-                onChangeCatalogQuery={setCatalogQuery}
-                onSelectCatalogProduct={setSelectedCatalogProduct}
                 onAddMealWithMode={handleAddMealWithMode}
               />
             )}
@@ -5742,14 +5707,8 @@ export default function WeeklyMenuPage() {
             {/* AI Single Meal Modal */}
             {activeModal === 'aiMeal' && (
               <AiMealModal
-                addMealKey={addMealKey}
-                addMealDayIndex={addMealDayIndex}
                 weekDates={weekDates}
-                selectedConditions={selectedConditions}
-                aiChatInput={aiChatInput}
                 onClose={() => setActiveModal(null)}
-                onChangeConditions={setSelectedConditions}
-                onChangeAiChatInput={setAiChatInput}
                 onGenerateSingleMeal={handleGenerateSingleMeal}
               />
             )}
@@ -5757,12 +5716,8 @@ export default function WeeklyMenuPage() {
             {/* Edit Meal Modal */}
             {activeModal === 'editMeal' && editingMeal && (
               <EditMealModal
-                editMealName={editMealName}
-                editMealMode={editMealMode}
                 modeConfig={MODE_CONFIG}
                 onClose={() => { setActiveModal(null); setEditingMeal(null); }}
-                onChangeName={setEditMealName}
-                onChangeMode={setEditMealMode}
                 onSave={saveEditMeal}
               />
             )}
@@ -5771,12 +5726,8 @@ export default function WeeklyMenuPage() {
             {activeModal === 'regenerateMeal' && regeneratingMeal && (
               <RegenerateMealModal
                 regeneratingMeal={regeneratingMeal}
-                selectedConditions={selectedConditions}
-                aiChatInput={aiChatInput}
                 isRegenerating={isRegenerating}
                 onClose={() => { setActiveModal(null); setRegeneratingMeal(null); }}
-                onChangeConditions={setSelectedConditions}
-                onChangeAiChatInput={setAiChatInput}
                 onRegenerateMeal={handleRegenerateMeal}
               />
             )}
@@ -5785,18 +5736,8 @@ export default function WeeklyMenuPage() {
             {activeModal === 'manualEdit' && manualEditMeal && (
               <ManualEditModal
                 manualEditMeal={manualEditMeal}
-                manualDishes={manualDishes}
-                manualMode={manualMode}
                 modeConfig={MODE_CONFIG}
-                catalogQuery={catalogQuery}
-                catalogResults={catalogResults}
-                selectedCatalogProduct={selectedCatalogProduct}
-                isCatalogSearching={isCatalogSearching}
-                catalogSearchError={catalogSearchError}
                 onClose={() => { setActiveModal(null); setManualEditMeal(null); }}
-                onChangeMode={setManualMode}
-                onChangeCatalogQuery={setCatalogQuery}
-                onSelectCatalogProduct={setSelectedCatalogProduct}
                 onApplyCatalogProduct={applyCatalogProductToManualEdit}
                 onAddDish={addManualDish}
                 onRemoveDish={removeManualDish}
@@ -5811,11 +5752,8 @@ export default function WeeklyMenuPage() {
             {activeModal === 'imageGenerate' && imageGenerateMeal && (
               <ImageGenerateModal
                 imageGenerateMeal={{ ...imageGenerateMeal, imageUrl: imageGenerateMeal.imageUrl ?? undefined }}
-                imageGenerationPrompt={imageGenerationPrompt}
-                imageReferencePreviews={imageReferencePreviews}
                 isGeneratingMealImage={isGeneratingMealImage}
                 onClose={() => closeImageGenerateModal(true)}
-                onChangePrompt={setImageGenerationPrompt}
                 onAddReferenceImages={(files: FileList) => {
                   const newFiles = Array.from(files);
                   setImageReferenceFiles(prev => [...prev, ...newFiles]);
@@ -5837,8 +5775,6 @@ export default function WeeklyMenuPage() {
             {/* Photo Edit Modal */}
             {activeModal === 'photoEdit' && photoEditMeal && (
               <PhotoEditModal
-                photoPreviews={photoPreviews}
-                photoFilesCount={photoFiles.length}
                 isAnalyzingPhoto={isAnalyzingPhoto}
                 onClose={() => { setActiveModal(null); setPhotoEditMeal(null); setPhotoFiles([]); setPhotoPreviews([]); }}
                 onPhotoSelect={(files: FileList) => {


### PR DESCRIPTION
## Summary

Phase B-3: モーダルコンポーネント 14 個を zustand store から直接 state を selector 取得するよう変更し、page.tsx からの props ドリリングを排除。

### 対象モーダルと削減 props

| モーダル | 削除した props | Before | After |
|---|---|---|---|
| AddFridgeModal | newFridgeName/Amount/Expiry + onChange 系 | 8 | 2 |
| AddShoppingModal | newShoppingName/Amount/Category + onChange 系 | 8 | 2 |
| AddMealModal | addMealKey / catalog 系 | 10 | 4 |
| AiAssistantModal | selectedConditions / aiChatInput + onChange 系 | 7 | 3 |
| AiMealModal | addMealKey / addMealDayIndex + selectedConditions + onChange 系 | 8 | 3 |
| EditMealModal | editMealName / editMealMode + onChange 系 | 7 | 2 |
| FridgeModal | fridgeItems | 4 | 3 |
| ImageGenerateModal | imageGenerationPrompt / imageReferencePreviews + onChangePrompt | 7 | 5 |
| ManualEditModal | manualDishes / manualMode / catalog 系 + onChange 系 | 14 | 6 |
| PhotoEditModal | photoPreviews / photoFilesCount | 6 | 4 |
| RegenerateMealModal | selectedConditions / aiChatInput + onChange 系 | 6 | 2 |
| ServingsModal | servingsConfig / onUpdateServingsConfig | 4 | 2 |
| ShoppingModal | shoppingList / shoppingListTotalServings / isRegeneratingShoppingList / shoppingListProgress | 14 | 10 |
| ShoppingRangeModal | shoppingRange / shoppingRangeStep / servingsConfig + onChange 系 | 9 | 3 |

**合計: 62 → 51 props** (削減: 約 53 props)

残り 6 モーダル (RecipeModal / StatsModal / NutritionDetailModal / ImproveMealModal / ConfirmDeleteModal / AddMealSlotModal) は page.tsx の useReducer 管理 state のため B-4 以降の対象。

### 検証

- `npm run typecheck`: 0 errors
- `npm run lint`: 0 errors (警告 2 件は別ファイル)

## Test plan

- [ ] 各モーダルが正常に開閉できること
- [ ] AddFridgeModal / AddShoppingModal でフォーム入力・追加が機能すること
- [ ] ShoppingRangeModal の範囲選択・人数変更・リスト生成が機能すること
- [ ] ServingsModal の人数設定保存が機能すること
- [ ] AiAssistantModal / AiMealModal / RegenerateMealModal の条件選択が機能すること
- [ ] ManualEditModal / EditMealModal の編集・保存が機能すること
- [ ] PhotoEditModal の写真選択・解析が機能すること
- [ ] ImageGenerateModal の画像生成が機能すること