### PR TITLE
fix(weekly-menu): add-from-photo の planned_meals 不在列INSERTによる常時500を修正 (#1026)

### DIFF
--- a/src/app/api/meal-plans/add-from-photo/route.ts
+++ b/src/app/api/meal-plans/add-from-photo/route.ts
@@ -83,6 +83,7 @@ export async function POST(request: Request) {
           user_id: user.id,
           day_date: dayDate,
           is_cheat_day: false,
+          is_sandbox: isSandbox,
         })
         .select('id')
         .single();
@@ -149,7 +150,6 @@ export async function POST(request: Request) {
       dishes: photoDishes.length > 0 ? photoDishes : null,
       is_simple: photoDishes.length <= 1,
       source_type: source === 'handson_tour' ? 'handson_tour' : 'manual',
-      is_sandbox: isSandbox,
     };
 
     if (catalogProductId) {


### PR DESCRIPTION
## 対応 Issue
#1026 [Crit] /api/meal-plans/add-from-photo が is_sandbox 列不在で常時500（写真食事登録が死亡）

## 変更
- `src/app/api/meal-plans/add-from-photo/route.ts`: `planned_meals` に存在しない `is_sandbox` キーを INSERT payload から除去（常時500の解消）。`user_daily_meals` 新規INSERTに `is_sandbox: isSandbox` を追加（sandbox判定を `user_daily_meals` 側に一元化、cleanup cronと整合）

## レビュー
Sonnet 5 + Fable の2モデル敵対的レビューで double-PASS。`planned_meals` に `is_sandbox` 列が無いこと・`user_daily_meals` に有ることを型定義とmigrationで実査、typecheck PASS。通常/sandbox両フローの退行なし。

## フォロー（別Issue）
- 既存日再利用分岐で `is_sandbox` が据え置かれ、sandbox日に実データが付くと90日cleanupで消えるデータ消失経路（両レビュアーが指摘、本diff範囲外）
- `api/menu-plans/add/route.ts` に同型のpayload/スキーマ不一致の疑い