### PR TITLE
fix(e2e): auth fixture の Supabase rate limit を解消

### DIFF
--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -2,6 +2,7 @@ import { test as base, expect, type Page, type BrowserContext } from "@playwrigh
 import * as fs from "fs";
 import { config as dotenvConfig } from "dotenv";
 import * as path from "path";
+import { REFRESH_TOKEN_PATH, refreshSupabaseSession } from "../global-setup";
 
 // Worker プロセスでも .env.local が読み込まれるよう dotenv を再実行する
 dotenvConfig({ path: path.resolve(__dirname, "../../../.env.local") });
@@ -16,12 +17,156 @@ const LOGIN_TIMEOUT_MS = 90_000;
 // UI リトライ設定
 const MAX_UI_RETRIES = 2;
 const RETRY_BASE_DELAY_MS = 2_000;
+// storageState が期限まで何秒未満なら expired と判定するバッファ
+const EXPIRY_BUFFER_SECONDS = 300; // 5 分
 
 /** globalSetup が保存した storageState ファイルのパス */
 const STORAGE_STATE_PATH = "tests/e2e/.auth/user.json";
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * storageState の access_token が期限切れ (または期限まで 5 分未満) かどうかを確認する。
+ * Cookie の中の Supabase セッション JSON から expires_at を取得して判定する。
+ */
+function isStorageStateExpired(): boolean {
+  try {
+    const raw = fs.readFileSync(STORAGE_STATE_PATH, "utf-8");
+    const state = JSON.parse(raw) as {
+      cookies?: Array<{ name: string; value: string; expires?: number }>;
+      origins?: Array<{
+        localStorage?: Array<{ name: string; value: string }>;
+      }>;
+    };
+
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    // Cookie ベースのセッション確認 (sb-...-auth-token)
+    if (state.cookies) {
+      for (const cookie of state.cookies) {
+        if (cookie.name?.startsWith("sb-") && cookie.name.endsWith("-auth-token")) {
+          try {
+            const decoded = decodeURIComponent(cookie.value);
+            const session = JSON.parse(decoded) as { expires_at?: number };
+            if (session.expires_at) {
+              const remaining = session.expires_at - nowSec;
+              if (remaining < EXPIRY_BUFFER_SECONDS) {
+                console.log(`[auth fixture] storageState Cookie セッション期限切れ (残り ${remaining}秒)`);
+                return true;
+              }
+              return false;
+            }
+          } catch {
+            // JSON parse 失敗は期限切れ扱い
+            return true;
+          }
+          // Cookie 自体の expires を確認
+          if (cookie.expires && cookie.expires - nowSec < EXPIRY_BUFFER_SECONDS) {
+            console.log(`[auth fixture] storageState Cookie expires 期限切れ`);
+            return true;
+          }
+        }
+      }
+    }
+
+    // localStorage ベースのセッション確認 (sb-...-auth-token)
+    if (state.origins) {
+      for (const origin of state.origins) {
+        for (const item of origin.localStorage ?? []) {
+          if (item.name?.startsWith("sb-") && item.name.endsWith("-auth-token")) {
+            try {
+              const session = JSON.parse(item.value) as { expires_at?: number };
+              if (session.expires_at) {
+                const remaining = session.expires_at - nowSec;
+                if (remaining < EXPIRY_BUFFER_SECONDS) {
+                  console.log(`[auth fixture] storageState localStorage セッション期限切れ (残り ${remaining}秒)`);
+                  return true;
+                }
+                return false;
+              }
+            } catch {
+              return true;
+            }
+          }
+        }
+      }
+    }
+
+    // セッション情報が見つからない場合は期限切れ扱い
+    return true;
+  } catch {
+    // ファイルが存在しない等のエラーは期限切れ扱い
+    return true;
+  }
+}
+
+/**
+ * refresh_token を使ってセッションを更新し、Cookie として Playwright コンテキストに注入する。
+ * password grant より rate limit が緩い。
+ */
+async function refreshSessionViaCookie(page: Page, baseURL: string): Promise<boolean> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !anonKey) return false;
+
+  try {
+    const raw = fs.readFileSync(REFRESH_TOKEN_PATH, "utf-8");
+    const { refresh_token } = JSON.parse(raw) as { refresh_token: string };
+    if (!refresh_token) return false;
+
+    console.log("[auth fixture] refresh_token でセッション更新中...");
+    const session = await refreshSupabaseSession(supabaseUrl, anonKey, refresh_token);
+    if (!session) return false;
+
+    // 新しい refresh_token を保存
+    if (session.refresh_token) {
+      fs.writeFileSync(
+        REFRESH_TOKEN_PATH,
+        JSON.stringify({
+          refresh_token: session.refresh_token,
+          expires_at: session.expires_at ?? (Math.floor(Date.now() / 1000) + 3600),
+          saved_at: Math.floor(Date.now() / 1000),
+        }),
+        "utf-8",
+      );
+    }
+
+    const supabaseRef = supabaseUrl.replace("https://", "").split(".")[0];
+    const cookieName = `sb-${supabaseRef}-auth-token`;
+    const domain = baseURL ? new URL(baseURL).hostname : "localhost";
+    const isSecure = baseURL.startsWith("https");
+    const cookieValue = encodeURIComponent(JSON.stringify(session));
+    const expiresAt = (session.expires_at as number) ?? (Math.floor(Date.now() / 1000) + 3600);
+
+    await page.context().clearCookies();
+    await page.context().addCookies([
+      {
+        name: cookieName,
+        value: cookieValue,
+        domain,
+        path: "/",
+        expires: expiresAt,
+        httpOnly: false,
+        secure: isSecure,
+        sameSite: "Lax",
+      },
+    ]);
+
+    const targetBase = baseURL || "";
+    await page.goto(`${targetBase}/home`);
+    await page.waitForURL(
+      (url) => !url.pathname.startsWith("/login") && !url.pathname.startsWith("/auth"),
+      { timeout: 30_000 },
+    );
+    console.log("[auth fixture] refresh_token でセッション更新成功");
+    return true;
+  } catch (err) {
+    console.warn(`[auth fixture] refreshSessionViaCookie error: ${err}`);
+    return false;
+  }
 }
 
 /**
@@ -108,12 +253,22 @@ async function isAlreadyLoggedIn(page: Page, baseURL: string): Promise<boolean> 
 }
 
 export async function login(page: Page, baseURL = ""): Promise<void> {
-  // storageState でセッションがロード済みの場合はログインをスキップ
-  if (await isAlreadyLoggedIn(page, baseURL)) {
-    return;
+  // 1. storageState の access_token が有効期限内かつ認証済みなら signin をスキップ
+  if (!isStorageStateExpired()) {
+    if (await isAlreadyLoggedIn(page, baseURL)) {
+      return;
+    }
   }
 
-  // Supabase API 経由で Cookie セッション注入を試みる (hydration 問題・UI login 問題を回避)
+  // 2. storageState が期限切れ → refresh_token で再取得 (password grant より rate limit が緩い)
+  if (fs.existsSync(REFRESH_TOKEN_PATH)) {
+    const refreshOk = await refreshSessionViaCookie(page, baseURL);
+    if (refreshOk) {
+      return;
+    }
+  }
+
+  // 3. refresh_token も使えない場合は password grant で直接 signin
   const cookieLoginOk = await injectSessionViaCookie(page, baseURL);
   if (cookieLoginOk) {
     return;

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -9,6 +9,7 @@
  *    (@supabase/ssr は localStorage でなく Cookie を使うため)
  * 3. /home に遷移して認証済み状態を確認
  * 4. storageState を保存
+ * 5. refresh_token を別ファイルに保存 (auth fixture での再認証に利用)
  *
  * ログイン失敗時は警告を出力して続行する (各テストが個別ログインにフォールバック)。
  */
