### PR TITLE
fix(api): recipes/comments + comparison/rankings の認証チェック修正

### DIFF
--- a/src/app/api/comparison/rankings/route.ts
+++ b/src/app/api/comparison/rankings/route.ts
@@ -10,11 +10,11 @@ import type {
 } from '@/types/comparison';
 
 export async function GET(request: Request) {
-  const supabase = await createClient();
   const { searchParams } = new URL(request.url);
   const periodType = searchParams.get('periodType') || 'weekly';
 
   try {
+    const supabase = await createClient();
     const { data: { user }, error: userError } = await supabase.auth.getUser();
     if (userError || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/recipes/[id]/comments/route.ts
+++ b/src/app/api/recipes/[id]/comments/route.ts
@@ -8,6 +8,12 @@ export async function GET(
 ) {
   const supabase = await createClient();
 
+  // 未認証は 401
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   const { data, error } = await supabase
     .from('recipe_comments')
     .select(`


### PR DESCRIPTION
## Summary

- `GET /api/recipes/[id]/comments` に auth check が欠落していたため、未認証でも 200 を返していた。`supabase.auth.getUser()` チェックを追加し、未認証は 401 を返すように修正。
- `GET /api/comparison/rankings` の `createClient()` 呼び出しが try ブロック外にあり、初期化失敗時に uncaught エラーとなり 500 を返す可能性があった。`createClient()` を try ブロック内に移動。

## 修正対象の E2E fail (Step 6.1)

- `/api/recipes/[id]/comments` GET 未認証 → 401 (修正前: 200)
- `/api/recipes/[id]/comments` POST 未認証 → 401 (修正前: auth check 自体はあったが createClient 初期化問題の波及リスクあり)
- `/api/recipes/[id]/comments` GET 認証あり → 200 + `{ comments: [...] }` shape (auth check 追加後に正常動作)
- `/api/comparison/rankings` GET 未認証 → 401 (createClient を try 内に移動で 500 落ちリスク解消)

## Test plan

- [ ] 未認証 GET `/api/recipes/{id}/comments` → 401
- [ ] 未認証 POST `/api/recipes/{id}/comments` → 401
- [ ] 認証あり GET `/api/recipes/{id}/comments` → 200 + `{ comments: [...] }`
- [ ] 未認証 GET `/api/comparison/rankings` → 401
- [ ] 認証あり GET `/api/comparison/rankings` → 200 + `{ rankings: [...], ... }`