### PR TITLE
fix(e2e): bug-36 selector を data-testid ベースに更新

### DIFF
--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -5294,6 +5294,7 @@ export default function WeeklyMenuPage() {
         />
       ) : (
         <button
+          data-testid="ai-assistant-banner-button"
           onClick={() => setShowV4Modal(true)}
           className="mx-3 mt-2 px-3.5 py-2.5 rounded-xl flex items-center justify-between"
           style={{ background: colors.accent }}

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -472,6 +472,7 @@ export default function SettingsPage() {
         <div>
           <Button
             variant="outline"
+            data-testid="logout-button"
             onClick={() => setShowLogoutModal(true)}
             className="w-full py-6 rounded-2xl border-red-100 text-red-500 hover:bg-red-50 hover:border-red-200 font-bold mb-4"
           >
@@ -534,6 +535,7 @@ export default function SettingsPage() {
               </p>
               <div className="flex flex-col gap-3">
                 <button
+                  data-testid="logout-confirm-button"
                   onClick={handleLogout}
                   className="w-full py-3 rounded-full bg-[#333] text-white font-bold hover:bg-black transition-colors shadow-lg"
                 >

--- a/tests/e2e/bug-36-localstorage-cleanup-on-signout.spec.ts
+++ b/tests/e2e/bug-36-localstorage-cleanup-on-signout.spec.ts
@@ -51,11 +51,8 @@ test("user-scoped localStorage keys are cleared after sign-out", async ({ authed
   await authedPage.goto("/settings");
   await authedPage.waitForLoadState("networkidle");
 
-  // ログアウトボタンを探す (テキストで検索)
-  const logoutButton = authedPage
-    .getByRole("button", { name: /ログアウト/ })
-    .or(authedPage.locator('button').filter({ hasText: /ログアウト/ }))
-    .first();
+  // ログアウトボタンを data-testid で取得
+  const logoutButton = authedPage.getByTestId("logout-button");
 
   const logoutVisible = await logoutButton.isVisible().catch(() => false);
 
@@ -78,15 +75,12 @@ test("user-scoped localStorage keys are cleared after sign-out", async ({ authed
     return;
   }
 
-  // ログアウトボタンをクリック
-  // /settings のログアウトボタンは確認モーダル (React) を開く。
-  // ネイティブ dialog ではないので、モーダル内の「ログアウト」ボタンを改めてクリックする。
+  // ログアウトボタンをクリック (確認モーダルが開く)
   authedPage.on("dialog", (dialog) => dialog.accept()); // ネイティブ dialog 対応（念のため）
   await logoutButton.click();
 
-  // 確認モーダルが開いた場合は、モーダル内の「ログアウト」ボタンをクリックする
-  // モーダル内のボタンはテキストが「ログアウト」の2番目のボタン (最初は開くボタン自体)
-  const confirmButton = authedPage.locator('button').filter({ hasText: /^ログアウト$/ }).last();
+  // 確認モーダル内の「ログアウト」ボタンを data-testid で取得してクリック
+  const confirmButton = authedPage.getByTestId("logout-confirm-button");
   const confirmVisible = await confirmButton.isVisible({ timeout: 3_000 }).catch(() => false);
   if (confirmVisible) {
     await confirmButton.click();
@@ -120,12 +114,12 @@ test("v4_include_existing is not written to localStorage (no persistence)", asyn
   // null または "false" であること
   expect(initial).not.toBe("true");
 
-  // AI アシスタントを開いて「期間を指定」モードに進む
-  const aiBubble = authedPage.locator('button:has(svg.lucide-sparkles)').first();
+  // AI アシスタントバナーボタンを data-testid で取得して開く
+  const aiBubble = authedPage.getByTestId("ai-assistant-banner-button");
   const bubbleVisible = await aiBubble.isVisible().catch(() => false);
   if (!bubbleVisible) {
-    // AI ボタンが見つからなければスキップ
-    console.warn("AI bubble not found, skipping localStorage write check");
+    // AI ボタンが見つからなければ silent pass を避けるため skip
+    test.skip(true, "AI assistant banner button not found on /menus/weekly – test skipped");
     return;
   }
 
@@ -133,7 +127,7 @@ test("v4_include_existing is not written to localStorage (no persistence)", asyn
   const rangeButton = authedPage.getByRole("button", { name: /期間を指定/ });
   const rangeVisible = await rangeButton.isVisible({ timeout: 8_000 }).catch(() => false);
   if (!rangeVisible) {
-    console.warn("Range button not found, skipping");
+    test.skip(true, "Range button not found in V4GenerateModal – test skipped");
     return;
   }
   await rangeButton.click();


### PR DESCRIPTION
## Summary

- `button:has(svg.lucide-sparkles)` 等の脆い CSS セレクタを `getByTestId()` に切り替え
- Refactor B 後の DOM 変更で外れていた 2 ケースを修正
- fallback パスで `return` による silent pass になっていた箇所を `test.skip()` に変更

## 変更ファイル

### 実装 (testID 追加のみ、ロジック変更なし)

- `src/app/(main)/settings/page.tsx`: ログアウトボタンに `data-testid="logout-button"` / モーダル確認ボタンに `data-testid="logout-confirm-button"` を追加
- `src/app/(main)/menus/weekly/page.tsx`: AI バナーボタンに `data-testid="ai-assistant-banner-button"` を追加

### spec

- `tests/e2e/bug-36-localstorage-cleanup-on-signout.spec.ts`: selector を testID ベースに更新

## Test plan

- [ ] `npm run test:e2e -- tests/e2e/bug-36-localstorage-cleanup-on-signout.spec.ts` で 2 ケース pass を確認
- [ ] 既存の settings / weekly ページの E2E テストが引き続き pass であることを確認