### PR TITLE
fix(backoffice): admin ユーザー管理の RLS 全滅を service_role 化で修正 (#1028)

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,5 +1,25 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import { createClient as createAdminClient } from '@supabase/supabase-js'
 import { cookies, headers } from 'next/headers'
+
+/**
+ * service_role キーで動作する Supabase クライアントを返す。
+ * RLS を完全にバイパスするため、呼び出し側で **必ず requireRole 等の認可チェックを
+ * 先に通した後**にのみ使用すること(認可前に使うと権限昇格になる)。
+ *
+ * admin/* の API ルートが管理者操作(他ユーザーの user_profiles 参照・更新等)を
+ * 行う際の共通ヘルパー。#1028 で organizations route の重複実装を集約した。
+ */
+export function getSupabaseAdmin() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !serviceKey) {
+    throw new Error('Supabase admin env is missing (NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY)')
+  }
+  return createAdminClient(url, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
 
 export function createClient(cookieStore?: ReturnType<typeof cookies>) {
   const store = cookieStore || cookies()

--- a/src/app/api/admin/organizations/route.ts
+++ b/src/app/api/admin/organizations/route.ts
@@ -10,20 +10,8 @@
 import { NextResponse } from 'next/server';
 import { requireRole } from '@/lib/auth/helpers';
 import { AuthError, ForbiddenError } from '@/lib/auth/errors';
-import { createClient } from '@/lib/supabase/server';
-import { createClient as createAdminClient } from '@supabase/supabase-js';
+import { createClient, getSupabaseAdmin } from '@/lib/supabase/server';
 import { z } from 'zod';
-
-function getSupabaseAdmin() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !serviceKey) {
-    throw new Error('Supabase admin env is missing (NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY)');
-  }
-  return createAdminClient(url, serviceKey, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
-}
 
 export const dynamic = 'force-dynamic';
 

--- a/src/app/api/admin/users/[id]/freeze/route.ts
+++ b/src/app/api/admin/users/[id]/freeze/route.ts
@@ -9,7 +9,7 @@
 import { NextResponse } from 'next/server';
 import { requireRole } from '@/lib/auth/helpers';
 import { AuthError, ForbiddenError } from '@/lib/auth/errors';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, getSupabaseAdmin } from '@/lib/supabase/server';
 import { FreezeBodySchema, UnfreezeBodySchema } from '@/lib/admin/users-schemas';
 
 export const dynamic = 'force-dynamic';
@@ -74,10 +74,13 @@ export async function POST(request: Request, { params }: Params) {
     );
   }
 
+  // requireRole 通過後のみ到達する。RLS は user_profiles に自分の行のみの
+  // ポリシーしか無いため、他ユーザーの存在確認・凍結更新には service_role が必須 (#1028)。
+  const supabaseAdmin = getSupabaseAdmin();
   const supabase = await createClient();
 
   // 対象ユーザーが存在するか確認
-  const { data: profile, error: profileError } = await supabase
+  const { data: profile, error: profileError } = await supabaseAdmin
     .from('user_profiles')
     .select('id, roles')
     .eq('id', id)
@@ -99,7 +102,7 @@ export async function POST(request: Request, { params }: Params) {
   }
 
   // frozen_at / frozen_reason / frozen_by を UPDATE (roles には手を加えない)
