### PR TITLE
ci: PR で typecheck/lint/test を回す CI を追加し auto-merge-all を削除 (#1034)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -152,18 +152,3 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # 全てのPRを自動マージ（PR作成時に auto-merge を有効化）
-  auto-merge-all:
-    runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.action == 'opened' &&
-      !startsWith(github.head_ref, 'claude/') &&
-      github.actor != 'dependabot[bot]'
-    steps:
-      - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      # typecheck は現状 green のためブロッキング（このジョブの成否＝typecheck）
+      - run: npm run typecheck
+      # lint / test は現状ベースラインが赤（apps/mobile の Jest 混入・integration の env 依存・
+      # eslint プラグイン版不整合・既存失敗数件）のため当面は非ブロッキング（可視化のみ）。
+      # 緑化して required 化する作業はフォローアップ Issue を参照。
+      - run: npm run lint
+        continue-on-error: true
+      - run: npm test
+        continue-on-error: true


### PR DESCRIPTION
## 概要 (Closes #1034 の第一段階)
全 PR を無検証で即マージしていた `auto-merge-all` job を削除し、PR で型/lint/テストを回す `ci.yml` を追加します。

## 変更
- **新規 `ci.yml`**: `pull_request` / `push:main` で `npm ci` → `typecheck`(ブロッキング) → `lint` / `test`(現状ベースライン赤のため当面 `continue-on-error` で可視化のみ)。
- **`auto-merge.yml`**: `auto-merge-all`(claude/でも dependabot でもない全 PR を `gh pr merge --auto --squash`)を削除。claude/・dependabot 用 job は据え置き。

## 補足（フォローアップ）
lint/test をベースライン緑化して required 化する作業は別 Issue で扱います（apps/mobile の Jest 混入除外・tests/integration の env 分離・eslint プラグイン版不整合・既存テスト失敗数件）。マージ後にオーケストレーターが branch protection で `check`(typecheck) を required に設定します。

関連: #1012 #1034