### PR TITLE
fix(emails): Resend lazy init — Vercel build error fix

### DIFF
--- a/src/lib/emails/send.ts
+++ b/src/lib/emails/send.ts
@@ -11,7 +11,13 @@ export const EmailEnvelopeSchema = z.object({
 });
 export type EmailEnvelope = z.infer<typeof EmailEnvelopeSchema>;
 
-const resend = new Resend(process.env.RESEND_API_KEY ?? '');
+let resendInstance: Resend | null = null;
+function getResend(): Resend {
+  if (!resendInstance) {
+    resendInstance = new Resend(process.env.RESEND_API_KEY ?? 're_dev_placeholder');
+  }
+  return resendInstance;
+}
 
 export async function sendEmail(envelope: EmailEnvelope) {
   const v = EmailEnvelopeSchema.parse(envelope);
@@ -19,7 +25,7 @@ export async function sendEmail(envelope: EmailEnvelope) {
     console.warn('[email] RESEND_API_KEY 未設定、送信スキップ', { to: v.to, subject: v.subject });
     return { id: 'dev-no-send', skipped: true };
   }
-  const result = await resend.emails.send({
+  const result = await getResend().emails.send({
     from: v.from,
     to: v.to,
     subject: v.subject,


### PR DESCRIPTION
## Summary
- main の Vercel build が `Missing API key. Pass it to the constructor 'new Resend(\"re_123\")'` で失敗
- 原因: src/lib/emails/send.ts:14 で Resend を module-level instance 化、build env で RESEND_API_KEY 未設定時に SDK が空文字 reject
- 修正: getResend() 関数で lazy init、placeholder key で安全に instance 生成、sendEmail 側で env チェックして実呼び出し到達しない

## Test plan
- [x] typecheck pass
- [x] 既存 send.test.ts (skip path 確認) は変更なし、回帰なし
- [ ] Vercel build が green になる (push 後 3 分後確認)