### PR TITLE
fix(menu-generation): menu-plans/add の常時500を解消し認可fail-close・バッジ付与を修正 (#1025)

### DIFF
--- a/src/app/api/menu-plans/add/route.ts
+++ b/src/app/api/menu-plans/add/route.ts
@@ -27,20 +27,33 @@ export async function POST(request: Request) {
     const isSandbox = body.sandbox === true;
 
     if (isSandbox) {
-      const { data: profile } = await supabase
+      // #1025 round-2: user_profiles の PK は id (auth.users(id) 参照) であり
+      // user_id 列は存在しない。.eq('user_id', ...) だと PostgREST が 42703 を返すが、
+      // error を握りつぶして data のみ見ると profile が常に undefined になり
+      // 以下の 2 ゲート (already_finished / admin_role) が無条件で素通りする
+      // fail-open バグだった。fail-closed (判定不能なら拒否) に修正する。
+      const { data: profile, error: profileError } = await supabase
         .from('user_profiles')
         .select('handson_tour_completed_at, handson_tour_skipped_at, roles')
-        .eq('user_id', user.id)
+        .eq('id', user.id)
         .single();
 
-      if (profile?.handson_tour_completed_at || profile?.handson_tour_skipped_at) {
+      if (profileError || !profile) {
+        console.error('user_profiles fetch error (sandbox eligibility):', profileError);
+        return NextResponse.json(
+          { error: { code: 'profile_not_found', message: 'プロファイルが見つかりません' } },
+          { status: 404 },
+        );
+      }
+
+      if (profile.handson_tour_completed_at || profile.handson_tour_skipped_at) {
         return NextResponse.json(
           { error: { code: 'sandbox_not_eligible', message: 'サンドボックスの利用条件を満たしていません', reason: 'already_finished' } },
           { status: 409 },
         );
       }
 
-      const hasAdminRole = Array.isArray(profile?.roles) &&
+      const hasAdminRole = Array.isArray(profile.roles) &&
         profile.roles.some((r: string) => (ADMIN_ROLES as readonly string[]).includes(r));
       if (hasAdminRole) {
         return NextResponse.json(
@@ -72,14 +85,16 @@ export async function POST(request: Request) {
       .slice(0, 10);
 
     // weekly_menus.request_id は weekly_menu_requests への NOT NULL FK。
-    // ここでの追加は AI 生成フローを経ない単発追加なので、コンテナ用に
-    // 完了済みリクエストを1件作る。status='completed' 固定なので
-    // cron の claim_menu_request (status='queued'/'processing' のみ拾う) には
-    // 拾われない。
+    // ここでの追加は AI 生成フローを経ない単発追加なので、コンテナ用にリクエストを
+    // 1件作る。status は非終端の 'pending' で作成し(cron の claim_menu_request は
+    // status='queued'/'processing' のみ拾うため 'pending' が誤って処理されることはない)、
+    // weekly_menus insert の成否を見てから 'completed'/'failed' に更新する
+    // (#1025 round-2: 先に 'completed' で作ると weekly_menus insert 失敗時に
+    // 「完了扱いだが対応献立が無い」孤児行が残るため)。
     const requestInsert: WeeklyMenuRequestInsert = {
       user_id: user.id,
       start_date: startDate,
-      status: 'completed',
+      status: 'pending',
     };
 
     const { data: requestRow, error: requestError } = await supabase
@@ -116,16 +131,41 @@ export async function POST(request: Request) {
 
     if (insertError) {
       console.error('weekly_menus insert error:', insertError);
+      // 補償: 対応する献立を作れなかった request を 'pending' のまま孤児にしない
+      const { error: failCompensationError } = await supabase
+        .from('weekly_menu_requests')
+        .update({
+          status: 'failed',
+          error_message: insertError.message,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', requestRow.id);
+      if (failCompensationError) {
+        console.error('weekly_menu_requests failed-compensation update error:', failCompensationError);
+      }
       return NextResponse.json(
         { error: { code: 'internal_error', message: 'サーバーエラーが発生しました', details: insertError.message } },
         { status: 500 },
       );
     }
 
-    // バッジ付与(副次処理: 失敗しても主処理は成功)
+    // weekly_menus insert 成功 → request を completed に確定(非致命: 失敗しても主処理は成功のまま)
+    const { error: completeError } = await supabase
+      .from('weekly_menu_requests')
+      .update({ status: 'completed', updated_at: new Date().toISOString() })
+      .eq('id', requestRow.id);
+    if (completeError) {
+      console.error('weekly_menu_requests completion update failed (non-fatal):', completeError);
+    }
+
+    // バッジ付与(副次処理: 失敗しても主処理は成功)。
+    // user_badges は RLS が SELECT のみで INSERT ポリシーが無いため、session client だと
+    // 常に 42501 で throw → catch で握りつぶされ badge_awarded が常に null になっていた
+    // (#1025 round-2)。weekly_menus と同じく service_role を使う。userId は認証済みの
+    // user.id を明示引数で渡す (awardBadge は auth.uid() に依存しないため他人への付与は不可)。
     let badgeAwarded: { code: string; name: string | null; obtained_at: string | null; icon_url: string | null } | null = null;
     try {
-      const badgeResult = await awardBadge(supabase, user.id, 'planner');
+      const badgeResult = await awardBadge(supabaseAdmin, user.id, 'planner');
       if (badgeResult.awarded) {
         console.info('planner badge awarded', { userId: user.id });
         badgeAwarded = {
@@ -139,7 +179,7 @@ export async function POST(request: Request) {
       console.error('planner badge award failed (non-fatal):', badgeErr);
     }
 
-    return NextResponse.json({ success: true, menuId: newMenu.id, badge_awarded: badgeAwarded });
+    return NextResponse.json({ success: true, menu_id: newMenu.id, badge_awarded: badgeAwarded });
   } catch (err: unknown) {
     console.error('menu-plans/add error:', err);
     return NextResponse.json(

--- a/src/app/api/menu-plans/add/route.ts
+++ b/src/app/api/menu-plans/add/route.ts
@@ -62,8 +62,15 @@ export async function POST(request: Request) {
         );
       }
 
-      const { data: hasActivity } = await supabase
+      const { data: hasActivity, error: activityError } = await supabase
         .rpc('user_has_non_sandbox_activity');
+      if (activityError) {
+        // 判定不能は拒否側に倒す(fail-closed、#1025 round-3)
+        return NextResponse.json(
+          { error: { code: 'sandbox_not_eligible', message: 'サンドボックスの利用条件を満たしていません', reason: 'existing_user' } },
+          { status: 409 },
+        );
+      }
       if (hasActivity) {
         return NextResponse.json(
           { error: { code: 'sandbox_not_eligible', message: 'サンドボックスの利用条件を満たしていません', reason: 'existing_user' } },

--- a/src/app/api/menu-plans/add/route.ts
+++ b/src/app/api/menu-plans/add/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, getSupabaseAdmin } from '@/lib/supabase/server';
 import { awardBadge } from '@/lib/badges/awardBadge';
+import type { Database, Json } from '@/types/database.types';
 
 const ADMIN_ROLES = ['admin', 'super_admin', 'org_admin', 'org_industrial_doctor'] as const;
+
+type WeeklyMenuRequestInsert = Database['public']['Tables']['weekly_menu_requests']['Insert'];
+type WeeklyMenuInsert = Database['public']['Tables']['weekly_menus']['Insert'];
 
 export async function POST(request: Request) {
   const supabase = await createClient();
@@ -55,25 +59,56 @@ export async function POST(request: Request) {
       }
     }
 
-    const insertData: Record<string, unknown> = {
+    // weekly_menus の実列は content(jsonb NOT NULL) / request_id(uuid NOT NULL, FK) /
+    // start_date(date NOT NULL) / user_id のみ (#1025)。body は MOCK_MENU_RESPONSE 由来の
+    // フラットな献立データ (dish_name/calories/...) であり、旧実装が使っていた
+    // week_start_date/menu_data/status/generation_id/is_sandbox という列は実在しない。
+    const { sandbox: _sandbox, source: _bodySource, ...menuContent } = body as Record<string, unknown>;
+    const content = { ...menuContent, source } as Json;
+
+    const offsetDays = typeof body.date_offset_days === 'number' ? body.date_offset_days : 0;
+    const startDate = new Date(Date.now() + offsetDays * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+
+    // weekly_menus.request_id は weekly_menu_requests への NOT NULL FK。
+    // ここでの追加は AI 生成フローを経ない単発追加なので、コンテナ用に
+    // 完了済みリクエストを1件作る。status='completed' 固定なので
+    // cron の claim_menu_request (status='queued'/'processing' のみ拾う) には
+    // 拾われない。
+    const requestInsert: WeeklyMenuRequestInsert = {
       user_id: user.id,
-      is_sandbox: isSandbox,
-      source: source,
+      start_date: startDate,
+      status: 'completed',
     };
 
-    const allowedFields = [
-      'week_start_date',
-      'menu_data',
-      'status',
-      'generation_id',
-    ];
-    for (const field of allowedFields) {
-      if (field in body && body[field] !== undefined) {
-        insertData[field] = body[field];
-      }
+    const { data: requestRow, error: requestError } = await supabase
+      .from('weekly_menu_requests')
+      .insert(requestInsert)
+      .select('id')
+      .single();
+
+    if (requestError || !requestRow) {
+      console.error('weekly_menu_requests insert error:', requestError);
+      return NextResponse.json(
+        { error: { code: 'internal_error', message: 'サーバーエラーが発生しました', details: requestError?.message } },
+        { status: 500 },
+      );
     }
 
-    const { data: newMenu, error: insertError } = await supabase
+    const insertData: WeeklyMenuInsert = {
+      user_id: user.id,
+      request_id: requestRow.id,
+      start_date: startDate,
+      content,
+    };
+
+    // weekly_menus には SELECT 用の RLS ポリシーしか存在せず INSERT ポリシーが無いため、
+    // authenticated セッションでの insert は常に RLS 違反 (42501) になる。ここまでで
+    // sandbox 適格性など本人認可チェックは完了済みなので、この insert のみ service_role を
+    // 使う (#1025: migration 禁止のためポリシー追加ではなくコード側で対応。#1028 と同一パターン)。
+    const supabaseAdmin = getSupabaseAdmin();
+    const { data: newMenu, error: insertError } = await supabaseAdmin
       .from('weekly_menus')
       .insert(insertData)
       .select()

--- a/tests/integration/handson-tour/menu-plans-add.test.ts
+++ b/tests/integration/handson-tour/menu-plans-add.test.ts
@@ -5,9 +5,17 @@
  * 不一致な payload (week_start_date/menu_data/status/generation_id/is_sandbox という
  * 存在しない列) を INSERT していたため常時 500 だった回帰防止テスト。
  *
+ * #1025 round-2: eligibility クエリが user_profiles.user_id (存在しない列) を引いていたため
+ * fail-open で admin_role / already_finished ゲートが無条件素通りしていた。fail-closed 化した
+ * ことで初めて拒否パス (403/409) が実効化するので、その分岐も併せて固定する。
+ *
  * Test patterns:
- *   1. 200 — sandbox 適格ユーザーが献立追加 → weekly_menus に実データが INSERT される
+ *   1. 200 — sandbox 適格ユーザーが献立追加 → weekly_menus に実データが INSERT され、
+ *            weekly_menu_requests は 'completed'、planner バッジが実際に付与される
  *   2. 401 — 認証なし
+ *   3. 403 — admin ロールは sandbox_not_eligible (admin_role) で拒否される (round-2 固定)
+ *   4. 409 — ツアー完了済みユーザーは sandbox_not_eligible (already_finished) で拒否される (round-2 固定)
+ *   5. 409 — 既存 (non-sandbox) activity があるユーザーは sandbox_not_eligible (existing_user) で拒否される (round-2 固定)
  *
  * Requires: SUPABASE_INTEGRATION_TEST=1
  */
@@ -53,7 +61,9 @@ describe.skipIf(!shouldRunIntegration())(
       if (user) await cleanupTestUser(user.id);
     });
 
-    it('1. 200 — sandbox 献立追加で weekly_menus に実データが INSERT される (#1025)', async () => {
+    it('1. 200 — sandbox 献立追加で weekly_menus に実データが INSERT され、request completed・badge 付与される (#1025)', async () => {
+      // 非 admin・ツアー未完了・既存 activity なし = sandbox 適格な fixture であること
+      // (round-2 で eligibility が実効化されたため、この前提が崩れると happy path が壊れる)
       user = await createTestUser({ onboardingCompleted: true });
 
       const { status, body } = await postMenuAdd(user.accessToken, {
@@ -64,13 +74,13 @@ describe.skipIf(!shouldRunIntegration())(
 
       expect(status).toBe(200);
       expect(body.success).toBe(true);
-      expect(body.menuId).toBeTruthy();
+      expect(body.menu_id).toBeTruthy();
 
       const client = adminClient();
       const { data: row, error } = await client
         .from('weekly_menus')
         .select('id, user_id, request_id, start_date, content')
-        .eq('id', body.menuId as string)
+        .eq('id', body.menu_id as string)
         .single();
 
       expect(error).toBeNull();
@@ -80,6 +90,26 @@ describe.skipIf(!shouldRunIntegration())(
       expect((row?.content as Record<string, unknown> | null)?.dish_name).toBe(
         MOCK_MENU_RESPONSE.dish_name,
       );
+
+      // weekly_menu_requests は孤児 'pending' のまま残らず 'completed' に確定していること (round-2)
+      const { data: requestRow } = await client
+        .from('weekly_menu_requests')
+        .select('status')
+        .eq('id', row!.request_id as string)
+        .single();
+      expect(requestRow?.status).toBe('completed');
+
+      // planner バッジが実際に付与されていること (round-2: service_role 経由で 42501 を回避)
+      const badge = body.badge_awarded as Record<string, unknown> | null;
+      expect(badge).not.toBeNull();
+      expect(badge?.code).toBe('planner');
+
+      const { data: userBadge } = await client
+        .from('user_badges')
+        .select('user_id, badge_id')
+        .eq('user_id', user.id)
+        .single();
+      expect(userBadge?.user_id).toBe(user.id);
     });
 
     it('2. 401 — 認証なしリクエスト', async () => {
@@ -89,6 +119,65 @@ describe.skipIf(!shouldRunIntegration())(
         body: JSON.stringify({ ...MOCK_MENU_RESPONSE, sandbox: true }),
       });
       expect(res.status).toBe(401);
+    });
+
+    it('3. 403 — admin ロールは sandbox_not_eligible/admin_role で拒否される (round-2)', async () => {
+      user = await createTestUser({ onboardingCompleted: true, roles: ['admin'] });
+
+      const { status, body } = await postMenuAdd(user.accessToken, {
+        ...MOCK_MENU_RESPONSE,
+        sandbox: true,
+        source: 'handson_tour',
+      });
+
+      expect(status).toBe(403);
+      const err = body.error as Record<string, unknown>;
+      expect(err.code).toBe('sandbox_not_eligible');
+      expect(err.reason).toBe('admin_role');
+    });
+
+    it('4. 409 — ツアー完了済みユーザーは sandbox_not_eligible/already_finished で拒否される (round-2)', async () => {
+      user = await createTestUser({
+        onboardingCompleted: true,
+        handsonTourCompletedAt: new Date().toISOString(),
+      });
+
+      const { status, body } = await postMenuAdd(user.accessToken, {
+        ...MOCK_MENU_RESPONSE,
+        sandbox: true,
+        source: 'handson_tour',
+      });
+
+      expect(status).toBe(409);
+      const err = body.error as Record<string, unknown>;
+      expect(err.code).toBe('sandbox_not_eligible');
+      expect(err.reason).toBe('already_finished');
+    });
+
+    it('5. 409 — 既存 (non-sandbox) activity があるユーザーは sandbox_not_eligible/existing_user で拒否される (round-2)', async () => {
+      user = await createTestUser({ onboardingCompleted: true });
+      const client = adminClient();
+
+      await client.from('meals').insert({
+        user_id: user.id,
+        eaten_at: new Date().toISOString().split('T')[0],
+        meal_type: 'dinner',
+        dish_name: 'テスト夕食',
+        is_sandbox: false,
+      });
+
+      const { status, body } = await postMenuAdd(user.accessToken, {
+        ...MOCK_MENU_RESPONSE,
+        sandbox: true,
+        source: 'handson_tour',
+      });
+
+      expect(status).toBe(409);
+      const err = body.error as Record<string, unknown>;
+      expect(err.code).toBe('sandbox_not_eligible');
+      expect(err.reason).toBe('existing_user');
+
+      await client.from('meals').delete().eq('user_id', user.id);
     });
   },
 );

--- a/tests/integration/handson-tour/menu-plans-add.test.ts
+++ b/tests/integration/handson-tour/menu-plans-add.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Integration test: POST /api/menu-plans/add
+ *
+ * #1025: weekly_menus の実スキーマ (content/request_id/start_date/user_id NOT NULL) と
+ * 不一致な payload (week_start_date/menu_data/status/generation_id/is_sandbox という
+ * 存在しない列) を INSERT していたため常時 500 だった回帰防止テスト。
+ *
+ * Test patterns:
+ *   1. 200 — sandbox 適格ユーザーが献立追加 → weekly_menus に実データが INSERT される
+ *   2. 401 — 認証なし
+ *
+ * Requires: SUPABASE_INTEGRATION_TEST=1
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { MOCK_MENU_RESPONSE } from '@homegohan/handson-tour-shared';
+import {
+  shouldRunIntegration,
+  createTestUser,
+  cleanupTestUser,
+  adminClient,
+  type TestUser,
+} from '../helpers/supabase';
+
+const BASE_URL =
+  process.env.API_BASE_URL ??
+  process.env.PLAYWRIGHT_BASE_URL ??
+  'http://localhost:3000';
+
+async function postMenuAdd(
+  accessToken: string,
+  body: Record<string, unknown>,
+  source = 'handson_tour',
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(`${BASE_URL}/api/menu-plans/add?source=${source}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Cookie: `sb-access-token=${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe.skipIf(!shouldRunIntegration())(
+  'POST /api/menu-plans/add (integration)',
+  () => {
+    let user: TestUser;
+
+    afterEach(async () => {
+      if (user) await cleanupTestUser(user.id);
+    });
+
+    it('1. 200 — sandbox 献立追加で weekly_menus に実データが INSERT される (#1025)', async () => {
+      user = await createTestUser({ onboardingCompleted: true });
+
+      const { status, body } = await postMenuAdd(user.accessToken, {
+        ...MOCK_MENU_RESPONSE,
+        sandbox: true,
+        source: 'handson_tour',
+      });
+
+      expect(status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.menuId).toBeTruthy();
+
+      const client = adminClient();
+      const { data: row, error } = await client
+        .from('weekly_menus')
+        .select('id, user_id, request_id, start_date, content')
+        .eq('id', body.menuId as string)
+        .single();
+
+      expect(error).toBeNull();
+      expect(row?.user_id).toBe(user.id);
+      expect(row?.request_id).toBeTruthy();
+      expect(row?.start_date).toBeTruthy();
+      expect((row?.content as Record<string, unknown> | null)?.dish_name).toBe(
+        MOCK_MENU_RESPONSE.dish_name,
+      );
+    });
+
+    it('2. 401 — 認証なしリクエスト', async () => {
+      const res = await fetch(`${BASE_URL}/api/menu-plans/add`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...MOCK_MENU_RESPONSE, sandbox: true }),
+      });
+      expect(res.status).toBe(401);
+    });
+  },
+);


### PR DESCRIPTION
## 対応 Issue
#1025 [Crit] /api/menu-plans/add がスキーマ不一致で常時500（献立追加が死亡）

## 変更（コードのみ・migration非依存）
- `weekly_menus` の payload を実列（`user_id`/`request_id`/`start_date`/`content`）に整合。不在列（is_sandbox/source/week_start_date/menu_data/status/generation_id）を除去。NOT NULL の `request_id` は `weekly_menu_requests` を先行作成して充足
- `weekly_menus` に INSERT RLS が無いため、認可（sandbox適格性）チェック後に `getSupabaseAdmin()` で当該INSERTのみ実行（#1028パターン）
- **認可 fail-close**: sandbox適格性の profile 取得（`.eq('id')`、round-1で誤って`user_id`だった）と `user_has_non_sandbox_activity` RPC の両方を error時fail-closed化（admin_role/already_finished/existing_user の3ゲート対称）
- **planner バッジ付与**: `user_badges` の INSERT RLS 不在で42501になっていたため `awardBadge(getSupabaseAdmin(), ...)` に修正（Issue記載の症状を解消）
- `weekly_menu_requests` を pending 先行→成功で completed / 失敗で failed 補償（孤児行防止）
- レスポンスキー menuId→menu_id（V4GenerateModal と整合）

## レビュー
Sonnet 5 + Fable の2モデル敵対レビューで round-3 まで実施し double-PASS。round-1 で両モデルが認可 fail-open Critical を検出、round-2 で全4点解消、round-3 で existing_user ゲートも対称に fail-close。typecheck PASS、拒否パス（403/409）+バッジ+孤児化防止のテスト追加。

## フォロー（別Issue）
- 非sandbox（通常追加）経路の統合テスト追加 / body の Zod 契約検証・レート制限