### PR TITLE
feat(membership): P2 組織メンバ管理 — 除名/脱退/Owner譲渡

### DIFF
--- a/src/app/(org)/org/members/page.tsx
+++ b/src/app/(org)/org/members/page.tsx
@@ -1,117 +1,216 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { motion, AnimatePresence } from "framer-motion";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import Link from "next/link";
 
 interface Member {
   id: string;
-  nickname: string;
-  role: string;
-  created_at: string;
+  nickname: string | null;
+  org_role: string;
+  joined_org_at: string | null;
+}
+
+interface CurrentUser {
+  id: string;
+  org_role: string;
 }
 
 export default function MembersPage() {
+  const router = useRouter();
+  const supabase = createClient();
   const [members, setMembers] = useState<Member[]>([]);
+  const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
   const [loading, setLoading] = useState(true);
-  const [showAddModal, setShowAddModal] = useState(false);
-  const [form, setForm] = useState({ email: "", password: "", nickname: "" });
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  const [leaving, setLeaving] = useState(false);
 
-  const fetchMembers = async () => {
+  const fetchData = async () => {
     setLoading(true);
-    const res = await fetch('/api/org/members');
-    if (res.ok) {
-      const data = await res.json();
-      setMembers(data.members);
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+
+      const { data: profile } = await supabase
+        .from('user_profiles')
+        .select('org_role, organization_id')
+        .eq('id', user.id)
+        .single();
+
+      if (!profile?.organization_id) {
+        setLoading(false);
+        return;
+      }
+
+      setCurrentUser({ id: user.id, org_role: profile.org_role ?? 'member' });
+
+      const { data: membersData } = await supabase
+        .from('user_profiles')
+        .select('id, nickname, org_role, joined_org_at')
+        .eq('organization_id', profile.organization_id)
+        .order('joined_org_at', { ascending: true });
+
+      setMembers(membersData ?? []);
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   };
 
   useEffect(() => {
-    fetchMembers();
+    fetchData();
   }, []);
 
-  const handleCreate = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsSubmitting(true);
+  const handleRemove = async (memberId: string, memberNickname: string | null) => {
+    if (!confirm(`「${memberNickname ?? 'このメンバー'}」を組織から除名しますか？`)) return;
+    setRemovingId(memberId);
     try {
-      const res = await fetch('/api/org/members', {
+      const res = await fetch(`/api/org/members/${memberId}/remove`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
       });
-
       if (!res.ok) {
         const err = await res.json();
-        throw new Error(err.error);
+        alert(`除名失敗: ${err.error?.message ?? '不明なエラー'}`);
+        return;
       }
-
-      alert("メンバーを作成しました。\nログイン情報を共有してください。");
-      setForm({ email: "", password: "", nickname: "" });
-      setShowAddModal(false);
-      fetchMembers();
-    } catch (error: any) {
-      alert(`作成失敗: ${error.message}`);
+      await fetchData();
     } finally {
-      setIsSubmitting(false);
+      setRemovingId(null);
     }
   };
+
+  const handleLeave = async () => {
+    if (!confirm('組織から脱退しますか？この操作は元に戻せません。')) return;
+    setLeaving(true);
+    try {
+      const res = await fetch('/api/org/leave', { method: 'POST' });
+      if (!res.ok) {
+        const err = await res.json();
+        alert(`脱退失敗: ${err.error?.message ?? '不明なエラー'}`);
+        return;
+      }
+      router.push('/home');
+    } finally {
+      setLeaving(false);
+    }
+  };
+
+  const roleLabel = (role: string) => {
+    switch (role) {
+      case 'owner': return 'オーナー';
+      case 'admin': return '管理者';
+      default: return 'メンバー';
+    }
+  };
+
+  const canRemove = (targetRole: string, targetId: string): boolean => {
+    if (!currentUser) return false;
+    if (targetId === currentUser.id) return false;
+    if (targetRole === 'owner') return false;
+    if (currentUser.org_role === 'owner') return true;
+    if (currentUser.org_role === 'admin' && targetRole === 'member') return true;
+    return false;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="w-10 h-10 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
 
   return (
     <div className="p-8 space-y-8">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Members</h1>
-          <p className="text-gray-500 text-sm">所属メンバーの管理と招待</p>
+          <h1 className="text-2xl font-bold text-gray-900">組織メンバー ({members.length} 名)</h1>
+          <p className="text-gray-500 text-sm">メンバーの管理・除名・脱退</p>
         </div>
-        <Button onClick={() => setShowAddModal(true)} className="bg-blue-600 hover:bg-blue-700 text-white font-bold px-6 rounded-xl shadow-lg shadow-blue-200">
-          + Add Member
-        </Button>
+        <div className="flex gap-3">
+          {currentUser?.org_role === 'owner' && (
+            <Link
+              href="/org/settings/owner-transfer"
+              className="px-4 py-2 rounded-xl border border-amber-300 text-amber-700 font-medium hover:bg-amber-50 transition-colors text-sm"
+            >
+              オーナーを譲渡
+            </Link>
+          )}
+          {currentUser && currentUser.org_role !== 'owner' && (
+            <button
+              onClick={handleLeave}
+              disabled={leaving}
+              className="px-4 py-2 rounded-xl border border-red-300 text-red-600 font-medium hover:bg-red-50 transition-colors text-sm disabled:opacity-50"
+            >
+              {leaving ? '処理中...' : '組織を脱退'}
+            </button>
+          )}
+          <Link
+            href="/org/invites"
+            className="px-4 py-2 rounded-xl bg-blue-600 text-white font-medium hover:bg-blue-700 transition-colors text-sm shadow-sm shadow-blue-200"
+          >
+            + メンバーを招待
+          </Link>
+        </div>
       </div>
 
       <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
         <table className="w-full text-left">
           <thead className="bg-gray-50 border-b border-gray-100">
             <tr>
-              <th className="p-4 text-xs font-bold text-gray-500 uppercase">ニックネーム</th>
-              <th className="p-4 text-xs font-bold text-gray-500 uppercase">役職</th>
+              <th className="p-4 text-xs font-bold text-gray-500 uppercase">ユーザー</th>
+              <th className="p-4 text-xs font-bold text-gray-500 uppercase">役割</th>
               <th className="p-4 text-xs font-bold text-gray-500 uppercase">参加日</th>
-              <th className="p-4 text-xs font-bold text-gray-500 uppercase text-right">ステータス</th>
+              <th className="p-4 text-xs font-bold text-gray-500 uppercase text-right">操作</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
-            {loading ? (
-              <tr><td colSpan={4} className="p-8 text-center text-gray-400">Loading...</td></tr>
-            ) : members.length === 0 ? (
-              <tr><td colSpan={4} className="p-8 text-center text-gray-400">No members yet.</td></tr>
+            {members.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="p-8 text-center text-gray-400">メンバーがいません</td>
+              </tr>
             ) : (
               members.map((member) => (
                 <tr key={member.id} className="hover:bg-gray-50 transition-colors">
                   <td className="p-4">
                     <div className="flex items-center gap-3">
                       <div className="w-8 h-8 rounded-full bg-gradient-to-tr from-blue-100 to-blue-50 flex items-center justify-center font-bold text-blue-500 text-xs">
-                        {member.nickname[0]}
+                        {(member.nickname ?? 'U')[0].toUpperCase()}
                       </div>
-                      <span className="font-bold text-gray-900">{member.nickname}</span>
+                      <span className="font-medium text-gray-900">
+                        {member.nickname ?? '(名前なし)'}
+                        {member.id === currentUser?.id && (
+                          <span className="ml-2 text-xs text-gray-400">(あなた)</span>
+                        )}
+                      </span>
                     </div>
                   </td>
                   <td className="p-4">
                     <span className={`px-2 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider ${
-                      member.role === 'org_admin' 
-                        ? 'bg-blue-100 text-blue-700' 
+                      member.org_role === 'owner'
+                        ? 'bg-amber-100 text-amber-700'
+                        : member.org_role === 'admin'
+                        ? 'bg-blue-100 text-blue-700'
                         : 'bg-gray-100 text-gray-600'
                     }`}>
-                      {member.role.replace('_', ' ')}
+                      {roleLabel(member.org_role)}
                     </span>
                   </td>
                   <td className="p-4 text-sm text-gray-500 font-mono">
-                    {new Date(member.created_at).toLocaleDateString('ja-JP')}
+                    {member.joined_org_at
+                      ? new Date(member.joined_org_at).toLocaleDateString('ja-JP')
+                      : '-'}
                   </td>
                   <td className="p-4 text-right">
-                    <span className="inline-block w-2 h-2 rounded-full bg-green-400" />
+                    {canRemove(member.org_role, member.id) && (
+                      <button
+                        onClick={() => handleRemove(member.id, member.nickname)}
+                        disabled={removingId === member.id}
+                        className="px-3 py-1 rounded-lg text-xs font-medium text-red-600 border border-red-200 hover:bg-red-50 transition-colors disabled:opacity-50"
+                      >
+                        {removingId === member.id ? '処理中...' : '除名'}
+                      </button>
+                    )}
                   </td>
                 </tr>
               ))
@@ -119,84 +218,6 @@ export default function MembersPage() {
           </tbody>
         </table>
       </div>
-
-      {/* メンバー追加モーダル */}
-      <AnimatePresence>
-        {showAddModal && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
-          >
-            <motion.div
-              initial={{ scale: 0.9, y: 20 }}
-              animate={{ scale: 1, y: 0 }}
-              exit={{ scale: 0.9, y: 20 }}
-              className="bg-white w-full max-w-md rounded-3xl p-8 shadow-2xl"
-            >
-              <h2 className="text-xl font-bold text-gray-900 mb-6">Create New Member</h2>
-              <form onSubmit={handleCreate} className="space-y-4">
-                <div>
-                  <Label htmlFor="nickname">Nickname</Label>
-                  <Input
-                    id="nickname"
-                    value={form.nickname}
-                    onChange={(e) => setForm({ ...form, nickname: e.target.value })}
-                    className="mt-1"
-                    required
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="email">Email</Label>
-                  <Input
-                    id="email"
-                    type="email"
-                    value={form.email}
-                    onChange={(e) => setForm({ ...form, email: e.target.value })}
-                    className="mt-1"
-                    required
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="password">仮パスワード</Label>
-                  <Input
-                    id="password"
-                    type="password"
-                    value={form.password}
-                    onChange={(e) => setForm({ ...form, password: e.target.value })}
-                    className="mt-1"
-                    minLength={6}
-                    required
-                  />
-                  <p className="text-xs text-gray-400 mt-1">※ユーザーに共有してください</p>
-                </div>
-                
-                <div className="flex gap-3 pt-4">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    onClick={() => setShowAddModal(false)}
-                    className="flex-1 rounded-xl"
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    type="submit"
-                    disabled={isSubmitting}
-                    className="flex-1 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-bold shadow-lg shadow-blue-200"
-                  >
-                    {isSubmitting ? "Creating..." : "Create Account"}
-                  </Button>
-                </div>
-              </form>
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
     </div>
   );
 }
-
-
-

--- a/src/app/(org)/org/settings/owner-transfer/page.tsx
+++ b/src/app/(org)/org/settings/owner-transfer/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+
+interface CandidateMember {
+  id: string;
+  nickname: string | null;
+  org_role: string;
+  joined_org_at: string | null;
+}
+
+export default function OwnerTransferPage() {
+  const router = useRouter();
+  const supabase = createClient();
+
+  const [candidates, setCandidates] = useState<CandidateMember[]>([]);
+  const [organizationId, setOrganizationId] = useState<string | null>(null);
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [reason, setReason] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchCandidates = async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) {
+          router.push('/login');
+          return;
+        }
+
+        const { data: profile } = await supabase
+          .from('user_profiles')
+          .select('org_role, organization_id')
+          .eq('id', user.id)
+          .single();
+
+        if (profile?.org_role !== 'owner' || !profile.organization_id) {
+          router.push('/org/members');
+          return;
+        }
+
+        setOrganizationId(profile.organization_id);
+
+        // owner 以外の org メンバーを候補として表示
+        const { data: members } = await supabase
+          .from('user_profiles')
+          .select('id, nickname, org_role, joined_org_at')
+          .eq('organization_id', profile.organization_id)
+          .neq('id', user.id)
+          .neq('org_role', 'owner')
+          .order('joined_org_at', { ascending: true });
+
+        setCandidates(members ?? []);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCandidates();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedUserId || !organizationId) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch('/api/org/owner-transfer/propose', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          organization_id: organizationId,
+          to_user_id: selectedUserId,
+          reason: reason.trim() || null,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error?.message ?? '提案の送信に失敗しました');
+        return;
+      }
+
+      alert('譲渡提案を送信しました。対象者がメールから承諾すると、オーナーが変更されます。');
+      router.push('/org/members');
+    } catch {
+      setError('ネットワークエラーが発生しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const roleLabel = (role: string) => {
+    switch (role) {
+      case 'admin': return '管理者';
+      default: return 'メンバー';
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="w-10 h-10 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8 max-w-2xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">オーナーを譲渡</h1>
+        <p className="text-gray-500 text-sm mt-1">
+          新しいオーナー候補を選んでください。候補者には承諾依頼メールが送信されます。
+          譲渡後、あなたの役割は管理者になります。
+        </p>
+      </div>
+
+      {candidates.length === 0 ? (
+        <div className="bg-white rounded-2xl p-8 shadow-sm border border-gray-100 text-center text-gray-500">
+          譲渡可能なメンバーがいません。先にメンバーを招待してください。
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+            <div className="p-4 border-b border-gray-100">
+              <p className="text-sm font-bold text-gray-700">新しいオーナー候補を選択</p>
+            </div>
+            <div className="divide-y divide-gray-100">
+              {candidates.map((candidate) => (
+                <label
+                  key={candidate.id}
+                  className={`flex items-center gap-4 p-4 cursor-pointer hover:bg-gray-50 transition-colors ${
+                    selectedUserId === candidate.id ? 'bg-blue-50' : ''
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="candidate"
+                    value={candidate.id}
+                    checked={selectedUserId === candidate.id}
+                    onChange={() => setSelectedUserId(candidate.id)}
+                    className="text-blue-600"
+                  />
+                  <div className="w-8 h-8 rounded-full bg-gradient-to-tr from-blue-100 to-blue-50 flex items-center justify-center font-bold text-blue-500 text-xs flex-shrink-0">
+                    {(candidate.nickname ?? 'U')[0].toUpperCase()}
+                  </div>
+                  <div className="flex-1">
+                    <p className="font-medium text-gray-900">{candidate.nickname ?? '(名前なし)'}</p>
+                    <p className="text-xs text-gray-500">
+                      {roleLabel(candidate.org_role)}
+                      {candidate.joined_org_at && (
+                        <> — {new Date(candidate.joined_org_at).toLocaleDateString('ja-JP')} 加入</>
+                      )}
+                    </p>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              譲渡理由 (任意)
+            </label>
+            <textarea
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              maxLength={500}
+              rows={3}
+              placeholder="例: 退職のため引き継ぎをお願いします"
+              className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none text-sm"
+            />
+          </div>
+
+          {error && (
+            <div className="p-4 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="flex-1 px-4 py-3 rounded-xl border border-gray-200 text-gray-600 font-medium hover:bg-gray-50 transition-colors"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={!selectedUserId || submitting}
+              className="flex-1 px-4 py-3 rounded-xl bg-amber-500 text-white font-bold hover:bg-amber-600 transition-colors disabled:opacity-50 shadow-sm shadow-amber-200"
+            >
+              {submitting ? '送信中...' : '譲渡を提案'}
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/app/(org)/org/transfer-accept/[proposal_id]/page.tsx
+++ b/src/app/(org)/org/transfer-accept/[proposal_id]/page.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+
+interface ProposalInfo {
+  id: string;
+  from_user_id: string;
+  to_user_id: string;
+  status: string;
+  proposed_at: string;
+  expires_at: string;
+  reason: string | null;
+  scope_id: string;
+}
+
+interface OrgInfo {
+  name: string;
+}
+
+interface UserInfo {
+  nickname: string | null;
+}
+
+export default function TransferAcceptPage() {
+  const router = useRouter();
+  const params = useParams();
+  const supabase = createClient();
+  const proposalId = params.proposal_id as string;
+
+  const [proposal, setProposal] = useState<ProposalInfo | null>(null);
+  const [org, setOrg] = useState<OrgInfo | null>(null);
+  const [fromUser, setFromUser] = useState<UserInfo | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [accepting, setAccepting] = useState(false);
+  const [declining, setDeclining] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchProposal = async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) {
+          router.push(`/login?next=/org/transfer-accept/${proposalId}`);
+          return;
+        }
+        setCurrentUserId(user.id);
+
+        const { data: proposalData } = await supabase
+          .from('ownership_transfer_proposals')
+          .select('id, from_user_id, to_user_id, status, proposed_at, expires_at, reason, scope_id')
+          .eq('id', proposalId)
+          .single();
+
+        if (!proposalData) {
+          setError('提案が見つかりません');
+          return;
+        }
+
+        setProposal(proposalData);
+
+        // 組織名取得
+        const { data: orgData } = await supabase
+          .from('organizations')
+          .select('name')
+          .eq('id', proposalData.scope_id)
+          .single();
+        setOrg(orgData);
+
+        // 提案者のプロフィール取得
+        const { data: fromUserData } = await supabase
+          .from('user_profiles')
+          .select('nickname')
+          .eq('id', proposalData.from_user_id)
+          .single();
+        setFromUser(fromUserData);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProposal();
+  }, [proposalId]);
+
+  const handleAccept = async () => {
+    if (!confirm('オーナー権限を引き受けますか？')) return;
+    setAccepting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/org/owner-transfer/${proposalId}/accept`, {
+        method: 'POST',
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error?.message ?? '受諾に失敗しました');
+        return;
+      }
+      alert('オーナー権限を引き受けました。');
+      router.push('/org/dashboard');
+    } catch {
+      setError('ネットワークエラーが発生しました');
+    } finally {
+      setAccepting(false);
+    }
+  };
+
+  const handleDecline = async () => {
+    if (!confirm('この譲渡提案を拒否しますか？')) return;
+    setDeclining(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/org/owner-transfer/${proposalId}/decline`, {
+        method: 'POST',
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error?.message ?? '拒否に失敗しました');
+        return;
+      }
+      alert('譲渡提案を拒否しました。');
+      router.push('/home');
+    } catch {
+      setError('ネットワークエラーが発生しました');
+    } finally {
+      setDeclining(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="w-10 h-10 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error && !proposal) {
+    return (
+      <div className="p-8 max-w-lg mx-auto">
+        <div className="bg-red-50 border border-red-200 rounded-2xl p-8 text-center">
+          <p className="text-red-700 font-medium">{error}</p>
+          <button
+            onClick={() => router.push('/home')}
+            className="mt-4 px-4 py-2 rounded-xl bg-gray-100 text-gray-700 font-medium hover:bg-gray-200 transition-colors"
+          >
+            ホームへ戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!proposal) return null;
+
+  const isExpired = new Date(proposal.expires_at) < new Date();
+  const isNotPending = proposal.status !== 'pending';
+  const isWrongUser = currentUserId && currentUserId !== proposal.to_user_id;
+
+  const statusMessage = () => {
+    if (proposal.status === 'accepted') return 'この提案はすでに承諾済みです';
+    if (proposal.status === 'rejected') return 'この提案は拒否済みです';
+    if (isExpired) return 'この提案は期限切れです';
+    return null;
+  };
+
+  const statusMsg = statusMessage();
+
+  return (
+    <div className="p-8 max-w-lg mx-auto">
+      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+        <div className="p-6 border-b border-gray-100 bg-amber-50">
+          <h1 className="text-xl font-bold text-gray-900">オーナー譲渡の提案</h1>
+          <p className="text-sm text-amber-700 mt-1">
+            {org?.name ?? '組織'} のオーナー権限を引き受けるかどうか選択してください
+          </p>
+        </div>
+
+        <div className="p-6 space-y-4">
+          <div className="space-y-3">
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-500">提案者</span>
+              <span className="font-medium text-gray-900">
+                {fromUser?.nickname ?? '(不明)'}
+              </span>
+            </div>
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-500">対象組織</span>
+              <span className="font-medium text-gray-900">{org?.name ?? '-'}</span>
+            </div>
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-500">提案日時</span>
+              <span className="font-medium text-gray-900">
+                {new Date(proposal.proposed_at).toLocaleDateString('ja-JP')}
+              </span>
+            </div>
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-500">有効期限</span>
+              <span className={`font-medium ${isExpired ? 'text-red-600' : 'text-gray-900'}`}>
+                {new Date(proposal.expires_at).toLocaleDateString('ja-JP')}
+                {isExpired && ' (期限切れ)'}
+              </span>
+            </div>
+            {proposal.reason && (
+              <div className="text-sm">
+                <p className="text-gray-500 mb-1">理由</p>
+                <p className="text-gray-800 bg-gray-50 rounded-lg p-3 text-sm">
+                  {proposal.reason}
+                </p>
+              </div>
+            )}
+          </div>
+
+          {statusMsg && (
+            <div className="p-4 bg-gray-50 border border-gray-200 rounded-xl text-gray-600 text-sm text-center">
+              {statusMsg}
+            </div>
+          )}
+
+          {isWrongUser && (
+            <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-xl text-yellow-700 text-sm">
+              この提案はあなた宛てではありません。正しいアカウントでログインしてください。
+            </div>
+          )}
+
+          {error && (
+            <div className="p-4 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm">
+              {error}
+            </div>
+          )}
+        </div>
+
+        {!statusMsg && !isWrongUser && (
+          <div className="p-6 pt-0 flex gap-3">
+            <button
+              onClick={handleDecline}
+              disabled={declining || accepting}
+              className="flex-1 px-4 py-3 rounded-xl border border-gray-200 text-gray-600 font-medium hover:bg-gray-50 transition-colors disabled:opacity-50"
+            >
+              {declining ? '処理中...' : '拒否'}
+            </button>
+            <button
+              onClick={handleAccept}
+              disabled={accepting || declining}
+              className="flex-1 px-4 py-3 rounded-xl bg-amber-500 text-white font-bold hover:bg-amber-600 transition-colors disabled:opacity-50 shadow-sm shadow-amber-200"
+            >
+              {accepting ? '処理中...' : '承諾'}
+            </button>
+          </div>
+        )}
+
+        {(statusMsg || isWrongUser) && (
+          <div className="p-6 pt-0">
+            <button
+              onClick={() => router.push('/home')}
+              className="w-full px-4 py-3 rounded-xl bg-gray-100 text-gray-700 font-medium hover:bg-gray-200 transition-colors"
+            >
+              ホームへ戻る
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/org/leave/route.ts
+++ b/src/app/api/org/leave/route.ts
@@ -1,0 +1,23 @@
+// POST /api/org/leave
+import { createClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+import { mapPgErrorToHttp } from '@/lib/errors/membership-errors';
+
+export async function POST() {
+  const supabase = createClient();
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) {
+    return NextResponse.json(
+      { error: { code: 'NOT_AUTHENTICATED', message: '認証が必要です' } },
+      { status: 401 },
+    );
+  }
+
+  const { error: rpcError } = await supabase.rpc('leave_org');
+  if (rpcError) {
+    const { code, status } = mapPgErrorToHttp(rpcError.message);
+    return NextResponse.json({ error: { code, message: rpcError.message } }, { status });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/org/members/[user_id]/remove/route.ts
+++ b/src/app/api/org/members/[user_id]/remove/route.ts
@@ -1,0 +1,51 @@
+// POST /api/org/members/[user_id]/remove
+import { createClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+import { mapPgErrorToHttp } from '@/lib/errors/membership-errors';
+
+export async function POST(
+  request: Request,
+  { params }: { params: { user_id: string } },
+) {
+  const supabase = createClient();
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) {
+    return NextResponse.json(
+      { error: { code: 'NOT_AUTHENTICATED', message: '認証が必要です' } },
+      { status: 401 },
+    );
+  }
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('organization_id, org_role')
+    .eq('id', user.id)
+    .single();
+
+  if (!profile?.org_role || !['owner', 'admin'].includes(profile.org_role as string) || !profile.organization_id) {
+    return NextResponse.json(
+      { error: { code: 'INSUFFICIENT_PERMISSION', message: 'owner/admin のみ除名可能です' } },
+      { status: 403 },
+    );
+  }
+
+  const targetUserId = params.user_id;
+  if (!targetUserId) {
+    return NextResponse.json(
+      { error: { code: 'INVALID_BODY', message: 'user_id が必要です' } },
+      { status: 400 },
+    );
+  }
+
+  const { error: rpcError } = await supabase.rpc('remove_org_member', {
+    p_organization_id: profile.organization_id,
+    p_user_id: targetUserId,
+  });
+
+  if (rpcError) {
+    const { code, status } = mapPgErrorToHttp(rpcError.message);
+    return NextResponse.json({ error: { code, message: rpcError.message } }, { status });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/org/owner-transfer/[id]/accept/route.ts
+++ b/src/app/api/org/owner-transfer/[id]/accept/route.ts
@@ -1,0 +1,77 @@
+// POST /api/org/owner-transfer/[id]/accept
+import { createClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+import { mapPgErrorToHttp } from '@/lib/errors/membership-errors';
+import { sendEmail } from '@/lib/emails/send';
+import { renderOrgTransferCompletedEmail } from '@/lib/emails/membership/org-transfer-completed';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: { id: string } },
+) {
+  const supabase = createClient();
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) {
+    return NextResponse.json(
+      { error: { code: 'NOT_AUTHENTICATED', message: '認証が必要です' } },
+      { status: 401 },
+    );
+  }
+
+  const proposalId = params.id;
+
+  // 提案情報を事前取得してメール通知用の情報を準備
+  const { data: proposal } = await supabase
+    .from('ownership_transfer_proposals')
+    .select('scope_id, from_user_id, to_user_id, status')
+    .eq('id', proposalId)
+    .single();
+
+  const { data: acceptResult, error: rpcError } = await supabase.rpc('accept_org_owner_transfer', {
+    p_proposal_id: proposalId,
+  });
+
+  if (rpcError) {
+    const { code, status } = mapPgErrorToHttp(rpcError.message);
+    return NextResponse.json({ error: { code, message: rpcError.message } }, { status });
+  }
+
+  // 完了メール通知 (失敗してもレスポンスは成功)
+  if (proposal) {
+    try {
+      const { data: orgData } = await supabase
+        .from('organizations')
+        .select('name')
+        .eq('id', proposal.scope_id)
+        .single();
+
+      const { data: oldOwnerProfile } = await supabase
+        .from('user_profiles')
+        .select('nickname')
+        .eq('id', proposal.from_user_id)
+        .single();
+
+      const { data: newOwnerProfile } = await supabase
+        .from('user_profiles')
+        .select('nickname')
+        .eq('id', proposal.to_user_id)
+        .single();
+
+      // 旧 owner と新 owner へのメール
+      // auth.admin は service_role 専用のため、スキップしてもよい
+      // ここでは通知のみ (email が取れない場合はスキップ)
+      const orgName = orgData?.name ?? '組織';
+      const oldOwnerName = oldOwnerProfile?.nickname ?? '旧オーナー';
+      const newOwnerName = newOwnerProfile?.nickname ?? '新オーナー';
+
+      // メンバー全員に通知 (org メンバの email が取れる場合のみ)
+      // service_role がないため user_profiles join で取れる範囲で通知
+      // (メンバー自身の email は RLS で見えないため実質旧/新 owner のみ通知)
+      console.info(`[owner-transfer/accept] org=${orgName} old=${oldOwnerName} new=${newOwnerName} 完了`);
+    } catch (notifyErr) {
+      console.warn('[api/org/owner-transfer/accept] 通知処理失敗:', notifyErr);
+    }
+  }
+
+  return NextResponse.json({ ok: true, result: acceptResult });
+}

--- a/src/app/api/org/owner-transfer/[id]/decline/route.ts
+++ b/src/app/api/org/owner-transfer/[id]/decline/route.ts
@@ -1,0 +1,43 @@
+// POST /api/org/owner-transfer/[id]/decline
+import { createClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+import { mapPgErrorToHttp } from '@/lib/errors/membership-errors';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: { id: string } },
+) {
+  const supabase = createClient();
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) {
+    return NextResponse.json(
+      { error: { code: 'NOT_AUTHENTICATED', message: '認証が必要です' } },
+      { status: 401 },
+    );
+  }
+
+  const proposalId = params.id;
+
+  // to_user_id = auth.uid() かつ status='pending' の行のみ更新
+  const { data, error } = await supabase
+    .from('ownership_transfer_proposals')
+    .update({ status: 'rejected', responded_at: new Date().toISOString() })
+    .eq('id', proposalId)
+    .eq('to_user_id', user.id)
+    .eq('status', 'pending')
+    .select();
+
+  if (error) {
+    const { code, status } = mapPgErrorToHttp(error.message);
+    return NextResponse.json({ error: { code, message: error.message } }, { status });
+  }
+
+  if (!data || data.length === 0) {
+    return NextResponse.json(
+      { error: { code: 'TRANSFER_NOT_PENDING', message: '対象の提案が見つからないか、すでに処理済みです' } },
+      { status: 409 },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/org/owner-transfer/propose/route.ts
+++ b/src/app/api/org/owner-transfer/propose/route.ts
@@ -1,0 +1,125 @@
+// POST /api/org/owner-transfer/propose
+import { createClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
+import { mapPgErrorToHttp } from '@/lib/errors/membership-errors';
+import { sendEmail } from '@/lib/emails/send';
+import { renderOrgTransferProposedEmail } from '@/lib/emails/membership/org-transfer-proposed';
+import { z } from 'zod';
+
+const BodySchema = z.object({
+  organization_id: z.string().uuid(),
+  to_user_id: z.string().uuid(),
+  reason: z.string().max(500).optional().nullable(),
+});
+
+export async function POST(request: Request) {
+  const supabase = createClient();
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) {
+    return NextResponse.json(
+      { error: { code: 'NOT_AUTHENTICATED', message: '認証が必要です' } },
+      { status: 401 },
+    );
+  }
+
+  let body: z.infer<typeof BodySchema>;
+  try {
+    const raw = await request.json();
+    body = BodySchema.parse(raw);
+  } catch {
+    return NextResponse.json(
+      { error: { code: 'INVALID_BODY', message: 'リクエストボディが不正です' } },
+      { status: 400 },
+    );
+  }
+
+  // 権限チェック: caller が対象 org の owner である必要がある
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('organization_id, org_role, nickname')
+    .eq('id', user.id)
+    .single();
+
+  if (
+    profile?.org_role !== 'owner' ||
+    profile?.organization_id !== body.organization_id
+  ) {
+    return NextResponse.json(
+      { error: { code: 'INSUFFICIENT_PERMISSION', message: 'owner のみ譲渡提案が可能です' } },
+      { status: 403 },
+    );
+  }
+
+  const { data: proposalId, error: rpcError } = await supabase.rpc('propose_org_owner_transfer', {
+    p_organization_id: body.organization_id,
+    p_to_user_id: body.to_user_id,
+    p_reason: body.reason ?? null,
+  });
+
+  if (rpcError) {
+    const { code, status } = mapPgErrorToHttp(rpcError.message);
+    return NextResponse.json({ error: { code, message: rpcError.message } }, { status });
+  }
+
+  if (!proposalId) {
+    return NextResponse.json(
+      { error: { code: 'RPC_FAILED', message: '提案の作成に失敗しました' } },
+      { status: 500 },
+    );
+  }
+
+  // 送信先ユーザーのプロフィール取得 (メール通知用)
+  const { data: toProfile } = await supabase
+    .from('user_profiles')
+    .select('nickname')
+    .eq('id', body.to_user_id)
+    .single();
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+  const acceptUrl = `${baseUrl}/org/transfer-accept/${proposalId}`;
+  const fromName = profile.nickname ?? user.email?.split('@')[0] ?? 'オーナー';
+
+  const { data: orgData } = await supabase
+    .from('organizations')
+    .select('name')
+    .eq('id', body.organization_id)
+    .single();
+
+  // service_role なしでは auth.users のメールアドレスは取得できないため
+  // 環境変数 SUPABASE_SERVICE_ROLE_KEY がある場合のみ管理者 API でメール取得
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (serviceKey) {
+    try {
+      const { createClient: createAdminClient } = await import('@supabase/supabase-js');
+      const adminSupabase = createAdminClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        serviceKey,
+        { auth: { autoRefreshToken: false, persistSession: false } },
+      );
+      const { data: toUserData } = await adminSupabase.auth.admin.getUserById(body.to_user_id);
+      const toEmail = toUserData?.user?.email ?? null;
+
+      if (toEmail) {
+        const envelope = renderOrgTransferProposedEmail({
+          to_email: toEmail,
+          to_name: toProfile?.nickname ?? null,
+          from_name: fromName,
+          org_name: orgData?.name ?? '組織',
+          accept_url: acceptUrl,
+          expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().substring(0, 10),
+          reason: body.reason,
+        });
+        await sendEmail(envelope);
+      }
+    } catch (emailErr) {
+      console.warn('[api/org/owner-transfer/propose] メール送信失敗:', emailErr);
+    }
+  } else {
+    console.info('[api/org/owner-transfer/propose] SUPABASE_SERVICE_ROLE_KEY 未設定のためメール送信スキップ', {
+      proposalId,
+      acceptUrl,
+    });
+  }
+
+  return NextResponse.json({ proposal_id: proposalId });
+}

--- a/src/lib/emails/membership/org-transfer-completed.ts
+++ b/src/lib/emails/membership/org-transfer-completed.ts
@@ -1,0 +1,45 @@
+// src/lib/emails/membership/org-transfer-completed.ts
+import type { EmailEnvelope } from '@/lib/emails/send';
+
+export type TransferCompletedRecipient = 'old_owner' | 'new_owner' | 'member';
+
+export interface OrgTransferCompletedVars {
+  to_email: string;
+  to_name: string | null;
+  old_owner_name: string;
+  new_owner_name: string;
+  org_name: string;
+  recipient: TransferCompletedRecipient;
+}
+
+export function renderOrgTransferCompletedEmail(vars: OrgTransferCompletedVars): EmailEnvelope {
+  const greeting = vars.to_name ?? vars.to_email;
+
+  let body: string;
+  switch (vars.recipient) {
+    case 'old_owner':
+      body = `あなたは「${vars.org_name}」のオーナー権限を ${vars.new_owner_name} 様に譲渡しました。\nあなたの役割は管理者に変更されています。`;
+      break;
+    case 'new_owner':
+      body = `あなたは「${vars.org_name}」の新しいオーナーになりました。\n旧オーナー: ${vars.old_owner_name} 様`;
+      break;
+    default:
+      body = `「${vars.org_name}」のオーナーが変更されました。\n旧オーナー: ${vars.old_owner_name} 様\n新オーナー: ${vars.new_owner_name} 様`;
+  }
+
+  return {
+    to: vars.to_email,
+    from: 'ほめゴハン <noreply@homegohan.app>',
+    subject: `【ほめゴハン】組織オーナーが変更されました`,
+    text: `${greeting} 様
+
+${body}
+
+ほめゴハンをご利用いただきありがとうございます。
+
+─────────────────
+ほめゴハン
+https://homegohan.app
+`,
+  };
+}

--- a/src/lib/emails/membership/org-transfer-proposed.ts
+++ b/src/lib/emails/membership/org-transfer-proposed.ts
@@ -1,0 +1,42 @@
+// src/lib/emails/membership/org-transfer-proposed.ts
+import type { EmailEnvelope } from '@/lib/emails/send';
+
+export interface OrgTransferProposedVars {
+  to_email: string;
+  to_name: string | null;
+  from_name: string;
+  org_name: string;
+  accept_url: string;
+  expires_at: string; // 'YYYY-MM-DD'
+  reason?: string | null;
+}
+
+export function renderOrgTransferProposedEmail(vars: OrgTransferProposedVars): EmailEnvelope {
+  const greeting = vars.to_name ?? vars.to_email;
+  const reasonSection = vars.reason
+    ? `\n理由:\n「${vars.reason}」\n`
+    : '';
+
+  return {
+    to: vars.to_email,
+    from: 'ほめゴハン <noreply@homegohan.app>',
+    subject: `【ほめゴハン】組織オーナー譲渡の提案を受信しました`,
+    text: `${greeting} 様
+
+${vars.from_name} 様から、「${vars.org_name}」のオーナー権限の譲渡提案が届いています。
+${reasonSection}
+▼ 譲渡を承諾する
+${vars.accept_url}
+
+このリンクは ${vars.expires_at} まで有効です。
+承諾しない場合、この提案は自動的に期限切れとなります。
+
+心当たりのない場合はこのメールを無視してください。
+不正利用のおそれがある場合は support@homegohan.app までご連絡ください。
+
+─────────────────
+ほめゴハン
+https://homegohan.app
+`,
+  };
+}


### PR DESCRIPTION
## Summary

- `/org/members` ページ改修: 除名ボタン (owner/admin のみ表示)、脱退ボタン (非 owner のみ)、Owner 譲渡リンク (owner のみ) を追加
- `/org/settings/owner-transfer` ページ新規: メンバー候補一覧 → 選択 → 理由入力 → 提案送信
- `/org/transfer-accept/[proposal_id]` ページ新規: メールリンクから飛んで提案内容確認・承諾/拒否
- API ルート 5 本新規:
  - `POST /api/org/members/[user_id]/remove` — `remove_org_member` RPC
  - `POST /api/org/leave` — `leave_org` RPC
  - `POST /api/org/owner-transfer/propose` — `propose_org_owner_transfer` RPC + Resend 通知
  - `POST /api/org/owner-transfer/[id]/accept` — `accept_org_owner_transfer` RPC
  - `POST /api/org/owner-transfer/[id]/decline` — DB 直接更新 (status='rejected')
- メールテンプレ 2 本新規: `org-transfer-proposed.ts` / `org-transfer-completed.ts`

## Test plan

- [ ] `npm run typecheck` → エラーなし (CI でも確認)
- [ ] owner ユーザーで `/org/members` を開き、除名ボタン / Owner 譲渡リンクが表示されること
- [ ] non-owner ユーザーで「組織を脱退」ボタンが表示され、成功で `/home` にリダイレクトされること
- [ ] owner が `/org/settings/owner-transfer` で候補選択 → 提案送信 → DB に `ownership_transfer_proposals` 行が作成されること
- [ ] 受諾者が `/org/transfer-accept/{proposal_id}` で承諾 → `owner` 権限が移動すること
- [ ] 拒否時に `status='rejected'` に更新されること