### PR TITLE
fix(e2e): auth fixture を worker 別ユーザー分散に対応

### DIFF
--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -2,15 +2,15 @@ import { test as base, expect, type Page, type BrowserContext } from "@playwrigh
 import * as fs from "fs";
 import { config as dotenvConfig } from "dotenv";
 import * as path from "path";
-import { REFRESH_TOKEN_PATH, refreshSupabaseSession } from "../global-setup";
+import {
+  refreshSupabaseSession,
+  getStorageStatePath,
+  getRefreshTokenPath,
+  getWorkerUserEmail,
+} from "../global-setup";
 
 // Worker プロセスでも .env.local が読み込まれるよう dotenv を再実行する
 dotenvConfig({ path: path.resolve(__dirname, "../../../.env.local") });
-
-export const E2E_USER = {
-  email: process.env.E2E_USER_EMAIL ?? "claude-debug-1777477826@homegohan.local",
-  password: process.env.E2E_USER_PASSWORD ?? "ClaudeDebug2026!",
-};
 
 // ログインタイムアウト
 const LOGIN_TIMEOUT_MS = 90_000;
@@ -20,8 +20,57 @@ const RETRY_BASE_DELAY_MS = 2_000;
 // storageState が期限まで何秒未満なら expired と判定するバッファ
 const EXPIRY_BUFFER_SECONDS = 300; // 5 分
 
