### PR TITLE
ci: migration 変更の自動マージ除外とドリフト検知を追加 (#1064 Phase 2)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -29,7 +29,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create PR and merge
+      # supabase/migrations/ を含む変更は人手レビュー必須のため自動マージしない (#1064)
+      - name: Check for migration changes
+        id: check_migrations
+        run: |
+          git fetch origin main --quiet
+          CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
+          echo "$CHANGED_FILES"
+          if echo "$CHANGED_FILES" | grep -q '^supabase/migrations/'; then
+            echo "has_migrations=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_migrations=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create PR
+        id: create_pr
         run: |
           BRANCH_NAME="${GITHUB_REF#refs/heads/}"
 
@@ -47,10 +61,22 @@ jobs:
             echo "PR already exists: $PR_URL"
           fi
 
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Skip auto-merge for migration changes
+        if: steps.check_migrations.outputs.has_migrations == 'true'
+        run: |
+          echo "::warning::supabase/migrations/ に変更が含まれるため自動マージをスキップします。人手レビューが必要です。(#1064)"
+
+      - name: Merge PR
+        if: steps.check_migrations.outputs.has_migrations == 'false'
+        run: |
           # 即マージ（squash）- 承認不要の場合
           # 注意: ブランチ保護で承認必須の場合は Settings > Actions > General で
           # "Allow GitHub Actions to create and approve pull requests" を有効にしてください
-          gh pr merge --squash "$PR_URL" --delete-branch || echo "Merge failed - may need manual approval"
+          gh pr merge --squash "${{ steps.create_pr.outputs.pr_url }}" --delete-branch || echo "Merge failed - may need manual approval"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Dependabotの場合は承認不要で自動マージ（patch/minor のみ）
@@ -141,13 +167,35 @@ jobs:
       github.event.action == 'opened' &&
       startsWith(github.head_ref, 'claude/')
     steps:
+      # supabase/migrations/ を含む変更は人手レビュー必須のため自動承認・自動マージしない (#1064)
+      - name: Check for migration changes
+        id: check_migrations
+        run: |
+          CHANGED_FILES=$(gh pr diff "$PR_URL" --name-only)
+          echo "$CHANGED_FILES"
+          if echo "$CHANGED_FILES" | grep -q '^supabase/migrations/'; then
+            echo "has_migrations=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_migrations=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Skip auto-approve/merge for migration changes
+        if: steps.check_migrations.outputs.has_migrations == 'true'
+        run: |
+          echo "::warning::supabase/migrations/ に変更が含まれるため自動承認・自動マージをスキップします。人手レビューが必要です。(#1064)"
+
       - name: Auto-approve Claude PR
+        if: steps.check_migrations.outputs.has_migrations == 'false'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for Claude PR
+        if: steps.check_migrations.outputs.has_migrations == 'false'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/deploy-supabase-migrations.yml
+++ b/.github/workflows/deploy-supabase-migrations.yml
@@ -53,6 +53,51 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
+      - name: Detect migration drift
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        run: |
+          npx --yes supabase@2.62.10 migration list --linked | tee /tmp/migration_list.txt
+          python3 - <<'PY'
+          import re
+          import sys
+
+          with open("/tmp/migration_list.txt", encoding="utf-8") as fh:
+              lines = fh.readlines()
+
+          drift = []
+          for raw_line in lines:
+              line = raw_line.rstrip("\n")
+              # supabase CLI の pretty 出力は `|Local|Remote|Time (UTC)|` 形式で
+              # 各行が "|" で始まり "|" で終わる。先頭/末尾のちょうど1個だけを
+              # 取り除いてから分割しないと、空セル(local-only/remote-only 行)の
+              # 位置がずれて誤検知・見逃しの原因になる。
+              if not (line.startswith("|") and line.endswith("|")):
+                  continue
+              inner = line[1:-1]
+              cols = [c.strip() for c in inner.split("|")]
+              if len(cols) < 2:
+                  continue
+              local, remote = cols[0], cols[1]
+              # ヘッダー行・区切り行 (LOCAL/REMOTE 文字列や ---- ) は除外し、
+              # migration バージョン (数値) の行のみを対象にする
+              if not (re.fullmatch(r"[0-9]*", local) and re.fullmatch(r"[0-9]*", remote)):
+                  continue
+              if local == "" and remote == "":
+                  continue
+              # 片方のみ埋まっている行 = remote-only または local-only のドリフト
+              if (local == "") != (remote == ""):
+                  drift.append(line)
+
+          if drift:
+              print("::error::Migration drift detected. See #1064.", file=sys.stderr)
+              for line in drift:
+                  print(line, file=sys.stderr)
+              sys.exit(1)
+          PY
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
       - name: Apply migrations
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,16 @@ CI では GitHub Secrets に登録する。
 
 ---
 
+## Supabase 本番スキーマ変更ポリシー
+
+本番 Supabase (project `flmeolcfutuwwbjmzyoz`) へのスキーマ変更は、必ず `supabase/migrations/*.sql` をファイル化して PR 経由でコミットすること。
+
+**禁止**: Supabase MCP の `apply_migration` やダッシュボードの SQL Editor で本番に直接 DDL を当てること。
+
+理由: #1064 で、秒精度のタイムスタンプ版 migration (MCP `apply_migration` 由来) とリポジトリの丸め連番版 migration がズレて `supabase db push` が全ブロックし、2 ヶ月間デプロイできない状態になった実例がある。スキーマ変更は必ずファイル化 → PR → CI の migration drift 検知を通すこと。
+
+---
+
 ## Claude Code Cloud (claude.ai/code) 動作要件
 
 ### 起動時 setup


### PR DESCRIPTION
## 概要 (#1064 Phase 2: 再発防止・コード限定)
本番 DB を触らない再発防止策のみ。Phase 0/1(本番台帳の修復)は別途ユーザー承認を得て実施。

## 変更
- **auto-merge.yml**: `supabase/migrations/` を含む claude/* の push/PR は自動マージ対象外にし、人手レビュー必須化。
- **deploy-supabase-migrations.yml**: `Apply migrations` の前に `migration list --linked` を解析し、remote-only/local-only の行があれば明確なエラー(`Migration drift detected. See #1064.`)で停止するステップを追加。
- **CLAUDE.md**: 本番スキーマ変更は必ず migration ファイル経由の PR で行うこと、Supabase MCP `apply_migration`/ダッシュボード SQL Editor での直接適用を禁止する旨を明記(#1064 の実例を理由として記載)。

## レビューで検出・修正した不具合
初回実装のドリフト検知 Python が `supabase migration list` の実出力(`|Local|Remote|Time (UTC)|` 形式、各行が `|` で始まる)を単純 `split("|")` していたため、先頭の空文字列を `local` と誤読するオフバイワンがあった。**このままだと完全に同期した正常な migration 行まで「ドリフトあり」と誤検知し、#1064 解消後も永久に全デプロイをブロックする**バグだったため、実バイナリの文字列抽出で出力フォーマットを確認し、行の先頭/末尾の `|` を厳密に1個ずつ除去してから分割する方式に修正。ローカルで3パターン(完全同期/remote-only/local-only)をシミュレートし正しく分類されることを検証済み。

## 補足(調査中に判明した誤認の訂正)
実装時に「`homegohan-app/` は独立した別リポジトリで本番に別途デプロイしている」という所見が出たが、検証の結果これは誤り。`homegohan-app/` 内部の git remote は親リポジトリと同一 URL であり、**自分自身の古いクローン(2026-05-08時点)がサブディレクトリに紛れ込んだだけ**。CLAUDE.md の既存記載(無視・編集しない)は妥当なため、このディレクトリには触れていない。

関連: #1012 #1064