### PR TITLE
feat(membership): P3 family 招待発行・受諾 API 補完 + メールテンプレート分割

### DIFF
--- a/src/app/api/family/invites/[id]/revoke/route.ts
+++ b/src/app/api/family/invites/[id]/revoke/route.ts
@@ -1,0 +1,60 @@
+// src/app/api/family/invites/[id]/revoke/route.ts
+// (設計書 02-flow-spec.md §3 相当, family 版 revoke)
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { MembershipErrorCode, mapPgErrorToHttp } from '@/lib/errors/membership-errors';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const supabase = await createClient();
+
+  // 認証必須 (owner/sub_owner のみが revoke 可能)
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json(
+      { error: { code: MembershipErrorCode.NOT_AUTHENTICATED, message: '認証が必要です' } },
+      { status: 401 },
+    );
+  }
+
+  const { id } = await params;
+
+  if (!id) {
+    return NextResponse.json(
+      { error: { code: 'INVALID_REQUEST', message: '招待 ID が必要です' } },
+      { status: 400 },
+    );
+  }
+
+  // RPC: revoke_family_invite
+  const { data, error } = await supabase.rpc('revoke_family_invite', {
+    p_invite_id: id,
+  });
+
+  if (error) {
+    const { code, status } = mapPgErrorToHttp(error.message ?? '');
+
+    if (code === MembershipErrorCode.INVITE_NOT_FOUND) {
+      return NextResponse.json(
+        { error: { code, message: '招待が見つかりません' } },
+        { status },
+      );
+    }
+    if (code === MembershipErrorCode.INSUFFICIENT_PERMISSION) {
+      return NextResponse.json(
+        { error: { code, message: 'この操作を行う権限がありません' } },
+        { status },
+      );
+    }
+
+    console.error('[api/family/invites/revoke] RPC error:', error);
+    return NextResponse.json(
+      { error: { code: MembershipErrorCode.RPC_FAILED, message: '招待の取り消しに失敗しました' } },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ data });
+}

--- a/src/app/api/family/invites/route.ts
+++ b/src/app/api/family/invites/route.ts
@@ -5,7 +5,8 @@ import { createClient } from '@/lib/supabase/server';
 import { CreateFamilyInviteBodySchema } from '@/schemas/membership/family-invite';
 import { MembershipErrorCode } from '@/lib/errors/membership-errors';
 import { sendEmail } from '@/lib/emails/send';
-import { renderFamilyInviteEmail } from '@/lib/emails/membership/family-invite';
+import { renderFamilyInviteExistingEmail } from '@/lib/emails/membership/family-invite-existing';
+import { renderFamilyInviteNewEmail } from '@/lib/emails/membership/family-invite-new';
 import { buildFamilyInviteUrl } from '@/lib/membership/urls';
 
 // 招待一覧取得