-/** globalSetup が保存した storageState ファイルのパス */
-const STORAGE_STATE_PATH = "tests/e2e/.auth/user.json";
+/** 分散対象ユーザー数 (global-setup と合わせる) */
+const MULTI_USER_COUNT = 4;
+
+/**
+ * worker インデックスに対応するユーザー認証情報を返す。
+ *
+ * - E2E_USER_EMAIL がマルチユーザーパターン外なら単一ユーザーモード
+ * - それ以外は workerIndex % 4 で e2e-user-01〜04 を割り当て
+ */
+export function getUserCredentials(workerIndex: number): { email: string; password: string } {
+  const envEmail = process.env.E2E_USER_EMAIL;
+  const password = process.env.E2E_USER_PASSWORD ?? "TestE2E2026!secure";
+  const isMultiUserPattern = !envEmail || /^e2e-user-\d+@homegohan\.test$/.test(envEmail);
+
+  if (!isMultiUserPattern) {
+    // backward compat: 単一ユーザーモード
+    return {
+      email: envEmail!,
+      password: process.env.E2E_USER_PASSWORD ?? "ClaudeDebug2026!",
+    };
+  }
+
+  const email = getWorkerUserEmail(workerIndex);
+  return { email, password };
+}
+
+/**
+ * worker インデックスに対応する storageState ファイルパスを返す。
+ *
+ * 単一ユーザーモード (E2E_USER_EMAIL がパターン外) では従来パスを返す。
+ */
+function resolveStorageStatePath(workerIndex: number): string {
+  const envEmail = process.env.E2E_USER_EMAIL;
+  const isMultiUserPattern = !envEmail || /^e2e-user-\d+@homegohan\.test$/.test(envEmail);
+  if (!isMultiUserPattern) {
+    return "tests/e2e/.auth/user.json";
+  }
+  return getStorageStatePath(workerIndex);
+}
+
+/**
+ * worker インデックスに対応する refresh token ファイルパスを返す。
+ */
+function resolveRefreshTokenPath(workerIndex: number): string {
+  const envEmail = process.env.E2E_USER_EMAIL;
+  const isMultiUserPattern = !envEmail || /^e2e-user-\d+@homegohan\.test$/.test(envEmail);
+  if (!isMultiUserPattern) {
+    return "tests/e2e/.auth/refresh.json";
+  }
+  return getRefreshTokenPath(workerIndex);
+}
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -31,9 +80,9 @@ async function sleep(ms: number): Promise<void> {
  * storageState の access_token が期限切れ (または期限まで 5 分未満) かどうかを確認する。
  * Cookie の中の Supabase セッション JSON から expires_at を取得して判定する。
  */
-function isStorageStateExpired(): boolean {
+function isStorageStateExpired(storageStatePath: string): boolean {
   try {
-    const raw = fs.readFileSync(STORAGE_STATE_PATH, "utf-8");
+    const raw = fs.readFileSync(storageStatePath, "utf-8");
     const state = JSON.parse(raw) as {
       cookies?: Array<{ name: string; value: string; expires?: number }>;
       origins?: Array<{
@@ -106,14 +155,18 @@ function isStorageStateExpired(): boolean {
  * refresh_token を使ってセッションを更新し、Cookie として Playwright コンテキストに注入する。
  * password grant より rate limit が緩い。
  */
-async function refreshSessionViaCookie(page: Page, baseURL: string): Promise<boolean> {
+async function refreshSessionViaCookie(
+  page: Page,
+  baseURL: string,
+  refreshTokenPath: string,
+): Promise<boolean> {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
   if (!supabaseUrl || !anonKey) return false;
 
   try {
-    const raw = fs.readFileSync(REFRESH_TOKEN_PATH, "utf-8");
+    const raw = fs.readFileSync(refreshTokenPath, "utf-8");
     const { refresh_token } = JSON.parse(raw) as { refresh_token: string };
     if (!refresh_token) return false;
 
@@ -124,7 +177,7 @@ async function refreshSessionViaCookie(page: Page, baseURL: string): Promise<boo
     // 新しい refresh_token を保存
     if (session.refresh_token) {
       fs.writeFileSync(
-        REFRESH_TOKEN_PATH,
+        refreshTokenPath,
         JSON.stringify({
           refresh_token: session.refresh_token,
           expires_at: session.expires_at ?? (Math.floor(Date.now() / 1000) + 3600),
@@ -173,7 +226,12 @@ async function refreshSessionViaCookie(page: Page, baseURL: string): Promise<boo
  * Supabase REST API でセッションを取得し、Cookie として Playwright コンテキストに注入する。
  * @supabase/ssr は Cookie ベースの認証を使うため、localStorage 注入では機能しない。
  */
-async function injectSessionViaCookie(page: Page, baseURL: string): Promise<boolean> {
+async function injectSessionViaCookie(
+  page: Page,
+  baseURL: string,
+  email: string,
+  password: string,
+): Promise<boolean> {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
@@ -189,7 +247,7 @@ async function injectSessionViaCookie(page: Page, baseURL: string): Promise<bool
         "Content-Type": "application/json",
         apikey: anonKey,
       },
-      body: JSON.stringify({ email: E2E_USER.email, password: E2E_USER.password }),
+      body: JSON.stringify({ email, password }),
     });
 
     if (!resp.ok) {
@@ -252,24 +310,28 @@ async function isAlreadyLoggedIn(page: Page, baseURL: string): Promise<boolean> 
   }
 }
 
-export async function login(page: Page, baseURL = ""): Promise<void> {
+export async function login(page: Page, baseURL = "", workerIndex = 0): Promise<void> {
+  const { email, password } = getUserCredentials(workerIndex);
+  const storageStatePath = resolveStorageStatePath(workerIndex);
+  const refreshTokenPath = resolveRefreshTokenPath(workerIndex);
+
   // 1. storageState の access_token が有効期限内かつ認証済みなら signin をスキップ
-  if (!isStorageStateExpired()) {
+  if (!isStorageStateExpired(storageStatePath)) {
     if (await isAlreadyLoggedIn(page, baseURL)) {
       return;
     }
   }
 
   // 2. storageState が期限切れ → refresh_token で再取得 (password grant より rate limit が緩い)
-  if (fs.existsSync(REFRESH_TOKEN_PATH)) {
-    const refreshOk = await refreshSessionViaCookie(page, baseURL);
+  if (fs.existsSync(refreshTokenPath)) {
+    const refreshOk = await refreshSessionViaCookie(page, baseURL, refreshTokenPath);
     if (refreshOk) {
       return;
     }
   }
 
   // 3. refresh_token も使えない場合は password grant で直接 signin
-  const cookieLoginOk = await injectSessionViaCookie(page, baseURL);
+  const cookieLoginOk = await injectSessionViaCookie(page, baseURL, email, password);
   if (cookieLoginOk) {
     return;
   }
@@ -295,8 +357,8 @@ export async function login(page: Page, baseURL = ""): Promise<void> {
         { timeout: 20_000 },
       ).catch(async () => { await new Promise((r) => setTimeout(r, 1000)); });
 
-      await page.locator("#email").fill(E2E_USER.email);
-      await page.locator("#password").fill(E2E_USER.password);
+      await page.locator("#email").fill(email);
+      await page.locator("#password").fill(password);
 
       const navigationPromise = page.waitForURL(
         (url) => !url.pathname.startsWith("/login") && !url.pathname.startsWith("/auth"),
@@ -336,8 +398,10 @@ export async function login(page: Page, baseURL = ""): Promise<void> {
 export async function newAuthedContext(
   browser: import("@playwright/test").Browser,
   extraOptions: Parameters<import("@playwright/test").Browser["newContext"]>[0] = {},
+  workerIndex = 0,
 ): Promise<BrowserContext> {
-  const storagePath = fs.existsSync(STORAGE_STATE_PATH) ? STORAGE_STATE_PATH : undefined;
+  const storageStatePath = resolveStorageStatePath(workerIndex);
+  const storagePath = fs.existsSync(storageStatePath) ? storageStatePath : undefined;
   return browser.newContext({
     storageState: storagePath,
     ...extraOptions,
@@ -350,9 +414,23 @@ type AuthFixtures = {
 
 export const test = base.extend<AuthFixtures>({
   authedPage: async ({ page, baseURL }, use) => {
-    await login(page, baseURL ?? "");
+    const workerIndex = test.info().workerIndex;
+    await login(page, baseURL ?? "", workerIndex);
     await use(page);
   },
 });
 
 export { expect };
+
+// backward compat: 既存コードが REFRESH_TOKEN_PATH / E2E_USER をインポートしている場合の互換
+export { MULTI_USER_COUNT };
+
+/** @deprecated workerIndex を受け取る getUserCredentials() を使うこと */
+export const E2E_USER = {
+  get email() {
+    return process.env.E2E_USER_EMAIL ?? "e2e-user-01@homegohan.test";
+  },
+  get password() {
+    return process.env.E2E_USER_PASSWORD ?? "TestE2E2026!secure";
+  },
+};

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -11,6 +11,11 @@
  * 4. storageState を保存
  * 5. refresh_token を別ファイルに保存 (auth fixture での再認証に利用)
  *
+ * workers=4 対応:
+ * - e2e-user-01〜04 の 4 ユーザーそれぞれで storageState を並列生成
+ * - 各 worker は test.workerIndex に応じてユーザーを切り替え (auth fixture 側)
+ * - backward compat: E2E_USER_EMAIL が設定済みかつパターン外なら単一ユーザーモード
+ *
  * ログイン失敗時は警告を出力して続行する (各テストが個別ログインにフォールバック)。
  */
 
@@ -19,11 +24,31 @@ import * as fs from "fs";
 import * as path from "path";
 import { seedClassifyFixtures } from "./setup/seed-classify-fixtures";
 
-const STORAGE_STATE_PATH = "tests/e2e/.auth/user.json";
-/** refresh_token と expires_at を保存するファイル */
-export const REFRESH_TOKEN_PATH = "tests/e2e/.auth/refresh.json";
+/** backward compat: 既存コードが参照するエクスポート (user-01 のパスを返す) */
+export const REFRESH_TOKEN_PATH = "tests/e2e/.auth/refresh-01.json";
 const MAX_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 2_000;
+
+/** 分散対象のユーザー数 */
+const MULTI_USER_COUNT = 4;
+
+/** worker インデックス (1-based) に対応するユーザーのメールアドレスを返す */
+export function getWorkerUserEmail(workerIndex: number): string {
+  const idx = (workerIndex % MULTI_USER_COUNT) + 1;
+  return `e2e-user-0${idx}@homegohan.test`;
+}
+
+/** worker インデックス (1-based) に対応する storageState ファイルパスを返す */
+export function getStorageStatePath(workerIndex: number): string {
+  const idx = (workerIndex % MULTI_USER_COUNT) + 1;
+  return `tests/e2e/.auth/user-0${idx}.json`;
+}
+
+/** worker インデックス (1-based) に対応する refresh token ファイルパスを返す */
+export function getRefreshTokenPath(workerIndex: number): string {
+  const idx = (workerIndex % MULTI_USER_COUNT) + 1;
+  return `tests/e2e/.auth/refresh-0${idx}.json`;
+}
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -98,28 +123,19 @@ export async function refreshSupabaseSession(
   }
 }
 
-async function globalSetup(config: FullConfig): Promise<void> {
-  // classify-test fixture を /tmp/classify-test/ に生成 (存在しない場合のみ)
-  seedClassifyFixtures();
-
-  const baseURL =
-    config.projects[0]?.use?.baseURL ??
-    process.env.PLAYWRIGHT_BASE_URL ??
-    "http://localhost:3000";
-
-  const email =
-    process.env.E2E_USER_EMAIL ?? "claude-debug-1777477826@homegohan.local";
-  const password = process.env.E2E_USER_PASSWORD ?? "ClaudeDebug2026!";
-
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
-
-  // 保存先ディレクトリを作成
-  const dir = path.dirname(STORAGE_STATE_PATH);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-
+/**
+ * 1ユーザー分の storageState を生成して保存する。
+ * MAX_RETRIES 回失敗しても警告のみで続行する。
+ */
+async function setupUserSession(
+  baseURL: string,
+  email: string,
+  password: string,
+  supabaseUrl: string,
+  supabaseAnonKey: string,
+  storageStatePath: string,
+  refreshTokenPath: string,
+): Promise<void> {
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
@@ -131,25 +147,17 @@ async function globalSetup(config: FullConfig): Promise<void> {
     const page = await context.newPage();
 
     try {
-      // 1. Supabase REST API でセッション取得
       let sessionInjected = false;
 
       if (supabaseUrl && supabaseAnonKey) {
-        console.log(`[global-setup] Supabase REST API でセッション取得中... (attempt ${attempt})`);
+        console.log(`[global-setup] ${email} セッション取得中... (attempt ${attempt})`);
         const session = await fetchSupabaseSession(supabaseUrl, supabaseAnonKey, email, password);
 
         if (session) {
-          // 2. @supabase/ssr は Cookie を使う。セッションを Cookie として設定する。
-          //    Cookie 名は sb-{project-ref}-auth-token
           const supabaseRef = supabaseUrl.replace("https://", "").split(".")[0];
           const cookieName = `sb-${supabaseRef}-auth-token`;
-
-          // baseURL の domain を取得
           const domain = new URL(baseURL).hostname;
-
-          // Cookie value は URL-encode された JSON
           const cookieValue = encodeURIComponent(JSON.stringify(session));
-
           const expiresAt = (session.expires_at as number) ?? (Date.now() / 1000 + 3600);
 
           await context.addCookies([
@@ -165,12 +173,11 @@ async function globalSetup(config: FullConfig): Promise<void> {
             },
           ]);
 
-          console.log(`[global-setup] Cookie セッション設定完了: ${cookieName} @ ${domain}`);
+          console.log(`[global-setup] Cookie セッション設定完了: ${cookieName} @ ${domain} (${email})`);
 
-          // refresh_token を別ファイルに保存 (auth fixture が rate limit 回避に利用)
           if (session.refresh_token) {
             fs.writeFileSync(
-              REFRESH_TOKEN_PATH,
+              refreshTokenPath,
               JSON.stringify({
                 refresh_token: session.refresh_token,
                 expires_at: session.expires_at ?? (Math.floor(Date.now() / 1000) + 3600),
@@ -178,28 +185,25 @@ async function globalSetup(config: FullConfig): Promise<void> {
               }),
               "utf-8",
             );
-            console.log(`[global-setup] refresh_token saved to ${REFRESH_TOKEN_PATH}`);
+            console.log(`[global-setup] refresh_token saved to ${refreshTokenPath}`);
           }
 
-          // 3. /home に遷移して認証済み状態を確認
           await page.goto(`${baseURL}/home`);
           await page.waitForURL(
             (url) => !url.pathname.startsWith("/login") && !url.pathname.startsWith("/auth"),
             { timeout: 30_000 },
           );
-          console.log(`[global-setup] 認証確認成功: ${page.url()}`);
+          console.log(`[global-setup] 認証確認成功 (${email}): ${page.url()}`);
           sessionInjected = true;
         }
       }
 
       if (!sessionInjected) {
-        // フォールバック: UI ログイン
-        console.log(`[global-setup] UI ログインにフォールバック (attempt ${attempt})`);
+        console.log(`[global-setup] UI ログインにフォールバック (${email}, attempt ${attempt})`);
         await page.goto(`${baseURL}/login`);
         await page.waitForLoadState("networkidle");
         await page.evaluate(() => { localStorage.removeItem("auth_last_fail_ts"); });
 
-        // React hydration 確認
         await page.waitForFunction(
           () => {
             const btn = document.querySelector('form button[type="submit"], button[type="submit"]');
@@ -232,15 +236,14 @@ async function globalSetup(config: FullConfig): Promise<void> {
         }
       }
 
-      // 4. storageState を保存
-      await context.storageState({ path: STORAGE_STATE_PATH });
-      console.log(`[global-setup] storageState saved to ${STORAGE_STATE_PATH} (attempt ${attempt})`);
+      await context.storageState({ path: storageStatePath });
+      console.log(`[global-setup] storageState saved to ${storageStatePath} (${email}, attempt ${attempt})`);
       await context.close();
       await browser.close();
       return;
     } catch (err) {
       lastError = err;
-      console.warn(`[global-setup] ログイン試行 ${attempt}/${MAX_RETRIES} 失敗: ${err}`);
+      console.warn(`[global-setup] ログイン試行 ${attempt}/${MAX_RETRIES} 失敗 (${email}): ${err}`);
       await context.close();
       await browser.close();
 
@@ -252,8 +255,105 @@ async function globalSetup(config: FullConfig): Promise<void> {
     }
   }
 
-  // ログイン失敗時はエラーをスローせず警告のみ出力して続行する。
-  console.warn(`[global-setup] ${MAX_RETRIES} 回試行後もログイン失敗。storageState なしで続行: ${lastError}`);
+  console.warn(`[global-setup] ${MAX_RETRIES} 回試行後もログイン失敗 (${email})。storageState なしで続行: ${lastError}`);
+}
+
+async function globalSetup(config: FullConfig): Promise<void> {
+  // classify-test fixture を /tmp/classify-test/ に生成 (存在しない場合のみ)
+  seedClassifyFixtures();
+
+  const baseURL =
+    config.projects[0]?.use?.baseURL ??
+    process.env.PLAYWRIGHT_BASE_URL ??
+    "http://localhost:3000";
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+  // 保存先ディレクトリを作成
+  const dir = path.dirname(getStorageStatePath(0));
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  // E2E_USER_EMAIL が設定済みでマルチユーザーパターン外の場合は単一ユーザーモード
+  const envEmail = process.env.E2E_USER_EMAIL;
+  const isMultiUserPattern = !envEmail || /^e2e-user-\d+@homegohan\.test$/.test(envEmail);
+
+  if (!isMultiUserPattern) {
+    // backward compat: 単一ユーザーモード
+    const password = process.env.E2E_USER_PASSWORD ?? "ClaudeDebug2026!";
+    console.log(`[global-setup] 単一ユーザーモード (E2E_USER_EMAIL=${envEmail})`);
+    await setupUserSession(
+      baseURL,
+      envEmail!,
+      password,
+      supabaseUrl,
+      supabaseAnonKey,
+      "tests/e2e/.auth/user.json",
+      "tests/e2e/.auth/refresh.json",
+    );
+    return;
+  }
+
+  // マルチユーザーモード: e2e-user-01〜04 を並列でセットアップ
+  const multiPassword = process.env.E2E_USER_PASSWORD ?? "TestE2E2026!secure";
+  console.log(`[global-setup] マルチユーザーモード: ${MULTI_USER_COUNT} ユーザーを並列セットアップ`);
+
+  const tasks: Promise<void>[] = [];
+  for (let i = 0; i < MULTI_USER_COUNT; i++) {
+    const idx = i + 1;
+    const userEmail = `e2e-user-0${idx}@homegohan.test`;
+    const storageStatePath = `tests/e2e/.auth/user-0${idx}.json`;
+    const refreshTokenPath = `tests/e2e/.auth/refresh-0${idx}.json`;
+    tasks.push(
+      setupUserSession(
+        baseURL,
+        userEmail,
+        multiPassword,
+        supabaseUrl,
+        supabaseAnonKey,
+        storageStatePath,
+        refreshTokenPath,
+      ),
+    );
+  }
+
+  await Promise.all(tasks);
+
+  // backward compat: user.json / refresh.json を user-01 のシンボリックリンクとして作成
+  const legacyStoragePath = "tests/e2e/.auth/user.json";
+  const legacyRefreshPath = "tests/e2e/.auth/refresh.json";
+  const target01Storage = "tests/e2e/.auth/user-01.json";
+  const target01Refresh = "tests/e2e/.auth/refresh-01.json";
+
+  for (const [linkPath, targetPath] of [
+    [legacyStoragePath, target01Storage],
+    [legacyRefreshPath, target01Refresh],
+  ] as const) {
+    try {
+      if (fs.existsSync(linkPath)) {
+        fs.unlinkSync(linkPath);
+      }
+      // 相対パスでシンボリックリンクを作成 (同一ディレクトリ内)
+      const linkName = path.basename(linkPath);
+      const targetName = path.basename(targetPath);
+      fs.symlinkSync(targetName, linkPath);
+      console.log(`[global-setup] symlink: ${linkName} -> ${targetName}`);
+    } catch (err) {
+      // シンボリックリンク作成失敗時はコピーでフォールバック
+      try {
+        if (fs.existsSync(targetPath)) {
+          fs.copyFileSync(targetPath, linkPath);
+          console.log(`[global-setup] fallback copy: ${targetPath} -> ${linkPath}`);
+        }
+      } catch {
+        console.warn(`[global-setup] backward compat ファイル作成失敗 (${linkPath}): ${err}`);
+      }
+    }
+  }
+
+  console.log(`[global-setup] マルチユーザーセットアップ完了`);
 }
 
 export default globalSetup;


### PR DESCRIPTION
## Summary

- `global-setup.ts` で `e2e-user-01〜04` の 4 ユーザーを並列サインインして個別 storageState を生成
- `auth.ts` に `getUserCredentials(workerIndex)` を追加し、`test.workerIndex % 4` でユーザーを分散割当
- storageState・refresh token ファイルを `user-0N.json` / `refresh-0N.json` に分散
- backward compat: `E2E_USER_EMAIL` がパターン外の環境は単一ユーザーモードで従来通り動作
- backward compat: `user.json` / `refresh.json` は `user-01.json` へのシンボリックリンクとして自動作成

## Background

workers=4 で全テストが同一ユーザー `e2e-user-01` に集中するため Supabase auth rate limit (429 over_request_rate_limit) が頻発していた。PR #945 の storageState 期限チェック + refresh_token Fix に加え、ユーザー自体を worker 別に分散することで解消する。

## Test plan

- [ ] `global-setup` 実行時に `user-01.json` 〜 `user-04.json` が並列生成されること
- [ ] `tests/e2e/refactor-baseline/` 12 spec が auth 失敗なく完走すること
- [ ] ログに `429` / `over_request_rate_limit` が出ないこと
- [ ] 単一ユーザーモード (E2E_USER_EMAIL 設定時) でも動作すること