### PR TITLE
fix(e2e): refactor-baseline selector updates

### DIFF
--- a/tests/e2e/refactor-baseline/modal-interaction-add-meal.spec.ts
+++ b/tests/e2e/refactor-baseline/modal-interaction-add-meal.spec.ts
@@ -43,7 +43,9 @@ async function openAddMealModal(page: import("@playwright/test").Page): Promise<
 
   if (hasEmptySlot) {
     await emptySlot.click();
-    const opened = await page.getByText(/を追加|AIに提案/).first()
+    // AddMealModal が開いたことを「AIに提案してもらう」ボタンで確認
+    // (週ページの空スロット「〇〇を追加」ボタンとは区別)
+    const opened = await page.getByRole("button", { name: /AIに提案してもらう/ }).first()
       .waitFor({ state: "visible", timeout: 8_000 })
       .then(() => true)
       .catch(() => false);
@@ -71,7 +73,8 @@ async function openAddMealModal(page: import("@playwright/test").Page): Promise<
   if (!hasBreakfastChoice) return false;
 
   await breakfastChoice.click();
-  const opened = await page.getByText(/を追加|AIに提案/).first()
+  // AddMealModal が開いたことを「AIに提案してもらう」ボタンで確認
+  const opened = await page.getByRole("button", { name: /AIに提案してもらう/ }).first()
     .waitFor({ state: "visible", timeout: 8_000 })
     .then(() => true)
     .catch(() => false);

--- a/tests/e2e/refactor-baseline/modal-interaction-add-trio.spec.ts
+++ b/tests/e2e/refactor-baseline/modal-interaction-add-trio.spec.ts
@@ -301,7 +301,7 @@ test.describe("AddMealSlotModal インタラクション", () => {
     return false;
   }
 
-  test("AddMealSlotModal に朝食・昼食・夕食・間食・夜食の 5 種別ボタンが表示される", async ({ tourPendingUser: page }) => {
+  test("AddMealSlotModal に朝食・昼食・夕食・おやつ・夜食の 5 種別ボタンが表示される", async ({ tourPendingUser: page }) => {
     test.setTimeout(60_000);
     await gotoWeekly(page);
 
@@ -323,8 +323,9 @@ test.describe("AddMealSlotModal インタラクション", () => {
 
     if (!isMealSlotModal) return;
 
-    // 5 種別ボタン (MEAL_LABELS に対応: 朝食/昼食/夕食/間食/夜食)
-    const mealLabels = ["朝食", "昼食", "夕食", "間食", "夜食"];
+    // 5 種別ボタン (MEAL_LABELS に対応: 朝食/昼食/夕食/おやつ/夜食)
+    // snack の MEAL_LABELS は「間食」ではなく「おやつ」
+    const mealLabels = ["朝食", "昼食", "夕食", "おやつ", "夜食"];
     for (const label of mealLabels) {
       const btn = page.getByRole("button", { name: new RegExp(label) }).first();
       const visible = await btn
@@ -476,7 +477,7 @@ test.describe("AddMealSlotModal インタラクション", () => {
     }
   });
 
-  test("間食・夜食ボタンが AddMealSlotModal 内に存在する", async ({ tourPendingUser: page }) => {
+  test("おやつ・夜食ボタンが AddMealSlotModal 内に存在する", async ({ tourPendingUser: page }) => {
     test.setTimeout(60_000);
     await gotoWeekly(page);
 
@@ -496,8 +497,9 @@ test.describe("AddMealSlotModal インタラクション", () => {
 
     if (!isMealSlotModal) return;
 
-    // 間食 (snack) と夜食 (midnight_snack) は基本 3 食以外の追加種別
-    const snackVisible = await page.getByText("間食").first()
+    // おやつ (snack) と夜食 (midnight_snack) は基本 3 食以外の追加種別
+    // snack の MEAL_LABELS は「間食」ではなく「おやつ」
+    const snackVisible = await page.getByText("おやつ").first()
       .waitFor({ state: "visible", timeout: 5_000 })
       .then(() => true)
       .catch(() => false);

--- a/tests/e2e/refactor-baseline/modal-interaction-nutrition.spec.ts
+++ b/tests/e2e/refactor-baseline/modal-interaction-nutrition.spec.ts
@@ -245,11 +245,11 @@ test.describe("SM-4: StatsModal 数値カード表示", () => {
     const opened = await openStatsModal(page);
     expect(opened).toBe(true);
 
-    // 自炊率カード
-    await expect(page.getByText("自炊率")).toBeVisible({ timeout: 5_000 });
+    // 自炊率カード (StatsModal 内の exact match — weekly page の「自炊率 N%」とは区別)
+    await expect(page.getByText("自炊率", { exact: true }).first()).toBeVisible({ timeout: 5_000 });
 
     // 平均kcal/日カード
-    await expect(page.getByText("平均kcal/日")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText("平均kcal/日", { exact: true })).toBeVisible({ timeout: 5_000 });
 
     // 今週の献立カード
     await expect(page.getByText("今週の献立")).toBeVisible({ timeout: 5_000 });
@@ -334,8 +334,9 @@ test.describe("SM-6: StatsModal 閉じる", () => {
     await xBtn.waitFor({ state: "visible", timeout: 5_000 });
     await xBtn.click();
 
-    // StatsModal が閉じること (「栄養分析」テキストが消える)
-    await expect(page.getByText("自炊率")).toBeHidden({ timeout: 5_000 });
+    // StatsModal が閉じること (「自炊率」exact match が非表示になる)
+    // weekly page の「自炊率 N%」は別テキストのため exact: true で区別する
+    await expect(page.getByText("自炊率", { exact: true }).first()).toBeHidden({ timeout: 5_000 });
 
     // 週ナビゲーションが引き続き表示されること
     await expect(page.locator('[aria-label="前の週"]')).toBeVisible({


### PR DESCRIPTION
## Summary

- `modal-interaction-add-meal.spec.ts`: `openAddMealModal` ヘルパーの「モーダルが開いた」判定を `getByText(/を追加|AIに提案/)` から `getByRole("button", { name: /AIに提案してもらう/ })` に変更。週ページの空スロットボタン「朝食を追加」等のテキストに誤マッチして `opened = true` になるケースを排除。
- `modal-interaction-nutrition.spec.ts`: SM-4 の `page.getByText("自炊率")` を `getByText("自炊率", { exact: true }).first()` に変更。StatsModal が開いている間も weekly ページのミニ stats 行「自炊率 N%」が DOM に残るため strict mode violation が発生していた。SM-6 の close 判定も同様に修正。
- `modal-interaction-add-trio.spec.ts`: `snack` の `MEAL_LABELS` が `"間食"` から `"おやつ"` に変更されていたため、テスト内のテキスト検索・テスト名を `"おやつ"` に統一 (2 箇所)。

## Test plan

- [ ] `npx playwright test tests/e2e/refactor-baseline/modal-interaction-*.spec.ts --list` で全テスト列挙されること
- [ ] `npm run typecheck` が 0 エラーであること (確認済み)
- [ ] CI の refactor-baseline spec で selector failure 件数が減少すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)