### PR TITLE
docs: supersede note for family/ and org/

### DIFF
--- a/docs/design/family/CLAUDE.md
+++ b/docs/design/family/CLAUDE.md
@@ -1,3 +1,19 @@
+> ⚠️ **重要**: 本ディレクトリは部分的に [`docs/design/membership/`](../membership/) によって supersede されました (2026-05-10)。
+>
+> ### membership/ で canonical となった範囲 (本ドキュメントの記述は参考用)
+> - 招待発行・受諾・拒否フロー
+> - メンバ管理 (追加・除名・脱退)
+> - 役割定義 (family: representative/adult/child)
+> - 代表譲渡フロー
+> - ペースト機能 (家族間レコード共有)
+> - 閲覧権限 (share_meals/share_health/share_menu)
+> - 運営強制操作
+>
+> ### 本ドキュメントが引き続き有効な範囲
+> - データモデルの core 構造 (テーブル基本定義、関連カラム)
+> - plan_key / member_limit / 課金関連 (operator/ 設計と整合)
+> - その他の運用・UI ガイドライン (招待関連以外: 献立リクエスト、買い物リスト、子供メンバー管理、18 歳移行、グループ分割等)
+
 # family/ 家族管理ドメイン 開発指針
 
 要件定義 `docs/requirements/01-family-management.md` の詳細設計。

--- a/docs/design/org/CLAUDE.md
+++ b/docs/design/org/CLAUDE.md
@@ -1,3 +1,18 @@
+> ⚠️ **重要**: 本ディレクトリは部分的に [`docs/design/membership/`](../membership/) によって supersede されました (2026-05-10)。
+>
+> ### membership/ で canonical となった範囲 (本ドキュメントの記述は参考用)
+> - 招待発行・受諾・拒否フロー
+> - メンバ管理 (追加・除名・脱退)
+> - 役割定義 (org: owner/admin/member)
+> - Owner 譲渡フロー
+> - 閲覧権限 (share_meals/share_health/share_menu — 該当する場合)
+> - 運営強制操作
+>
+> ### 本ドキュメントが引き続き有効な範囲
+> - データモデルの core 構造 (テーブル基本定義、関連カラム)
+> - plan_key / 課金関連 (operator/ 設計と整合)
+> - その他の運用・UI ガイドライン (招待関連以外: ライセンス管理、産業医機能、HR Webhook、チャレンジ、SSO/SAML 等)
+
 # org/ 組織管理ドメイン 開発指針
 
 要件定義 `docs/requirements/02-organization-management.md` の詳細設計。


### PR DESCRIPTION
## Summary

- `docs/design/family/CLAUDE.md` と `docs/design/org/CLAUDE.md` の冒頭に supersede note を追加
- `docs/design/membership/` が招待・メンバー管理・役割定義・Owner 譲渡等の canonical であることを明示
- 各 CLAUDE.md が引き続き有効な範囲 (データモデル core / plan_key・課金 / 招待関連以外の UI ガイドライン) も明記

## Test plan

- [ ] `docs/design/family/CLAUDE.md` の冒頭に blockquote 形式の警告が表示されること
- [ ] `docs/design/org/CLAUDE.md` の冒頭に blockquote 形式の警告が表示されること
- [ ] membership/ へのリンク (`../membership/`) が正しく解決されること (GitHub で確認)
- [ ] 既存ドキュメント本文への影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)