### PR TITLE
feat(membership): Phase P0 残 RPC 7件 + Zod全面整備 + ErrorCode enum

### DIFF
--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -96,6 +96,7 @@ export async function updateSession(request: NextRequest) {
     '/legal',
     '/company',
     '/news',
+    '/invite',  // 招待トークンページ (認証不要で内容確認できる必要がある)
   ]
   const isPublicPath = publicPaths.some(
     (path) =>

--- a/src/lib/errors/membership-errors.ts
+++ b/src/lib/errors/membership-errors.ts
@@ -1,32 +1,72 @@
 // src/lib/errors/membership-errors.ts
 // (設計書 01-data-model.md §1.2)
-export const MembershipErrorCode = {
-  // 招待
-  INVITE_NOT_FOUND:           'INVITE_NOT_FOUND',
-  INVITE_EXPIRED:             'INVITE_EXPIRED',
-  INVITE_ALREADY_USED:        'INVITE_ALREADY_USED',
-  INVITE_REVOKED:             'INVITE_REVOKED',
-  INVITE_EMAIL_MISMATCH:      'INVITE_EMAIL_MISMATCH',
 
-  // 競合
-  ALREADY_IN_ORG:             'ALREADY_IN_ORG',
-  ALREADY_IN_FAMILY:          'ALREADY_IN_FAMILY',
-  IS_ORG_OWNER:               'IS_ORG_OWNER',
-  IS_FAMILY_REPRESENTATIVE:   'IS_FAMILY_REPRESENTATIVE',
+export enum MembershipErrorCode {
+  // org
+  ORG_NOT_FOUND = 'ORG_NOT_FOUND',
+  NOT_IN_ORG = 'NOT_IN_ORG',
+  ALREADY_IN_ORG = 'ALREADY_IN_ORG',
+  SEAT_LIMIT_EXCEEDED = 'SEAT_LIMIT_EXCEEDED',
+  OWNER_CANNOT_LEAVE = 'OWNER_CANNOT_LEAVE',
+  INSUFFICIENT_PERMISSION = 'INSUFFICIENT_PERMISSION',
+  USER_NOT_IN_ORG = 'USER_NOT_IN_ORG',
+  // family
+  FAMILY_NOT_FOUND = 'FAMILY_NOT_FOUND',
+  NOT_IN_FAMILY = 'NOT_IN_FAMILY',
+  ALREADY_IN_FAMILY = 'ALREADY_IN_FAMILY',
+  USER_NOT_IN_FAMILY = 'USER_NOT_IN_FAMILY',
+  NOT_FAMILY_ADULT = 'NOT_FAMILY_ADULT',
+  MEMBER_LIMIT_EXCEEDED = 'MEMBER_LIMIT_EXCEEDED',
+  // invite
+  INVITE_NOT_FOUND = 'INVITE_NOT_FOUND',
+  INVITE_EXPIRED = 'INVITE_EXPIRED',
+  INVITE_ALREADY_USED = 'INVITE_ALREADY_USED',
+  INVITE_REVOKED = 'INVITE_REVOKED',
+  EMAIL_MISMATCH = 'EMAIL_MISMATCH',
+  INVITE_EMAIL_MISMATCH = 'INVITE_EMAIL_MISMATCH',
+  // transfer
+  TRANSFER_NOT_FOUND = 'TRANSFER_NOT_FOUND',
+  TRANSFER_NOT_PENDING = 'TRANSFER_NOT_PENDING',
+  // misc
+  NOT_AUTHENTICATED = 'NOT_AUTHENTICATED',
+  RATE_LIMITED = 'RATE_LIMITED',
+  RPC_FAILED = 'RPC_FAILED',
+  EMAIL_SEND_FAILED = 'EMAIL_SEND_FAILED',
+}
 
-  // 権限
-  NOT_AUTHENTICATED:          'NOT_AUTHENTICATED',
-  NOT_ORG_ADMIN:              'NOT_ORG_ADMIN',
-  NOT_FAMILY_ADULT:           'NOT_FAMILY_ADULT',
-  NOT_OPERATOR:               'NOT_OPERATOR',
+export const ErrorStatusMap: Record<MembershipErrorCode, number> = {
+  [MembershipErrorCode.ORG_NOT_FOUND]: 404,
+  [MembershipErrorCode.NOT_IN_ORG]: 403,
+  [MembershipErrorCode.ALREADY_IN_ORG]: 409,
+  [MembershipErrorCode.SEAT_LIMIT_EXCEEDED]: 409,
+  [MembershipErrorCode.OWNER_CANNOT_LEAVE]: 409,
+  [MembershipErrorCode.INSUFFICIENT_PERMISSION]: 403,
+  [MembershipErrorCode.USER_NOT_IN_ORG]: 404,
+  [MembershipErrorCode.FAMILY_NOT_FOUND]: 404,
+  [MembershipErrorCode.NOT_IN_FAMILY]: 403,
+  [MembershipErrorCode.ALREADY_IN_FAMILY]: 409,
+  [MembershipErrorCode.USER_NOT_IN_FAMILY]: 404,
+  [MembershipErrorCode.NOT_FAMILY_ADULT]: 403,
+  [MembershipErrorCode.MEMBER_LIMIT_EXCEEDED]: 409,
+  [MembershipErrorCode.INVITE_NOT_FOUND]: 404,
+  [MembershipErrorCode.INVITE_EXPIRED]: 410,
+  [MembershipErrorCode.INVITE_ALREADY_USED]: 409,
+  [MembershipErrorCode.INVITE_REVOKED]: 409,
+  [MembershipErrorCode.EMAIL_MISMATCH]: 403,
+  [MembershipErrorCode.INVITE_EMAIL_MISMATCH]: 403,
+  [MembershipErrorCode.TRANSFER_NOT_FOUND]: 404,
+  [MembershipErrorCode.TRANSFER_NOT_PENDING]: 409,
+  [MembershipErrorCode.NOT_AUTHENTICATED]: 401,
+  [MembershipErrorCode.RATE_LIMITED]: 429,
+  [MembershipErrorCode.RPC_FAILED]: 500,
+  [MembershipErrorCode.EMAIL_SEND_FAILED]: 500,
+};
 
-  // 制限
-  SEAT_LIMIT_EXCEEDED:        'SEAT_LIMIT_EXCEEDED',
-  MEMBER_LIMIT_EXCEEDED:      'MEMBER_LIMIT_EXCEEDED',
-
-  // 内部
-  RPC_FAILED:                 'RPC_FAILED',
-  EMAIL_SEND_FAILED:          'EMAIL_SEND_FAILED',
-} as const;
-
-export type MembershipErrorCode = typeof MembershipErrorCode[keyof typeof MembershipErrorCode];
+export function mapPgErrorToHttp(message: string): { code: MembershipErrorCode | 'UNKNOWN'; status: number } {
+  for (const code of Object.values(MembershipErrorCode)) {
+    if (message.includes(code)) {
+      return { code, status: ErrorStatusMap[code] };
+    }
+  }
+  return { code: 'UNKNOWN', status: 500 };
+}

--- a/src/schemas/membership/family-member.ts
+++ b/src/schemas/membership/family-member.ts
@@ -1,6 +1,27 @@
 // src/schemas/membership/family-member.ts
 import { z } from 'zod';
 import { apiResponse } from '@/schemas/common';
+import { FamilyRoleSchema } from './family-group';
+
+export const FamilyMemberStatusSchema = z.enum(['active', 'removed', 'left']);
+
+export const FamilyMemberSchema = z.object({
+  id: z.string().uuid(),
+  family_id: z.string().uuid(),
+  user_id: z.string().uuid().nullable(),
+  role: FamilyRoleSchema,
+  display_name: z.string().nullable(),
+  relationship: z.string().nullable(),
+  tags: z.array(z.string()),
+  share_meals: z.boolean(),
+  share_health: z.boolean(),
+  share_menu: z.boolean(),
+  child_profile: z.record(z.string(), z.unknown()).nullable(),
+  avatar_color: z.string(),
+  status: FamilyMemberStatusSchema,
+  joined_at: z.string().datetime(),
+  removed_at: z.string().datetime().nullable(),
+});
 
 export const AddFamilyChildBodySchema = z.object({
   family_id: z.string().uuid(),
@@ -24,6 +45,8 @@ export const LeaveFamilyResponseSchema = apiResponse(z.object({
   left_at: z.string().datetime(),
 }));
 
+export type FamilyMemberStatus = z.infer<typeof FamilyMemberStatusSchema>;
+export type FamilyMember = z.infer<typeof FamilyMemberSchema>;
 export type AddFamilyChildBody = z.infer<typeof AddFamilyChildBodySchema>;
 export type PromoteChildBody = z.infer<typeof PromoteChildBodySchema>;
 export type RemoveFamilyMemberBody = z.infer<typeof RemoveFamilyMemberBodySchema>;

--- a/src/schemas/membership/index.ts
+++ b/src/schemas/membership/index.ts
@@ -2,6 +2,7 @@
 // (設計書 01-data-model.md §0.3)
 // 全 membership スキーマの re-export
 
+export * from './organization';
 export * from './organization-invite';
 export * from './organization-invite-action';
 export * from './organization-member';
@@ -11,6 +12,8 @@ export * from './family-invite';
 export * from './family-invite-action';
 export * from './family-member';
 export * from './family-representative-transfer';
+export * from './ownership-transfer';
+export * from './membership-audit';
 export * from './meal-paste';
 export * from './share-settings';
 export * from './operator-membership';

--- a/src/schemas/membership/membership-audit.ts
+++ b/src/schemas/membership/membership-audit.ts
@@ -1,0 +1,44 @@
+// src/schemas/membership/membership-audit.ts
+// (設計書 01-data-model.md §5)
+import { z } from 'zod';
+
+export const AuditScopeSchema = z.enum(['organization', 'family']);
+
+export const AuditActionSchema = z.enum([
+  'group_created',
+  'group_dissolved',
+  'invite_created',
+  'invite_accepted',
+  'invite_rejected',
+  'invite_revoked',
+  'invite_expired',
+  'member_added',
+  'member_removed',
+  'member_left',
+  'child_added',
+  'child_promoted',
+  'role_changed',
+  'owner_transfer_proposed',
+  'owner_transferred',
+  'representative_transfer_proposed',
+  'representative_transferred',
+  'operator_force_owner_transfer',
+  'operator_force_representative_transfer',
+  'operator_force_dissolve',
+  'paste_executed',
+]);
+
+export const MembershipAuditSchema = z.object({
+  id: z.string().uuid(),
+  scope: AuditScopeSchema,
+  scope_id: z.string().uuid(),
+  action: AuditActionSchema,
+  actor_id: z.string().uuid().nullable(),
+  target_user_id: z.string().uuid().nullable(),
+  metadata: z.record(z.string(), z.unknown()),
+  created_at: z.string().datetime(),
+});
+
+export type AuditScope = z.infer<typeof AuditScopeSchema>;
+export type AuditAction = z.infer<typeof AuditActionSchema>;
+export type MembershipAudit = z.infer<typeof MembershipAuditSchema>;

--- a/src/schemas/membership/organization-member.ts
+++ b/src/schemas/membership/organization-member.ts
@@ -1,6 +1,17 @@
 // src/schemas/membership/organization-member.ts
 import { z } from 'zod';
 import { apiResponse } from '@/schemas/common';
+import { OrgRoleSchema } from './organization-invite';
+
+export const OrgMemberSchema = z.object({
+  id: z.string().uuid(),
+  organization_id: z.string().uuid(),
+  org_role: OrgRoleSchema,
+  nickname: z.string().nullable(),
+  email: z.string().email().optional(),
+  is_active_in_org: z.boolean().nullable(),
+  joined_org_at: z.string().date().nullable(),
+});
 
 export const RemoveOrgMemberBodySchema = z.object({
   organization_id: z.string().uuid(),
@@ -12,5 +23,6 @@ export const LeaveOrgResponseSchema = apiResponse(z.object({
   left_at: z.string().datetime(),
 }));
 
+export type OrgMember = z.infer<typeof OrgMemberSchema>;
 export type RemoveOrgMemberBody = z.infer<typeof RemoveOrgMemberBodySchema>;
 export type LeaveOrgResponse = z.infer<typeof LeaveOrgResponseSchema>;

--- a/src/schemas/membership/organization.ts
+++ b/src/schemas/membership/organization.ts
@@ -1,0 +1,57 @@
+// src/schemas/membership/organization.ts
+// (設計書 01-data-model.md §2)
+import { z } from 'zod';
+import { apiResponse } from '@/schemas/common';
+
+export const OrgRoleEnumSchema = z.enum(['owner', 'admin', 'member']);
+
+// plan_key 9 種 (canonical: 設計書 §1.1)
+export const OrgPlanKeySchema = z.enum([
+  'free',
+  'starter',
+  'basic',
+  'standard',
+  'professional',
+  'business',
+  'enterprise',
+  'trial',
+  'custom',
+]);
+
+export const OrgStatusSchema = z.enum(['active', 'suspended', 'dissolved']);
+
+export const OrganizationSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  owner_id: z.string().uuid().nullable(),
+  plan: z.string().nullable(),
+  status: OrgStatusSchema,
+  contact_email: z.string().email().nullable(),
+  contact_name: z.string().nullable(),
+  industry: z.string().nullable(),
+  employee_count: z.number().int().nullable(),
+  logo_url: z.string().url().nullable(),
+  settings: z.record(z.string(), z.unknown()).nullable(),
+  subscription_status: z.string().nullable(),
+  subscription_expires_at: z.string().datetime().nullable(),
+  dissolved_at: z.string().datetime().nullable(),
+  created_at: z.string().datetime().nullable(),
+  updated_at: z.string().datetime().nullable(),
+});
+
+export const CreateOrganizationBodySchema = z.object({
+  name: z.string().min(1).max(100),
+  plan: OrgPlanKeySchema.default('free'),
+  contact_email: z.string().email().optional(),
+});
+
+export const CreateOrganizationResponseSchema = apiResponse(z.object({
+  organization: OrganizationSchema,
+}));
+
+export type OrgRoleEnum = z.infer<typeof OrgRoleEnumSchema>;
+export type OrgPlanKey = z.infer<typeof OrgPlanKeySchema>;
+export type OrgStatus = z.infer<typeof OrgStatusSchema>;
+export type Organization = z.infer<typeof OrganizationSchema>;
+export type CreateOrganizationBody = z.infer<typeof CreateOrganizationBodySchema>;
+export type CreateOrganizationResponse = z.infer<typeof CreateOrganizationResponseSchema>;

--- a/src/schemas/membership/ownership-transfer.ts
+++ b/src/schemas/membership/ownership-transfer.ts
@@ -1,0 +1,49 @@
+// src/schemas/membership/ownership-transfer.ts
+// (設計書 01-data-model.md §4)
+import { z } from 'zod';
+import { apiResponse } from '@/schemas/common';
+
+export const TransferScopeSchema = z.enum(['organization', 'family']);
+export const TransferStatusSchema = z.enum(['pending', 'accepted', 'rejected', 'expired']);
+
+export const OwnershipTransferProposalSchema = z.object({
+  id: z.string().uuid(),
+  scope: TransferScopeSchema,
+  scope_id: z.string().uuid(),
+  from_user_id: z.string().uuid(),
+  to_user_id: z.string().uuid(),
+  status: TransferStatusSchema,
+  proposed_at: z.string().datetime(),
+  expires_at: z.string().datetime(),
+  resolved_at: z.string().datetime().nullable(),
+});
+
+export const ProposeTransferBodySchema = z.object({
+  scope: TransferScopeSchema,
+  scope_id: z.string().uuid(),
+  to_user_id: z.string().uuid(),
+});
+
+export const ProposeTransferResponseSchema = apiResponse(z.object({
+  proposal_id: z.string().uuid(),
+  expires_at: z.string().datetime(),
+}));
+
+export const AcceptTransferBodySchema = z.object({
+  proposal_id: z.string().uuid(),
+});
+
+export const AcceptTransferResponseSchema = apiResponse(z.object({
+  scope: TransferScopeSchema,
+  scope_id: z.string().uuid(),
+  new_owner_id: z.string().uuid(),
+  transferred_at: z.string().datetime(),
+}));
+
+export type TransferScope = z.infer<typeof TransferScopeSchema>;
+export type TransferStatus = z.infer<typeof TransferStatusSchema>;
+export type OwnershipTransferProposal = z.infer<typeof OwnershipTransferProposalSchema>;
+export type ProposeTransferBody = z.infer<typeof ProposeTransferBodySchema>;
+export type ProposeTransferResponse = z.infer<typeof ProposeTransferResponseSchema>;
+export type AcceptTransferBody = z.infer<typeof AcceptTransferBodySchema>;
+export type AcceptTransferResponse = z.infer<typeof AcceptTransferResponseSchema>;

--- a/supabase/migrations/20260511000133_membership_remaining_rpcs.sql
+++ b/supabase/migrations/20260511000133_membership_remaining_rpcs.sql
@@ -1,0 +1,369 @@
+-- migration: 20260511000133_membership_remaining_rpcs.sql
+-- 残 RPC: revoke_org_invite, revoke_family_invite, get_invite_details,
+--         update_my_share_settings, is_inactive_user,
+--         list_orgs_with_inactive_owner, list_families_with_inactive_representative
+
+-- ----------------------------------------------------------------
+-- 1. revoke_org_invite
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.revoke_org_invite(p_invite_id UUID)
+RETURNS organization_invites
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
+DECLARE
+  v_invite organization_invites;
+  v_caller_org_id UUID;
+  v_caller_role org_role_enum;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- 招待を取得
+  SELECT * INTO v_invite FROM organization_invites WHERE id = p_invite_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'INVITE_NOT_FOUND' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- 呼び出し元が対象 org の owner/admin か検証
+  SELECT organization_id, org_role INTO v_caller_org_id, v_caller_role
+    FROM user_profiles WHERE id = auth.uid();
+
+  IF v_caller_org_id IS DISTINCT FROM v_invite.organization_id
+     OR v_caller_role IS NULL
+     OR v_caller_role NOT IN ('owner', 'admin') THEN
+    RAISE EXCEPTION 'INSUFFICIENT_PERMISSION' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- pending のみ revoke 可能
+  UPDATE organization_invites
+    SET status = 'revoked', revoked_at = NOW(), revoked_by = auth.uid()
+    WHERE id = p_invite_id AND status = 'pending'
+    RETURNING * INTO v_invite;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'INVITE_NOT_FOUND' USING ERRCODE = 'P0001';
+  END IF;
+
+  INSERT INTO membership_audit (scope, scope_id, action, actor_id, metadata)
+  VALUES ('organization', v_invite.organization_id, 'invite_revoked', auth.uid(),
+          jsonb_build_object('invite_id', p_invite_id));
+
+  RETURN v_invite;
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.revoke_org_invite FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.revoke_org_invite TO authenticated;
+
+-- ----------------------------------------------------------------
+-- 2. revoke_family_invite
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.revoke_family_invite(p_invite_id UUID)
+RETURNS family_invites
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
+DECLARE
+  v_invite family_invites;
+  v_caller_role family_role_enum;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- 招待を取得
+  SELECT * INTO v_invite FROM family_invites WHERE id = p_invite_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'INVITE_NOT_FOUND' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- 呼び出し元が対象 family の representative/adult か検証
+  SELECT role INTO v_caller_role FROM family_members
+    WHERE family_id = v_invite.family_id AND user_id = auth.uid() AND status = 'active';
+
+  IF v_caller_role IS NULL OR v_caller_role NOT IN ('representative', 'adult') THEN
+    RAISE EXCEPTION 'INSUFFICIENT_PERMISSION' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- pending のみ revoke 可能
+  UPDATE family_invites
+    SET status = 'revoked', revoked_at = NOW(), revoked_by = auth.uid()
+    WHERE id = p_invite_id AND status = 'pending'
+    RETURNING * INTO v_invite;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'INVITE_NOT_FOUND' USING ERRCODE = 'P0001';
+  END IF;
+
+  INSERT INTO membership_audit (scope, scope_id, action, actor_id, metadata)
+  VALUES ('family', v_invite.family_id, 'invite_revoked', auth.uid(),
+          jsonb_build_object('invite_id', p_invite_id));
+
+  RETURN v_invite;
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.revoke_family_invite FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.revoke_family_invite TO authenticated;
+
+-- ----------------------------------------------------------------
+-- 3. get_invite_details  (認証不要: anon + authenticated)
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_invite_details(p_token TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
+DECLARE
+  v_org_invite  organization_invites;
+  v_fam_invite  family_invites;
+  v_org_name    TEXT;
+  v_fam_name    TEXT;
+  v_invited_by_name TEXT;
+  v_is_existing BOOLEAN;
+  v_email_matches BOOLEAN;
+BEGIN
+  -- org 招待を検索
+  SELECT * INTO v_org_invite
+    FROM organization_invites
+    WHERE token = p_token;
+
+  IF FOUND THEN
+    -- 組織名
+    SELECT name INTO v_org_name FROM organizations WHERE id = v_org_invite.organization_id;
+
+    -- 招待者名
+    SELECT COALESCE(up.nickname, au.email) INTO v_invited_by_name
+      FROM user_profiles up
+      JOIN auth.users au ON au.id = up.id
+      WHERE up.id = v_org_invite.invited_by;
+
+    -- 既存ユーザー判定
+    SELECT EXISTS(SELECT 1 FROM auth.users WHERE lower(email) = lower(v_org_invite.email))
+      INTO v_is_existing;
+
+    -- caller の email 一致判定
+    v_email_matches := FALSE;
+    IF auth.uid() IS NOT NULL THEN
+      SELECT lower(au.email) = lower(v_org_invite.email)
+        INTO v_email_matches
+        FROM auth.users au WHERE au.id = auth.uid();
+    END IF;
+
+    RETURN jsonb_build_object(
+      'scope',                   'organization',
+      'scope_id',                v_org_invite.organization_id,
+      'scope_name',              v_org_name,
+      'role',                    v_org_invite.invited_role,
+      'invited_by_name',         v_invited_by_name,
+      'expires_at',              v_org_invite.expires_at,
+      'email',                   v_org_invite.email,
+      'status',                  v_org_invite.status,
+      'is_existing_user',        v_is_existing,
+      'current_user_email_matches', v_email_matches
+    );
+  END IF;
+
+  -- family 招待を検索
+  SELECT * INTO v_fam_invite
+    FROM family_invites
+    WHERE token = p_token;
+
+  IF FOUND THEN
+    -- 家族名
+    SELECT name INTO v_fam_name FROM family_groups WHERE id = v_fam_invite.family_id;
+
+    -- 招待者名
+    SELECT COALESCE(up.nickname, au.email) INTO v_invited_by_name
+      FROM user_profiles up
+      JOIN auth.users au ON au.id = up.id
+      WHERE up.id = v_fam_invite.invited_by;
+
+    -- 既存ユーザー判定
+    SELECT EXISTS(SELECT 1 FROM auth.users WHERE lower(email) = lower(v_fam_invite.email))
+      INTO v_is_existing;
+
+    -- caller の email 一致判定
+    v_email_matches := FALSE;
+    IF auth.uid() IS NOT NULL THEN
+      SELECT lower(au.email) = lower(v_fam_invite.email)
+        INTO v_email_matches
+        FROM auth.users au WHERE au.id = auth.uid();
+    END IF;
+
+    RETURN jsonb_build_object(
+      'scope',                   'family',
+      'scope_id',                v_fam_invite.family_id,
+      'scope_name',              v_fam_name,
+      'role',                    v_fam_invite.invited_role,
+      'invited_by_name',         v_invited_by_name,
+      'expires_at',              v_fam_invite.expires_at,
+      'email',                   v_fam_invite.email,
+      'status',                  v_fam_invite.status,
+      'is_existing_user',        v_is_existing,
+      'current_user_email_matches', v_email_matches
+    );
+  END IF;
+
+  -- 見つからない場合 NULL
+  RETURN NULL;
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.get_invite_details FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_invite_details TO anon, authenticated;
+
+-- ----------------------------------------------------------------
+-- 4. update_my_share_settings
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.update_my_share_settings(
+  p_share_meals  BOOLEAN,
+  p_share_health BOOLEAN,
+  p_share_menu   BOOLEAN
+) RETURNS family_members
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
+DECLARE
+  v_member family_members;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED' USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE family_members
+    SET share_meals  = p_share_meals,
+        share_health = p_share_health,
+        share_menu   = p_share_menu
+    WHERE user_id = auth.uid() AND status = 'active'
+    RETURNING * INTO v_member;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'NOT_IN_FAMILY' USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN v_member;
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.update_my_share_settings FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_my_share_settings TO authenticated;
+
+-- ----------------------------------------------------------------
+-- 5. is_inactive_user
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.is_inactive_user(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
+DECLARE
+  v_last_sign_in TIMESTAMPTZ;
+BEGIN
+  SELECT last_sign_in_at
+  INTO v_last_sign_in
+  FROM auth.users
+  WHERE id = p_user_id;
+
+  -- ユーザーが存在しない
+  IF NOT FOUND THEN
+    RETURN TRUE;
+  END IF;
+
+  -- 30 日以上 sign-in なし または一度もサインインしていない
+  RETURN (v_last_sign_in IS NULL OR v_last_sign_in < NOW() - INTERVAL '30 days');
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.is_inactive_user FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_inactive_user TO authenticated;
+
+-- ----------------------------------------------------------------
+-- 6. list_orgs_with_inactive_owner
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.list_orgs_with_inactive_owner()
+RETURNS TABLE (
+  organization_id       UUID,
+  organization_name     TEXT,
+  owner_user_id         UUID,
+  owner_email           TEXT,
+  owner_last_sign_in    TIMESTAMPTZ,
+  member_count          BIGINT,
+  dissolved             BOOLEAN
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
+BEGIN
+  -- super_admin チェック
+  IF NOT EXISTS (
+    SELECT 1 FROM user_profiles
+    WHERE id = auth.uid() AND 'super_admin' = ANY(roles)
+  ) THEN
+    RAISE EXCEPTION 'INSUFFICIENT_PERMISSION' USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    o.id                          AS organization_id,
+    o.name                        AS organization_name,
+    up.id                         AS owner_user_id,
+    au.email                      AS owner_email,
+    au.last_sign_in_at            AS owner_last_sign_in,
+    (SELECT COUNT(*)
+       FROM user_profiles mp
+       WHERE mp.organization_id = o.id
+    )                             AS member_count,
+    (o.status = 'dissolved')      AS dissolved
+  FROM organizations o
+  JOIN user_profiles up ON up.organization_id = o.id AND up.org_role = 'owner'
+  JOIN auth.users au ON au.id = up.id
+  WHERE au.last_sign_in_at IS NULL
+     OR au.last_sign_in_at < NOW() - INTERVAL '30 days';
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.list_orgs_with_inactive_owner FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.list_orgs_with_inactive_owner TO authenticated;
+
+-- ----------------------------------------------------------------
+-- 7. list_families_with_inactive_representative
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.list_families_with_inactive_representative()
+RETURNS TABLE (
+  family_id                UUID,
+  family_name              TEXT,
+  representative_user_id   UUID,
+  representative_email     TEXT,
+  member_count             BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public AS $$
+BEGIN
+  -- super_admin チェック
+  IF NOT EXISTS (
+    SELECT 1 FROM user_profiles
+    WHERE id = auth.uid() AND 'super_admin' = ANY(roles)
+  ) THEN
+    RAISE EXCEPTION 'INSUFFICIENT_PERMISSION' USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    fg.id                         AS family_id,
+    fg.name                       AS family_name,
+    fm.user_id                    AS representative_user_id,
+    au.email                      AS representative_email,
+    (SELECT COUNT(*)
+       FROM family_members mc
+       WHERE mc.family_id = fg.id AND mc.status = 'active'
+    )                             AS member_count
+  FROM family_groups fg
+  JOIN family_members fm ON fm.family_id = fg.id
+                         AND fm.role = 'representative'
+                         AND fm.status = 'active'
+  JOIN auth.users au ON au.id = fm.user_id
+  WHERE fg.status = 'active'
+    AND (au.last_sign_in_at IS NULL
+         OR au.last_sign_in_at < NOW() - INTERVAL '30 days');
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.list_families_with_inactive_representative FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.list_families_with_inactive_representative TO authenticated;


### PR DESCRIPTION
## Summary

- `supabase/migrations/20260511000133_membership_remaining_rpcs.sql` 追加 (7 RPC)
  - `revoke_org_invite` / `revoke_family_invite` — SECURITY DEFINER + 権限チェック
  - `get_invite_details` — anon+authenticated 両対応、org/family 判別
  - `update_my_share_settings` — family_members share 設定更新
  - `is_inactive_user` — 30日サインインなし判定
  - `list_orgs_with_inactive_owner` / `list_families_with_inactive_representative` — super_admin 専用
- `src/lib/errors/membership-errors.ts` — `enum` 形式に刷新、HTTP status mapping 追加
- `src/schemas/membership/` — organization.ts / ownership-transfer.ts / membership-audit.ts 新規追加、OrgMemberSchema / FamilyMemberSchema 既存ファイルに追加
- `lib/supabase/middleware.ts` — `/invite` を public route として追加

## Notes

- **Migration apply が必要**: `20260511000133_membership_remaining_rpcs.sql` を Supabase MCP または手動で本番 apply してください (project ref: `flmeolcfutuwwbjmzyoz`)
- **types regen が必要**: migration apply 後に `npx supabase@2.62.10 gen types typescript --project-id flmeolcfutuwwbjmzyoz > src/types/database.types.ts` を実行
- typecheck: PASS (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)