### PR TITLE
fix(security): 献立生成のなりすましと meal/regenerate の IDOR を修正 (#1017 #1019)

### DIFF
--- a/src/app/api/ai/menu/meal/regenerate/route.ts
+++ b/src/app/api/ai/menu/meal/regenerate/route.ts
@@ -4,15 +4,18 @@ import { NextResponse } from 'next/server';
 import { waitUntil } from '@vercel/functions';
 import { callGenerateMenuV4WithRetry, markWeeklyMenuRequestFailed } from '@/lib/generate-menu-v4-retry';
 import { callGenerateMenuV5WithRetry } from '@/lib/generate-menu-v5-retry';
+import type { Tables } from '@homegohan/shared';
 
 // Vercel Proプランでは最大300秒まで延長可能
 export const maxDuration = 300;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export async function POST(request: Request) {
   const supabase = await createClient();
 
   try {
-    const { mealId, dayDate, mealType, preferences, note } = await request.json();
+    const { mealId, preferences, note } = await request.json();
 
     // 1. ユーザー認証
     const { data: { user }, error: userError } = await supabase.auth.getUser();
@@ -20,10 +23,31 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    // 2. mealIdが必須
-    if (!mealId) {
-      return NextResponse.json({ error: 'mealId is required' }, { status: 400 });
+    // 2. mealIdが必須 + UUID形式チェック
+    if (!mealId || typeof mealId !== 'string' || !UUID_RE.test(mealId)) {
+      return NextResponse.json({ error: 'mealId must be a valid UUID' }, { status: 400 });
     }
+
+    // 2.5 所有権検証（IDOR対策）: 自分が所有する planned_meal かどうかを確認し、
+    // meal_type / dayDate はクライアント入力ではなく DB から取得した値を正とする
+    const { data: plannedMeal, error: plannedMealError } = await supabase
+      .from('planned_meals')
+      .select('id, meal_type, user_daily_meals!inner(day_date, user_id)')
+      .eq('id', mealId)
+      .eq('user_daily_meals.user_id', user.id)
+      .maybeSingle();
+
+    if (plannedMealError) {
+      return NextResponse.json({ error: plannedMealError.message }, { status: 500 });
+    }
+
+    const day = (plannedMeal?.user_daily_meals as unknown as Pick<Tables<'user_daily_meals'>, 'day_date'> | null) ?? null;
+    if (!plannedMeal || !day?.day_date || !plannedMeal.meal_type) {
+      return NextResponse.json({ error: 'Meal not found' }, { status: 404 });
+    }
+
+    const dayDate = day.day_date;
+    const mealType = plannedMeal.meal_type;
 
     console.log(`📝 Regenerating meal: ${mealId}`);
 

--- a/src/app/api/ai/menu/meal/regenerate/route.ts
+++ b/src/app/api/ai/menu/meal/regenerate/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 import { waitUntil } from '@vercel/functions';
 import { callGenerateMenuV4WithRetry, markWeeklyMenuRequestFailed } from '@/lib/generate-menu-v4-retry';
 import { callGenerateMenuV5WithRetry } from '@/lib/generate-menu-v5-retry';
+import { createLogger } from '@/lib/db-logger';
 import type { Tables } from '@homegohan/shared';
 
 // Vercel Proプランでは最大300秒まで延長可能
@@ -38,7 +39,12 @@ export async function POST(request: Request) {
       .maybeSingle();
 
     if (plannedMealError) {
-      return NextResponse.json({ error: plannedMealError.message }, { status: 500 });
+      createLogger('api/ai/menu/meal/regenerate').withUser(user.id).error(
+        'planned_meal の所有権確認に失敗しました',
+        plannedMealError,
+        { mealId },
+      );
+      return NextResponse.json({ error: '献立の取得に失敗しました' }, { status: 500 });
     }
 
     const day = (plannedMeal?.user_daily_meals as unknown as Pick<Tables<'user_daily_meals'>, 'day_date'> | null) ?? null;

--- a/src/lib/generate-menu-v4-retry.ts
+++ b/src/lib/generate-menu-v4-retry.ts
@@ -150,10 +150,12 @@ export async function callGenerateMenuV4WithRetry(params: GenerateMenuV4CallPara
   const { timeoutMs, maxAttempts, baseDelayMs, maxDelayMs } = normalizeRetryOptions(params.retry);
   const supabaseUrl = params.supabaseUrl.replace(/\/+$/, '');
   const url = `${supabaseUrl}/functions/v1/generate-menu-v4`;
+  // Authorization は service-role 信頼モデルの根幹のため、extraHeaders による
+  // 上書きを許さない（意図せぬ extraHeaders.Authorization 混入で権限判定が壊れるのを防ぐ）。
   const headers: Record<string, string> = {
+    ...params.extraHeaders,
     'Content-Type': 'application/json',
     Authorization: `Bearer ${params.serviceRoleKey}`,
-    ...params.extraHeaders,
   };
 
   let lastFailure: AttemptFailure | null = null;

--- a/src/lib/generate-menu-v5-retry.ts
+++ b/src/lib/generate-menu-v5-retry.ts
@@ -99,11 +99,13 @@ export async function callGenerateMenuV5WithRetry(params: GenerateMenuV5CallPara
   const { timeoutMs, maxAttempts, baseDelayMs, maxDelayMs } = normalizeRetryOptions(params.retry);
   const supabaseUrl = params.supabaseUrl.replace(/\/+$/, "");
   const url = `${supabaseUrl}/functions/v1/generate-menu-v5`;
+  // Authorization/apikey は service-role 信頼モデルの根幹のため、extraHeaders による
+  // 上書きを許さない（意図せぬ extraHeaders.Authorization 混入で権限判定が壊れるのを防ぐ）。
   const headers: Record<string, string> = {
+    ...params.extraHeaders,
     "Content-Type": "application/json",
     Authorization: `Bearer ${params.serviceRoleKey}`,
     apikey: params.serviceRoleKey,
-    ...params.extraHeaders,
   };
 
   let lastFailure: AttemptFailure | null = null;

--- a/supabase/functions/_shared/save-meal.ts
+++ b/supabase/functions/_shared/save-meal.ts
@@ -275,13 +275,24 @@ export async function saveMealToDb(
     ? await runSupabaseQuery(
         () => supabase
           .from("planned_meals")
-          .select("id, dishes, image_url")
+          .select("id, dishes, image_url, meal_type, user_daily_meals!inner(user_id)")
           .eq("id", targetSlot.plannedMealId)
           .maybeSingle(),
         `planned_meals.lookup:${targetSlot.plannedMealId}`,
         null,
       )
     : null;
+
+  // 最終防衛線: service-role クライアントは RLS を通らないため、ここで明示的に所有権を検証する。
+  // （#1017/#1019 共通ガード。他ユーザーの planned_meal を誤って/悪意を持って更新しないための最後の砦）
+  if (targetSlot.plannedMealId && existingMeal) {
+    const ownerUserId = (existingMeal as any)?.user_daily_meals?.user_id;
+    if (String(ownerUserId ?? "") !== String(userId)) {
+      throw new Error(
+        `Ownership check failed: planned_meal ${targetSlot.plannedMealId} does not belong to userId ${userId}`,
+      );
+    }
+  }
 
   if (targetSlot.plannedMealId && !existingMeal?.id) {
     console.warn(`planned_meal ${targetSlot.plannedMealId} not found (may have been cleared), will insert new`);

--- a/supabase/functions/_shared/save-meal.ts
+++ b/supabase/functions/_shared/save-meal.ts
@@ -275,7 +275,7 @@ export async function saveMealToDb(
     ? await runSupabaseQuery(
         () => supabase
           .from("planned_meals")
-          .select("id, dishes, image_url, meal_type, user_daily_meals!inner(user_id)")
+          .select("id, dishes, image_url, user_daily_meals!inner(user_id)")
           .eq("id", targetSlot.plannedMealId)
           .maybeSingle(),
         `planned_meals.lookup:${targetSlot.plannedMealId}`,

--- a/supabase/functions/generate-menu-v4/index.ts
+++ b/supabase/functions/generate-menu-v4/index.ts
@@ -2736,20 +2736,37 @@ Deno.serve(async (req: Request) => {
     const isContinue = body._continue === true;
 
     const authHeader = req.headers.get("Authorization") ?? "";
-    const accessToken = authHeader.replace(/^Bearer\\s+/i, "").trim();
+    const accessToken = authHeader.replace(/^Bearer\s+/i, "").trim();
     if (!accessToken) throw new Error("Missing access token");
     if (!requestId) throw new Error("request_id is required");
 
-    // 継続呼び出し（_continue=true）の場合、SERVICE_ROLE_KEYで呼ばれるので getUser()は使えない
+    // 継続呼び出し（_continue=true）は SERVICE_ROLE_KEY で呼ばれる（自関数からの内部呼び出しのみ）
+    const isServiceRoleCaller = Boolean(supabaseServiceKey) && accessToken === supabaseServiceKey;
+
     if (isContinue) {
+      // 継続呼び出しは service role key を提示した場合のみ許可（誰でも継続を名乗れる穴を防ぐ）
+      if (!isServiceRoleCaller) {
+        return new Response(
+          JSON.stringify({ error: "Unauthorized: continuation requires service role authorization" }),
+          { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+        );
+      }
       if (!body.userId) throw new Error("userId is required for continuation calls");
       userId = body.userId;
       console.log(`📍 Continuation call with userId: ${userId}`);
-    } else if (body.userId) {
+    } else if (isServiceRoleCaller && body.userId) {
+      // 信頼済みバックエンド（Next.js API route）からの呼び出し。userId はサーバ側で検証済み。
       userId = body.userId;
     } else {
+      // 非継続かつ service role 以外の呼び出しは、Authorization トークンから必ず userId を導出する
+      // （body.userId はなりすまし防止のため採用しない）
       const { data: userData, error: userErr } = await supabase.auth.getUser(accessToken);
-      if (userErr || !userData?.user) throw new Error(`Auth failed: ${userErr?.message ?? "no user"}`);
+      if (userErr || !userData?.user) {
+        return new Response(
+          JSON.stringify({ error: "Unauthorized" }),
+          { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+        );
+      }
       userId = userData.user.id;
     }
 

--- a/supabase/functions/generate-menu-v4/index.ts
+++ b/supabase/functions/generate-menu-v4/index.ts
@@ -2741,7 +2741,14 @@ Deno.serve(async (req: Request) => {
     if (!requestId) throw new Error("request_id is required");
 
     // 継続呼び出し（_continue=true）は SERVICE_ROLE_KEY で呼ばれる（自関数からの内部呼び出しのみ）
-    const isServiceRoleCaller = Boolean(supabaseServiceKey) && accessToken === supabaseServiceKey;
+    // SERVICE_ROLE_JWT / SUPABASE_SERVICE_ROLE_KEY のどちらが設定されていても一致を許容する
+    // （呼び出し元は常に SUPABASE_SERVICE_ROLE_KEY を送るが、Edge 側の env 優先順位と食い違うと
+    //   全呼び出しが 401 になる退行を防ぐため、両方の設定値を許容リストとして扱う）
+    const configuredServiceRoleKeys = [
+      Deno.env.get("SERVICE_ROLE_JWT"),
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY"),
+    ].filter((key): key is string => Boolean(key));
+    const isServiceRoleCaller = Boolean(accessToken) && configuredServiceRoleKeys.includes(accessToken);
 
     if (isContinue) {
       // 継続呼び出しは service role key を提示した場合のみ許可（誰でも継続を名乗れる穴を防ぐ）
@@ -2768,6 +2775,26 @@ Deno.serve(async (req: Request) => {
         );
       }
       userId = userData.user.id;
+
+      // request_id の所有権検証（IDOR対策）: 認証済みユーザーが他人の request_id を渡して
+      // weekly_menu_requests 行（status/progress/generated_data）を書き換えられないよう、
+      // mutation を始める前に検証する。service role 経由（isServiceRoleCaller）は body.userId を
+      // 信頼する設計のため対象外。
+      const ownerRow = await runSupabaseQuery<{ user_id: string } | null>(
+        () => (supabase as any)
+          .from("weekly_menu_requests")
+          .select("user_id")
+          .eq("id", requestId)
+          .maybeSingle(),
+        `weekly_menu_requests.owner_check:${requestId}`,
+        null,
+      );
+      if (!ownerRow || String(ownerRow.user_id) !== String(userId)) {
+        return new Response(
+          JSON.stringify({ error: "Not Found" }),
+          { status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+        );
+      }
     }
 
     // 現在のステップを取得

--- a/supabase/functions/generate-menu-v5/index.ts
+++ b/supabase/functions/generate-menu-v5/index.ts
@@ -3401,15 +3401,33 @@ Deno.serve(async (req: Request) => {
     const accessToken = authHeader.replace(/^Bearer\s+/i, "").trim();
     if (!requestId) throw new Error("request_id is required");
 
+    // 継続呼び出し（_continue=true）は SERVICE_ROLE_KEY で呼ばれる（自関数からの内部呼び出しのみ）
+    const isServiceRoleCaller = Boolean(supabaseServiceKey) && accessToken === supabaseServiceKey;
+
     if (isContinue) {
+      // 継続呼び出しは service role key を提示した場合のみ許可（誰でも継続を名乗れる穴を防ぐ）
+      if (!isServiceRoleCaller) {
+        return new Response(
+          JSON.stringify({ error: "Unauthorized: continuation requires service role authorization" }),
+          { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+        );
+      }
       if (!body.userId) throw new Error("userId is required for continuation calls");
       userId = body.userId;
-    } else if (body.userId) {
+    } else if (isServiceRoleCaller && body.userId) {
+      // 信頼済みバックエンド（Next.js API route）からの呼び出し。userId はサーバ側で検証済み。
       userId = body.userId;
     } else {
+      // 非継続かつ service role 以外の呼び出しは、Authorization トークンから必ず userId を導出する
+      // （body.userId はなりすまし防止のため採用しない）
       if (!accessToken) throw new Error("Missing access token");
       const { data: userData, error: userErr } = await supabase.auth.getUser(accessToken);
-      if (userErr || !userData?.user) throw new Error(`Auth failed: ${userErr?.message ?? "no user"}`);
+      if (userErr || !userData?.user) {
+        return new Response(
+          JSON.stringify({ error: "Unauthorized" }),
+          { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+        );
+      }
       userId = userData.user.id;
     }
 

--- a/supabase/functions/generate-menu-v5/index.ts
+++ b/supabase/functions/generate-menu-v5/index.ts
@@ -399,6 +399,7 @@ async function executeStep3_Save(
   console.log("💾 V5 Step 3: Nutrition & saving (direct)...");
 
   const reqRow = await loadRequestRow(supabase, requestId);
+  if (String(reqRow.user_id) !== String(userId)) throw new Error("userId mismatch for request");
   const generatedData: V5GeneratedData = (reqRow.generated_data ?? {}) as any;
   const ultimateMode = generatedData.ultimateMode ?? false;
   const totalSteps = ultimateMode ? 6 : 3;
@@ -2911,6 +2912,7 @@ async function executeStep4_NutritionFeedback(
   console.log("📊 V5 Step 4: Nutrition feedback analysis...");
 
   const reqRow = await loadRequestRow(supabase, requestId);
+  if (String(reqRow.user_id) !== String(userId)) throw new Error("userId mismatch for request");
   const generatedData: V5GeneratedData = (reqRow.generated_data ?? {}) as any;
   const dates = generatedData.dates ?? [];
   const generatedMeals: Record<string, GeneratedMeal> = (generatedData.generatedMeals ?? {}) as any;
@@ -3035,6 +3037,7 @@ async function executeStep5_RegenerateWithAdvice(
   console.log("🔄 V5 Step 5: Regenerating meals with advice...");
 
   const reqRow = await loadRequestRow(supabase, requestId);
+  if (String(reqRow.user_id) !== String(userId)) throw new Error("userId mismatch for request");
   const generatedData: V5GeneratedData = (reqRow.generated_data ?? {}) as any;
   const generatedMeals: Record<string, GeneratedMeal> = (generatedData.generatedMeals ?? {}) as any;
   const targetSlots = generatedData.targetSlots ?? [];
@@ -3220,6 +3223,7 @@ async function executeStep6_FinalSave(
   console.log("💾 V5 Step 6: Final save...");
 
   const reqRow = await loadRequestRow(supabase, requestId);
+  if (String(reqRow.user_id) !== String(userId)) throw new Error("userId mismatch for request");
   const generatedData: V5GeneratedData = (reqRow.generated_data ?? {}) as any;
   const targetSlots = sortTargetSlots(generatedData.targetSlots ?? normalizeTargetSlots(reqRow.target_slots ?? []));
   const totalSlots = targetSlots.length;
@@ -3402,7 +3406,14 @@ Deno.serve(async (req: Request) => {
     if (!requestId) throw new Error("request_id is required");
 
     // 継続呼び出し（_continue=true）は SERVICE_ROLE_KEY で呼ばれる（自関数からの内部呼び出しのみ）
-    const isServiceRoleCaller = Boolean(supabaseServiceKey) && accessToken === supabaseServiceKey;
+    // SERVICE_ROLE_JWT / SUPABASE_SERVICE_ROLE_KEY のどちらが設定されていても一致を許容する
+    // （呼び出し元は常に SUPABASE_SERVICE_ROLE_KEY を送るが、Edge 側の env 優先順位と食い違うと
+    //   全呼び出しが 401 になる退行を防ぐため、両方の設定値を許容リストとして扱う）
+    const configuredServiceRoleKeys = [
+      Deno.env.get("SERVICE_ROLE_JWT"),
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY"),
+    ].filter((key): key is string => Boolean(key));
+    const isServiceRoleCaller = Boolean(accessToken) && configuredServiceRoleKeys.includes(accessToken);
 
     if (isContinue) {
       // 継続呼び出しは service role key を提示した場合のみ許可（誰でも継続を名乗れる穴を防ぐ）
@@ -3429,6 +3440,26 @@ Deno.serve(async (req: Request) => {
         );
       }
       userId = userData.user.id;
+
+      // request_id の所有権検証（IDOR対策）: 認証済みユーザーが他人の request_id を渡して
+      // weekly_menu_requests 行（status/progress/generated_data）を書き換えられないよう、
+      // mutation を始める前に検証する。service role 経由（isServiceRoleCaller）は body.userId を
+      // 信頼する設計のため対象外。
+      const ownerRow = await runSupabaseQuery<{ user_id: string } | null>(
+        () => supabase
+          .from("weekly_menu_requests")
+          .select("user_id")
+          .eq("id", requestId)
+          .maybeSingle(),
+        `weekly_menu_requests.owner_check:${requestId}`,
+        null,
+      );
+      if (!ownerRow || String(ownerRow.user_id) !== String(userId)) {
+        return new Response(
+          JSON.stringify({ error: "Not Found" }),
+          { status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+        );
+      }
     }
 
     let currentStep = 1;


### PR DESCRIPTION
## 対応 Issue
- #1017 [Crit][security] generate-menu-v4/v5 が body.userId 無検証で他人になりすまし(+v4 Bearer regex バグ)
- #1019 [Crit][security] /api/ai/menu/meal/regenerate が mealId 所有権未検証で IDOR

## 脆弱性と修正
1. **#1017 なりすまし**: generate-menu-v4/v5 が非継続呼び出しでも `body.userId` をトークンと照合せず採用していた。**非 service-role 呼び出しでは必ず `getUser(accessToken)` から userId を導出**し body.userId を不採用に。body.userId を信頼するのは service role key 提示時のみ(`_continue` も service role 必須)。service-role 判定は `SERVICE_ROLE_JWT` / `SUPABASE_SERVICE_ROLE_KEY` の**両 env 名を許容**(本番呼び出し元は後者を送るため、env 非対称での 401 全損を回避)。
2. **#1017 request_id 所有権**: getUser 経路で userId 確定直後(mutation 前)に `weekly_menu_requests.user_id === userId` を検証し不一致は 404。被害者の request_id を使った status/progress 改ざんの残存 IDOR を封鎖。
3. **#1017 v4 Bearer regex**: `/^Bearer\s+/i`(バックスラッシュ1個)に修正し、正規 JWT 認証パスが機能するように。
4. **#1017 v5 多層防御**: v4 が全ステップに持つ `reqRow.user_id !== userId` チェックを v5 step3-6 にも追加し対称化。
5. **#1019 meal/regenerate IDOR**: `user_daily_meals!inner` + `eq(user_id)` の所有権検証 + UUID 形式検証を追加(他人の mealId は 404)。day_date/meal_type は DB 由来を正としクライアント値を無視。`_shared/save-meal.ts` に最終防衛線の所有権ガード(service-role で RLS 無効な update の前に throw)を #1017/#1019 共通の1実装として追加。

## レビュー(2モデル敵対的 × 2ラウンド)
Sonnet 5 + Fable の独立レビュー。round 1 で Fable が Critical「service-role 判定の env 名非対称(SERVICE_ROLE_JWT vs SUPABASE_SERVICE_ROLE_KEY)で初回生成・リトライ・cron が401全損しうる退行」を検出、Sonnet が Warning「v5 step3-6 の多層防御欠如」を検出 → 両 env 対応 + request_id 所有権 + v5 step3-6 で修正。round 2 は両モデル PASS。なりすまし・IDOR が塞がれ、正規の初回生成/継続/リトライ/cron/自分の meal 再生成が壊れないこと、typecheck クリーン、deno check 新規エラーゼロを確認。

## スコープ外(フォローアップ・非ブロッキング)
top-level catch が所有権チェッククエリ自体の DB エラー時に requestId 行へ status:failed を書く既存パターン(攻撃者は DB エラーを誘発できず、献立データ本体には影響なし)。両モデルが非ブロッキングと判定。

## 補足
コード/Edge Function のみで migration を含まないため、#1064 ドリフトに関わらず Vercel/Edge deploy 経由で本番反映される。

Refs #1012