### PR TITLE
fix(security): Edge Function の認証バイパスを修正 (#1016 #1018)

### DIFF
--- a/scripts/resume-embedding-regeneration.mjs
+++ b/scripts/resume-embedding-regeneration.mjs
@@ -230,11 +230,13 @@ async function processTable(tableName, startOffset = 0, model = DATASET_EMBEDDIN
       await new Promise(r => setTimeout(r, 500));
       
     } catch (error) {
-      // 認証系の恒久エラー（401/403）はリトライしても解決しないため中断する（run側の `!res.ok` → break と挙動を揃える）
+      // 認証系の恒久エラー（401/403）はリトライしても解決しないため中断する。
+      // ここで握り潰さず main() まで伝播させ、ジョブステータスに "failed" を記録させたうえで
+      // 非0 exit させる（"completed" として誤って正常終了扱いにしないため）。
       if (error.isAuthFailure) {
         console.error(`\n   ❌ 認証エラーのため中断します: ${error.message}`);
         console.error(`   SUPABASE_SERVICE_ROLE_KEY が正しく設定されているか確認してください。`);
-        break;
+        throw error;
       }
 
       // すべてのエラーに対して5秒待ってリトライ（無限）
@@ -297,8 +299,39 @@ async function main() {
     }
   }
   
-  await processTable(table, startOffset, model, dimensions, jobId, onlyMissing);
-  
+  try {
+    await processTable(table, startOffset, model, dimensions, jobId, onlyMissing);
+  } catch (error) {
+    if (error.isAuthFailure) {
+      console.error(`\n❌ 認証エラーのため処理を中断しました: ${error.message}`);
+      // "completed" と誤って記録しないよう、失敗ステータスを明示的に保存する
+      if (jobId && SERVICE_ROLE_KEY) {
+        try {
+          await fetch(`${SUPABASE_URL}/rest/v1/embedding_jobs`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "Authorization": `Bearer ${SERVICE_ROLE_KEY}`,
+              "apikey": SERVICE_ROLE_KEY,
+              "Prefer": "resolution=merge-duplicates",
+            },
+            body: JSON.stringify({
+              job_id: jobId,
+              status: "failed",
+              error_message: error.message,
+              completed_at: new Date().toISOString(),
+            }),
+          }).catch(() => {});
+        } catch (e) {
+          // 無視
+        }
+      }
+      process.exit(1);
+    }
+    // 認証失敗以外は従来どおり main().catch() に伝播させる
+    throw error;
+  }
+
   const elapsed = ((Date.now() - startTime) / 1000 / 60).toFixed(1);
   console.log(`\n🎉 All done! Total time: ${elapsed} minutes`);
   