@@ -141,25 +142,41 @@ export async function POST(request: Request) {
   const scopeName = familyGroup?.name ?? '家族グループ';
   const expiresDate = invite.expires_at.slice(0, 10); // YYYY-MM-DD
 
-  // Resend でメール送信
+  // 既存ユーザー判定: get_invite_details で is_existing_user を確認
+  let isExistingUser = false;
+  let inviteeDisplayName: string | null = null;
   try {
-    const envelope = renderFamilyInviteEmail({
-      display_name: null,   // 受領者名は不明 (invite 時点では)
+    const { data: inviteDetails } = await supabase.rpc('get_invite_details', {
+      p_token: invite.token,
+    });
+    if (inviteDetails) {
+      const details = inviteDetails as { is_existing_user?: boolean; invitee_display_name?: string | null };
+      isExistingUser = details.is_existing_user ?? false;
+      inviteeDisplayName = details.invitee_display_name ?? null;
+    }
+  } catch (detailsError) {
+    // 詳細取得失敗は警告のみ。既存ユーザー判定できない場合は新規向けテンプレートにフォールバック
+    console.warn('[api/family/invites] get_invite_details failed:', detailsError);
+  }
+
+  // Resend でメール送信 (失敗は warn のみ)
+  try {
+    const emailVars = {
+      display_name: isExistingUser ? inviteeDisplayName : null,
       email_address: email,
       inviter_name: inviterName,
       scope_name: scopeName,
       invite_url,
       expires_at: expiresDate,
       custom_message: custom_message ?? null,
-    });
+    };
+    const envelope = isExistingUser
+      ? renderFamilyInviteExistingEmail(emailVars)
+      : renderFamilyInviteNewEmail(emailVars);
     await sendEmail(envelope);
   } catch (emailError) {
     // メール送信失敗は警告のみ (invite row は残す)
-    console.error('[api/family/invites] email send failed:', emailError);
-    return NextResponse.json(
-      { error: { code: MembershipErrorCode.EMAIL_SEND_FAILED, message: 'メールの送信に失敗しました。招待リンクを直接共有してください。' } },
-      { status: 500 },
-    );
+    console.warn('[api/family/invites] email send failed (invite row kept):', emailError);
   }
 
   return NextResponse.json(

--- a/src/components/membership/AcceptFamilyInviteModal.tsx
+++ b/src/components/membership/AcceptFamilyInviteModal.tsx
@@ -1,0 +1,7 @@
+// src/components/membership/AcceptFamilyInviteModal.tsx
+// (設計書 03-ui-spec.md §2.1 パターン B — 受諾モーダル)
+// P1 implementer 向け公開 export。実装は FamilyInviteAcceptModal に集約。
+export {
+  FamilyInviteAcceptModal as AcceptFamilyInviteModal,
+  type FamilyInviteAcceptModalProps as AcceptFamilyInviteModalProps,
+} from './FamilyInviteAcceptModal';

--- a/src/lib/emails/membership/family-invite-existing.ts
+++ b/src/lib/emails/membership/family-invite-existing.ts
@@ -1,0 +1,40 @@
+// src/lib/emails/membership/family-invite-existing.ts
+// (設計書 04-email-templates.md §4 テンプレート C: 家族招待 — 既存ユーザー向け)
+import type { InviteEmailVars, EmailEnvelope } from './templates';
+
+/**
+ * 家族招待メール (既存ユーザー向け)
+ * subject: 「【ほめゴハン】{family_name}に家族として招待されました」
+ */
+export function renderFamilyInviteExistingEmail(vars: InviteEmailVars): EmailEnvelope {
+  const greeting = vars.display_name ?? vars.email_address;
+  const customSection = vars.custom_message
+    ? `\n${vars.inviter_name} 様からのメッセージ:\n「${vars.custom_message}」\n`
+    : '';
+
+  return {
+    to: vars.email_address,
+    from: 'ほめゴハン <noreply@homegohan.app>',
+    subject: `【ほめゴハン】${vars.scope_name}に家族として招待されました`,
+    text: `${greeting} 様
+
+${vars.inviter_name} 様からほめゴハンの家族グループ「${vars.scope_name}」にあなたを招待しています。
+
+家族グループに参加すると、献立や買い物リスト、栄養記録を共有できます。
+過去の個人記録はあなただけが閲覧でき、新しい記録から家族との共有を選べます。
+${customSection}
+▼ 招待を承諾する
+${vars.invite_url}
+
+このリンクは ${vars.expires_at} まで有効です。
+期限切れの場合は、招待者に再送を依頼してください。
+
+心当たりのない場合はこのメールを無視してください。
+不正利用のおそれがある場合は support@homegohan.app までご連絡ください。
+
+─────────────────
+ほめゴハン
+https://homegohan.app
+`,
+  };
+}

--- a/src/lib/emails/membership/family-invite-new.ts
+++ b/src/lib/emails/membership/family-invite-new.ts
@@ -1,0 +1,40 @@
+// src/lib/emails/membership/family-invite-new.ts
+// (設計書 04-email-templates.md §4 テンプレート C: 家族招待 — 新規ユーザー向け)
+import type { InviteEmailVars, EmailEnvelope } from './templates';
+
+/**
+ * 家族招待メール (新規ユーザー向け)
+ * subject: 「【ほめゴハン】{family_name}に家族として招待されました — アカウントを作成して参加」
+ */
+export function renderFamilyInviteNewEmail(vars: InviteEmailVars): EmailEnvelope {
+  const customSection = vars.custom_message
+    ? `\n${vars.inviter_name} 様からのメッセージ:\n「${vars.custom_message}」\n`
+    : '';
+
+  return {
+    to: vars.email_address,
+    from: 'ほめゴハン <noreply@homegohan.app>',
+    subject: `【ほめゴハン】${vars.scope_name}に家族として招待されました — アカウントを作成して参加`,
+    text: `${vars.email_address} 様
+
+${vars.inviter_name} 様からほめゴハンの家族グループ「${vars.scope_name}」にあなたを招待しています。
+
+ほめゴハンは、栄養管理と健康記録をサポートするサービスです。
+下記リンクからアカウントを作成して、家族グループのメンバーとして参加できます。
+
+家族グループに参加すると、献立や買い物リスト、栄養記録を家族と共有できます。
+${customSection}
+▼ アカウントを作成して招待を承諾する
+${vars.invite_url}
+
+このリンクは ${vars.expires_at} まで有効です。
+
+心当たりのない場合はこのメールを無視してください。
+不正利用のおそれがある場合は support@homegohan.app までご連絡ください。
+
+─────────────────
+ほめゴハン
+https://homegohan.app
+`,
+  };
+}


### PR DESCRIPTION
## Summary

- `POST /api/family/invites/[id]/revoke` を新規追加 (`revoke_family_invite` RPC 呼び出し)
- `invites/route.ts`: `get_invite_details` で既存/新規ユーザーを判定してメールテンプレートを分岐。メール送信失敗を warn のみに変更 (invite row 保持)
- `family-invite-existing.ts`: 既存ユーザー向け家族招待テンプレート (subject: 「【ほめゴハン】{family_name}に家族として招待されました」)
- `family-invite-new.ts`: 新規ユーザー向け家族招待テンプレート
- `AcceptFamilyInviteModal.tsx`: P1 implementer 向け re-export (`FamilyInviteAcceptModal` を `AcceptFamilyInviteModal` として公開)

## Test plan

- [ ] `typecheck` pass (エラーなし)
- [ ] `lint` で新規ファイルのエラーなし (既存 warning のみ)
- [ ] `POST /api/family/invites/[id]/revoke` で pending invite が revoked になること
- [ ] 招待発行時に既存ユーザーは existing テンプレ、新規ユーザーは new テンプレでメールが届くこと

## AcceptFamilyInviteModal interface (P1 implementer 共有)

```ts
// src/components/membership/AcceptFamilyInviteModal.tsx (re-export)
// 実装本体: src/components/membership/FamilyInviteAcceptModal.tsx

export interface AcceptFamilyInviteModalProps {
  token: string;          // invite token (URL から取得)
  familyName: string;     // 家族グループ名
  inviterName: string;    // 招待者の表示名
  expiresAt: string;      // ISO 文字列
  onAccepted?: () => void;  // 承諾成功後コールバック
  onRejected?: () => void;  // 拒否後コールバック
  onDefer?: () => void;     // 「後で」コールバック (省略可)
}
```

内部で `POST /api/family/invites/{token}/accept` と `POST /api/family/invites/{token}/reject` を呼ぶ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)