### PR TITLE
fix(e2e): auth fixture を worker 別 password 対応に修正

### DIFF
--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -31,7 +31,6 @@ const MULTI_USER_COUNT = 4;
  */
 export function getUserCredentials(workerIndex: number): { email: string; password: string } {
   const envEmail = process.env.E2E_USER_EMAIL;
-  const password = process.env.E2E_USER_PASSWORD ?? "TestE2E2026!secure";
   const isMultiUserPattern = !envEmail || /^e2e-user-\d+@homegohan\.test$/.test(envEmail);
 
   if (!isMultiUserPattern) {
@@ -42,6 +41,12 @@ export function getUserCredentials(workerIndex: number): { email: string; passwo
     };
   }
 
+  const idx = (workerIndex % 4) + 1;
+  const padded = String(idx).padStart(2, "0");
+  const password =
+    process.env[`E2E_USER_${padded}_PASSWORD`] ??
+    process.env.E2E_USER_PASSWORD ??
+    "TestE2E2026!secure";
   const email = getWorkerUserEmail(workerIndex);
   return { email, password };
 }

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -297,20 +297,32 @@ async function globalSetup(config: FullConfig): Promise<void> {
   }
 
   // マルチユーザーモード: e2e-user-01〜04 を並列でセットアップ
-  const multiPassword = process.env.E2E_USER_PASSWORD ?? "TestE2E2026!secure";
   console.log(`[global-setup] マルチユーザーモード: ${MULTI_USER_COUNT} ユーザーを並列セットアップ`);
 
   const tasks: Promise<void>[] = [];
   for (let i = 0; i < MULTI_USER_COUNT; i++) {
     const idx = i + 1;
-    const userEmail = `e2e-user-0${idx}@homegohan.test`;
-    const storageStatePath = `tests/e2e/.auth/user-0${idx}.json`;
-    const refreshTokenPath = `tests/e2e/.auth/refresh-0${idx}.json`;
+    const padded = String(idx).padStart(2, "0");
+    const userEmail = `e2e-user-${padded}@homegohan.test`;
+    const storageStatePath = `tests/e2e/.auth/user-${padded}.json`;
+    const refreshTokenPath = `tests/e2e/.auth/refresh-${padded}.json`;
+
+    // パスワード優先順位: 個別環境変数 > 共通環境変数 > fallback
+    const perUserPassword = process.env[`E2E_USER_${padded}_PASSWORD`];
+    const commonPassword = process.env.E2E_USER_PASSWORD;
+    const userPassword = perUserPassword ?? commonPassword ?? "TestE2E2026!secure";
+    const passwordSource = perUserPassword
+      ? `個別 (E2E_USER_${padded}_PASSWORD)`
+      : commonPassword
+        ? "共通 (E2E_USER_PASSWORD)"
+        : "fallback";
+    console.log(`[global-setup] user-${padded}: password 由来 = ${passwordSource}`);
+
     tasks.push(
       setupUserSession(
         baseURL,
         userEmail,
-        multiPassword,
+        userPassword,
         supabaseUrl,
         supabaseAnonKey,
         storageStatePath,


### PR DESCRIPTION
## Summary

- PR #946 のバグ修正: 全 worker が `E2E_USER_PASSWORD` を共通参照していたため、`e2e-user-01〜04` の個別パスワードと不一致で `invalid_credentials` 400 が発生
- `getUserCredentials()` (auth.ts) および global-setup のマルチユーザーループ (global-setup.ts) の両方で、パスワード取得を以下の優先順位に統一:
  - `E2E_USER_0N_PASSWORD` (個別) → `E2E_USER_PASSWORD` (共通) → `"TestE2E2026!secure"` (fallback)
- global-setup のログにパスワード由来 (個別 / 共通 / fallback) を出力するよう追加

## 変更ファイル

- `tests/e2e/fixtures/auth.ts` — `getUserCredentials()` のパスワード解決ロジック修正
- `tests/e2e/global-setup.ts` — マルチユーザーループのパスワード解決ロジック修正 + ログ追加

## Test plan

- [ ] `invalid_credentials` エラー 0 件
- [ ] `email_not_confirmed` エラー 0 件
- [ ] refactor-baseline/ の全 spec が pass