-  const { error: updateError } = await supabase
+  const { error: updateError } = await supabaseAdmin
     .from('user_profiles')
     .update({
       frozen_at: new Date().toISOString(),
@@ -193,10 +196,13 @@ export async function DELETE(request: Request, { params }: Params) {
   }
 
   const { reason } = parseResult.data;
+  // requireRole 通過後のみ到達する。RLS は user_profiles に自分の行のみの
+  // ポリシーしか無いため、他ユーザーの存在確認・凍結解除には service_role が必須 (#1028)。
+  const supabaseAdmin = getSupabaseAdmin();
   const supabase = await createClient();
 
   // 対象ユーザーが存在するか確認
-  const { data: profile, error: profileError } = await supabase
+  const { data: profile, error: profileError } = await supabaseAdmin
     .from('user_profiles')
     .select('id')
     .eq('id', id)
@@ -210,7 +216,7 @@ export async function DELETE(request: Request, { params }: Params) {
   }
 
   // frozen_at / frozen_reason / frozen_by を NULL にリセット (凍結解除)
-  const { error: updateError } = await supabase
+  const { error: updateError } = await supabaseAdmin
     .from('user_profiles')
     .update({
       frozen_at: null,

--- a/src/app/api/admin/users/[id]/role/route.ts
+++ b/src/app/api/admin/users/[id]/role/route.ts
@@ -13,7 +13,7 @@
 import { NextResponse } from 'next/server';
 import { requireRole } from '@/lib/auth/helpers';
 import { AuthError, ForbiddenError } from '@/lib/auth/errors';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, getSupabaseAdmin } from '@/lib/supabase/server';
 import { RoleChangeBodySchema } from '@/lib/admin/users-schemas';
 
 export const dynamic = 'force-dynamic';
@@ -70,10 +70,16 @@ async function handleRoleChange(request: Request, params: Params) {
     );
   }
 
+  // requireRole 通過後のみ到達する。RLS は user_profiles に自分の行のみの
+  // ポリシーしか無いため、他ユーザーの存在確認には service_role が必須 (#1028)。
+  const supabaseAdmin = getSupabaseAdmin();
+  // admin_set_user_roles は SECURITY DEFINER 関数で auth.uid() から呼び出し元の
+  // 権限・自己変更禁止を判定するため、RPC 呼び出しは session client のまま維持する
+  // (service_role で呼ぶと auth.uid() が NULL になり常に FORBIDDEN になる)。
   const supabase = await createClient();
 
   // 対象ユーザー存在確認
-  const { data: profile, error: profileError } = await supabase
+  const { data: profile, error: profileError } = await supabaseAdmin
     .from('user_profiles')
     .select('id, roles')
     .eq('id', id)
@@ -86,7 +92,7 @@ async function handleRoleChange(request: Request, params: Params) {
     );
   }
 
-  // ロール更新
+  // ロール更新 (auth.uid() 依存の SECURITY DEFINER 関数のため session client で呼ぶ)
   const { error: updateError } = await supabase
     .rpc('admin_set_user_roles', { p_user_id: id, p_roles: roles });
 

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -7,7 +7,7 @@
 import { NextResponse } from 'next/server';
 import { requireRole } from '@/lib/auth/helpers';
 import { AuthError, ForbiddenError } from '@/lib/auth/errors';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, getSupabaseAdmin } from '@/lib/supabase/server';
 import { UserPatchBodySchema } from '@/lib/admin/users-schemas';
 
 export const dynamic = 'force-dynamic';
@@ -35,10 +35,15 @@ export async function GET(_request: Request, { params }: Params) {
   }
 
   const { id } = params;
+  // requireRole 通過後のみ到達する。RLS は user_profiles に自分の行のみの
+  // ポリシーしか無いため、他ユーザーの詳細取得には service_role が必須 (#1028)。
+  const supabaseAdmin = getSupabaseAdmin();
+  // support_tickets / personal_subscriptions / admin_audit_logs は本 Issue の対象外
+  // (既存の RLS・graceful degradation のまま session client を使用)。
   const supabase = await createClient();
 
   // ユーザープロファイル取得
-  const { data: profile, error: profileError } = await supabase
+  const { data: profile, error: profileError } = await supabaseAdmin
     .from('user_profiles')
     .select('*')
     .eq('id', id)
@@ -175,19 +180,31 @@ export async function PATCH(request: Request, { params }: Params) {
   }
 
   const { admin_note } = parseResult.data;
+  // requireRole 通過後のみ到達する。RLS は user_profiles に自分の行のみの
+  // ポリシーしか無いため、他ユーザーの admin_note 更新には service_role が必須 (#1028)。
+  const supabaseAdmin = getSupabaseAdmin();
   const supabase = await createClient();
 
   // admin_note をプロファイルに保存
