### PR TITLE
feat(membership): Phase P1 完成 — org 招待 + 5 パターン UI + Resend

### DIFF
--- a/src/app/(org)/org/invites/page.tsx
+++ b/src/app/(org)/org/invites/page.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+// src/app/(org)/org/invites/page.tsx
+// (設計書 03-ui-spec.md §1.1)
+// 招待発行フォーム + 招待履歴一覧 (revoke ボタン付き)
+
 import { useEffect, useState, useCallback } from "react";
 import { motion } from "framer-motion";
 
@@ -7,13 +11,10 @@ interface Invite {
   id: string;
   email: string;
   role: string;
-  departmentName: string | null;
   token: string;
-  expiresAt: string;
-  acceptedAt: string | null;
-  createdAt: string;
-  isExpired: boolean;
-  isAccepted: boolean;
+  status: string;
+  expires_at: string;
+  invite_url?: string;
 }
 
 export default function OrgInvitesPage() {
@@ -21,8 +22,10 @@ export default function OrgInvitesPage() {
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [newEmail, setNewEmail] = useState("");
-  const [newRole, setNewRole] = useState("member");
+  const [newRole, setNewRole] = useState<"admin" | "member">("member");
+  const [customMessage, setCustomMessage] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
   const fetchInvites = useCallback(async () => {
@@ -30,7 +33,18 @@ export default function OrgInvitesPage() {
       const res = await fetch("/api/org/invites");
       if (res.ok) {
         const data = await res.json();
-        setInvites(data.invites);
+        // 新 API レスポンス (invites 配列) を処理
+        const items = data.invites ?? [];
+        setInvites(
+          items.map((i: Record<string, unknown>) => ({
+            id: i.id as string,
+            email: (i.email as string) ?? "",
+            role: (i.role as string) ?? (i.invited_role as string) ?? "member",
+            token: (i.token as string) ?? "",
+            status: getStatus(i),
+            expires_at: (i.expires_at ?? i.expiresAt) as string,
+          })),
+        );
       }
     } catch (error) {
       console.error("Failed to fetch invites:", error);
@@ -48,41 +62,52 @@ export default function OrgInvitesPage() {
     if (!newEmail) return;
 
     setSubmitting(true);
+    setSubmitError(null);
     try {
       const res = await fetch("/api/org/invites", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: newEmail, role: newRole }),
+        body: JSON.stringify({
+          email: newEmail,
+          role: newRole,
+          custom_message: customMessage || undefined,
+        }),
       });
 
       if (res.ok) {
         setNewEmail("");
+        setCustomMessage("");
+        setNewRole("member");
         setShowForm(false);
         fetchInvites();
       } else {
         const data = await res.json();
-        alert(data.error || "招待の作成に失敗しました");
+        setSubmitError(data.error?.message ?? data.error ?? "招待の作成に失敗しました");
       }
     } catch (error) {
       console.error("Failed to create invite:", error);
+      setSubmitError("通信エラーが発生しました");
     } finally {
       setSubmitting(false);
     }
   };
 
-  const handleDeleteInvite = async (inviteId: string) => {
+  const handleRevokeInvite = async (inviteId: string) => {
     if (!confirm("この招待を取り消しますか？")) return;
 
     try {
-      const res = await fetch(`/api/org/invites?id=${inviteId}`, {
-        method: "DELETE",
+      const res = await fetch(`/api/org/invites/${inviteId}/revoke`, {
+        method: "POST",
       });
 
       if (res.ok) {
         fetchInvites();
+      } else {
+        const data = await res.json();
+        alert(data.error?.message ?? "招待の取り消しに失敗しました");
       }
     } catch (error) {
-      console.error("Failed to delete invite:", error);
+      console.error("Failed to revoke invite:", error);
     }
   };
 
@@ -91,6 +116,26 @@ export default function OrgInvitesPage() {
     navigator.clipboard.writeText(link);
     setCopiedId(id);
     setTimeout(() => setCopiedId(null), 2000);
+  };
+
+  const statusLabel = (status: string) => {
+    switch (status) {
+      case "pending":   return { label: "保留中",    className: "bg-yellow-100 text-yellow-700" };
+      case "accepted":  return { label: "承諾済",    className: "bg-green-100 text-green-700" };
+      case "rejected":  return { label: "拒否済",    className: "bg-gray-100 text-gray-600" };
+      case "expired":   return { label: "期限切れ",  className: "bg-red-100 text-red-700" };
+      case "revoked":   return { label: "取消済",    className: "bg-orange-100 text-orange-700" };
+      default:          return { label: status,       className: "bg-gray-100 text-gray-600" };
+    }
+  };
+
+  const roleLabel = (role: string) => {
+    switch (role) {
+      case "owner":  return "オーナー";
+      case "admin":  return "管理者";
+      case "member": return "メンバー";
+      default:       return role;
+    }
   };
 
   if (loading) {
@@ -105,14 +150,14 @@ export default function OrgInvitesPage() {
     <div className="p-8 space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-800">メンバー招待</h1>
+          <h1 className="text-2xl font-bold text-gray-800">組織招待管理</h1>
           <p className="text-gray-500 mt-1">メールで招待リンクを共有してください</p>
         </div>
         <button
           onClick={() => setShowForm(!showForm)}
           className="px-6 py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 transition-colors"
         >
-          + 新規招待
+          + 新しいメンバーを招待
         </button>
       </div>
 
@@ -142,24 +187,44 @@ export default function OrgInvitesPage() {
             </label>
             <select
               value={newRole}
-              onChange={(e) => setNewRole(e.target.value)}
+              onChange={(e) => setNewRole(e.target.value as "admin" | "member")}
               className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               <option value="member">メンバー</option>
-              <option value="manager">マネージャー</option>
+              <option value="admin">管理者</option>
             </select>
           </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              メッセージ (任意)
+            </label>
+            <input
+              type="text"
+              value={customMessage}
+              onChange={(e) => setCustomMessage(e.target.value)}
+              maxLength={500}
+              className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="招待メッセージ (省略可)"
+            />
+          </div>
+
+          {submitError && (
+            <div className="rounded-xl bg-red-50 border border-red-200 p-3 text-xs text-red-600">
+              {submitError}
+            </div>
+          )}
+
           <div className="flex gap-3">
             <button
               type="submit"
               disabled={submitting}
               className="px-6 py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
             >
-              {submitting ? "作成中..." : "招待を作成"}
+              {submitting ? "送信中..." : "招待を送信"}
             </button>
             <button
               type="button"
-              onClick={() => setShowForm(false)}
+              onClick={() => { setShowForm(false); setSubmitError(null); }}
               className="px-6 py-3 bg-gray-100 text-gray-700 rounded-xl font-medium hover:bg-gray-200 transition-colors"
             >
               キャンセル
@@ -169,42 +234,47 @@ export default function OrgInvitesPage() {
       )}
 
       <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-50">
+          <h2 className="font-semibold text-gray-700">招待履歴</h2>
+        </div>
         <div className="divide-y divide-gray-50">
-          {invites.map((invite) => (
-            <div key={invite.id} className="p-4 flex items-center justify-between">
-              <div>
-                <p className="font-medium text-gray-800">{invite.email}</p>
-                <div className="flex items-center gap-2 mt-1">
-                  <span className="text-sm text-gray-500">{invite.role}</span>
-                  {invite.isAccepted ? (
-                    <span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs rounded-full">承認済</span>
-                  ) : invite.isExpired ? (
-                    <span className="px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full">期限切れ</span>
-                  ) : (
-                    <span className="px-2 py-0.5 bg-yellow-100 text-yellow-700 text-xs rounded-full">保留中</span>
+          {invites.map((invite) => {
+            const { label, className: sc } = statusLabel(invite.status);
+            return (
+              <div key={invite.id} className="p-4 flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="font-medium text-gray-800 truncate">{invite.email}</p>
+                  <div className="flex items-center gap-2 mt-1 flex-wrap">
+                    <span className="text-sm text-gray-500">{roleLabel(invite.role)}</span>
+                    <span className={`px-2 py-0.5 text-xs rounded-full ${sc}`}>{label}</span>
+                    {invite.expires_at && (
+                      <span className="text-xs text-gray-400">
+                        期限 {new Date(invite.expires_at).toLocaleDateString("ja-JP")}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  {invite.status === "pending" && invite.token && (
+                    <button
+                      onClick={() => copyInviteLink(invite.token, invite.id)}
+                      className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg text-sm hover:bg-gray-200 transition-colors"
+                    >
+                      {copiedId === invite.id ? "コピー済 ✓" : "リンクをコピー"}
+                    </button>
+                  )}
+                  {invite.status === "pending" && (
+                    <button
+                      onClick={() => handleRevokeInvite(invite.id)}
+                      className="px-4 py-2 bg-red-50 text-red-600 rounded-lg text-sm hover:bg-red-100 transition-colors"
+                    >
+                      取消
+                    </button>
                   )}
                 </div>
               </div>
-              <div className="flex items-center gap-2">
-                {!invite.isAccepted && !invite.isExpired && (
-                  <button
-                    onClick={() => copyInviteLink(invite.token, invite.id)}
-                    className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg text-sm hover:bg-gray-200 transition-colors"
-                  >
-                    {copiedId === invite.id ? "コピー済 ✓" : "リンクをコピー"}
-                  </button>
-                )}
-                {!invite.isAccepted && (
-                  <button
-                    onClick={() => handleDeleteInvite(invite.id)}
-                    className="px-4 py-2 bg-red-50 text-red-600 rounded-lg text-sm hover:bg-red-100 transition-colors"
-                  >
-                    取消
-                  </button>
-                )}
-              </div>
-            </div>
-          ))}
+            );
+          })}
           {invites.length === 0 && (
             <div className="p-8 text-center text-gray-400">
               招待はありません
@@ -216,3 +286,10 @@ export default function OrgInvitesPage() {
   );
 }
 
+// 旧 GET レスポンスと新 POST レスポンスを両方サポートするステータス解決
+function getStatus(i: Record<string, unknown>): string {
+  if (i.status) return i.status as string;
+  if (i.isAccepted) return "accepted";
+  if (i.isExpired) return "expired";
+  return "pending";
+}

--- a/src/app/api/org/invites/[id]/revoke/route.ts
+++ b/src/app/api/org/invites/[id]/revoke/route.ts
@@ -1,0 +1,50 @@
+// src/app/api/org/invites/[id]/revoke/route.ts
+// (設計書 02-flow-spec.md §3 — POST /api/org/invites/{id}/revoke)
+// owner/admin のみ実行可 (RLS + org ロール確認)
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { mapPgErrorToHttp } from '@/lib/errors/membership-errors';
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  const supabase = createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json(
+      { error: { code: 'NOT_AUTHENTICATED', message: '認証が必要です' } },
+      { status: 401 },
+    );
+  }
+
+  // 呼び出し者が owner/admin かを user_profiles で確認
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('org_role, organization_id')
+    .eq('id', user.id)
+    .single();
+
+  const allowedRoles = ['owner', 'admin'];
+  if (!profile?.org_role || !allowedRoles.includes(profile.org_role as string)) {
+    return NextResponse.json(
+      { error: { code: 'INSUFFICIENT_PERMISSION', message: 'owner/admin のみ取消可能です' } },
+      { status: 403 },
+    );
+  }
+
+  const { error } = await supabase.rpc('revoke_org_invite', { p_invite_id: id });
+
+  if (error) {
+    const { code, status } = mapPgErrorToHttp(error.message);
+    return NextResponse.json(
+      { error: { code, message: error.message } },
+      { status },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/org/invites/[token]/accept/route.ts
+++ b/src/app/api/org/invites/[token]/accept/route.ts
@@ -1,0 +1,41 @@
+// src/app/api/org/invites/[token]/accept/route.ts
+// (設計書 02-flow-spec.md §1.2 Happy path — POST /api/org/invites/{token}/accept)
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { mapPgErrorToHttp } from '@/lib/errors/membership-errors';
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+
+  const supabase = createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json(
+      { error: { code: 'NOT_AUTHENTICATED', message: '認証が必要です' } },
+      { status: 401 },
+    );
+  }
+
+  const { data, error } = await supabase.rpc('accept_org_invite', { p_token: token });
+
+  if (error) {
+    const { code, status } = mapPgErrorToHttp(error.message);
+    return NextResponse.json(
+      { error: { code, message: error.message } },
+      { status },
+    );
+  }
+
+  // accept_org_invite returns updated user_profiles row
+  const profile = data as { organization_id: string | null; org_role?: string | null } | null;
+
+  return NextResponse.json({
+    ok: true,
+    organization_id: profile?.organization_id ?? null,
+    role: (profile as Record<string, unknown>)?.org_role ?? null,
+  });
+}

--- a/src/app/api/org/invites/[token]/reject/route.ts
+++ b/src/app/api/org/invites/[token]/reject/route.ts
@@ -1,0 +1,28 @@
+// src/app/api/org/invites/[token]/reject/route.ts
+// (設計書 02-flow-spec.md §3 — POST /api/org/invites/{token}/reject)
+// 認証不要 (RPC は anon/authenticated 両対応)
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { mapPgErrorToHttp } from '@/lib/errors/membership-errors';
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+
+  const supabase = createClient();
+
+  const { error } = await supabase.rpc('reject_org_invite', { p_token: token });
+
+  if (error) {
+    const { code, status } = mapPgErrorToHttp(error.message);
+    return NextResponse.json(
+      { error: { code, message: error.message } },
+      { status },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/org/invites/route.ts
+++ b/src/app/api/org/invites/route.ts
@@ -1,20 +1,25 @@
 import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
-import crypto from 'crypto';
+import { mapPgErrorToHttp } from '@/lib/errors/membership-errors';
+import { sendEmail } from '@/lib/emails/send';
+import { renderOrgInviteExistingEmail } from '@/lib/emails/membership/org-invite-existing';
+import { renderOrgInviteNewEmail } from '@/lib/emails/membership/org-invite-new';
+import type { InviteEmailVars } from '@/lib/emails/membership/templates';
 
 // 招待一覧取得
 export async function GET(request: Request) {
-  const supabase = await createClient();
+  const supabase = createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
   if (userError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const { data: profile } = await supabase
     .from('user_profiles')
-    .select('organization_id, roles')
+    .select('organization_id, org_role')
     .eq('id', user.id)
     .single();
 
-  if (!profile?.roles?.includes('org_admin') || !profile?.organization_id) {
+  const allowedGetRoles = ['owner', 'admin'];
+  if (!profile?.org_role || !allowedGetRoles.includes(profile.org_role as string) || !profile?.organization_id) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
@@ -58,98 +63,141 @@ export async function GET(request: Request) {
   }
 }
 
-// 招待作成
+// 招待作成 (RPC create_org_invite + Resend 送信)
 export async function POST(request: Request) {
-  const supabase = await createClient();
+  const supabase = createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
-  if (userError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  if (userError || !user) {
+    return NextResponse.json({ error: { code: 'NOT_AUTHENTICATED', message: '認証が必要です' } }, { status: 401 });
+  }
 
   const { data: profile } = await supabase
     .from('user_profiles')
-    .select('organization_id, roles')
+    .select('organization_id, org_role, nickname')
     .eq('id', user.id)
     .single();
 
-  if (!profile?.roles?.includes('org_admin') || !profile?.organization_id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  const allowedOrgRoles = ['owner', 'admin'];
+  if (!profile?.org_role || !allowedOrgRoles.includes(profile.org_role as string) || !profile?.organization_id) {
+    return NextResponse.json(
+      { error: { code: 'INSUFFICIENT_PERMISSION', message: 'owner/admin のみ招待可能です' } },
+      { status: 403 },
+    );
   }
 
+  let body: { email?: string; role?: string; custom_message?: string };
   try {
-    const body = await request.json();
-    const { email, role = 'member', departmentId } = body;
-
-    if (!email) {
-      return NextResponse.json({ error: 'Email is required' }, { status: 400 });
-    }
-
-    // 既存の招待確認
-    const { data: existing } = await supabase
-      .from('organization_invites')
-      .select('id')
-      .eq('organization_id', profile.organization_id)
-      .eq('email', email)
-      .is('accepted_at', null)
-      .gt('expires_at', new Date().toISOString())
-      .single();
-
-    if (existing) {
-      return NextResponse.json({ error: 'Active invite already exists for this email' }, { status: 400 });
-    }
-
-    // 既存ユーザー確認（auth.usersはRLSで取れないので、emailでの既存チェックは省略）
-
-    // 招待トークン生成
-    const token = crypto.randomBytes(32).toString('hex');
-    const expiresAt = new Date();
-    expiresAt.setDate(expiresAt.getDate() + 7); // 7日間有効
-
-    const { data, error } = await supabase
-      .from('organization_invites')
-      .insert({
-        organization_id: profile.organization_id,
-        email,
-        role,
-        department_id: departmentId || null,
-        token,
-        expires_at: expiresAt.toISOString(),
-        created_by: user.id,
-      })
-      .select()
-      .single();
-
-    if (error) throw error;
-
-    // 招待リンク生成
-    const inviteUrl = `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/invite/${token}`;
-
-    return NextResponse.json({
-      success: true,
-      invite: {
-        id: data.id,
-        email: data.email,
-        inviteUrl,
-        expiresAt: data.expires_at,
-      },
-    });
-
-  } catch (error: any) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: { code: 'INVALID_BODY', message: 'リクエストボディが不正です' } }, { status: 400 });
   }
+
+  const { email, role = 'member', custom_message } = body;
+
+  if (!email) {
+    return NextResponse.json({ error: { code: 'INVALID_BODY', message: 'email は必須です' } }, { status: 400 });
+  }
+  if (!['admin', 'member'].includes(role)) {
+    return NextResponse.json({ error: { code: 'INVALID_BODY', message: 'role は admin または member のみ' } }, { status: 400 });
+  }
+
+  // create_org_invite RPC 呼び出し (既存 pending は RPC 内で revoke)
+  const { data: invite, error: rpcError } = await supabase.rpc('create_org_invite', {
+    p_organization_id: profile.organization_id,
+    p_email: email.toLowerCase(),
+    p_role: role as 'admin' | 'member',
+    p_custom_message: custom_message,
+  });
+
+  if (rpcError) {
+    const { code, status } = mapPgErrorToHttp(rpcError.message);
+    return NextResponse.json({ error: { code, message: rpcError.message } }, { status });
+  }
+
+  if (!invite) {
+    return NextResponse.json({ error: { code: 'RPC_FAILED', message: '招待の作成に失敗しました' } }, { status: 500 });
+  }
+
+  const inviteRow = invite as {
+    id: string;
+    token: string;
+    email: string;
+    invited_role: string;
+    status: string;
+    expires_at: string;
+    custom_message: string | null;
+    organization_id: string | null;
+  };
+
+  const baseUrl = process.env.NEXT_PUBLIC_INVITE_BASE_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+  const inviteUrl = `${baseUrl}/invite/${inviteRow.token}`;
+
+  // 組織名を取得
+  const { data: orgData } = await supabase
+    .from('organizations')
+    .select('name')
+    .eq('id', profile.organization_id)
+    .single();
+
+  // 既存ユーザー判定: auth.admin.listUsers は service_role 専用のため
+  // get_invite_details の is_existing_user フィールドを使用
+  const { data: inviteDetails } = await supabase.rpc('get_invite_details', {
+    p_token: inviteRow.token,
+  });
+
+  const isExistingUser = (inviteDetails as Record<string, unknown> | null)?.is_existing_user === true;
+
+  const expiresDate = inviteRow.expires_at.substring(0, 10); // 'YYYY-MM-DD'
+  const inviterName = profile.nickname ?? user.email?.split('@')[0] ?? '招待者';
+  const scopeName = orgData?.name ?? '組織';
+
+  const emailVars: InviteEmailVars = {
+    display_name: null,
+    email_address: email.toLowerCase(),
+    inviter_name: inviterName,
+    scope_name: scopeName,
+    invite_url: inviteUrl,
+    expires_at: expiresDate,
+    custom_message: custom_message ?? null,
+  };
+
+  // Resend 送信 (失敗時は warn のみ — 招待 row は残す)
+  try {
+    const envelope = isExistingUser
+      ? renderOrgInviteExistingEmail(emailVars)
+      : renderOrgInviteNewEmail(emailVars);
+    await sendEmail(envelope);
+  } catch (emailErr) {
+    console.warn('[api/org/invites] メール送信失敗 (招待は有効):', emailErr);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    invite: {
+      id: inviteRow.id,
+      email: inviteRow.email,
+      role: inviteRow.invited_role,
+      status: inviteRow.status,
+      expires_at: inviteRow.expires_at,
+      invite_url: inviteUrl,
+    },
+  });
 }
 
 // 招待削除
 export async function DELETE(request: Request) {
-  const supabase = await createClient();
+  const supabase = createClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
   if (userError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const { data: profile } = await supabase
     .from('user_profiles')
-    .select('organization_id, roles')
+    .select('organization_id, org_role')
     .eq('id', user.id)
     .single();
 
-  if (!profile?.roles?.includes('org_admin') || !profile?.organization_id) {
+  const allowedDeleteRoles = ['owner', 'admin'];
+  if (!profile?.org_role || !allowedDeleteRoles.includes(profile.org_role as string) || !profile?.organization_id) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -2,13 +2,13 @@
 
 // src/app/invite/[token]/page.tsx
 // (設計書 03-ui-spec.md §2 — 5 パターン分岐)
-// P1 が org/family 共通版を作成予定。P3 では family 招待を優先実装。
-// P1 との merge 時: invite_type ('family'|'organization') による分岐を追加。
+// org/family 共通版: invite_type ('family'|'organization') による分岐
 
 import { useState, useEffect, use } from 'react';
 import { useRouter } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { FamilyInviteAcceptModal } from '@/components/membership/FamilyInviteAcceptModal';
+import { InviteLayout } from '@/components/membership/InviteLayout';
 
 interface InviteDetails {
   status: 'pending' | 'accepted' | 'rejected' | 'expired' | 'revoked';
@@ -18,6 +18,7 @@ interface InviteDetails {
   inviter_name: string;
   expires_at: string;
   custom_message: string | null;
+  is_existing_user?: boolean;
 }
 
 type PageProps = {
@@ -34,6 +35,10 @@ export default function InvitePage({ params }: PageProps) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // org accept/reject state
+  const [orgLoading, setOrgLoading] = useState(false);
+  const [orgError, setOrgError] = useState<string | null>(null);
 
   useEffect(() => {
     const init = async () => {
@@ -58,6 +63,58 @@ export default function InvitePage({ params }: PageProps) {
     init();
   }, [token, supabase]);
 
+  // org invite accept
+  const handleOrgAccept = async () => {
+    setOrgError(null);
+    setOrgLoading(true);
+    try {
+      const res = await fetch(`/api/org/invites/${token}/accept`, { method: 'POST' });
+      const json = await res.json();
+      if (!res.ok) {
+        const code = json.error?.code;
+        switch (code) {
+          case 'INVITE_EXPIRED':
+            setOrgError('この招待の期限が切れています。招待者に再送を依頼してください。');
+            break;
+          case 'ALREADY_IN_ORG':
+            setOrgError('既に組織に所属しています。');
+            break;
+          case 'INVITE_ALREADY_USED':
+            setOrgError('この招待は既に使用済みです。');
+            break;
+          case 'INVITE_REVOKED':
+            setOrgError('この招待は取り消されています。');
+            break;
+          case 'INVITE_EMAIL_MISMATCH':
+            setOrgError('招待のメールアドレスと現在のアカウントが一致しません。');
+            break;
+          default:
+            setOrgError(json.error?.message ?? '招待の承諾に失敗しました');
+        }
+        return;
+      }
+      router.push('/org/dashboard');
+    } catch {
+      setOrgError('通信エラーが発生しました');
+    } finally {
+      setOrgLoading(false);
+    }
+  };
+
+  // org invite reject
+  const handleOrgReject = async () => {
+    setOrgLoading(true);
+    try {
+      await fetch(`/api/org/invites/${token}/reject`, { method: 'POST' });
+      router.push('/');
+    } catch {
+      // エラーでも UI 側は遷移
+      router.push('/');
+    } finally {
+      setOrgLoading(false);
+    }
+  };
+
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
@@ -69,21 +126,23 @@ export default function InvitePage({ params }: PageProps) {
   // パターン D: invalid / expired / accepted / rejected / revoked
   if (error || !invite) {
     return (
-      <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center gap-4 p-6">
-        <div className="text-5xl">📩</div>
-        <h1 className="text-xl font-bold text-gray-700">招待が見つかりません</h1>
-        <p className="text-gray-500 text-sm text-center">
-          {error ?? '招待リンクが無効です'}
-        </p>
-        <button
-          onClick={() => router.push('/')}
-          className="mt-2 px-6 py-3 rounded-full bg-green-500 text-white font-medium text-sm"
-        >
-          ホームへ戻る
-        </button>
-      </div>
+      <InviteLayout scope="organization">
+        <div className="max-w-sm w-full rounded-2xl bg-white shadow-lg border border-gray-100 p-6 text-center space-y-4">
+          <div className="text-5xl">📩</div>
+          <h1 className="text-xl font-bold text-gray-700">招待が見つかりません</h1>
+          <p className="text-gray-500 text-sm">{error ?? '招待リンクが無効です'}</p>
+          <button
+            onClick={() => router.push('/')}
+            className="w-full rounded-full bg-gray-200 py-3 text-gray-600 font-medium text-sm hover:bg-gray-300 transition-colors"
+          >
+            ホームへ戻る
+          </button>
+        </div>
+      </InviteLayout>
     );
   }
+
+  const scope = invite.invite_type === 'family' ? 'family' : 'organization';
 
   if (invite.status !== 'pending') {
     const statusMessages: Record<string, string> = {
@@ -93,52 +152,47 @@ export default function InvitePage({ params }: PageProps) {
       revoked: '取り消し済み',
     };
     return (
-      <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center gap-4 p-6">
-        <div className="text-5xl">📩</div>
-        <h1 className="text-xl font-bold text-gray-700">招待は無効です</h1>
-        <p className="text-gray-500 text-sm text-center">
-          この招待は{statusMessages[invite.status] ?? invite.status}です
-        </p>
-        <button
-          onClick={() => router.push('/')}
-          className="mt-2 px-6 py-3 rounded-full bg-gray-200 text-gray-600 font-medium text-sm"
-        >
-          ホームへ戻る
-        </button>
-      </div>
+      <InviteLayout scope={scope}>
+        <div className="max-w-sm w-full rounded-2xl bg-white shadow-lg border border-gray-100 p-6 text-center space-y-4">
+          <div className="text-5xl">📩</div>
+          <h1 className="text-xl font-bold text-gray-700">招待は無効です</h1>
+          <p className="text-gray-500 text-sm">
+            この招待は{statusMessages[invite.status] ?? invite.status}です
+          </p>
+          <p className="text-xs text-gray-400">招待者に再発行を依頼してください</p>
+          <button
+            onClick={() => router.push('/')}
+            className="w-full rounded-full bg-gray-200 py-3 text-gray-600 font-medium text-sm hover:bg-gray-300 transition-colors"
+          >
+            ホームへ戻る
+          </button>
+        </div>
+      </InviteLayout>
     );
   }
 
   // パターン A: pending + 未ログイン
   if (!isLoggedIn) {
     return (
-      <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-6">
+      <InviteLayout scope={scope} scopeName={invite.scope_name} inviterName={invite.inviter_name} expiresAt={invite.expires_at}>
         <div className="max-w-sm w-full rounded-2xl bg-white shadow-lg border border-gray-100 overflow-hidden">
           <div className="bg-green-50 px-6 py-5 border-b border-green-100">
             <div className="text-3xl mb-2">🏠</div>
             <h1 className="text-lg font-bold text-gray-900">ほめゴハン 招待</h1>
           </div>
           <div className="px-6 py-5 space-y-4">
-            <p className="text-sm text-gray-700">
-              <span className="font-medium">{invite.inviter_name}</span> 様から
-              「<span className="font-medium">{invite.scope_name}</span>」
-              {invite.invite_type === 'family' ? '家族グループ' : '組織'}への招待が届いています
-            </p>
-            <p className="text-xs text-gray-400">
-              期限: {new Date(invite.expires_at).toLocaleDateString('ja-JP')} まで
-            </p>
             <p className="text-sm text-gray-500">
               この招待を承諾するにはログインまたはアカウント作成が必要です
             </p>
             <div className="space-y-2">
               <button
-                onClick={() => router.push(`/login?redirect=/invite/${token}`)}
+                onClick={() => router.push(`/login?redirect=/invite/${token}&email=${encodeURIComponent(invite.email)}`)}
                 className="w-full rounded-full bg-green-500 py-3 text-white font-bold text-sm hover:bg-green-600 transition-colors"
               >
                 ログインする
               </button>
               <button
-                onClick={() => router.push(`/signup?redirect=/invite/${token}`)}
+                onClick={() => router.push(`/signup?redirect=/invite/${token}&email=${encodeURIComponent(invite.email)}`)}
                 className="w-full rounded-full border border-green-300 py-3 text-green-600 font-medium text-sm hover:bg-green-50 transition-colors"
               >
                 アカウントを作成
@@ -146,36 +200,32 @@ export default function InvitePage({ params }: PageProps) {
             </div>
           </div>
         </div>
-      </div>
+      </InviteLayout>
     );
   }
 
   // パターン C: pending + ログイン中 + email 不一致
   if (currentEmail && invite.email !== currentEmail) {
     return (
-      <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-6">
-        <div className="max-w-sm w-full rounded-2xl bg-white shadow-lg border border-gray-100 overflow-hidden">
-          <div className="px-6 py-6 space-y-4">
-            <h1 className="text-lg font-bold text-gray-900">この招待は他の方宛てです</h1>
-            <div className="text-sm text-gray-600 space-y-1">
-              <p>招待先: <span className="font-medium">{invite.email}</span></p>
-              <p>あなた: <span className="font-medium">{currentEmail}</span></p>
-            </div>
-            <p className="text-sm text-gray-500">
-              正しいアカウントでログインし直してください
-            </p>
-            <button
-              onClick={async () => {
-                await supabase.auth.signOut();
-                router.push(`/login?redirect=/invite/${token}`);
-              }}
-              className="w-full rounded-full bg-gray-700 py-3 text-white font-medium text-sm hover:bg-gray-800 transition-colors"
-            >
-              ログアウトしてやり直す
-            </button>
+      <InviteLayout scope={scope}>
+        <div className="max-w-sm w-full rounded-2xl bg-white shadow-lg border border-gray-100 p-6 space-y-4">
+          <h1 className="text-lg font-bold text-gray-900">この招待は他の方宛てです</h1>
+          <div className="text-sm text-gray-600 space-y-1">
+            <p>招待先: <span className="font-medium">{invite.email}</span></p>
+            <p>あなた: <span className="font-medium">{currentEmail}</span></p>
           </div>
+          <p className="text-sm text-gray-500">正しいアカウントでログインし直してください</p>
+          <button
+            onClick={async () => {
+              await supabase.auth.signOut();
+              router.push(`/login?redirect=/invite/${token}`);
+            }}
+            className="w-full rounded-full bg-gray-700 py-3 text-white font-medium text-sm hover:bg-gray-800 transition-colors"
+          >
+            ログアウトしてやり直す
+          </button>
         </div>
-      </div>
+      </InviteLayout>
     );
   }
 
@@ -196,20 +246,65 @@ export default function InvitePage({ params }: PageProps) {
     );
   }
 
-  // org 招待 (P1 が実装予定 — フォールバック)
+  // パターン B: pending + ログイン中 + email 一致 (organization)
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center gap-4 p-6">
-      <div className="text-5xl">🏢</div>
-      <h1 className="text-xl font-bold text-gray-700">組織への招待</h1>
-      <p className="text-gray-500 text-sm text-center">
-        「{invite.scope_name}」からの招待です (P1 で実装予定)
-      </p>
-      <button
-        onClick={() => router.push('/')}
-        className="mt-2 px-6 py-3 rounded-full bg-gray-200 text-gray-600 font-medium text-sm"
-      >
-        ホームへ戻る
-      </button>
-    </div>
+    <InviteLayout scope="organization" scopeName={invite.scope_name} inviterName={invite.inviter_name} expiresAt={invite.expires_at}>
+      <div className="max-w-sm w-full rounded-2xl bg-white shadow-lg border border-gray-100 overflow-hidden">
+        <div className="bg-blue-50 px-6 py-5 border-b border-blue-100">
+          <div className="text-3xl mb-2">🏢</div>
+          <h2 className="text-lg font-bold text-gray-900">
+            {invite.scope_name}への招待
+          </h2>
+          <p className="text-sm text-gray-500 mt-1">
+            {invite.inviter_name} 様から招待が届いています
+          </p>
+        </div>
+
+        <div className="px-6 py-5 space-y-5">
+          {invite.custom_message && (
+            <div className="rounded-xl bg-gray-50 p-3 text-sm text-gray-600 italic">
+              「{invite.custom_message}」
+            </div>
+          )}
+
+          <p className="text-xs text-gray-400">
+            期限: {new Date(invite.expires_at).toLocaleDateString('ja-JP')} まで
+          </p>
+
+          {orgError && (
+            <div className="rounded-xl bg-red-50 border border-red-200 p-3 text-xs text-red-600">
+              {orgError}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <button
+              onClick={handleOrgAccept}
+              disabled={orgLoading}
+              className="w-full rounded-full bg-blue-600 py-3 text-white font-bold text-sm hover:bg-blue-700 transition-colors disabled:opacity-50"
+            >
+              {orgLoading ? '処理中…' : '承諾する'}
+            </button>
+
+            <div className="flex gap-2">
+              <button
+                onClick={handleOrgReject}
+                disabled={orgLoading}
+                className="flex-1 rounded-full border border-red-200 py-3 text-red-500 font-medium text-sm hover:bg-red-50 transition-colors disabled:opacity-50"
+              >
+                拒否する
+              </button>
+              <button
+                onClick={() => router.push('/')}
+                disabled={orgLoading}
+                className="flex-1 rounded-full border border-gray-200 py-3 text-gray-500 font-medium text-sm hover:bg-gray-50 transition-colors disabled:opacity-50"
+              >
+                後で
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </InviteLayout>
   );
 }

--- a/src/components/membership/InviteLayout.tsx
+++ b/src/components/membership/InviteLayout.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+// src/components/membership/InviteLayout.tsx
+// (設計書 03-ui-spec.md §2.2)
+// 共通レイアウト: scope_name / role / invited_by_name / expires_at 表示
+
+import { type ReactNode } from 'react';
+
+interface InviteLayoutProps {
+  scope: 'organization' | 'family';
+  scopeName?: string;
+  inviterName?: string;
+  role?: string;
+  expiresAt?: string;
+  children: ReactNode;
+}
+
+export function InviteLayout({
+  scope,
+  scopeName,
+  inviterName,
+  expiresAt,
+  children,
+}: InviteLayoutProps) {
+  const scopeLabel = scope === 'organization' ? '組織' : '家族グループ';
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      {/* ヘッダー */}
+      <header className="bg-white border-b border-gray-100 px-6 py-4 flex items-center gap-3">
+        <span className="text-2xl">🍚</span>
+        <h1 className="text-base font-bold text-gray-900">ほめゴハン 招待</h1>
+      </header>
+
+      {/* メインコンテンツ */}
+      <main className="flex-1 flex flex-col items-center justify-center p-6">
+        {scopeName && inviterName && (
+          <div className="max-w-sm w-full mb-4 text-center text-sm text-gray-500">
+            <span className="font-medium text-gray-700">{inviterName}</span> 様から
+            「<span className="font-medium text-gray-700">{scopeName}</span>」
+            {scopeLabel}への招待が届いています
+          </div>
+        )}
+
+        {children}
+
+        {expiresAt && (
+          <p className="mt-4 text-xs text-gray-400 text-center">
+            期限: {new Date(expiresAt).toLocaleDateString('ja-JP')} まで
+          </p>
+        )}
+      </main>
+
+      {/* フッター */}
+      <footer className="py-6 text-center text-xs text-gray-400 border-t border-gray-100">
+        <p>
+          不正利用のおそれがある場合は{' '}
+          <a href="mailto:support@homegohan.app" className="underline">
+            support@homegohan.app
+          </a>{' '}
+          までご連絡ください
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/src/lib/emails/membership/org-invite-existing.ts
+++ b/src/lib/emails/membership/org-invite-existing.ts
@@ -1,0 +1,34 @@
+// src/lib/emails/membership/org-invite-existing.ts
+// (設計書 04-email-templates.md §2)
+import type { InviteEmailVars } from './templates';
+import type { EmailEnvelope } from '@/lib/emails/send';
+
+export function renderOrgInviteExistingEmail(vars: InviteEmailVars): EmailEnvelope {
+  const greeting = vars.display_name ?? vars.email_address;
+  const customSection = vars.custom_message
+    ? `\n${vars.inviter_name} 様からのメッセージ:\n「${vars.custom_message}」\n`
+    : '';
+
+  return {
+    to: vars.email_address,
+    from: 'ほめゴハン <noreply@homegohan.app>',
+    subject: `[ほめゴハン] ${vars.scope_name} からメンバー招待が届きました`,
+    text: `${greeting} 様
+
+${vars.scope_name} の ${vars.inviter_name} 様から、ほめゴハンの組織メンバーとして招待が届きました。
+${customSection}
+▼ 招待を承諾する
+${vars.invite_url}
+
+このリンクは ${vars.expires_at} まで有効です。
+期限切れの場合は、招待者に再送を依頼してください。
+
+心当たりのない場合はこのメールを無視してください。
+不正利用のおそれがある場合は support@homegohan.app までご連絡ください。
+
+─────────────────
+ほめゴハン
+https://homegohan.app
+`,
+  };
+}

--- a/src/lib/emails/membership/org-invite-new.ts
+++ b/src/lib/emails/membership/org-invite-new.ts
@@ -1,0 +1,35 @@
+// src/lib/emails/membership/org-invite-new.ts
+// (設計書 04-email-templates.md §3)
+import type { InviteEmailVars } from './templates';
+import type { EmailEnvelope } from '@/lib/emails/send';
+
+export function renderOrgInviteNewEmail(vars: InviteEmailVars): EmailEnvelope {
+  const customSection = vars.custom_message
+    ? `\n${vars.inviter_name} 様からのメッセージ:\n「${vars.custom_message}」\n`
+    : '';
+
+  return {
+    to: vars.email_address,
+    from: 'ほめゴハン <noreply@homegohan.app>',
+    subject: `[ほめゴハン] ${vars.scope_name} があなたを招待しています — アカウントを作成して参加`,
+    text: `${vars.email_address} 様
+
+${vars.scope_name} の ${vars.inviter_name} 様からほめゴハンへのご招待が届きました。
+
+ほめゴハンは、栄養管理と健康記録をサポートするサービスです。
+下記リンクからアカウントを作成して、組織メンバーとして参加できます。
+${customSection}
+▼ アカウントを作成して招待を承諾する
+${vars.invite_url}
+
+このリンクは ${vars.expires_at} まで有効です。
+
+心当たりのない場合はこのメールを無視してください。
+不正利用のおそれがある場合は support@homegohan.app までご連絡ください。
+
+─────────────────
+ほめゴハン
+https://homegohan.app
+`,
+  };
+}


### PR DESCRIPTION
## Summary

- **A. /invite/[token] ページ**: org 招待の accept/reject ボタンを実装。既存の family 分岐はそのまま維持。`InviteLayout` 共通コンポーネントを採用
- **B. API routes**: `accept_org_invite` / `reject_org_invite` / `revoke_org_invite` RPC を呼ぶ 3 エンドポイント新規作成
- **C. POST /api/org/invites 改修**: `create_org_invite` RPC 経由に書き換え、`get_invite_details` で既存ユーザー判定し Resend でメール送信 (失敗時 warn のみ)
- **D. Resend テンプレ**: `org-invite-existing.ts` / `org-invite-new.ts` を新規作成 (設計書 04 準拠)
- **E. /org/invites ページ**: revoke API 使用、status 表示改善、custom_message フォーム追加

## Test plan

- [ ] `npm run typecheck` — 0 errors (確認済)
- [ ] `npm run lint` — 既存の test ファイル由来の 3 errors のみ (新規ファイルは 0 errors)
- [ ] `/invite/{token}` で org 招待の 5 パターン手動確認
- [ ] `/api/org/invites` POST で招待作成 + メール送信確認
- [ ] `/api/org/invites/{token}/accept` で承諾 → org/dashboard redirect
- [ ] `/api/org/invites/{id}/revoke` で取消 → status=revoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)