### PR TITLE
feat(membership): P6 運営管理者 緊急介入 UI + API

### DIFF
--- a/src/app/(operator)/operator/membership/audit/page.tsx
+++ b/src/app/(operator)/operator/membership/audit/page.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+/**
+ * /operator/membership/audit
+ * membership_audit テーブル一覧 + フィルタ
+ * 05-operator-emergency-ui.md §5.4 準拠
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+
+type AuditRow = {
+  id: string;
+  scope: string;
+  scope_id: string;
+  action: string;
+  actor_id: string | null;
+  target_user_id: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+};
+
+type MetaDetailModalProps = {
+  row: AuditRow;
+  onClose: () => void;
+};
+
+function MetaDetailModal({ row, onClose }: MetaDetailModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-lg mx-4 p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold text-gray-900">監査ログ詳細</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl font-bold">&#215;</button>
+        </div>
+        <dl className="space-y-3 text-sm">
+          <div>
+            <dt className="font-medium text-gray-500">ID</dt>
+            <dd className="text-gray-900 font-mono text-xs">{row.id}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-500">日時</dt>
+            <dd className="text-gray-900">{new Date(row.created_at).toLocaleString('ja-JP')}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-500">Scope / ID</dt>
+            <dd className="text-gray-900">{row.scope} / <span className="font-mono text-xs">{row.scope_id}</span></dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-500">Action</dt>
+            <dd className="text-gray-900">{row.action}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-500">Actor</dt>
+            <dd className="text-gray-900 font-mono text-xs">{row.actor_id ?? '(system)'}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-500">Target User</dt>
+            <dd className="text-gray-900 font-mono text-xs">{row.target_user_id ?? '-'}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-500">Metadata</dt>
+            <dd className="bg-gray-50 rounded p-3 font-mono text-xs whitespace-pre-wrap break-all">
+              {JSON.stringify(row.metadata, null, 2)}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  );
+}
+
+const SCOPE_OPTIONS = [
+  { value: '', label: 'All' },
+  { value: 'organization', label: '組織' },
+  { value: 'family', label: '家族' },
+];
+
+const ACTION_OPTIONS = [
+  { value: '', label: 'All' },
+  { value: 'operator_force_owner_transfer', label: 'operator_force_owner_transfer' },
+  { value: 'operator_force_representative_transfer', label: 'operator_force_representative_transfer' },
+  { value: 'operator_force_dissolve', label: 'operator_force_dissolve' },
+  { value: 'invite_accepted', label: 'invite_accepted' },
+  { value: 'member_left', label: 'member_left' },
+  { value: 'owner_transferred', label: 'owner_transferred' },
+  { value: 'representative_transferred', label: 'representative_transferred' },
+];
+
+export default function MembershipAuditPage() {
+  const [rows, setRows] = useState<AuditRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [detailRow, setDetailRow] = useState<AuditRow | null>(null);
+
+  // フィルタ
+  const [scope, setScope] = useState('');
+  const [action, setAction] = useState('');
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [page, setPage] = useState(1);
+  const limit = 50;
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const sp = new URLSearchParams();
+      if (scope) sp.set('scope', scope);
+      if (action) sp.set('action', action);
+      if (from) sp.set('from', from);
+      if (to) sp.set('to', to);
+      sp.set('page', String(page));
+      sp.set('limit', String(limit));
+
+      const res = await fetch(`/api/operator/membership/audit?${sp.toString()}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error?.message ?? `HTTP ${res.status}`);
+      }
+      const json = await res.json();
+      setRows(json.data ?? []);
+      setTotal(json.meta?.total ?? 0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'データ取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, [scope, action, from, to, page]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    setPage(1);
+    fetchData();
+  }
+
+  const totalPages = Math.ceil(total / limit);
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">メンバシップ 監査ログ</h1>
+        <p className="text-sm text-gray-500 mt-1">全ての membership_audit イベントを閲覧できます (super_admin のみ)</p>
+      </div>
+
+      {/* フィルタ */}
+      <form onSubmit={handleSearch} className="bg-white rounded-xl shadow-sm border border-gray-200 p-4 mb-6">
+        <div className="flex flex-wrap items-end gap-4">
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">Scope</label>
+            <select
+              value={scope}
+              onChange={(e) => setScope(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+            >
+              {SCOPE_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">Action</label>
+            <select
+              value={action}
+              onChange={(e) => setAction(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+            >
+              {ACTION_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label || 'All'}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">From</label>
+            <input
+              type="date"
+              value={from}
+              onChange={(e) => setFrom(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">To</label>
+            <input
+              type="date"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+            />
+          </div>
+          <button
+            type="submit"
+            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700"
+          >
+            検索
+          </button>
+          <button
+            type="button"
+            onClick={() => { setScope(''); setAction(''); setFrom(''); setTo(''); setPage(1); }}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
+          >
+            リセット
+          </button>
+        </div>
+      </form>
+
+      {/* テーブル */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+        {loading && (
+          <div className="flex items-center justify-center py-12 text-gray-500 text-sm">
+            読み込み中...
+          </div>
+        )}
+
+        {error && (
+          <div className="p-4 text-red-700 text-sm">{error}</div>
+        )}
+
+        {!loading && !error && rows.length === 0 && (
+          <div className="flex items-center justify-center py-12 text-gray-500 text-sm">
+            ログがありません
+          </div>
+        )}
+
+        {!loading && !error && rows.length > 0 && (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-200 text-left text-gray-500 bg-gray-50">
+                    <th className="px-4 py-3 font-medium">日時</th>
+                    <th className="px-4 py-3 font-medium">Scope</th>
+                    <th className="px-4 py-3 font-medium">Action</th>
+                    <th className="px-4 py-3 font-medium">Actor</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {rows.map((row) => {
+                    const isOperator = row.action.startsWith('operator_force');
+                    const operatorId = isOperator
+                      ? (row.metadata.operator_id as string | undefined)
+                      : null;
+                    return (
+                      <tr
+                        key={row.id}
+                        className="hover:bg-gray-50 cursor-pointer"
+                        onClick={() => setDetailRow(row)}
+                      >
+                        <td className="px-4 py-3 text-gray-600 whitespace-nowrap">
+                          {new Date(row.created_at).toLocaleString('ja-JP')}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+                            row.scope === 'organization'
+                              ? 'bg-blue-100 text-blue-700'
+                              : 'bg-green-100 text-green-700'
+                          }`}>
+                            {row.scope === 'organization' ? '組織' : '家族'}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-gray-900 font-mono text-xs">{row.action}</td>
+                        <td className="px-4 py-3 text-gray-600 text-xs">
+                          {isOperator ? (
+                            <span className="text-orange-600 font-medium">
+                              [SYS] op:{operatorId ? operatorId.slice(0, 8) : '?'}
+                            </span>
+                          ) : row.actor_id ? (
+                            <span className="font-mono">{row.actor_id.slice(0, 8)}...</span>
+                          ) : (
+                            <span className="text-gray-400">-</span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            {/* ページネーション */}
+            <div className="flex items-center justify-between px-4 py-3 border-t border-gray-200">
+              <p className="text-xs text-gray-500">全 {total} 件 / {page} / {totalPages} ページ</p>
+              <div className="flex gap-2">
+                <button
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => p - 1)}
+                  className="px-3 py-1.5 text-xs font-medium text-gray-700 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+                >
+                  前へ
+                </button>
+                <button
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                  className="px-3 py-1.5 text-xs font-medium text-gray-700 border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-50"
+                >
+                  次へ
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {detailRow && (
+        <MetaDetailModal row={detailRow} onClose={() => setDetailRow(null)} />
+      )}
+    </div>
+  );
+}

--- a/src/app/(operator)/operator/membership/families/[id]/transfer/page.tsx
+++ b/src/app/(operator)/operator/membership/families/[id]/transfer/page.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+/**
+ * /operator/membership/families/[id]/transfer
+ * 家族グループ代表者強制譲渡画面
+ * 05-operator-emergency-ui.md §5.3 準拠
+ */
+
+import { useState, useEffect, useCallback, use } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import ForceActionConfirmModal from '@/components/operator/membership/ForceActionConfirmModal';
+
+type Candidate = {
+  id: string;
+  nickname: string | null;
+  role: string;
+  last_login_at: string | null;
+  email: string | null;
+};
+
+function formatLastLogin(v: string | null): string {
+  if (!v) return '未ログイン';
+  try {
+    return new Intl.DateTimeFormat('ja-JP', {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+    }).format(new Date(v));
+  } catch {
+    return v;
+  }
+}
+
+export default function FamilyTransferPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id: familyId } = use(params);
+  const router = useRouter();
+
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [reason, setReason] = useState('');
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const fetchCandidates = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operator/membership/family/${familyId}/candidates`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error?.message ?? `HTTP ${res.status}`);
+      }
+      const json = await res.json();
+      setCandidates(json.data ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'データ取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, [familyId]);
+
+  useEffect(() => { fetchCandidates(); }, [fetchCandidates]);
+
+  const selected = candidates.find((c) => c.id === selectedId);
+
+  async function handleTransferConfirm() {
+    if (!selectedId) return;
+    const res = await fetch(`/api/operator/membership/family/${familyId}/transfer`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ to_user_id: selectedId, reason }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error?.message ?? `HTTP ${res.status}`);
+    }
+    router.push('/operator/membership/families/inactive');
+  }
+
+  const canSubmit = selectedId !== null && reason.trim().length > 0;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href="/operator/membership/families/inactive"
+          className="text-sm text-blue-600 hover:underline"
+        >
+          &#8592; 一覧に戻る
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 mt-2">家族グループ代表者 強制譲渡</h1>
+        <p className="text-sm text-gray-500 mt-1">家族グループ ID: {familyId}</p>
+      </div>
+
+      {loading && (
+        <div className="flex items-center justify-center py-12 text-gray-500 text-sm">
+          候補メンバを読み込み中...
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 p-4 bg-red-50 text-red-700 rounded-lg text-sm">{error}</div>
+      )}
+
+      {!loading && !error && (
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 space-y-6">
+          {/* 候補メンバ一覧 */}
+          <div>
+            <h2 className="text-sm font-semibold text-gray-700 mb-3">新代表者候補</h2>
+            {candidates.length === 0 ? (
+              <p className="text-sm text-gray-500">譲渡可能なメンバがいません</p>
+            ) : (
+              <div className="space-y-2">
+                {candidates.map((c) => (
+                  <label
+                    key={c.id}
+                    className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                      selectedId === c.id
+                        ? 'border-blue-500 bg-blue-50'
+                        : 'border-gray-200 hover:bg-gray-50'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="candidate"
+                      value={c.id}
+                      checked={selectedId === c.id}
+                      onChange={() => setSelectedId(c.id)}
+                      className="text-blue-600"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-gray-900">
+                        {c.email ?? c.nickname ?? c.id}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        {c.role} &mdash; 最終ログイン: {formatLastLogin(c.last_login_at)}
+                      </p>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* 理由入力 */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2">
+              理由 <span className="text-red-500">*</span>
+              <span className="text-xs font-normal text-gray-500 ml-1">(全メンバへの通知メールに記載)</span>
+            </label>
+            <textarea
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={4}
+              className="w-full border border-gray-300 rounded-lg p-3 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-400"
+              placeholder="例: 代表者が90日以上未ログインのため、運営側で次期代表者へ譲渡します。"
+            />
+          </div>
+
+          {/* ボタン */}
+          <div className="flex justify-end gap-3">
+            <Link
+              href="/operator/membership/families/inactive"
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
+            >
+              キャンセル
+            </Link>
+            <button
+              disabled={!canSubmit}
+              onClick={() => setShowConfirm(true)}
+              className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50"
+            >
+              強制譲渡を実行
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showConfirm && selected && (
+        <ForceActionConfirmModal
+          scope="family"
+          scopeName={`家族グループ (${familyId})`}
+          action="transfer"
+          newAssignee={{
+            id: selected.id,
+            label: selected.email ?? selected.nickname ?? selected.id,
+          }}
+          reason={reason}
+          onConfirm={handleTransferConfirm}
+          onCancel={() => setShowConfirm(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(operator)/operator/membership/families/inactive/page.tsx
+++ b/src/app/(operator)/operator/membership/families/inactive/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+/**
+ * /operator/membership/families/inactive
+ * inactive representative を持つ家族グループ一覧
+ * 05-operator-emergency-ui.md §5.2 準拠
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import ForceActionConfirmModal from '@/components/operator/membership/ForceActionConfirmModal';
+import InactiveOwnerTable, { type InactiveOwner } from '@/components/operator/membership/InactiveOwnerTable';
+
+type FamilyRow = {
+  family_id: string;
+  family_name: string;
+  representative_user_id: string;
+  representative_email: string;
+  member_count: number;
+};
+
+function toInactiveOwner(row: FamilyRow): InactiveOwner {
+  return {
+    scope_id: row.family_id,
+    scope_name: row.family_name,
+    owner_id: row.representative_user_id,
+    owner_email: row.representative_email,
+    last_login_at: null,
+  };
+}
+
+export default function InactiveFamiliesPage() {
+  const router = useRouter();
+  const [rows, setRows] = useState<FamilyRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dissolveTarget, setDissolveTarget] = useState<InactiveOwner | null>(null);
+  const [dissolveReason, setDissolveReason] = useState('');
+  const [dissolveConfirm, setDissolveConfirm] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/operator/membership/families/inactive');
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error?.message ?? `HTTP ${res.status}`);
+      }
+      const json = await res.json();
+      setRows(json.data ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'データ取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  function handleDissolveClick(item: InactiveOwner) {
+    setDissolveTarget(item);
+    setDissolveReason('');
+    setDissolveConfirm(false);
+  }
+
+  async function handleDissolveConfirm() {
+    if (!dissolveTarget) return;
+    const res = await fetch(`/api/operator/membership/family/${dissolveTarget.scope_id}/dissolve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: dissolveReason }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error?.message ?? `HTTP ${res.status}`);
+    }
+    setDissolveTarget(null);
+    router.refresh();
+    await fetchData();
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">代表者長期不在の家族グループ</h1>
+          <p className="text-sm text-gray-500 mt-1">30日以上未ログインまたは削除済みアカウントが代表者の家族グループ</p>
+        </div>
+        <button
+          onClick={fetchData}
+          className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
+        >
+          更新
+        </button>
+      </div>
+
+      {loading && (
+        <div className="flex items-center justify-center py-12 text-gray-500 text-sm">
+          読み込み中...
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 p-4 bg-red-50 text-red-700 rounded-lg text-sm">{error}</div>
+      )}
+
+      {!loading && !error && (
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <InactiveOwnerTable
+            items={rows.map(toInactiveOwner)}
+            scope="family"
+            onDissolve={handleDissolveClick}
+          />
+        </div>
+      )}
+
+      {/* 解散理由入力 */}
+      {dissolveTarget && !dissolveConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4 p-6">
+            <h2 className="text-lg font-bold text-gray-900 mb-4">
+              家族グループ解散 — 「{dissolveTarget.scope_name}」
+            </h2>
+            <p className="text-sm text-gray-600 mb-3">
+              解散理由を入力してください (全メンバに通知されます)
+            </p>
+            <textarea
+              value={dissolveReason}
+              onChange={(e) => setDissolveReason(e.target.value)}
+              rows={4}
+              className="w-full border border-gray-300 rounded-lg p-3 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-red-400"
+              placeholder="例: 代表者が90日以上未ログインのため、運営側で解散します。"
+            />
+            <div className="flex justify-end gap-3 mt-4">
+              <button
+                onClick={() => setDissolveTarget(null)}
+                className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+              >
+                キャンセル
+              </button>
+              <button
+                disabled={dissolveReason.trim().length === 0}
+                onClick={() => setDissolveConfirm(true)}
+                className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50"
+              >
+                次へ
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 解散確認 modal */}
+      {dissolveTarget && dissolveConfirm && (
+        <ForceActionConfirmModal
+          scope="family"
+          scopeName={dissolveTarget.scope_name}
+          action="dissolve"
+          reason={dissolveReason}
+          onConfirm={handleDissolveConfirm}
+          onCancel={() => { setDissolveConfirm(false); }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(operator)/operator/membership/layout.tsx
+++ b/src/app/(operator)/operator/membership/layout.tsx
@@ -1,0 +1,115 @@
+/**
+ * /operator/membership layout
+ * super_admin ロールガード + 共通ナビ
+ * docs/design/membership/05-operator-emergency-ui.md §5.1 準拠
+ */
+
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { requireRole } from '@/lib/auth/helpers';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+
+const navItems = [
+  {
+    label: '組織管理',
+    children: [
+      { href: '/operator/membership/orgs/inactive', label: 'inactive owner 検索' },
+    ],
+  },
+  {
+    label: '家族管理',
+    children: [
+      { href: '/operator/membership/families/inactive', label: 'inactive 代表者検索' },
+    ],
+  },
+  {
+    label: '監査',
+    children: [
+      { href: '/operator/membership/audit', label: '監査ログ閲覧' },
+    ],
+  },
+];
+
+export default async function OperatorMembershipLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  try {
+    await requireRole(['super_admin']);
+  } catch (err) {
+    if (err instanceof AuthError || err instanceof ForbiddenError) {
+      redirect('/login?redirect=/operator/membership/orgs/inactive');
+    }
+    throw err;
+  }
+
+  return (
+    <div className="min-h-screen flex bg-slate-50">
+      {/* Sidebar */}
+      <aside className="w-60 bg-slate-900 text-white flex flex-col shadow-xl flex-shrink-0">
+        {/* Header */}
+        <div className="p-5 border-b border-slate-700">
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-lg bg-red-600 flex items-center justify-center text-lg font-bold">
+              M
+            </div>
+            <div>
+              <p className="text-sm font-bold text-white">緊急介入</p>
+              <p className="text-xs text-slate-400">Membership Admin</p>
+            </div>
+          </div>
+        </div>
+
+        {/* 環境バッジ */}
+        {process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ? (
+          <div className="mx-4 mt-3 px-3 py-1 bg-red-600 text-white text-xs font-bold text-center rounded">
+            PROD
+          </div>
+        ) : (
+          <div className="mx-4 mt-3 px-3 py-1 bg-yellow-500 text-black text-xs font-bold text-center rounded">
+            LOCAL / STAGING
+          </div>
+        )}
+
+        {/* Navigation */}
+        <nav className="flex-1 p-4 space-y-4 mt-2">
+          {navItems.map((group) => (
+            <div key={group.label}>
+              <p className="text-xs text-slate-500 px-3 pb-1 uppercase tracking-wider">
+                {group.label}
+              </p>
+              {group.children.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="flex items-center gap-3 px-3 py-2 rounded-lg text-slate-300 hover:text-white hover:bg-slate-700 transition-colors text-sm"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+          ))}
+        </nav>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-slate-700">
+          <Link
+            href="/super-admin/plans"
+            className="flex items-center gap-2 px-3 py-2 text-slate-400 hover:text-white text-sm rounded-lg hover:bg-slate-700 transition-colors"
+          >
+            <span>&#8592;</span>
+            <span>Super Admin に戻る</span>
+          </Link>
+        </div>
+      </aside>
+
+      {/* Main Content */}
+      <main className="flex-1 overflow-y-auto">
+        <div className="p-8 max-w-7xl mx-auto">
+          {children}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/(operator)/operator/membership/orgs/[id]/transfer/page.tsx
+++ b/src/app/(operator)/operator/membership/orgs/[id]/transfer/page.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+/**
+ * /operator/membership/orgs/[id]/transfer
+ * 組織 owner 強制譲渡画面
+ * 05-operator-emergency-ui.md §5.3 準拠
+ */
+
+import { useState, useEffect, useCallback, use } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import ForceActionConfirmModal from '@/components/operator/membership/ForceActionConfirmModal';
+
+type Candidate = {
+  id: string;
+  nickname: string | null;
+  org_role: string | null;
+  last_login_at: string | null;
+  email: string | null;
+};
+
+function formatLastLogin(v: string | null): string {
+  if (!v) return '未ログイン';
+  try {
+    return new Intl.DateTimeFormat('ja-JP', {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+    }).format(new Date(v));
+  } catch {
+    return v;
+  }
+}
+
+export default function OrgTransferPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id: orgId } = use(params);
+  const router = useRouter();
+
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [reason, setReason] = useState('');
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const fetchCandidates = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operator/membership/org/${orgId}/candidates`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error?.message ?? `HTTP ${res.status}`);
+      }
+      const json = await res.json();
+      setCandidates(json.data ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'データ取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId]);
+
+  useEffect(() => { fetchCandidates(); }, [fetchCandidates]);
+
+  const selected = candidates.find((c) => c.id === selectedId);
+
+  async function handleTransferConfirm() {
+    if (!selectedId) return;
+    const res = await fetch(`/api/operator/membership/org/${orgId}/transfer`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ to_user_id: selectedId, reason }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error?.message ?? `HTTP ${res.status}`);
+    }
+    router.push('/operator/membership/orgs/inactive');
+  }
+
+  const canSubmit = selectedId !== null && reason.trim().length > 0;
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href="/operator/membership/orgs/inactive"
+          className="text-sm text-blue-600 hover:underline"
+        >
+          &#8592; 一覧に戻る
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-900 mt-2">組織オーナー 強制譲渡</h1>
+        <p className="text-sm text-gray-500 mt-1">組織 ID: {orgId}</p>
+      </div>
+
+      {loading && (
+        <div className="flex items-center justify-center py-12 text-gray-500 text-sm">
+          候補メンバを読み込み中...
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 p-4 bg-red-50 text-red-700 rounded-lg text-sm">{error}</div>
+      )}
+
+      {!loading && !error && (
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 space-y-6">
+          {/* 候補メンバ一覧 */}
+          <div>
+            <h2 className="text-sm font-semibold text-gray-700 mb-3">新オーナー候補</h2>
+            {candidates.length === 0 ? (
+              <p className="text-sm text-gray-500">譲渡可能なメンバがいません</p>
+            ) : (
+              <div className="space-y-2">
+                {candidates.map((c) => (
+                  <label
+                    key={c.id}
+                    className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                      selectedId === c.id
+                        ? 'border-blue-500 bg-blue-50'
+                        : 'border-gray-200 hover:bg-gray-50'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="candidate"
+                      value={c.id}
+                      checked={selectedId === c.id}
+                      onChange={() => setSelectedId(c.id)}
+                      className="text-blue-600"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-gray-900">
+                        {c.email ?? c.nickname ?? c.id}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        {c.org_role ?? 'member'} &mdash; 最終ログイン: {formatLastLogin(c.last_login_at)}
+                      </p>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* 理由入力 */}
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-2">
+              理由 <span className="text-red-500">*</span>
+              <span className="text-xs font-normal text-gray-500 ml-1">(全メンバへの通知メールに記載)</span>
+            </label>
+            <textarea
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={4}
+              className="w-full border border-gray-300 rounded-lg p-3 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-400"
+              placeholder="例: オーナーが90日以上未ログインのため、運営側で次期オーナーへ譲渡します。"
+            />
+          </div>
+
+          {/* ボタン */}
+          <div className="flex justify-end gap-3">
+            <Link
+              href="/operator/membership/orgs/inactive"
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
+            >
+              キャンセル
+            </Link>
+            <button
+              disabled={!canSubmit}
+              onClick={() => setShowConfirm(true)}
+              className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50"
+            >
+              強制譲渡を実行
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showConfirm && selected && (
+        <ForceActionConfirmModal
+          scope="organization"
+          scopeName={`組織 (${orgId})`}
+          action="transfer"
+          newAssignee={{
+            id: selected.id,
+            label: selected.email ?? selected.nickname ?? selected.id,
+          }}
+          reason={reason}
+          onConfirm={handleTransferConfirm}
+          onCancel={() => setShowConfirm(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(operator)/operator/membership/orgs/inactive/page.tsx
+++ b/src/app/(operator)/operator/membership/orgs/inactive/page.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+/**
+ * /operator/membership/orgs/inactive
+ * inactive owner を持つ組織一覧
+ * 05-operator-emergency-ui.md §5.2 準拠
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import ForceActionConfirmModal from '@/components/operator/membership/ForceActionConfirmModal';
+import InactiveOwnerTable, { type InactiveOwner } from '@/components/operator/membership/InactiveOwnerTable';
+
+type OrgRow = {
+  organization_id: string;
+  organization_name: string;
+  owner_user_id: string;
+  owner_email: string;
+  owner_last_sign_in: string | null;
+  member_count: number;
+  dissolved: boolean;
+};
+
+function toInactiveOwner(row: OrgRow): InactiveOwner {
+  return {
+    scope_id: row.organization_id,
+    scope_name: row.organization_name,
+    owner_id: row.owner_user_id,
+    owner_email: row.owner_email,
+    last_login_at: row.owner_last_sign_in,
+  };
+}
+
+export default function InactiveOrgsPage() {
+  const router = useRouter();
+  const [rows, setRows] = useState<OrgRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dissolveTarget, setDissolveTarget] = useState<InactiveOwner | null>(null);
+  const [dissolveReason, setDissolveReason] = useState('');
+  const [dissolveConfirm, setDissolveConfirm] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/operator/membership/orgs/inactive');
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error?.message ?? `HTTP ${res.status}`);
+      }
+      const json = await res.json();
+      setRows(json.data ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'データ取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  function handleDissolveClick(item: InactiveOwner) {
+    setDissolveTarget(item);
+    setDissolveReason('');
+    setDissolveConfirm(false);
+  }
+
+  async function handleDissolveConfirm() {
+    if (!dissolveTarget) return;
+    const res = await fetch(`/api/operator/membership/org/${dissolveTarget.scope_id}/dissolve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: dissolveReason }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error?.message ?? `HTTP ${res.status}`);
+    }
+    setDissolveTarget(null);
+    router.refresh();
+    await fetchData();
+  }
+
+  const activeRows = rows.filter((r) => !r.dissolved);
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">オーナー長期不在の組織</h1>
+          <p className="text-sm text-gray-500 mt-1">30日以上未ログインまたは削除済みアカウントが owner の組織</p>
+        </div>
+        <button
+          onClick={fetchData}
+          className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
+        >
+          更新
+        </button>
+      </div>
+
+      {loading && (
+        <div className="flex items-center justify-center py-12 text-gray-500 text-sm">
+          読み込み中...
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 p-4 bg-red-50 text-red-700 rounded-lg text-sm">{error}</div>
+      )}
+
+      {!loading && !error && (
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <InactiveOwnerTable
+            items={activeRows.map(toInactiveOwner)}
+            scope="org"
+            onDissolve={handleDissolveClick}
+          />
+        </div>
+      )}
+
+      {/* 解散理由入力 */}
+      {dissolveTarget && !dissolveConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4 p-6">
+            <h2 className="text-lg font-bold text-gray-900 mb-4">
+              組織解散 — 「{dissolveTarget.scope_name}」
+            </h2>
+            <p className="text-sm text-gray-600 mb-3">
+              解散理由を入力してください (全メンバに通知されます)
+            </p>
+            <textarea
+              value={dissolveReason}
+              onChange={(e) => setDissolveReason(e.target.value)}
+              rows={4}
+              className="w-full border border-gray-300 rounded-lg p-3 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-red-400"
+              placeholder="例: オーナーが90日以上未ログインのため、運営側で解散します。"
+            />
+            <div className="flex justify-end gap-3 mt-4">
+              <button
+                onClick={() => setDissolveTarget(null)}
+                className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+              >
+                キャンセル
+              </button>
+              <button
+                disabled={dissolveReason.trim().length === 0}
+                onClick={() => setDissolveConfirm(true)}
+                className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50"
+              >
+                次へ
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 解散確認 modal */}
+      {dissolveTarget && dissolveConfirm && (
+        <ForceActionConfirmModal
+          scope="organization"
+          scopeName={dissolveTarget.scope_name}
+          action="dissolve"
+          reason={dissolveReason}
+          onConfirm={handleDissolveConfirm}
+          onCancel={() => { setDissolveConfirm(false); }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/api/operator/membership/audit/route.ts
+++ b/src/app/api/operator/membership/audit/route.ts
@@ -1,0 +1,73 @@
+/**
+ * GET /api/operator/membership/audit
+ * membership_audit テーブル一覧 + フィルタ
+ * 05-operator-emergency-ui.md §7 準拠
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { requireSuperAdmin } from '@/lib/auth/operator-permissions';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const QuerySchema = z.object({
+  scope: z.enum(['organization', 'family']).optional(),
+  action: z.string().optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  page: z.coerce.number().int().min(1).default(1),
+});
+
+export async function GET(request: NextRequest) {
+  try {
+    await requireSuperAdmin();
+    const supabase = createClient();
+
+    const { searchParams } = new URL(request.url);
+    const parsed = QuerySchema.safeParse(Object.fromEntries(searchParams));
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: { code: 'VALIDATION_ERROR', message: '入力値が不正です', details: parsed.error.flatten() } },
+        { status: 400 },
+      );
+    }
+
+    const { scope, action, from, to, limit, page } = parsed.data;
+
+    let query = supabase
+      .from('membership_audit')
+      .select('*', { count: 'exact' })
+      .order('created_at', { ascending: false })
+      .range((page - 1) * limit, page * limit - 1);
+
+    if (scope) query = query.eq('scope', scope);
+    if (action) query = query.ilike('action', `%${action}%`);
+    if (from) query = query.gte('created_at', from);
+    if (to) query = query.lte('created_at', to + 'T23:59:59Z');
+
+    const { data, error, count } = await query;
+
+    if (error) {
+      return NextResponse.json(
+        { error: { code: 'INTERNAL_ERROR', message: error.message } },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      data: data ?? [],
+      meta: { total: count ?? 0, page, limit },
+    });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: err.message } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'FORBIDDEN', message: err.message } }, { status: 403 });
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message } }, { status: 500 });
+  }
+}

--- a/src/app/api/operator/membership/families/inactive/route.ts
+++ b/src/app/api/operator/membership/families/inactive/route.ts
@@ -1,0 +1,37 @@
+/**
+ * GET /api/operator/membership/families/inactive
+ * inactive representative を持つ家族グループ一覧を返す
+ * 05-operator-emergency-ui.md §7 準拠
+ */
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { requireSuperAdmin } from '@/lib/auth/operator-permissions';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    await requireSuperAdmin();
+    const supabase = createClient();
+
+    const { data, error } = await supabase.rpc('list_families_with_inactive_representative');
+    if (error) {
+      return NextResponse.json(
+        { error: { code: 'INTERNAL_ERROR', message: error.message } },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ data: data ?? [] });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: err.message } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'FORBIDDEN', message: err.message } }, { status: 403 });
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message } }, { status: 500 });
+  }
+}

--- a/src/app/api/operator/membership/family/[id]/candidates/route.ts
+++ b/src/app/api/operator/membership/family/[id]/candidates/route.ts
@@ -1,0 +1,90 @@
+/**
+ * GET /api/operator/membership/family/[id]/candidates
+ * 指定家族グループの transferable メンバ一覧を返す (service_role 経由)
+ * 05-operator-emergency-ui.md §E 準拠
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import { requireSuperAdmin } from '@/lib/auth/operator-permissions';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+
+export const dynamic = 'force-dynamic';
+
+function getServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Supabase service role env missing');
+  return createSupabaseClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    await requireSuperAdmin();
+    const { id: familyId } = params;
+
+    const admin = getServiceRoleClient();
+
+    // adult ロールの active メンバを candidate とする
+    const { data: members, error } = await admin
+      .from('family_members')
+      .select('user_id, role, joined_at')
+      .eq('family_id', familyId)
+      .eq('status', 'active')
+      .in('role', ['adult', 'representative'])
+      .neq('role', 'representative')
+      .order('joined_at', { ascending: true });
+
+    if (error) {
+      return NextResponse.json(
+        { error: { code: 'INTERNAL_ERROR', message: error.message } },
+        { status: 500 },
+      );
+    }
+
+    const userIds = (members ?? []).map((m) => m.user_id);
+
+    // user_profiles からニックネームを取得
+    const { data: profiles } = await admin
+      .from('user_profiles')
+      .select('id, nickname, last_login_at')
+      .in('id', userIds);
+
+    const profileMap: Record<string, { nickname: string | null; last_login_at: string | null }> = {};
+    for (const p of profiles ?? []) {
+      profileMap[p.id] = { nickname: p.nickname, last_login_at: p.last_login_at };
+    }
+
+    // email 取得
+    const { data: authUsers } = await admin.auth.admin.listUsers();
+    const emailMap: Record<string, string> = {};
+    for (const u of authUsers?.users ?? []) {
+      if (userIds.includes(u.id) && u.email) {
+        emailMap[u.id] = u.email;
+      }
+    }
+
+    const candidates = (members ?? []).map((m) => ({
+      id: m.user_id,
+      role: m.role,
+      nickname: profileMap[m.user_id]?.nickname ?? null,
+      email: emailMap[m.user_id] ?? null,
+      last_login_at: profileMap[m.user_id]?.last_login_at ?? null,
+    }));
+
+    return NextResponse.json({ data: candidates });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: err.message } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'FORBIDDEN', message: err.message } }, { status: 403 });
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message } }, { status: 500 });
+  }
+}

--- a/src/app/api/operator/membership/family/[id]/dissolve/route.ts
+++ b/src/app/api/operator/membership/family/[id]/dissolve/route.ts
@@ -1,0 +1,127 @@
+/**
+ * POST /api/operator/membership/family/[id]/dissolve
+ * 家族グループ強制解散
+ * 05-operator-emergency-ui.md §7 準拠
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import { requireSuperAdmin } from '@/lib/auth/operator-permissions';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { sendEmail } from '@/lib/emails/send';
+import { renderForceDissolveEmail } from '@/lib/emails/membership/operator-force-dissolve';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const BodySchema = z.object({
+  reason: z.string().min(1).max(1000),
+});
+
+function getServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Supabase service role env missing');
+  return createSupabaseClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    await requireSuperAdmin();
+    const { id: familyId } = params;
+
+    const body = await req.json().catch(() => null);
+    const parsed = BodySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: { code: 'VALIDATION_ERROR', message: '入力値が不正です', details: parsed.error.flatten() } },
+        { status: 400 },
+      );
+    }
+    const { reason } = parsed.data;
+
+    // 解散前に全メンバ情報を取得
+    const admin = getServiceRoleClient();
+    const { data: preMembers } = await admin
+      .from('family_members')
+      .select('user_id')
+      .eq('family_id', familyId)
+      .eq('status', 'active');
+
+    const { data: preFg } = await admin
+      .from('family_groups')
+      .select('name')
+      .eq('id', familyId)
+      .single();
+
+    const supabase = createClient();
+
+    // RPC 実行
+    const { data: family, error: rpcError } = await supabase.rpc('operator_force_dissolve_family', {
+      p_family_id: familyId,
+      p_reason: reason,
+    });
+
+    if (rpcError) {
+      return NextResponse.json(
+        { error: { code: 'INTERNAL_ERROR', message: rpcError.message } },
+        { status: 500 },
+      );
+    }
+
+    // 通知メール (failed silent)
+    try {
+      const userIds = (preMembers ?? []).map((m) => m.user_id);
+      const { data: authUsers } = await admin.auth.admin.listUsers();
+      const emailMap: Record<string, string> = {};
+      for (const u of authUsers?.users ?? []) {
+        if (userIds.includes(u.id) && u.email) {
+          emailMap[u.id] = u.email;
+        }
+      }
+
+      const { data: profiles } = await admin
+        .from('user_profiles')
+        .select('id, nickname')
+        .in('id', userIds);
+      const nicknameMap: Record<string, string> = {};
+      for (const p of profiles ?? []) {
+        nicknameMap[p.id] = p.nickname ?? '';
+      }
+
+      const familyName = preFg?.name ?? '';
+      const emailTasks = userIds.map((uid) => {
+        const recipientEmail = emailMap[uid];
+        if (!recipientEmail) return Promise.resolve();
+        const envelope = renderForceDissolveEmail({
+          recipient_email: recipientEmail,
+          recipient_name: nicknameMap[uid] ?? null,
+          scope: 'family',
+          scope_name: familyName,
+          reason,
+        });
+        return sendEmail(envelope);
+      });
+
+      await Promise.allSettled(emailTasks);
+    } catch (emailErr) {
+      console.error('[operator/family/dissolve] 通知メール送信失敗 (graceful):', emailErr);
+    }
+
+    return NextResponse.json({ data: family });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: err.message } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'FORBIDDEN', message: err.message } }, { status: 403 });
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message } }, { status: 500 });
+  }
+}

--- a/src/app/api/operator/membership/family/[id]/transfer/route.ts
+++ b/src/app/api/operator/membership/family/[id]/transfer/route.ts
@@ -1,0 +1,143 @@
+/**
+ * POST /api/operator/membership/family/[id]/transfer
+ * 家族代表者強制譲渡
+ * 05-operator-emergency-ui.md §7 準拠
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import { requireSuperAdmin } from '@/lib/auth/operator-permissions';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { sendEmail } from '@/lib/emails/send';
+import { renderForceTransferEmail } from '@/lib/emails/membership/operator-force-transfer';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const BodySchema = z.object({
+  to_user_id: z.string().uuid(),
+  reason: z.string().min(1).max(1000),
+});
+
+function getServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Supabase service role env missing');
+  return createSupabaseClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    await requireSuperAdmin();
+    const { id: familyId } = params;
+
+    const body = await req.json().catch(() => null);
+    const parsed = BodySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: { code: 'VALIDATION_ERROR', message: '入力値が不正です', details: parsed.error.flatten() } },
+        { status: 400 },
+      );
+    }
+    const { to_user_id, reason } = parsed.data;
+
+    const supabase = createClient();
+
+    // RPC 実行
+    const { data: family, error: rpcError } = await supabase.rpc('operator_force_representative_transfer', {
+      p_family_id: familyId,
+      p_new_rep_id: to_user_id,
+      p_reason: reason,
+    });
+
+    if (rpcError) {
+      const code = rpcError.message.includes('TARGET_NOT_IN_FAMILY')
+        ? 'TARGET_NOT_IN_FAMILY'
+        : rpcError.message.includes('NOT_OPERATOR')
+          ? 'FORBIDDEN'
+          : 'INTERNAL_ERROR';
+      return NextResponse.json({ error: { code, message: rpcError.message } }, { status: code === 'FORBIDDEN' ? 403 : 400 });
+    }
+
+    // 通知メール (failed silent)
+    try {
+      const admin = getServiceRoleClient();
+
+      const { data: members } = await admin
+        .from('family_members')
+        .select('user_id')
+        .eq('family_id', familyId)
+        .eq('status', 'active');
+
+      const { data: fg } = await admin
+        .from('family_groups')
+        .select('name, representative_id')
+        .eq('id', familyId)
+        .single();
+
+      const userIds = (members ?? []).map((m) => m.user_id);
+      const { data: authUsers } = await admin.auth.admin.listUsers();
+      const emailMap: Record<string, string> = {};
+      for (const u of authUsers?.users ?? []) {
+        if (userIds.includes(u.id) && u.email) {
+          emailMap[u.id] = u.email;
+        }
+      }
+
+      const { data: profiles } = await admin
+        .from('user_profiles')
+        .select('id, nickname')
+        .in('id', userIds);
+      const nicknameMap: Record<string, string> = {};
+      for (const p of profiles ?? []) {
+        nicknameMap[p.id] = p.nickname ?? '';
+      }
+
+      const familyName = fg?.name ?? '';
+      const oldRepId = fg?.representative_id ?? null;
+      const newOwnerEmail = emailMap[to_user_id] ?? '';
+      const oldOwnerEmail = oldRepId ? (emailMap[oldRepId] ?? '') : '';
+
+      const emailTasks = userIds.map((uid) => {
+        const recipientEmail = emailMap[uid];
+        if (!recipientEmail) return Promise.resolve();
+
+        let role: 'old_owner' | 'new_owner' | 'member' = 'member';
+        if (uid === oldRepId) role = 'old_owner';
+        if (uid === to_user_id) role = 'new_owner';
+
+        const envelope = renderForceTransferEmail({
+          recipient_email: recipientEmail,
+          recipient_name: nicknameMap[uid] ?? null,
+          scope: 'family',
+          scope_name: familyName,
+          old_owner_email: oldOwnerEmail,
+          new_owner_email: newOwnerEmail,
+          reason,
+          recipient_role: role,
+        });
+        return sendEmail(envelope);
+      });
+
+      await Promise.allSettled(emailTasks);
+    } catch (emailErr) {
+      console.error('[operator/family/transfer] 通知メール送信失敗 (graceful):', emailErr);
+    }
+
+    return NextResponse.json({ data: family });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: err.message } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'FORBIDDEN', message: err.message } }, { status: 403 });
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message } }, { status: 500 });
+  }
+}

--- a/src/app/api/operator/membership/org/[id]/candidates/route.ts
+++ b/src/app/api/operator/membership/org/[id]/candidates/route.ts
@@ -1,0 +1,80 @@
+/**
+ * GET /api/operator/membership/org/[id]/candidates
+ * 指定組織の transferable メンバ一覧を返す (service_role 経由)
+ * 05-operator-emergency-ui.md §E 準拠
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import { requireSuperAdmin } from '@/lib/auth/operator-permissions';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+
+export const dynamic = 'force-dynamic';
+
+function getServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('Supabase service role env missing');
+  }
+  return createSupabaseClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    await requireSuperAdmin();
+    const { id: orgId } = params;
+
+    const admin = getServiceRoleClient();
+
+    const { data, error } = await admin
+      .from('user_profiles')
+      .select('id, nickname, org_role, last_login_at')
+      .eq('organization_id', orgId)
+      .neq('org_role', 'owner')
+      .order('last_login_at', { ascending: false, nullsFirst: false });
+
+    if (error) {
+      return NextResponse.json(
+        { error: { code: 'INTERNAL_ERROR', message: error.message } },
+        { status: 500 },
+      );
+    }
+
+    // auth.users からメールアドレスを取得
+    const userIds = (data ?? []).map((r) => r.id);
+    const emailMap: Record<string, string> = {};
+
+    if (userIds.length > 0) {
+      const { data: authUsers } = await admin.auth.admin.listUsers();
+      for (const u of authUsers?.users ?? []) {
+        if (userIds.includes(u.id) && u.email) {
+          emailMap[u.id] = u.email;
+        }
+      }
+    }
+
+    const candidates = (data ?? []).map((row) => ({
+      id: row.id,
+      nickname: row.nickname,
+      org_role: row.org_role,
+      last_login_at: row.last_login_at,
+      email: emailMap[row.id] ?? null,
+    }));
+
+    return NextResponse.json({ data: candidates });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: err.message } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'FORBIDDEN', message: err.message } }, { status: 403 });
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message } }, { status: 500 });
+  }
+}

--- a/src/app/api/operator/membership/org/[id]/dissolve/route.ts
+++ b/src/app/api/operator/membership/org/[id]/dissolve/route.ts
@@ -1,0 +1,121 @@
+/**
+ * POST /api/operator/membership/org/[id]/dissolve
+ * 組織強制解散
+ * 05-operator-emergency-ui.md §7 準拠
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import { requireSuperAdmin } from '@/lib/auth/operator-permissions';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { sendEmail } from '@/lib/emails/send';
+import { renderForceDissolveEmail } from '@/lib/emails/membership/operator-force-dissolve';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const BodySchema = z.object({
+  reason: z.string().min(1).max(1000),
+});
+
+function getServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Supabase service role env missing');
+  return createSupabaseClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    await requireSuperAdmin();
+    const { id: orgId } = params;
+
+    const body = await req.json().catch(() => null);
+    const parsed = BodySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: { code: 'VALIDATION_ERROR', message: '入力値が不正です', details: parsed.error.flatten() } },
+        { status: 400 },
+      );
+    }
+    const { reason } = parsed.data;
+
+    // 解散前に全メンバ情報を取得 (解散後は取得困難)
+    const admin = getServiceRoleClient();
+    const { data: preMembers } = await admin
+      .from('user_profiles')
+      .select('id, nickname')
+      .eq('organization_id', orgId);
+
+    const { data: preOrg } = await admin
+      .from('organizations')
+      .select('name')
+      .eq('id', orgId)
+      .single();
+
+    const supabase = createClient();
+
+    // RPC 実行
+    const { data: org, error: rpcError } = await supabase.rpc('operator_force_dissolve_org', {
+      p_organization_id: orgId,
+      p_reason: reason,
+    });
+
+    if (rpcError) {
+      return NextResponse.json(
+        { error: { code: 'INTERNAL_ERROR', message: rpcError.message } },
+        { status: 500 },
+      );
+    }
+
+    // 通知メール (failed silent)
+    try {
+      const userIds = (preMembers ?? []).map((m) => m.id);
+      const { data: authUsers } = await admin.auth.admin.listUsers();
+      const emailMap: Record<string, string> = {};
+      const nicknameMap: Record<string, string> = {};
+      for (const m of preMembers ?? []) {
+        nicknameMap[m.id] = m.nickname ?? '';
+      }
+      for (const u of authUsers?.users ?? []) {
+        if (userIds.includes(u.id) && u.email) {
+          emailMap[u.id] = u.email;
+        }
+      }
+
+      const orgName = preOrg?.name ?? '';
+      const emailTasks = userIds.map((uid) => {
+        const recipientEmail = emailMap[uid];
+        if (!recipientEmail) return Promise.resolve();
+        const envelope = renderForceDissolveEmail({
+          recipient_email: recipientEmail,
+          recipient_name: nicknameMap[uid] ?? null,
+          scope: 'organization',
+          scope_name: orgName,
+          reason,
+        });
+        return sendEmail(envelope);
+      });
+
+      await Promise.allSettled(emailTasks);
+    } catch (emailErr) {
+      console.error('[operator/org/dissolve] 通知メール送信失敗 (graceful):', emailErr);
+    }
+
+    return NextResponse.json({ data: org });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: err.message } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'FORBIDDEN', message: err.message } }, { status: 403 });
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message } }, { status: 500 });
+  }
+}

--- a/src/app/api/operator/membership/org/[id]/transfer/route.ts
+++ b/src/app/api/operator/membership/org/[id]/transfer/route.ts
@@ -1,0 +1,133 @@
+/**
+ * POST /api/operator/membership/org/[id]/transfer
+ * 組織 owner 強制譲渡
+ * 05-operator-emergency-ui.md §7 準拠
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createClient as createSupabaseClient } from '@supabase/supabase-js';
+import { requireSuperAdmin } from '@/lib/auth/operator-permissions';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+import { sendEmail } from '@/lib/emails/send';
+import { renderForceTransferEmail } from '@/lib/emails/membership/operator-force-transfer';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const BodySchema = z.object({
+  to_user_id: z.string().uuid(),
+  reason: z.string().min(1).max(1000),
+});
+
+function getServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Supabase service role env missing');
+  return createSupabaseClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    await requireSuperAdmin();
+    const { id: orgId } = params;
+
+    const body = await req.json().catch(() => null);
+    const parsed = BodySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: { code: 'VALIDATION_ERROR', message: '入力値が不正です', details: parsed.error.flatten() } },
+        { status: 400 },
+      );
+    }
+    const { to_user_id, reason } = parsed.data;
+
+    const supabase = createClient();
+
+    // RPC 実行
+    const { data: org, error: rpcError } = await supabase.rpc('operator_force_owner_transfer', {
+      p_organization_id: orgId,
+      p_new_owner_id: to_user_id,
+      p_reason: reason,
+    });
+
+    if (rpcError) {
+      const code = rpcError.message.includes('TARGET_NOT_IN_ORG')
+        ? 'TARGET_NOT_IN_ORG'
+        : rpcError.message.includes('NOT_OPERATOR')
+          ? 'FORBIDDEN'
+          : 'INTERNAL_ERROR';
+      return NextResponse.json({ error: { code, message: rpcError.message } }, { status: code === 'FORBIDDEN' ? 403 : 400 });
+    }
+
+    // 通知メール (failed silent)
+    try {
+      const admin = getServiceRoleClient();
+
+      // 全メンバ取得
+      const { data: members } = await admin
+        .from('user_profiles')
+        .select('id, nickname')
+        .eq('organization_id', orgId);
+
+      const userIds = (members ?? []).map((m) => m.id);
+      const { data: authUsers } = await admin.auth.admin.listUsers();
+      const emailMap: Record<string, string> = {};
+      const nicknameMap: Record<string, string> = {};
+      for (const m of members ?? []) {
+        nicknameMap[m.id] = m.nickname ?? '';
+      }
+      for (const u of authUsers?.users ?? []) {
+        if (userIds.includes(u.id) && u.email) {
+          emailMap[u.id] = u.email;
+        }
+      }
+
+      // 旧 owner / 新 owner のメール取得
+      const oldOwnerId = (org as { owner_id?: string } | null)?.owner_id;
+      const orgName = (org as { name?: string } | null)?.name ?? '';
+      const newOwnerEmail = emailMap[to_user_id] ?? '';
+      const oldOwnerEmail = oldOwnerId ? (emailMap[oldOwnerId] ?? '') : '';
+
+      const emailTasks = userIds.map((uid) => {
+        const recipientEmail = emailMap[uid];
+        if (!recipientEmail) return Promise.resolve();
+
+        let role: 'old_owner' | 'new_owner' | 'member' = 'member';
+        if (uid === oldOwnerId) role = 'old_owner';
+        if (uid === to_user_id) role = 'new_owner';
+
+        const envelope = renderForceTransferEmail({
+          recipient_email: recipientEmail,
+          recipient_name: nicknameMap[uid] ?? null,
+          scope: 'organization',
+          scope_name: orgName,
+          old_owner_email: oldOwnerEmail,
+          new_owner_email: newOwnerEmail,
+          reason,
+          recipient_role: role,
+        });
+        return sendEmail(envelope);
+      });
+
+      await Promise.allSettled(emailTasks);
+    } catch (emailErr) {
+      console.error('[operator/org/transfer] 通知メール送信失敗 (graceful):', emailErr);
+    }
+
+    return NextResponse.json({ data: org });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: err.message } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'FORBIDDEN', message: err.message } }, { status: 403 });
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message } }, { status: 500 });
+  }
+}

--- a/src/app/api/operator/membership/orgs/inactive/route.ts
+++ b/src/app/api/operator/membership/orgs/inactive/route.ts
@@ -1,0 +1,37 @@
+/**
+ * GET /api/operator/membership/orgs/inactive
+ * inactive owner を持つ組織一覧を返す
+ * 05-operator-emergency-ui.md §7 準拠
+ */
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { requireSuperAdmin } from '@/lib/auth/operator-permissions';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    await requireSuperAdmin();
+    const supabase = createClient();
+
+    const { data, error } = await supabase.rpc('list_orgs_with_inactive_owner');
+    if (error) {
+      return NextResponse.json(
+        { error: { code: 'INTERNAL_ERROR', message: error.message } },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ data: data ?? [] });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: err.message } }, { status: 401 });
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json({ error: { code: 'FORBIDDEN', message: err.message } }, { status: 403 });
+    }
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message } }, { status: 500 });
+  }
+}

--- a/src/components/operator/membership/ForceActionConfirmModal.tsx
+++ b/src/components/operator/membership/ForceActionConfirmModal.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+/**
+ * 強制操作確認 modal
+ * docs/design/membership/05-operator-emergency-ui.md §6.1 準拠
+ */
+
+import { useState } from 'react';
+
+export type ForceActionConfirmModalProps = {
+  scope: 'organization' | 'family';
+  scopeName: string;
+  action: 'transfer' | 'dissolve';
+  newAssignee?: { id: string; label: string };
+  reason: string;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+};
+
+export default function ForceActionConfirmModal({
+  scope,
+  scopeName,
+  action,
+  newAssignee,
+  reason,
+  onConfirm,
+  onCancel,
+}: ForceActionConfirmModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const scopeLabel = scope === 'organization' ? '組織' : '家族グループ';
+  const actionLabel = action === 'transfer' ? '強制譲渡' : '強制解散';
+
+  async function handleConfirm() {
+    setLoading(true);
+    setError(null);
+    try {
+      await onConfirm();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '操作に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4">
+        {/* Header */}
+        <div className="p-6 border-b border-gray-200">
+          <h2 className="text-lg font-bold text-gray-900">確認</h2>
+        </div>
+
+        {/* Body */}
+        <div className="p-6 space-y-4">
+          {action === 'transfer' && newAssignee ? (
+            <p className="text-gray-700">
+              <span className="font-semibold">「{scopeName}」</span> の{scopeLabel}オーナーを
+              <br />
+              <span className="font-semibold text-blue-700">{newAssignee.label}</span> に{actionLabel}します。
+            </p>
+          ) : (
+            <p className="text-gray-700">
+              <span className="font-semibold">「{scopeName}」</span> を{actionLabel}します。
+            </p>
+          )}
+
+          <div className="bg-gray-50 rounded-lg p-3 text-sm text-gray-600">
+            <span className="font-medium">理由:</span> {reason}
+          </div>
+
+          <p className="text-sm text-gray-500">全メンバに通知メールが送信されます。</p>
+          <p className="text-sm font-semibold text-red-600">この操作は取り消せません。</p>
+
+          {error && (
+            <p className="text-sm text-red-600 bg-red-50 rounded p-2">{error}</p>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="p-6 border-t border-gray-200 flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            disabled={loading}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={loading}
+            className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50 flex items-center gap-2"
+          >
+            {loading && (
+              <span className="inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+            )}
+            実行する
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/operator/membership/InactiveOwnerTable.tsx
+++ b/src/components/operator/membership/InactiveOwnerTable.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+/**
+ * inactive owner / representative テーブルコンポーネント
+ * docs/design/membership/05-operator-emergency-ui.md §6.2 準拠
+ */
+
+import Link from 'next/link';
+
+export type InactiveOwner = {
+  scope_id: string;
+  scope_name: string;
+  owner_id: string;
+  owner_email: string;
+  last_login_at: string | null;
+};
+
+type Props = {
+  items: InactiveOwner[];
+  scope: 'org' | 'family';
+  onDissolve?: (item: InactiveOwner) => void;
+};
+
+function formatLastLogin(lastLoginAt: string | null): string {
+  if (!lastLoginAt) return '未ログイン';
+  try {
+    return new Intl.DateTimeFormat('ja-JP', {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+    }).format(new Date(lastLoginAt));
+  } catch {
+    return lastLoginAt;
+  }
+}
+
+export default function InactiveOwnerTable({ items, scope, onDissolve }: Props) {
+  if (items.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-500 text-sm">
+        対象の{scope === 'org' ? '組織' : '家族グループ'}はありません
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200 text-left text-gray-500">
+            <th className="pb-3 pr-4 font-medium">{scope === 'org' ? '組織名' : '家族グループ名'}</th>
+            <th className="pb-3 pr-4 font-medium">{scope === 'org' ? 'オーナー' : '代表者'}</th>
+            <th className="pb-3 pr-4 font-medium">最終ログイン</th>
+            <th className="pb-3 font-medium">操作</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {items.map((item) => (
+            <tr key={item.scope_id} className="hover:bg-gray-50">
+              <td className="py-3 pr-4 font-medium text-gray-900">{item.scope_name}</td>
+              <td className="py-3 pr-4 text-gray-600">{item.owner_email}</td>
+              <td className="py-3 pr-4 text-gray-600">{formatLastLogin(item.last_login_at)}</td>
+              <td className="py-3">
+                <div className="flex items-center gap-2">
+                  <Link
+                    href={`/operator/membership/${scope === 'org' ? 'orgs' : 'families'}/${item.scope_id}/transfer`}
+                    className="px-3 py-1.5 text-xs font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors"
+                  >
+                    対応
+                  </Link>
+                  {onDissolve && (
+                    <button
+                      onClick={() => onDissolve(item)}
+                      className="px-3 py-1.5 text-xs font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 transition-colors"
+                    >
+                      解散
+                    </button>
+                  )}
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/lib/auth/operator-permissions.ts
+++ b/src/lib/auth/operator-permissions.ts
@@ -1,0 +1,88 @@
+/**
+ * 運営管理者 (operator) 権限定義
+ * docs/design/membership/05-operator-emergency-ui.md §1 準拠
+ */
+
+import { createClient } from '@/lib/supabase/server';
+import { AuthError, ForbiddenError } from './errors';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 権限定義
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type OperatorPermission =
+  | 'membership:org:transfer'        // org owner 強制譲渡
+  | 'membership:org:dissolve'        // org 強制解散
+  | 'membership:family:transfer'     // family 代表強制譲渡
+  | 'membership:family:dissolve'     // family 強制解散
+  | 'membership:audit:read';         // 監査ログ閲覧
+
+export const SUPER_ADMIN_PERMISSIONS: OperatorPermission[] = [
+  'membership:org:transfer',
+  'membership:org:dissolve',
+  'membership:family:transfer',
+  'membership:family:dissolve',
+  'membership:audit:read',
+];
+
+/**
+ * ロール配列と要求パーミッションから操作可否を判定する。
+ * super_admin はすべての操作が可能。
+ * admin は監査ログ閲覧のみ可能。
+ */
+export function canOperate(roles: string[], permission: OperatorPermission): boolean {
+  if (roles.includes('super_admin')) return true;
+  if (roles.includes('admin') && permission === 'membership:audit:read') return true;
+  return false;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// サーバーサイド ヘルパー
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 現在の認証ユーザーが super_admin かどうかを確認する。
+ * API Route ハンドラの冒頭で呼び出す。
+ * 未認証なら AuthError (401)、権限不足なら ForbiddenError (403) を throw する。
+ */
+export async function requireSuperAdmin(): Promise<{ userId: string }> {
+  const supabase = createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    throw new AuthError('AUTH_UNAUTHENTICATED', '認証が必要です');
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from('user_profiles')
+    .select('roles')
+    .eq('id', user.id)
+    .single();
+
+  if (profileError || !profile) {
+    throw new AuthError('AUTH_PROFILE_NOT_FOUND', 'プロフィールが見つかりません');
+  }
+
+  const roles: string[] = (profile.roles ?? []) as string[];
+  if (!roles.includes('super_admin')) {
+    throw new ForbiddenError('PERM_DENIED', 'super_admin 権限が必要です');
+  }
+
+  return { userId: user.id };
+}
+
+/**
+ * 指定 userId が super_admin かどうかを boolean で返す。
+ * Server Component や Server Action から使用する。
+ */
+export async function isSuperAdmin(userId: string): Promise<boolean> {
+  const supabase = createClient();
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('roles')
+    .eq('id', userId)
+    .single();
+
+  if (!profile) return false;
+  const roles: string[] = (profile.roles ?? []) as string[];
+  return roles.includes('super_admin');
+}

--- a/src/lib/emails/membership/operator-force-dissolve.ts
+++ b/src/lib/emails/membership/operator-force-dissolve.ts
@@ -1,0 +1,49 @@
+/**
+ * 運営強制解散 通知メールテンプレート
+ * docs/design/membership/05-operator-emergency-ui.md §8 準拠
+ */
+
+import type { EmailEnvelope } from './templates';
+
+export type ForceDissolveEmailVars = {
+  recipient_email: string;
+  recipient_name?: string | null;
+  scope: 'organization' | 'family';
+  scope_name: string;
+  reason: string;
+};
+
+/**
+ * 強制解散 通知メールを構築する。
+ */
+export function renderForceDissolveEmail(vars: ForceDissolveEmailVars): EmailEnvelope {
+  const scopeLabel = vars.scope === 'organization' ? '組織' : '家族グループ';
+  const greeting = vars.recipient_name ?? vars.recipient_email;
+
+  const body = `${greeting} 様
+
+ほめゴハン運営事務局よりご連絡いたします。
+
+あなたが所属していた${scopeLabel}「${vars.scope_name}」が、運営側の判断により解散されました。
+
+▼ 解散理由
+${vars.reason}
+
+メンバーシップは自動的に解除されています。
+今後も引き続きほめゴハンを個人でご利用いただけます。
+
+ご不明な点がございましたら support@homegohan.app までお問い合わせください。
+
+─────────────────
+ほめゴハン
+https://homegohan.app
+`;
+
+  const subjectScope = vars.scope === 'organization' ? '組織' : '家族グループ';
+  return {
+    to: vars.recipient_email,
+    from: 'ほめゴハン <noreply@homegohan.app>',
+    subject: `【ほめゴハン】運営により${subjectScope}「${vars.scope_name}」が解散されました`,
+    text: body,
+  };
+}

--- a/src/lib/emails/membership/operator-force-transfer.ts
+++ b/src/lib/emails/membership/operator-force-transfer.ts
@@ -1,0 +1,101 @@
+/**
+ * 運営強制譲渡 通知メールテンプレート
+ * docs/design/membership/05-operator-emergency-ui.md §8 準拠
+ */
+
+import type { EmailEnvelope } from './templates';
+
+export type ForceTransferEmailVars = {
+  recipient_email: string;
+  recipient_name?: string | null;
+  scope: 'organization' | 'family';
+  scope_name: string;
+  old_owner_email: string;
+  new_owner_email: string;
+  reason: string;
+  /** 受信者の立場 */
+  recipient_role: 'old_owner' | 'new_owner' | 'member';
+};
+
+/**
+ * 強制譲渡 通知メールを構築する。
+ * 旧 owner / 新 owner / 一般メンバで本文を切り替える。
+ */
+export function renderForceTransferEmail(vars: ForceTransferEmailVars): EmailEnvelope {
+  const scopeLabel = vars.scope === 'organization' ? '組織' : '家族グループ';
+  const greeting = vars.recipient_name ?? vars.recipient_email;
+
+  let body: string;
+  switch (vars.recipient_role) {
+    case 'old_owner':
+      body = `${greeting} 様
+
+ほめゴハン運営事務局よりご連絡いたします。
+
+あなたが管理していた${scopeLabel}「${vars.scope_name}」のオーナー権限が、以下の理由により運営側で移譲されました。
+
+▼ 移譲先
+${vars.new_owner_email}
+
+▼ 移譲理由
+${vars.reason}
+
+ご不明な点がございましたら support@homegohan.app までお問い合わせください。
+
+─────────────────
+ほめゴハン
+https://homegohan.app
+`;
+      break;
+
+    case 'new_owner':
+      body = `${greeting} 様
+
+ほめゴハン運営事務局よりご連絡いたします。
+
+${scopeLabel}「${vars.scope_name}」のオーナー権限が、運営側の判断により以下の通りあなたに移譲されました。
+
+▼ 旧オーナー
+${vars.old_owner_email}
+
+▼ 移譲理由
+${vars.reason}
+
+${scopeLabel}の管理をよろしくお願いいたします。
+ご不明な点がございましたら support@homegohan.app までお問い合わせください。
+
+─────────────────
+ほめゴハン
+https://homegohan.app
+`;
+      break;
+
+    default:
+      body = `${greeting} 様
+
+ほめゴハン運営事務局よりご連絡いたします。
+
+あなたが所属する${scopeLabel}「${vars.scope_name}」のオーナーが、運営側の判断により変更されました。
+
+▼ 新オーナー
+${vars.new_owner_email}
+
+▼ 変更理由
+${vars.reason}
+
+ご不明な点がございましたら support@homegohan.app までお問い合わせください。
+
+─────────────────
+ほめゴハン
+https://homegohan.app
+`;
+  }
+
+  const subjectScope = vars.scope === 'organization' ? '組織' : '家族グループ';
+  return {
+    to: vars.recipient_email,
+    from: 'ほめゴハン <noreply@homegohan.app>',
+    subject: `【ほめゴハン】運営により${subjectScope}の所有権が移譲されました`,
+    text: body,
+  };
+}


### PR DESCRIPTION
## Summary

- `requireSuperAdmin()` lib 追加 (super_admin gate / isSuperAdmin boolean)
- `(operator)/operator/membership/` ルートグループ新規作成: layout (super_admin gate + サイドナビ), inactive 一覧 x2, transfer x2, audit
- API ルート 9 本: inactive 一覧 GET x2, candidates GET x2, transfer POST x2, dissolve POST x2, audit GET
- 通知メールテンプレ 2 本 (transfer / dissolve) + Promise.allSettled failed silent 送信
- ForceActionConfirmModal / InactiveOwnerTable 共通コンポーネント

## Test plan

- [ ] typecheck: OK (エラー 0)
- [ ] lint: 新規ファイルに警告・エラーなし (既存 e2e test 3 件の pre-existing エラーのみ)
- [ ] `/operator/membership/orgs/inactive` が super_admin でアクセス可能
- [ ] 非 super_admin は `/login` にリダイレクト
- [ ] 強制譲渡 API: to_user_id + reason で RPC 呼び出し、通知メール並列送信
- [ ] 強制解散 API: reason で RPC 呼び出し、解散前メンバへ通知メール
- [ ] 監査ログページ: scope/action/日付フィルタ、詳細 modal 表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)