--- a/scripts/resume-embedding-regeneration.mjs
+++ b/scripts/resume-embedding-regeneration.mjs
@@ -51,7 +51,14 @@ async function fetchWithRetry(url, options) {
       
       if (!res.ok) {
         const errText = await res.text();
-        
+
+        // 認証系の恒久エラー（401/403）はリトライしても解決しないため即座に中断する
+        if (res.status === 401 || res.status === 403) {
+          const authError = new Error(`Authentication failed (HTTP ${res.status}): ${errText}`);
+          authError.isAuthFailure = true;
+          throw authError;
+        }
+
         // 一時的なエラーの場合、5秒待ってリトライ
         if (isTemporaryError(errText)) {
           retryCount++;
@@ -60,18 +67,23 @@ async function fetchWithRetry(url, options) {
           await new Promise(r => setTimeout(r, RETRY_DELAY));
           continue; // 無限にリトライ
         }
-        
+
         throw new Error(errText);
       }
-      
+
       // 成功したらリトライカウンターをリセット
       if (retryCount > 0) {
         console.log(`\n   ✅ リトライ成功！処理を続行します。`);
         retryCount = 0;
       }
-      
+
       return res;
     } catch (error) {
+      // 認証系の恒久エラーはリトライせず、そのまま呼び出し元に伝播させる
+      if (error.isAuthFailure) {
+        throw error;
+      }
+
       // ネットワークエラーの場合、5秒待ってリトライ
       if (error.message.includes('fetch') || error.message.includes('network') || error.message.includes('ECONNREFUSED')) {
         retryCount++;
@@ -80,7 +92,7 @@ async function fetchWithRetry(url, options) {
         await new Promise(r => setTimeout(r, RETRY_DELAY));
         continue; // 無限にリトライ
       }
-      
+
       // 永続的なエラーの場合はスロー
       throw error;
     }
@@ -218,6 +230,13 @@ async function processTable(tableName, startOffset = 0, model = DATASET_EMBEDDIN
       await new Promise(r => setTimeout(r, 500));
       
     } catch (error) {
+      // 認証系の恒久エラー（401/403）はリトライしても解決しないため中断する（run側の `!res.ok` → break と挙動を揃える）
+      if (error.isAuthFailure) {
+        console.error(`\n   ❌ 認証エラーのため中断します: ${error.message}`);
+        console.error(`   SUPABASE_SERVICE_ROLE_KEY が正しく設定されているか確認してください。`);
+        break;
+      }
+
       // すべてのエラーに対して5秒待ってリトライ（無限）
       console.error(`\n   ❌ エラー発生: ${error.message.substring(0, 200)}`);
       console.error(`   ⏳ ${RETRY_DELAY / 1000}秒待機してからリトライします...`);
@@ -225,7 +244,7 @@ async function processTable(tableName, startOffset = 0, model = DATASET_EMBEDDIN
       continue; // 同じoffsetでリトライ（無限）
     }
   }
-  
+
   console.log(`\n   ✅ Completed ${tableName}: ${totalProcessed} rows`);
 }
 

--- a/scripts/resume-embedding-regeneration.mjs
+++ b/scripts/resume-embedding-regeneration.mjs
@@ -8,8 +8,14 @@ import { DATASET_EMBEDDING_DIMENSIONS, DATASET_EMBEDDING_MODEL } from "../shared
 import { buildProgressSnapshot } from "../shared/progress-reporting.mjs";
 
 const SUPABASE_URL = process.env.SUPABASE_URL || "https://flmeolcfutuwwbjmzyoz.supabase.co";
-const ANON_KEY = process.env.SUPABASE_ANON_KEY || "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZsbWVvbGNmdXR1d3diam16eW96Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjM5NzAxODYsImV4cCI6MjA3OTU0NjE4Nn0.VVxUxKexNeN6dUiAMDkCNlnIoXa-F5rfBqHPBDcwdnU";
+// regenerate-embeddings は service role key（または CRON_SECRET/SERVICE_ROLE_SECRET）以外を拒否するため、
+// anon key ではなく service role key を使用する。
 const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+
+if (!SERVICE_ROLE_KEY) {
+  console.error("❌ SUPABASE_SERVICE_ROLE_KEY environment variable is required");
+  process.exit(1);
+}
 
 const BATCH_LIMIT = 100;
 const RETRY_DELAY = 5000; // リトライ間隔（5秒）
@@ -140,7 +146,7 @@ async function processTable(tableName, startOffset = 0, model = DATASET_EMBEDDIN
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": `Bearer ${ANON_KEY}`,
+          "Authorization": `Bearer ${SERVICE_ROLE_KEY}`,
         },
         body: JSON.stringify({
           table: tableName,

--- a/scripts/run-embedding-regeneration.mjs
+++ b/scripts/run-embedding-regeneration.mjs
@@ -8,7 +8,14 @@ import { DATASET_EMBEDDING_DIMENSIONS, DATASET_EMBEDDING_MODEL } from "../shared
 import { buildProgressSnapshot } from "../shared/progress-reporting.mjs";
 
 const SUPABASE_URL = "https://flmeolcfutuwwbjmzyoz.supabase.co";
-const ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZsbWVvbGNmdXR1d3diam16eW96Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjM5NzAxODYsImV4cCI6MjA3OTU0NjE4Nn0.VVxUxKexNeN6dUiAMDkCNlnIoXa-F5rfBqHPBDcwdnU";
+// regenerate-embeddings は service role key（または CRON_SECRET/SERVICE_ROLE_SECRET）以外を拒否するため、
+// anon key ではなく service role key を使用する。
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SERVICE_ROLE_KEY) {
+  console.error("❌ SUPABASE_SERVICE_ROLE_KEY environment variable is required");
+  process.exit(1);
+}
 
 const TABLES = [
   "dataset_ingredients",
@@ -31,7 +38,7 @@ async function processTable(tableName) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "Authorization": `Bearer ${ANON_KEY}`,
+        "Authorization": `Bearer ${SERVICE_ROLE_KEY}`,
       },
       body: JSON.stringify({
         table: tableName,

--- a/supabase/functions/backfill-ingredient-embeddings/index.ts
+++ b/supabase/functions/backfill-ingredient-embeddings/index.ts
@@ -31,23 +31,6 @@ function getBearerToken(req: Request): string | null {
   return auth.trim();
 }
 
-function decodeJwtPayload(token: string): Record<string, unknown> | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length < 2) return null;
-    const payload = parts[1];
-    // base64url -> base64
-    const b64 = payload.replace(/-/g, "+").replace(/_/g, "/");
-    // pad
-    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
-    const json = atob(padded);
-    const obj = JSON.parse(json);
-    return obj && typeof obj === "object" ? (obj as Record<string, unknown>) : null;
-  } catch {
-    return null;
-  }
-}
-
 function clampInt(n: number, min: number, max: number) {
   return Math.max(min, Math.min(max, Math.trunc(n)));
 }
@@ -111,12 +94,9 @@ Deno.serve(async (req) => {
     return new Response("ok", { headers: corsHeaders });
   }
 
-  // Security: service_role JWT only (avoid letting user JWTs burn tokens)
+  // Security: service_role key の完全一致のみで判定（署名未検証のJWTペイロードは信用しない）
   const token = getBearerToken(req);
-  if (!token) return jsonResponse({ error: "unauthorized" }, 401);
-  const payload = decodeJwtPayload(token);
-  const role = String(payload?.role ?? "");
-  if (role !== "service_role") {
+  if (!token || !SERVICE_ROLE_KEY || token !== SERVICE_ROLE_KEY) {
     return jsonResponse({ error: "unauthorized" }, 401);
   }
 

--- a/supabase/functions/create-derived-recipe/index.ts
+++ b/supabase/functions/create-derived-recipe/index.ts
@@ -45,21 +45,6 @@ function getBearerToken(req: Request): string | null {
   return auth.trim();
 }
 
-function decodeJwtPayload(token: string): Record<string, unknown> | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length < 2) return null;
-    const payload = parts[1];
-    const b64 = payload.replace(/-/g, "+").replace(/_/g, "/");
-    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
-    const json = atob(padded);
-    const obj = JSON.parse(json);
-    return obj && typeof obj === "object" ? (obj as Record<string, unknown>) : null;
-  } catch {
-    return null;
-  }
-}
-
 function clampInt(n: number, min: number, max: number) {
   return Math.max(min, Math.min(max, Math.trunc(n)));
 }