-  const { error: updateError } = await supabase
+  const { data: updated, error: updateError } = await supabaseAdmin
     .from('user_profiles')
     .update({ admin_note } as Record<string, unknown>)
-    .eq('id', id);
+    .eq('id', id)
+    .select('id');
 
   if (updateError) {
     console.error('[api/admin/users/[id]] PATCH error:', updateError.message);
     return NextResponse.json(
       { error: { code: 'INTERNAL_ERROR', message: '更新に失敗しました' } },
       { status: 500 },
+    );
+  }
+
+  // 更新0行 = 対象ユーザーが存在しない (#1028: 以前は 0 行でも 200 偽成功していた)
+  if (!updated || updated.length === 0) {
+    return NextResponse.json(
+      { error: { code: 'NOT_FOUND', message: 'ユーザーが見つかりません' } },
+      { status: 404 },
     );
   }
 

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -6,7 +6,7 @@
 import { NextResponse } from 'next/server';
 import { requireRole } from '@/lib/auth/helpers';
 import { AuthError, ForbiddenError } from '@/lib/auth/errors';
-import { createClient } from '@/lib/supabase/server';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { UsersSearchSchema } from '@/lib/admin/users-schemas';
 
 export const dynamic = 'force-dynamic';
@@ -40,7 +40,9 @@ export async function GET(request: Request) {
   }
 
   const params = parseResult.data;
-  const supabase = await createClient();
+  // requireRole 通過後のみ到達する。RLS は user_profiles に自分の行のみの
+  // ポリシーしか無いため、admin/support 向け一覧取得には service_role が必須 (#1028)。
+  const supabase = getSupabaseAdmin();
 
   // ユーザープロファイルを検索
   let query = supabase
@@ -117,7 +119,7 @@ export async function GET(request: Request) {
 
   const users = (data ?? []).map((u) => ({
     id: u.id,
-    email: null, // email は auth.users から取得が必要 (service_role キー使用不可のため省略)
+    email: null, // email は auth.users から取得が必要 (#1028 のスコープ外。別 Issue で対応)
     nickname: u.nickname,
     plan_key: u.plan_key_cached ?? 'free',
     roles: u.roles ?? ['user'],


### PR DESCRIPTION
## 対応 Issue
#1028 [Crit] admin ユーザー管理が RLS レイヤで全滅（他ユーザーの一覧/詳細/凍結/ロール変更が自分の行のみに制限され機能不全）

## 変更（コードのみ・migration非依存）
- `lib/supabase/server.ts`: `getSupabaseAdmin()`（service_role）を共通エクスポート
- admin 系ルート（`organizations`/`users`/`users/[id]`/`freeze`/`role`）で、一覧・詳細・凍結・存在確認を service_role クライアントに切替。**全ハンドラで `requireRole()` を service_role 生成より前に配置**し失敗時 early return（権限昇格の穴なし）
- `role/route.ts`: `admin_set_user_roles` RPC は `auth.uid()` 依存の SECURITY DEFINER のため session client を維持（正）
- `users/[id]` PATCH: 0行更新→404 検出を追加（サイレント偽成功の是正）

## レビュー
Sonnet 5 + Fable の2モデル敵対的レビューで double-PASS。#1013-1015 の特権列トリガーとの衝突なし（service_role はガード対象外）、typecheck PASS、正常系退行なし。

## フォロー（#1064 後の migration 波）
- 本番スキーマダンプで `user_profiles.admin_note` 列が**不在**を確認。`admin_note` PATCH を機能させるには `ALTER TABLE user_profiles ADD COLUMN admin_note TEXT` の migration が必要（#1064 ドリフト解消後にデプロイ）。それまで PATCH は列不在で500（従来は fail-silent の偽成功で、いずれにせよ保存されず。退行ではない）
- 一覧検索 `.or()` の `q` 生補間（既存コード・admin限定・境界内）のエスケープ