@@ -19,6 +20,8 @@ import * as path from "path";
 import { seedClassifyFixtures } from "./setup/seed-classify-fixtures";
 
 const STORAGE_STATE_PATH = "tests/e2e/.auth/user.json";
+/** refresh_token と expires_at を保存するファイル */
+export const REFRESH_TOKEN_PATH = "tests/e2e/.auth/refresh.json";
 const MAX_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 2_000;
 
@@ -57,6 +60,40 @@ async function fetchSupabaseSession(
     return data;
   } catch (err) {
     console.warn(`[global-setup] fetchSupabaseSession error: ${err}`);
+    return null;
+  }
+}
+
+/**
+ * refresh_token を使って新しいセッションを取得する (rate limit が password grant より緩い)。
+ */
+export async function refreshSupabaseSession(
+  supabaseUrl: string,
+  anonKey: string,
+  refreshToken: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const resp = await fetch(`${supabaseUrl}/auth/v1/token?grant_type=refresh_token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        apikey: anonKey,
+      },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+    if (!resp.ok) {
+      const body = await resp.text();
+      console.warn(`[global-setup] Supabase refresh API error ${resp.status}: ${body.substring(0, 200)}`);
+      return null;
+    }
+    const data = await resp.json() as Record<string, unknown>;
+    if (!data.access_token) {
+      console.warn(`[global-setup] Supabase refresh: no access_token in response`);
+      return null;
+    }
+    return data;
+  } catch (err) {
+    console.warn(`[global-setup] refreshSupabaseSession error: ${err}`);
     return null;
   }
 }
@@ -129,6 +166,20 @@ async function globalSetup(config: FullConfig): Promise<void> {
           ]);
 
           console.log(`[global-setup] Cookie セッション設定完了: ${cookieName} @ ${domain}`);
+
+          // refresh_token を別ファイルに保存 (auth fixture が rate limit 回避に利用)
+          if (session.refresh_token) {
+            fs.writeFileSync(
+              REFRESH_TOKEN_PATH,
+              JSON.stringify({
+                refresh_token: session.refresh_token,
+                expires_at: session.expires_at ?? (Math.floor(Date.now() / 1000) + 3600),
+                saved_at: Math.floor(Date.now() / 1000),
+              }),
+              "utf-8",
+            );
+            console.log(`[global-setup] refresh_token saved to ${REFRESH_TOKEN_PATH}`);
+          }
 
           // 3. /home に遷移して認証済み状態を確認
           await page.goto(`${baseURL}/home`);


### PR DESCRIPTION
## Summary

- **Fix 1**: `tests/e2e/fixtures/auth.ts` に `isStorageStateExpired()` を追加。storageState の Cookie 内 Supabase セッション JSON から `expires_at` を読み取り、期限まで 5 分未満なら「期限切れ」と判定。期限内は `isAlreadyLoggedIn()` チェックのみで signin をスキップ。
- **Fix 2**: `tests/e2e/global-setup.ts` に `refreshSupabaseSession()` を追加・export。global-setup でセッション取得後に `refresh_token` を `tests/e2e/.auth/refresh.json` に保存。auth fixture の `login()` は storageState 期限切れ時に refresh_token grant (password grant より rate limit が緩い) で先に再取得を試みる。
- **フロー**: 期限内 storageState → skip signin / 期限切れ + refresh.json 存在 → refresh_token grant / refresh 失敗 → password grant / password 失敗 → UI login フォールバック

## Test plan

- [ ] `rm tests/e2e/.auth/user.json && E2E_USER_EMAIL=e2e-user-01@homegohan.test ... npm run test:e2e -- tests/e2e/refactor-baseline/ --workers=4` で auth rate limit (400/500) が発生しないことを確認
- [ ] `global-setup` ログに `[global-setup] refresh_token saved to tests/e2e/.auth/refresh.json` が出ることを確認
- [ ] 2 回目実行時 (storageState が期限内) にログに `[auth fixture] storageState Cookie セッション期限切れ` が出ないことを確認 (signin スキップ)