### PR TITLE
test(e2e): /api/recipes/[id]/comments + /api/comparison/rankings 追加

### DIFF
--- a/tests/e2e/api/recipes-comments-rankings.spec.ts
+++ b/tests/e2e/api/recipes-comments-rankings.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * /api/recipes/[id]/comments + /api/comparison/rankings の API E2E
+ *
+ * Refactor C-1 (PR #915) で両ルートの `as any` を Tables<>/TablesInsert<> に置換。
+ * E2E カバレッジが皆無だったためスモーク確認を追加。
+ *
+ * 実行方法:
+ *   PLAYWRIGHT_BASE_URL=https://homegohan-app.vercel.app \
+ *     npm run test:e2e -- tests/e2e/api/recipes-comments-rankings.spec.ts
+ */
+
+import { expect } from "@playwright/test";
+import { test } from "../fixtures/auth";
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+
+// ─── /api/recipes/[id]/comments ──────────────────────────────────────────────
+
+test.describe("/api/recipes/[id]/comments", () => {
+  test("GET 未認証 → 401/403", async ({ request }) => {
+    // dummy uuid。認証より先に未認証拒否される設計を期待
+    const dummyId = "00000000-0000-0000-0000-000000000001";
+    const res = await request.get(
+      `${BASE_URL}/api/recipes/${dummyId}/comments`,
+    );
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test("POST 未認証 → 401/403", async ({ request }) => {
+    const dummyId = "00000000-0000-0000-0000-000000000001";
+    const res = await request.post(
+      `${BASE_URL}/api/recipes/${dummyId}/comments`,
+      {
+        data: { body: "test comment" },
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test("GET 認証あり → 200 + 配列 (存在しない recipe id は 404 でも許容)", async ({
+    authedPage,
+  }) => {
+    // dummy uuid で叩いて、200 (空配列) または 404 を許容
+    const dummyId = "00000000-0000-0000-0000-000000000001";
+    const res = await authedPage.request.get(
+      `${BASE_URL}/api/recipes/${dummyId}/comments`,
+    );
+    expect([200, 404]).toContain(res.status());
+    if (res.status() === 200) {
+      const body = await res.json();
+      // shape: { comments: [...] } か [...] の想定
+      const comments = Array.isArray(body) ? body : body.comments;
+      expect(Array.isArray(comments)).toBe(true);
+    }
+  });
+
+  test("POST 認証あり (存在しない recipe) → 404 / 400 / 422 のいずれか", async ({
+    authedPage,
+  }) => {
+    const dummyId = "00000000-0000-0000-0000-000000000001";
+    const res = await authedPage.request.post(
+      `${BASE_URL}/api/recipes/${dummyId}/comments`,
+      {
+        data: { body: "test comment from e2e" },
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    // 存在しない recipe への投稿は 404 / 400 / 422 のどれかになる想定
+    expect([400, 404, 422, 500]).toContain(res.status());
+  });
+});
+
+// ─── /api/comparison/rankings ─────────────────────────────────────────────────
+
+test.describe("/api/comparison/rankings", () => {
+  test("GET 未認証 → 401/403", async ({ request }) => {
+    const res = await request.get(`${BASE_URL}/api/comparison/rankings`);
+    expect([401, 403]).toContain(res.status());
+  });
+
+  test("GET 認証あり → 200 + JSON", async ({ authedPage }) => {
+    const res = await authedPage.request.get(
+      `${BASE_URL}/api/comparison/rankings`,
+    );
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    // shape: { rankings: [...] } または { items: [...] } または [...] のいずれかを許容
+    expect(typeof body).toBe("object");
+  });
+});


### PR DESCRIPTION
## Summary

Refactor C-1 (PR #915) で `as any` を `Tables<>` 系に置換した両 API ルートだが E2E カバレッジが皆無だったので、スモーク確認を追加。

- `/api/recipes/[id]/comments`: GET / POST の認証 + 未認証 4 ケース
- `/api/comparison/rankings`: GET の認証 + 未認証 2 ケース
- 合計 6 ケース

## Test plan

- [ ] `npm run test:e2e -- tests/e2e/api/recipes-comments-rankings.spec.ts` で全 case pass
- recipe id は dummy UUID を使用 (実 seed 不要)。存在しない id への操作は 404/400/422/500 のいずれかを許容

## 関連

- ギャップ分析で C 判定だった範囲をカバー
- PR #915 で型安全化したルートの動作証跡