@@ -487,12 +472,11 @@ Deno.serve(async (req) => {
     return new Response("ok", { headers: corsHeaders });
   }
 
-  // service_role JWT only
+  // service_role key の完全一致のみで判定（署名未検証のJWTペイロードは信用しない）
   const token = getBearerToken(req);
-  if (!token) return jsonResponse({ error: "unauthorized" }, 401);
-  const payload = decodeJwtPayload(token);
-  const role = String(payload?.role ?? "");
-  if (role !== "service_role") return jsonResponse({ error: "unauthorized" }, 401);
+  if (!token || !SERVICE_ROLE_KEY || token !== SERVICE_ROLE_KEY) {
+    return jsonResponse({ error: "unauthorized" }, 401);
+  }
 
   if (req.method !== "POST") {
     return jsonResponse({ error: "method_not_allowed" }, 405);

--- a/supabase/functions/knowledge-gpt/index.ts
+++ b/supabase/functions/knowledge-gpt/index.ts
@@ -394,15 +394,8 @@ Deno.serve(async (req) => {
     const token = authHeader.match(/^Bearer\s+(.+)$/i)?.[1] ?? authHeader;
     const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 
-    // サービスロールキーかどうかを確認（文字列比較 + JWTペイロードのroleチェック）
-    const isServiceRole = token === serviceRoleKey || (() => {
-      try {
-        const payload = JSON.parse(atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")));
-        return payload?.role === "service_role";
-      } catch {
-        return false;
-      }
-    })();
+    // サービスロールキーかどうかを確認（署名検証されないJWTペイロードのroleは信用せず、完全一致のみで判定）
+    const isServiceRole = serviceRoleKey.length > 0 && token === serviceRoleKey;
 
     if (!isServiceRole) {
       const supabaseAuth = createClient(

--- a/supabase/functions/normalize-shopping-list/index.ts
+++ b/supabase/functions/normalize-shopping-list/index.ts
@@ -20,6 +20,16 @@ import { requireAuth } from "../_shared/auth.ts";
 // 過大入力によるLLMコスト濫用/DoS防止のための上限
 const MAX_INGREDIENTS = 500;
 
+// 認証ヘルパー（_shared/auth.ts）が返す Response には CORS ヘッダーが付与されていないため、
+// ブラウザからの呼び出し（functions.invoke）でも CORS エラーにならないようここで付け直す。
+function withCors(res: Response): Response {
+  const headers = new Headers(res.headers);
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    headers.set(key, value);
+  }
+  return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+}
+
 // ============================================
 // 型定義
 // ============================================
@@ -281,7 +291,7 @@ Deno.serve(async (req: Request) => {
 
   // 認証必須
   const authResult = await requireAuth(req);
-  if (authResult instanceof Response) return authResult;
+  if (authResult instanceof Response) return withCors(authResult);
 
   const requestId = generateRequestId();
   const executionId = generateExecutionId();

--- a/supabase/functions/normalize-shopping-list/index.ts
+++ b/supabase/functions/normalize-shopping-list/index.ts
@@ -15,6 +15,10 @@ import { createLogger, generateRequestId } from "../_shared/db-logger.ts";
 import { getFastLLMApiKey, getFastLLMChatCompletionsUrl, getFastLLMModel } from "../_shared/fast-llm.ts";
 import { fetchWithRetry } from "../_shared/network-retry.ts";
 import { withOpenAIUsageContext, generateExecutionId } from "../_shared/llm-usage.ts";
+import { requireAuth } from "../_shared/auth.ts";
+
+// 過大入力によるLLMコスト濫用/DoS防止のための上限
+const MAX_INGREDIENTS = 500;
 
 // ============================================
 // 型定義
@@ -275,6 +279,10 @@ Deno.serve(async (req: Request) => {
     return new Response("ok", { headers: corsHeaders });
   }
 
+  // 認証必須
+  const authResult = await requireAuth(req);
+  if (authResult instanceof Response) return authResult;
+
   const requestId = generateRequestId();
   const executionId = generateExecutionId();
   const logger = createLogger("normalize-shopping-list", requestId);
@@ -293,6 +301,18 @@ Deno.serve(async (req: Request) => {
     if (!ingredients || !Array.isArray(ingredients)) {
       return new Response(
         JSON.stringify({ error: "ingredients array is required" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    if (ingredients.length > MAX_INGREDIENTS) {
+      return new Response(
+        JSON.stringify({
+          error: `ingredients array exceeds maximum length of ${MAX_INGREDIENTS}`,
+        }),
         {
           status: 400,
           headers: { ...corsHeaders, "Content-Type": "application/json" },

--- a/supabase/functions/regenerate-embeddings/index.ts
+++ b/supabase/functions/regenerate-embeddings/index.ts
@@ -8,6 +8,7 @@ import {
   fetchDatasetEmbeddings,
   isDatasetEmbeddingConfig,
 } from "../../../shared/dataset-embedding.mjs";
+import { requireServiceRole } from "../_shared/auth.ts";
 
 /**
  * 埋め込みベクトル再生成 Edge Function
@@ -73,6 +74,10 @@ Deno.serve(async (req) => {
       },
     });
   }
+
+  // cron/内部専用: service role key または CRON_SECRET のみ許可
+  const authError = requireServiceRole(req);
+  if (authError) return authError;
 
   try {
     const body = await req.json().catch(() => ({}));

--- a/supabase/functions/regenerate-embeddings/index.ts
+++ b/supabase/functions/regenerate-embeddings/index.ts
@@ -75,9 +75,14 @@ Deno.serve(async (req) => {
     });
   }
 
-  // cron/内部専用: service role key または CRON_SECRET のみ許可
-  const authError = requireServiceRole(req);
-  if (authError) return authError;
+  // cron/内部専用: service role key の完全一致、または CRON_SECRET/SERVICE_ROLE_SECRET のいずれかを満たせば許可
+  const authHeader = req.headers.get("Authorization") ?? "";
+  const bearerToken = authHeader.replace(/^Bearer\s+/i, "").trim();
+  const isServiceRoleKey = SUPABASE_SERVICE_ROLE_KEY.length > 0 && bearerToken === SUPABASE_SERVICE_ROLE_KEY;
+  if (!isServiceRoleKey) {
+    const authError = requireServiceRole(req);
+    if (authError) return authError;
+  }
 
   try {
     const body = await req.json().catch(() => ({}));

--- a/supabase/functions/regenerate-embeddings/index.ts
+++ b/supabase/functions/regenerate-embeddings/index.ts
@@ -75,10 +75,13 @@ Deno.serve(async (req) => {
     });
   }
 
-  // cron/内部専用: service role key の完全一致、または CRON_SECRET/SERVICE_ROLE_SECRET のいずれかを満たせば許可
+  // cron/内部専用: service role key の完全一致（SERVICE_ROLE_JWT / SUPABASE_SERVICE_ROLE_KEY のどちらでも可）、
+  // または CRON_SECRET/SERVICE_ROLE_SECRET のいずれかを満たせば許可
   const authHeader = req.headers.get("Authorization") ?? "";
   const bearerToken = authHeader.replace(/^Bearer\s+/i, "").trim();
-  const isServiceRoleKey = SUPABASE_SERVICE_ROLE_KEY.length > 0 && bearerToken === SUPABASE_SERVICE_ROLE_KEY;
+  const isServiceRoleKey =
+    !!bearerToken &&
+    (bearerToken === Deno.env.get("SERVICE_ROLE_JWT") || bearerToken === Deno.env.get("SUPABASE_SERVICE_ROLE_KEY"));
   if (!isServiceRoleKey) {
     const authError = requireServiceRole(req);
     if (authError) return authError;

--- a/supabase/functions/regenerate-shopping-list-v2/index.ts
+++ b/supabase/functions/regenerate-shopping-list-v2/index.ts
@@ -25,6 +25,16 @@ const corsHeaders = {
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 
+// 認証ヘルパー（_shared/auth.ts）が返す Response には CORS ヘッダーが付与されていないため、
+// ブラウザからの呼び出し（functions.invoke）でも CORS エラーにならないようここで付け直す。
+function withCors(res: Response): Response {
+  const headers = new Headers(res.headers);
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    headers.set(key, value);
+  }
+  return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+}
+
 // ============================================
 // 型定義
 // ============================================
@@ -619,11 +629,6 @@ Deno.serve(async (req: Request) => {
     return new Response("ok", { headers: corsHeaders });
   }
 
-  // 認証必須（署名検証されたユーザーJWTのみ許可、body.userIdは信用しない）
-  const authResult = await requireAuth(req);
-  if (authResult instanceof Response) return authResult;
-  const authenticatedUserId = authResult.userId;
-
   try {
     const { requestId, userId: bodyUserId, startDate, endDate, servingsConfig } = await req.json();
 
@@ -637,17 +642,44 @@ Deno.serve(async (req: Request) => {
       );
     }
 
-    if (bodyUserId && bodyUserId !== authenticatedUserId) {
-      return new Response(
-        JSON.stringify({ error: "userId does not match authenticated user" }),
-        {
-          status: 403,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
-    }
+    // 認証: 二系統を許可する
+    // 1) 信頼された内部呼び出し（src/app/api/shopping-list/regenerate/route.ts が
+    //    サーバー側で getUser 済みのうえ SUPABASE_SERVICE_ROLE_KEY を Bearer に付けて呼ぶ）
+    //    → body.userId をそのまま採用（必須）
+    // 2) それ以外はユーザーJWTを requireAuth で検証し、authResult.userId を採用
+    const authHeader = req.headers.get("Authorization") ?? "";
+    const accessToken = authHeader.replace(/^Bearer\s+/i, "").trim();
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+    const isTrustedInternalCall = serviceRoleKey.length > 0 && accessToken === serviceRoleKey;
 
-    const userId = authenticatedUserId;
+    let userId: string;
+
+    if (isTrustedInternalCall) {
+      if (!bodyUserId || typeof bodyUserId !== "string") {
+        return new Response(
+          JSON.stringify({ error: "userId is required for service-role calls" }),
+          {
+            status: 400,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          }
+        );
+      }
+      userId = bodyUserId;
+    } else {
+      const authResult = await requireAuth(req);
+      if (authResult instanceof Response) return withCors(authResult);
+
+      if (bodyUserId && bodyUserId !== authResult.userId) {
+        return new Response(
+          JSON.stringify({ error: "userId does not match authenticated user" }),
+          {
+            status: 403,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          }
+        );
+      }
+      userId = authResult.userId;
+    }
 
     // Service Role Keyでクライアント作成（RLSバイパス）
     const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
@@ -656,7 +688,9 @@ Deno.serve(async (req: Request) => {
 
     // 非同期で処理開始（即座にレスポンス返す。レスポンス後も処理が打ち切られないようwaitUntilに委ねる）
     const backgroundTask = processRegeneration(supabase, requestId, userId, startDate, endDate, servingsConfig || null);
+    // @ts-ignore EdgeRuntime
     if (typeof EdgeRuntime !== "undefined" && EdgeRuntime.waitUntil) {
+      // @ts-ignore EdgeRuntime
       EdgeRuntime.waitUntil(backgroundTask);
     }
 

--- a/supabase/functions/regenerate-shopping-list-v2/index.ts
+++ b/supabase/functions/regenerate-shopping-list-v2/index.ts
@@ -12,6 +12,7 @@ import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { getFastLLMApiKey, getFastLLMChatCompletionsUrl, getFastLLMModel } from "../_shared/fast-llm.ts";
 import { withOpenAIUsageContext, generateExecutionId } from "../_shared/llm-usage.ts";
 import { createLogger } from "../_shared/db-logger.ts";
+import { requireAuth } from "../_shared/auth.ts";
 
 // ============================================
 // CORS
@@ -618,12 +619,17 @@ Deno.serve(async (req: Request) => {
     return new Response("ok", { headers: corsHeaders });
   }
 
-  try {
-    const { requestId, userId, startDate, endDate, servingsConfig } = await req.json();
+  // 認証必須（署名検証されたユーザーJWTのみ許可、body.userIdは信用しない）
+  const authResult = await requireAuth(req);
+  if (authResult instanceof Response) return authResult;
+  const authenticatedUserId = authResult.userId;
 
-    if (!requestId || !userId || !startDate || !endDate) {
+  try {
+    const { requestId, userId: bodyUserId, startDate, endDate, servingsConfig } = await req.json();
+
+    if (!requestId || !startDate || !endDate) {
       return new Response(
-        JSON.stringify({ error: "requestId, userId, startDate, endDate are required" }),
+        JSON.stringify({ error: "requestId, startDate, endDate are required" }),
         {
           status: 400,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
@@ -631,13 +637,28 @@ Deno.serve(async (req: Request) => {
       );
     }
 
+    if (bodyUserId && bodyUserId !== authenticatedUserId) {
+      return new Response(
+        JSON.stringify({ error: "userId does not match authenticated user" }),
+        {
+          status: 403,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const userId = authenticatedUserId;
+
     // Service Role Keyでクライアント作成（RLSバイパス）
     const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
     const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
-    // 非同期で処理開始（即座にレスポンス返す）
-    processRegeneration(supabase, requestId, userId, startDate, endDate, servingsConfig || null);
+    // 非同期で処理開始（即座にレスポンス返す。レスポンス後も処理が打ち切られないようwaitUntilに委ねる）
+    const backgroundTask = processRegeneration(supabase, requestId, userId, startDate, endDate, servingsConfig || null);
+    if (typeof EdgeRuntime !== "undefined" && EdgeRuntime.waitUntil) {
+      EdgeRuntime.waitUntil(backgroundTask);
+    }
 
     return new Response(
       JSON.stringify({ success: true, requestId }),

--- a/supabase/functions/regenerate-shopping-list-v2/index.ts
+++ b/supabase/functions/regenerate-shopping-list-v2/index.ts
@@ -632,17 +632,7 @@ Deno.serve(async (req: Request) => {
   try {
     const { requestId, userId: bodyUserId, startDate, endDate, servingsConfig } = await req.json();
 
-    if (!requestId || !startDate || !endDate) {
-      return new Response(
-        JSON.stringify({ error: "requestId, startDate, endDate are required" }),
-        {
-          status: 400,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
-    }
-
-    // 認証: 二系統を許可する
+    // 認証（auth-first: body必須フィールドのバリデーションより先に行う）: 二系統を許可する
     // 1) 信頼された内部呼び出し（src/app/api/shopping-list/regenerate/route.ts が
     //    サーバー側で getUser 済みのうえ SUPABASE_SERVICE_ROLE_KEY を Bearer に付けて呼ぶ）
     //    → body.userId をそのまま採用（必須）
@@ -679,6 +669,16 @@ Deno.serve(async (req: Request) => {
         );
       }
       userId = authResult.userId;
+    }
+
+    if (!requestId || !startDate || !endDate) {
+      return new Response(
+        JSON.stringify({ error: "requestId, startDate, endDate are required" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
     }
 
     // Service Role Keyでクライアント作成（RLSバイパス）


### PR DESCRIPTION
## 対応 Issue
- #1016 [Crit][security] knowledge-gpt が verify_jwt=false + 署名未検証で認証バイパス
- #1018 [Crit][security] 認可のない Edge Function 3本(regenerate-shopping-list-v2 / regenerate-embeddings / normalize-shopping-list)

## 脆弱性と修正
1. **#1016 knowledge-gpt**: `atob` で JWT payload をデコードして `role==="service_role"` を見るだけの署名未検証判定を撤廃。`token === SUPABASE_SERVICE_ROLE_KEY` の**完全一致のみ**に置換(process-meal-image-jobs と同型)。同型の署名未検証判定があった `create-derived-recipe` / `backfill-ingredient-embeddings` も同時是正(将来の verify_jwt=false 化での即バイパス転落を予防)。
2. **#1018 regenerate-shopping-list-v2**: body.userId を無検証で service-role に渡す IDOR を封鎖。**dual-path 認証**(service role key 完全一致なら信頼された内部呼び出しとして body.userId を採用、それ以外は requireAuth でユーザー JWT 検証 + 不一致 403)。EdgeRuntime.waitUntil で応答後処理の打ち切りも防止。
3. **#1018 normalize-shopping-list**: requireAuth 追加 + ingredients 上限(MAX_INGREDIENTS=500)でコスト濫用/DoS 防止。
4. **#1018 regenerate-embeddings**: service role key 完全一致 OR requireServiceRole(CRON_SECRET/SERVICE_ROLE_SECRET)で cron/内部専用に閉じる。ops スクリプト2本を anon key → service role key に更新し、認証失敗時は fail-fast / status:failed 記録。
5. 認証失敗レスポンスに CORS ヘッダを付与(withCors)。

## レビュー(2モデル敵対的 × 3ラウンド)
Sonnet 5 + Fable の独立レビュー。round 1 で両モデルが Critical「regenerate-shopping-list-v2 の素の requireAuth が唯一の本番呼び出し元(service role key + body.userId)を401で全損させる退行」を検出 → dual-path で修正。round 2・round 3 とも両モデル PASS。認証バイパスが塞がれたこと、IDOR が再導入されていないこと(空/未設定キーで fail-close)、正規の内部 service-role 呼び出しの正常系が壊れないこと、deno check 新規エラーゼロを確認。

## 補足
- config.toml の verify_jwt は変更していない(内部の完全一致判定でバイパスは塞がるため)。
- これはコード/Edge Function のみの変更で migration を含まないため、#1064 ドリフトに関わらず Vercel/Edge deploy 経由で本番反映される。

Refs #1012