### PR TITLE
refactor: as any を Tables<>/LegacyDishDetail/Record<> 等に置換 (batch 2)

### DIFF
--- a/src/app/(main)/health/checkups/new/page.tsx
+++ b/src/app/(main)/health/checkups/new/page.tsx
@@ -58,6 +58,8 @@ interface FormData {
   creatinine: string;
   egfr: string;
   uric_acid: string;
+  // 画像（AI解析後に設定される）
+  image_url?: string;
 }
 
 const initialFormData: FormData = {
@@ -232,7 +234,7 @@ export default function NewHealthCheckupPage() {
         checkup_date: formData.checkup_date,
         facility_name: formData.facility_name || null,
         checkup_type: formData.checkup_type || null,
-        image_url: (formData as any).image_url || null,
+        image_url: formData.image_url || null,
       };
 
       numericFields.forEach(field => {

--- a/src/app/(main)/health/insights/page.tsx
+++ b/src/app/(main)/health/insights/page.tsx
@@ -143,14 +143,16 @@ export default function HealthInsightsPage() {
 
         {/* フィルター */}
         <div className="flex gap-2">
-          {[
-            { key: 'all', label: 'すべて' },
-            { key: 'unread', label: '未読' },
-            { key: 'alerts', label: 'アラート', count: alertCount },
-          ].map((f) => (
+          {(
+            [
+              { key: 'all', label: 'すべて' },
+              { key: 'unread', label: '未読' },
+              { key: 'alerts', label: 'アラート', count: alertCount },
+            ] as { key: 'all' | 'unread' | 'alerts'; label: string; count?: number }[]
+          ).map((f) => (
             <button
               key={f.key}
-              onClick={() => setFilter(f.key as any)}
+              onClick={() => setFilter(f.key)}
               className="px-4 py-2 rounded-full text-sm font-medium flex items-center gap-1"
               style={{
                 backgroundColor: filter === f.key ? colors.accent : colors.card,

--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -129,7 +129,9 @@ export default function HomePage() {
   const [checkinFeedback, setCheckinFeedback] = useState<
     { type: 'success' | 'error'; message: string } | null
   >(null);
-  const [checkinForm, setCheckinForm] = useState({
+  type CheckinFormKey = 'sleepHours' | 'sleepQuality' | 'fatigue' | 'focus' | 'hunger';
+  type CheckinForm = Record<CheckinFormKey, number>;
+  const [checkinForm, setCheckinForm] = useState<CheckinForm>({
     sleepHours: 7,
     sleepQuality: 3,
     fatigue: 3,
@@ -560,17 +562,19 @@ export default function HomePage() {
                       </div>
 
                       {/* 各項目（5段階） */}
-                      {[
-                        { key: 'sleepQuality', label: '💤 睡眠の質', options: ['悪い', 'やや悪い', '普通', '良い', '最高'] },
-                        { key: 'fatigue', label: '😫 疲労度', options: ['元気', 'やや疲れ', '普通', '疲れ', 'ヘトヘト'] },
-                        { key: 'focus', label: '🎯 集中力', options: ['低い', 'やや低い', '普通', '良い', '最高'] },
-                        { key: 'hunger', label: '🍽️ 空腹感', options: ['ない', '少し', '普通', 'ある', 'すごくある'] },
-                      ].map((item) => (
+                      {(
+                        [
+                          { key: 'sleepQuality' as CheckinFormKey, label: '💤 睡眠の質', options: ['悪い', 'やや悪い', '普通', '良い', '最高'] },
+                          { key: 'fatigue' as CheckinFormKey, label: '😫 疲労度', options: ['元気', 'やや疲れ', '普通', '疲れ', 'ヘトヘト'] },
+                          { key: 'focus' as CheckinFormKey, label: '🎯 集中力', options: ['低い', 'やや低い', '普通', '良い', '最高'] },
+                          { key: 'hunger' as CheckinFormKey, label: '🍽️ 空腹感', options: ['ない', '少し', '普通', 'ある', 'すごくある'] },
+                        ] as const
+                      ).map((item) => (
                         <div key={item.key}>
                           <div className="flex items-center justify-between mb-2">
                             <span className="text-xs font-medium" style={{ color: colors.textLight }}>{item.label}</span>
                             <span className="text-xs" style={{ color: colors.textMuted }}>
-                              {item.options[(checkinForm as any)[item.key] - 1]}
+                              {item.options[checkinForm[item.key] - 1]}
                             </span>
                           </div>
                           <div className="flex gap-1">
@@ -579,7 +583,7 @@ export default function HomePage() {
                                 key={val}
                                 onClick={() => setCheckinForm({ ...checkinForm, [item.key]: val })}
                                 className={`flex-1 py-1.5 rounded-lg text-xs font-bold transition-all ${
-                                  (checkinForm as any)[item.key] === val
+                                  checkinForm[item.key] === val
                                     ? 'bg-purple-500 text-white'
                                     : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
                                 }`}

--- a/src/app/(main)/menus/weekly/_components/modals/NutritionDetailModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/NutritionDetailModal.tsx
@@ -122,7 +122,7 @@ export function NutritionDetailModal({
               {/* レーダーチャート */}
               <div className="flex justify-center mb-4">
                 <NutritionRadarChart
-                  nutrition={dayNutrition as any}
+                  nutrition={dayNutrition}
                   selectedNutrients={radarChartNutrients}
                   size={220}
                   showLabels={true}

--- a/src/app/(main)/menus/weekly/_components/modals/StatsModal.tsx
+++ b/src/app/(main)/menus/weekly/_components/modals/StatsModal.tsx
@@ -184,7 +184,7 @@ export function StatsModal({
               {/* レーダーチャート */}
               <div className="flex justify-center mb-3">
                 <NutritionRadarChart
-                  nutrition={todayNutrition as any}
+                  nutrition={todayNutrition}
                   selectedNutrients={radarChartNutrients}
                   size={180}
                   showLabels={true}
@@ -262,7 +262,7 @@ export function StatsModal({
               {/* 週間レーダーチャート */}
               <div className="flex justify-center mb-3">
                 <NutritionRadarChart
-                  nutrition={weekNutrition.averages as any}
+                  nutrition={weekNutrition.averages}
                   selectedNutrients={radarChartNutrients}
                   size={180}
                   showLabels={true}

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -134,6 +134,34 @@ interface ShoppingRangeSelection {
 // 全ての食事タイプ
 const ALL_MEAL_TYPES: MealType[] = ['breakfast', 'lunch', 'dinner', 'snack', 'midnight_snack'];
 
+// 旧形式（cal/protein/fat/carbs 等の短縮キー）との後方互換のための型拡張
+// dish データが古いスキーマで保存されている可能性があるため
+type LegacyDishDetail = DishDetail & {
+  cal?: number;
+  protein?: number;
+  fat?: number;
+  carbs?: number;
+  fiber?: number;
+  sugar?: number;
+  sodium?: number;
+  potassium?: number;
+  calcium?: number;
+  phosphorus?: number;
+  iron?: number;
+  zinc?: number;
+  cholesterol?: number;
+  vitaminA?: number;
+  vitaminB1?: number;
+  vitaminB2?: number;
+  vitaminB6?: number;
+  vitaminB12?: number;
+  vitaminC?: number;
+  vitaminD?: number;
+  vitaminE?: number;
+  vitaminK?: number;
+  folicAcid?: number;
+};
+
 // Reference UI Color Palette
 const colors = {
   bg: '#F7F6F3',
@@ -1745,7 +1773,8 @@ export default function WeeklyMenuPage() {
   const [isLoadingServingsConfig, setIsLoadingServingsConfig] = useState(false);
 
   // feedbackChannelRef (nutrition 系は nutritionReducer 管理)
-  const feedbackChannelRef = useRef<RealtimeChannel | null>(null);
+  // RealtimeChannel か、ポーリング用のカスタムクリーンアップオブジェクトのどちらかを保持する
+  const feedbackChannelRef = useRef<RealtimeChannel | { unsubscribe: () => void } | null>(null);
 
   // 買い物リスト範囲選択 (Phase B-3 shoppingStore 予定)
   const [shoppingRange, setShoppingRange] = useState<ShoppingRangeSelection>({
@@ -1814,7 +1843,7 @@ export default function WeeklyMenuPage() {
 
   // Recipe / AI / manualEdit / photo / imageGenerate → reducers 管理 (Phase B-2 移行済み)
   // formDraft 系 (manualDishes/mode/catalogQuery 等) → Phase B-3 formDraftStore 予定
-  const [manualDishes, setManualDishes] = useState<DishDetail[]>([]);
+  const [manualDishes, setManualDishes] = useState<LegacyDishDetail[]>([]);
   const [manualMode, setManualMode] = useState<MealMode>('cook');
   const [catalogQuery, setCatalogQuery] = useState('');
   const [catalogResults, setCatalogResults] = useState<CatalogProductSummary[]>([]);
@@ -2359,19 +2388,20 @@ export default function WeeklyMenuPage() {
         async (payload) => {
           try {
             console.log('📡 Realtime update received:', payload.new);
-            const newData = payload.new as { 
-              status: string; 
+            const newData = payload.new as {
+              status: string;
               mode?: string;
-              progress?: { 
-                phase?: string; 
-                message?: string; 
+              error_message?: string | null;
+              progress?: {
+                phase?: string;
+                message?: string;
                 percentage?: number;
                 // V4形式のフィールド
                 currentStep?: number;
                 totalSteps?: number;
                 completedSlots?: number;
                 totalSlots?: number;
-              } 
+              }
             };
             const newStatus = newData?.status;
             
@@ -2417,7 +2447,7 @@ export default function WeeklyMenuPage() {
               localStorage.removeItem('weeklyMenuGenerating');
               localStorage.removeItem('singleMealGenerating');
               cleanupRealtime();
-              setGenerationFailedError((newData as any).error_message || '献立の生成に失敗しました。もう一度お試しください。');
+              setGenerationFailedError(newData.error_message || '献立の生成に失敗しました。もう一度お試しください。');
               setGenerationFailedRequestId(requestId);
             }
             // status === 'queued' / 'pending' / 'processing' の場合は継続して監視
@@ -2487,11 +2517,11 @@ export default function WeeklyMenuPage() {
   useEffect(() => {
     const dateStr = weekDates[selectedDayIndex]?.dateStr;
     if (typeof window !== 'undefined' && dateStr) {
-      (window as any).__weeklyCurrentDate = dateStr;
+      window.__weeklyCurrentDate = dateStr;
     }
     return () => {
       if (typeof window !== 'undefined') {
-        try { delete (window as any).__weeklyCurrentDate; } catch { /* noop */ }
+        try { delete window.__weeklyCurrentDate; } catch { /* noop */ }
       }
     };
   }, [selectedDayIndex, weekDates]);
@@ -2543,9 +2573,9 @@ export default function WeeklyMenuPage() {
     // 既存の購読/ポーリングをクリーンアップ
     if (feedbackChannelRef.current) {
       if ('unsubscribe' in feedbackChannelRef.current) {
-        (feedbackChannelRef.current as any).unsubscribe();
+        feedbackChannelRef.current.unsubscribe();
       } else {
-        supabase.removeChannel(feedbackChannelRef.current as RealtimeChannel);
+        supabase.removeChannel(feedbackChannelRef.current);
       }
       feedbackChannelRef.current = null;
     }
@@ -2704,7 +2734,7 @@ export default function WeeklyMenuPage() {
               clearInterval(pollInterval);
               supabase.removeChannel(channel);
             }
-          } as any;
+          };
         }
       } else {
         setNutritionFeedback('分析結果を取得できませんでした。');
@@ -2730,7 +2760,7 @@ export default function WeeklyMenuPage() {
     // クリーンアップ：モーダルが閉じたら購読/ポーリングを停止
     return () => {
       if (!showNutritionDetailModal && feedbackChannelRef.current) {
-        (feedbackChannelRef.current as any).unsubscribe?.();
+        feedbackChannelRef.current.unsubscribe?.();
         feedbackChannelRef.current = null;
       }
     };
@@ -3904,7 +3934,7 @@ export default function WeeklyMenuPage() {
       return;
     }
     
-    const totalCal = validDishes.reduce((sum, d) => sum + (d.calories_kcal ?? (d as any).cal ?? 0), 0);
+    const totalCal = validDishes.reduce((sum, d) => sum + (d.calories_kcal ?? d.cal ?? 0), 0);
     const dishName = validDishes.map(d => d.name).join('、');
     
     try {
@@ -4554,10 +4584,11 @@ export default function WeeklyMenuPage() {
     // 新規生成中はEmptySlotコンポーネントで表示
 
     // dishes配列から主菜と他の品数を取得
-    const dishesArray: DishDetail[] = Array.isArray(meal.dishes) 
-      ? meal.dishes 
-      : meal.dishes 
-        ? Object.values(meal.dishes).filter(Boolean) as DishDetail[]
+    // LegacyDishDetail にキャスト：旧形式(cal/protein等)と新形式(calories_kcal/protein_g等)の両方に対応
+    const dishesArray: LegacyDishDetail[] = Array.isArray(meal.dishes)
+      ? meal.dishes as LegacyDishDetail[]
+      : meal.dishes
+        ? Object.values(meal.dishes).filter(Boolean) as LegacyDishDetail[]
         : [];
     
     // 複数回目の食事の場合はラベルに番号を追加
@@ -4692,10 +4723,11 @@ export default function WeeklyMenuPage() {
     // プレースホルダーは使用しないので、meal.isGenerating は参照しない
     
     // dishes は配列形式に対応（可変数）
-    const dishesArray: DishDetail[] = Array.isArray(meal.dishes) 
-      ? meal.dishes 
-      : meal.dishes 
-        ? Object.values(meal.dishes).filter(Boolean) as DishDetail[]
+    // LegacyDishDetail にキャスト：旧形式(cal/protein等)と新形式(calories_kcal/protein_g等)の両方に対応
+    const dishesArray: LegacyDishDetail[] = Array.isArray(meal.dishes)
+      ? meal.dishes as LegacyDishDetail[]
+      : meal.dishes
+        ? Object.values(meal.dishes).filter(Boolean) as LegacyDishDetail[]
         : [];
     const hasDishes = dishesArray.length > 0;
     
@@ -4795,7 +4827,7 @@ export default function WeeklyMenuPage() {
                     // タップした料理だけを表示
                     setSelectedRecipe(dish.name);
                     // 古い形式(cal, protein等)と新しい形式(calories_kcal, protein_g等)の両方に対応
-                    const d = dish as any;
+                    const d = dish as LegacyDishDetail;
                     const normalizedDish = {
                       ...dish,
                       // 新しい形式を優先、なければ古い形式からマッピング
@@ -4825,7 +4857,7 @@ export default function WeeklyMenuPage() {
                     };
                     setSelectedRecipeData({
                       ...normalizedDish,
-                      imageUrl: (dish as any).image_url ?? meal.imageUrl ?? null,
+                      imageUrl: dish.image_url ?? meal.imageUrl ?? null,
                       // この料理だけを配列に入れる（UIの互換性のため）
                       dishes: [normalizedDish],
                       // 全料理の材料（買い物リスト用）
@@ -4838,15 +4870,15 @@ export default function WeeklyMenuPage() {
                 >
                   <div className="flex justify-between mb-1">
                     <span style={{ fontSize: 9, fontWeight: 700, color: config.color }}>{config.label}</span>
-                    <span style={{ fontSize: 9, color: colors.textMuted }}>{dish.calories_kcal ?? (dish as any).cal ?? '-'}kcal</span>
+                    <span style={{ fontSize: 9, color: colors.textMuted }}>{dish.calories_kcal ?? dish.cal ?? '-'}kcal</span>
                   </div>
                   <p style={{ fontSize: 13, fontWeight: 500, color: colors.text, margin: 0 }}>{dish.name}</p>
                   {/* 栄養素（P/F/C）- 新旧形式両対応 */}
-                  {(dish.protein_g || dish.fat_g || dish.carbs_g || (dish as any).protein || (dish as any).fat || (dish as any).carbs) && (
+                  {(dish.protein_g || dish.fat_g || dish.carbs_g || dish.protein || dish.fat || dish.carbs) && (
                     <div className="flex gap-2 mt-1 text-[8px]" style={{ color: colors.textMuted }}>
-                      {((dish.protein_g ?? (dish as any).protein) ?? 0) > 0 && <span>P:{dish.protein_g ?? (dish as any).protein}g</span>}
-                      {((dish.fat_g ?? (dish as any).fat) ?? 0) > 0 && <span>F:{dish.fat_g ?? (dish as any).fat}g</span>}
-                      {((dish.carbs_g ?? (dish as any).carbs) ?? 0) > 0 && <span>C:{dish.carbs_g ?? (dish as any).carbs}g</span>}
+                      {((dish.protein_g ?? dish.protein) ?? 0) > 0 && <span>P:{dish.protein_g ?? dish.protein}g</span>}
+                      {((dish.fat_g ?? dish.fat) ?? 0) > 0 && <span>F:{dish.fat_g ?? dish.fat}g</span>}
+                      {((dish.carbs_g ?? dish.carbs) ?? 0) > 0 && <span>C:{dish.carbs_g ?? dish.carbs}g</span>}
                     </div>
                   )}
                   <span className="inline-flex items-center gap-1 mt-auto text-[9px]" style={{ color: colors.blue }}>
@@ -5257,7 +5289,7 @@ export default function WeeklyMenuPage() {
         <ProgressTodoCard
           progress={generationProgress}
           colors={colors}
-          phases={(generationProgress as any)?.isUltimateMode ? ULTIMATE_PROGRESS_PHASES : PROGRESS_PHASES}
+          phases={generationProgress?.isUltimateMode ? ULTIMATE_PROGRESS_PHASES : PROGRESS_PHASES}
         />
       ) : (
         <button
@@ -5368,7 +5400,7 @@ export default function WeeklyMenuPage() {
                           <div className="space-y-1">
                             {radarChartNutrients.slice(0, 6).map(key => {
                               const def = getNutrientDefinition(key);
-                              const value = (dayNutrition as any)[key] ?? 0;
+                              const value = (dayNutrition as Record<string, number>)[key] ?? 0;
                               const percentage = calculateDriPercentage(key, value);
                               const isGood = percentage >= 80 && percentage <= 120;
                               const isLow = percentage < 50;

--- a/src/app/api/ai/consultation/sessions/[sessionId]/close/route.ts
+++ b/src/app/api/ai/consultation/sessions/[sessionId]/close/route.ts
@@ -151,7 +151,7 @@ ${importantMessages.map((m: any) => `- ${m.content.substring(0, 200)}`).join('\n
             if (!summaryContent) throw new Error('要約の生成に失敗しました');
 
             const parsed = safeJsonParse(summaryContent);
-            if (!parsed || typeof parsed !== 'object' || typeof (parsed as any).summary !== 'string') {
+            if (!parsed || typeof parsed !== 'object' || typeof parsed.summary !== 'string') {
               throw new Error('Invalid summary JSON');
             }
 

--- a/src/app/api/ai/consultation/sessions/[sessionId]/summarize/route.ts
+++ b/src/app/api/ai/consultation/sessions/[sessionId]/summarize/route.ts
@@ -54,9 +54,9 @@ function buildExistingSummary(session: any): any | null {
   if (!session || typeof session !== 'object') return null;
   if (!session.summary) return null;
 
-  const cs = session.context_snapshot && typeof session.context_snapshot === 'object' ? session.context_snapshot : {};
-  const keyFacts = Array.isArray((cs as any).key_facts) ? (cs as any).key_facts : [];
-  const userInsights = Array.isArray((cs as any).user_insights) ? (cs as any).user_insights : [];
+  const cs: Record<string, unknown> = session.context_snapshot && typeof session.context_snapshot === 'object' ? session.context_snapshot as Record<string, unknown> : {};
+  const keyFacts = Array.isArray(cs.key_facts) ? cs.key_facts : [];
+  const userInsights = Array.isArray(cs.user_insights) ? cs.user_insights : [];
   const keyTopics = Array.isArray(session.key_topics) ? session.key_topics : [];
   const actionsTaken = Array.isArray(session.action_history)
     ? session.action_history
@@ -180,7 +180,7 @@ ${importantMessages.map((m: any) => `- ${m.content.substring(0, 200)}`).join('\n
         if (!summaryContent) throw new Error('要約の生成に失敗しました');
 
         const parsed = safeJsonParse(summaryContent);
-        if (!parsed || typeof parsed !== 'object' || typeof (parsed as any).summary !== 'string') {
+        if (!parsed || typeof parsed !== 'object' || typeof parsed.summary !== 'string') {
           throw new Error('Invalid summary JSON');
         }
 

--- a/src/app/api/ai/image/generate/route.ts
+++ b/src/app/api/ai/image/generate/route.ts
@@ -134,7 +134,7 @@ export async function POST(request: Request) {
       console.error('Upload error:', uploadError);
 
       const errorMessage = uploadError.message || String(uploadError);
-      const errorStatus = (uploadError as any).statusCode || (uploadError as any).status;
+      const errorStatus = uploadError.status;
 
       if (
         errorMessage.includes('Bucket not found') ||

--- a/src/app/api/health/streaks/route.ts
+++ b/src/app/api/health/streaks/route.ts
@@ -15,7 +15,8 @@ export async function GET(request: NextRequest) {
   const rawType = searchParams.get('type') || 'daily_record';
 
   const ALLOWED_STREAK_TYPES = ['daily_record', 'meal_record', 'health_record', 'exercise_record'] as const;
-  if (!ALLOWED_STREAK_TYPES.includes(rawType as any)) {
+  type StreakType = (typeof ALLOWED_STREAK_TYPES)[number];
+  if (!ALLOWED_STREAK_TYPES.includes(rawType as StreakType)) {
     return NextResponse.json({ error: 'Invalid streak type' }, { status: 400 });
   }
   const streakType = rawType;
@@ -117,7 +118,8 @@ export async function DELETE(request: NextRequest) {
   const rawTypeDelete = searchParams.get('type') || 'daily_record';
 
   const ALLOWED_STREAK_TYPES_DELETE = ['daily_record', 'meal_record', 'health_record', 'exercise_record'] as const;
-  if (!ALLOWED_STREAK_TYPES_DELETE.includes(rawTypeDelete as any)) {
+  type StreakTypeDelete = (typeof ALLOWED_STREAK_TYPES_DELETE)[number];
+  if (!ALLOWED_STREAK_TYPES_DELETE.includes(rawTypeDelete as StreakTypeDelete)) {
     return NextResponse.json({ error: 'Invalid streak type' }, { status: 400 });
   }
   const streakType = rawTypeDelete;

--- a/src/app/api/meal-plans/meals/route.ts
+++ b/src/app/api/meal-plans/meals/route.ts
@@ -122,7 +122,7 @@ export async function POST(request: Request) {
       plannedMealId: newMeal.id,
       userId: user.id,
       triggerSource,
-      jobSeeds: dishImagePayload.jobs as any,
+      jobSeeds: dishImagePayload.jobs,
       requestId,
     });
     if (dishImagePayload.jobs.length > 0) {

--- a/src/app/api/meals/route.ts
+++ b/src/app/api/meals/route.ts
@@ -173,7 +173,7 @@ export async function POST(request: Request) {
       plannedMealId: meal.id,
       userId: user.id,
       triggerSource,
-      jobSeeds: dishImagePayload.jobs as any,
+      jobSeeds: dishImagePayload.jobs,
       requestId,
     });
     if (dishImagePayload.jobs.length > 0) {

--- a/src/app/api/pantry/from-photo/route.ts
+++ b/src/app/api/pantry/from-photo/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
+import type { Tables } from '@homegohan/shared';
 
 /**
  * 冷蔵庫写真解析結果をpantry_itemsに保存
@@ -86,7 +87,7 @@ export async function POST(request: Request) {
       created: 0,
       updated: 0,
       skipped: 0,
-      items: [] as any[],
+      items: [] as Tables<'pantry_items'>[],
     };
 
     // 各アイテムを処理

--- a/src/app/onboarding/questions/page.tsx
+++ b/src/app/onboarding/questions/page.tsx
@@ -536,8 +536,9 @@ function OnboardingQuestionsContent() {
 
   const currentQuestion = QUESTIONS[currentStep];
   const isNumberQuestion = currentQuestion?.type === 'number';
-  const numberMin = isNumberQuestion && typeof (currentQuestion as any).min === 'number' ? (currentQuestion as any).min : 1;
-  const numberMax = isNumberQuestion && typeof (currentQuestion as any).max === 'number' ? (currentQuestion as any).max : 10;
+  const currentQuestionFields = currentQuestion as Record<string, unknown>;
+  const numberMin = isNumberQuestion && typeof currentQuestionFields.min === 'number' ? currentQuestionFields.min : 1;
+  const numberMax = isNumberQuestion && typeof currentQuestionFields.max === 'number' ? currentQuestionFields.max : 10;
   const numberValue = isNumberQuestion ? Number.parseInt(inputValue, 10) : NaN;
   const isNumberValid = isNumberQuestion && Number.isFinite(numberValue) && numberValue >= numberMin && numberValue <= numberMax;
   const hasTags = tags.length > 0;

--- a/src/components/AIChatBubble.tsx
+++ b/src/components/AIChatBubble.tsx
@@ -182,7 +182,7 @@ export default function AIChatBubble() {
   const computeDefaultDayMenuDate = (): string => {
     const todayStr = new Date().toISOString().split('T')[0];
     if (typeof window !== 'undefined') {
-      const fromWeekly = (window as any).__weeklyCurrentDate;
+      const fromWeekly = window.__weeklyCurrentDate;
       if (typeof fromWeekly === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(fromWeekly)) {
         if (fromWeekly !== todayStr) return fromWeekly;
       }

--- a/src/components/NutritionRadarChart.tsx
+++ b/src/components/NutritionRadarChart.tsx
@@ -20,37 +20,8 @@ import {
 // Types
 // ============================================
 
-interface DayNutrition {
-  caloriesKcal: number;
-  proteinG: number;
-  fatG: number;
-  carbsG: number;
-  sodiumG: number;
-  sugarG: number;
-  fiberG: number;
-  potassiumMg: number;
-  calciumMg: number;
-  phosphorusMg: number;
-  magnesiumMg: number;
-  ironMg: number;
-  zincMg: number;
-  iodineUg: number;
-  cholesterolMg: number;
-  vitaminAUg: number;
-  vitaminB1Mg: number;
-  vitaminB2Mg: number;
-  vitaminB6Mg: number;
-  vitaminB12Ug: number;
-  vitaminCMg: number;
-  vitaminDUg: number;
-  vitaminEMg: number;
-  vitaminKUg: number;
-  folicAcidUg: number;
-  saturatedFatG: number;
-}
-
 interface NutritionRadarChartProps {
-  nutrition: DayNutrition;
+  nutrition: Record<string, number>;
   selectedNutrients?: string[] | null;
   size?: number;
   showLabels?: boolean;
@@ -98,7 +69,7 @@ export function NutritionRadarChart({
   const chartData = useMemo(() => {
     return nutrients.map(key => {
       const def = getNutrientDefinition(key);
-      const value = (nutrition as any)[key] ?? 0;
+      const value = nutrition[key] ?? 0;
       const percentage = calculateDriPercentage(key, value);
       
       return {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,13 @@
+/**
+ * グローバル window 拡張型定義
+ *
+ * Bug-5 (#21): weekly メニューページが現在表示中の日付を window.__weeklyCurrentDate に
+ * publish し、AIChatBubble 等の別コンポーネントが参照する。
+ */
+export {};
+
+declare global {
+  interface Window {
+    __weeklyCurrentDate?: string;
+  }
+}


### PR DESCRIPTION
## Summary

Refactor C 第 2 弾。残 44 件の `as any` を 37 件削減し、残 7 件まで圧縮（目標 24 件以下を大幅達成）。

- **Before**: 44 件（PR #915 batch 1 後）
- **After**: 7 件

## 主な変更

| カテゴリ | 対応内容 |
|---|---|
| `NutritionRadarChart` | `DayNutrition` インターフェースを廃止し `Record<string, number>` に変更。型安全なインデックスアクセスが可能に |
| `weekly/page.tsx` (LegacyDishDetail) | 旧形式フィールド（`cal`, `protein`, `fat`, `carbs` 等）を `LegacyDishDetail = DishDetail & {...}` 型エイリアスで型安全に管理 |
| `weekly/page.tsx` (feedbackChannelRef) | `RealtimeChannel | { unsubscribe: () => void } | null` ユニオン型に変更 |
| `window.__weeklyCurrentDate` | `src/types/global.d.ts` で `Window` インターフェース拡張、`as any` 不要に |
| `generationProgress?.isUltimateMode` | `GenerationProgress` 型に既にフィールドがあったため直接アクセスに |
| `health/streaks/route.ts` | `(typeof ALLOWED)[number]` 型でキャスト |
| `meal-plans/meals`, `meals` route | `jobSeeds` の型が既に一致していたため `as any` を削除 |
| `pantry/from-photo` | `items: [] as Tables<'pantry_items'>[]` に |
| `home/page.tsx` | `CheckinForm = Record<CheckinFormKey, number>` 型定義でインデックスアクセスを型安全に |
| `health/checkups/new` | `FormData` に `image_url?: string` フィールドを追加 |
| `health/insights` | フィルター配列に型を明示し `setFilter` に直接渡せるように |
| `AIChatBubble` | `global.d.ts` の Window 拡張で `window.__weeklyCurrentDate` を直接アクセス |
| `onboarding/questions` | `Record<string, unknown>` キャストで `min`/`max` に型安全にアクセス |
| `consultation/close`, `summarize` | `safeJsonParse` が `any` を返すため `parsed.summary` 直接アクセスに |
| `consultation/summarize` | `context_snapshot` を `Record<string, unknown>` に |

## 残り 7 件（据え置き理由）

すべて `ai/` ルートの OpenAI SDK 呼び出しで `response_format` と `max_completion_tokens`/`max_tokens` を同時指定する際の SDK 型制約によるもの。外部ライブラリの型定義の制限のため型生成不可。

## Test plan

- [x] `npm run typecheck` — エラー 0 件
- [x] `npm run lint` — エラー 0 件（既存 warning のみ）