### PR TITLE
fix(weekly-menu): 週間献立の状態二重管理(split-brain)を解消 (#1031)

### DIFF
--- a/src/__tests__/app/menus/weekly/modal-contracts.test.ts
+++ b/src/__tests__/app/menus/weekly/modal-contracts.test.ts
@@ -1,0 +1,168 @@
+// src/__tests__/app/menus/weekly/modal-contracts.test.ts
+// Issue #1031: 「store に seed した値がモーダルに正しく描画されるか」の契約テスト。
+//
+// #1031 以前は page.tsx が local useState を保持し、モーダルは store を直接
+// read/write していたため、page.tsx がどれだけ store に値を書いても
+// (あるいは store にどれだけ値を積んでも) モーダル側の表示は
+// 「常に空」「常にデフォルト」になっていた。
+//
+// このテストは page.tsx を経由せず、モーダルコンポーネント単体に対して
+// 「store に値を seed → render → DOM に反映されているか」を直接検証する
+// (= #1031 の受入基準そのもの)。
+//
+// NOTE: このリポジトリの tsconfig.json は Next.js の SWC コンパイラ向けに
+// `jsx: "preserve"` を指定しており、Vitest (esbuild/rolldown 経由) の .tsx
+// 変換と非互換 ("Failed to parse source... jsx to preserve" エラー)。
+// 共有設定である vitest.config.ts を変更する影響範囲を避けるため、本ファイルは
+// あえて拡張子 .ts + React.createElement を使い JSX 構文を回避する。
+
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+
+import { usePantryStore } from '@/app/(main)/menus/weekly/_state/pantryStore';
+import { useShoppingStore } from '@/app/(main)/menus/weekly/_state/shoppingStore';
+import { useFormDraftStore } from '@/app/(main)/menus/weekly/_state/formDraftStore';
+import { useServingsConfigStore } from '@/app/(main)/menus/weekly/_state/servingsConfigStore';
+
+import { FridgeModal } from '@/app/(main)/menus/weekly/_components/modals/FridgeModal';
+import { AddFridgeModal } from '@/app/(main)/menus/weekly/_components/modals/AddFridgeModal';
+import { ShoppingModal } from '@/app/(main)/menus/weekly/_components/modals/ShoppingModal';
+import { EditMealModal } from '@/app/(main)/menus/weekly/_components/modals/EditMealModal';
+import { ServingsModal } from '@/app/(main)/menus/weekly/_components/modals/ServingsModal';
+
+import type { PantryItem, ShoppingListItem } from '@/types/domain';
+
+const h = React.createElement;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderComponent(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  act(() => {
+    root = createRoot(container);
+  });
+
+  // 各テスト前に全 store を初期状態へ戻す (テスト間の汚染防止)
+  usePantryStore.setState({ fridgeItems: [] });
+  useShoppingStore.getState().resetShoppingState();
+  useFormDraftStore.setState({
+    newFridgeName: '',
+    newFridgeAmount: '',
+    newFridgeExpiry: '',
+    editMealName: '',
+    editMealMode: 'cook',
+  });
+  useServingsConfigStore.setState({ servingsConfig: null, isLoadingServingsConfig: false });
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+const noop = () => {};
+
+const MODE_CONFIG_FAKE = {
+  cook: { icon: () => null, label: '自炊', color: '#000', bg: '#fff' },
+  quick: { icon: () => null, label: '時短', color: '#000', bg: '#fff' },
+};
+
+describe('モーダル契約テスト: store seed → 描画 assert (#1031 受入基準)', () => {
+  it('FridgeModal: pantryStore.fridgeItems に1品追加すると描画される', () => {
+    usePantryStore.getState().setFridgeItems([
+      { id: 'f1', name: 'にんじん', amount: '2本', category: 'other', expirationDate: null } as PantryItem,
+    ]);
+
+    renderComponent(
+      h(FridgeModal, { onClose: noop, onOpenAddFridge: noop, onDeleteItem: noop })
+    );
+
+    expect(container.textContent).toContain('にんじん');
+    expect(container.textContent).not.toContain('冷蔵庫は空です');
+  });
+
+  it('FridgeModal: fridgeItems が空なら「冷蔵庫は空です」を表示する (0件の契約も検証)', () => {
+    renderComponent(
+      h(FridgeModal, { onClose: noop, onOpenAddFridge: noop, onDeleteItem: noop })
+    );
+    expect(container.textContent).toContain('冷蔵庫は空です');
+  });
+
+  it('AddFridgeModal: formDraftStore.newFridgeName を seed すると input value に反映される', () => {
+    useFormDraftStore.getState().setNewFridgeName('たまねぎ');
+
+    renderComponent(h(AddFridgeModal, { onAdd: noop, onClose: noop }));
+
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+    expect(input.value).toBe('たまねぎ');
+  });
+
+  it('ShoppingModal: shoppingStore.shoppingList に seed した商品名が描画される', () => {
+    const items: ShoppingListItem[] = [
+      {
+        id: 's1',
+        itemName: 'にんじん',
+        quantity: '2本',
+        category: '青果（野菜・果物）',
+        isChecked: false,
+      } as ShoppingListItem,
+    ];
+    useShoppingStore.getState().setShoppingList(items);
+
+    renderComponent(
+      h(ShoppingModal, {
+        groupedShoppingList: [['青果（野菜・果物）', items]],
+        hasAnyMealsThisWeek: true,
+        onClose: noop,
+        onOpenAddShopping: noop,
+        onOpenShoppingRange: noop,
+        onToggleItem: noop,
+        onDeleteItem: noop,
+        onDeleteAll: noop,
+        onToggleVariant: noop,
+        onOpenServingsModal: noop,
+        onDismissProgress: noop,
+        onSetSuccessMessage: noop,
+      })
+    );
+
+    expect(container.textContent).toContain('にんじん');
+    expect(container.textContent).not.toContain('買い物リストは空です');
+  });
+
+  it('EditMealModal: formDraftStore.editMealName を seed すると input value に反映される (既存料理名が表示されない #1031 の症状に対する回帰防止)', () => {
+    useFormDraftStore.getState().setEditMealName('肉じゃが');
+    useFormDraftStore.getState().setEditMealMode('cook');
+
+    renderComponent(
+      h(EditMealModal, { modeConfig: MODE_CONFIG_FAKE as any, onClose: noop, onSave: noop })
+    );
+
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+    expect(input.value).toBe('肉じゃが');
+  });
+
+  it('ServingsModal: servingsConfigStore.servingsConfig を seed すると保存済み人数が表示される (常にデフォルト2人表示になる #1031 の症状に対する回帰防止)', () => {
+    useServingsConfigStore.getState().setServingsConfig({
+      default: 5,
+      byDayMeal: { monday: { breakfast: 1 } },
+    });
+
+    renderComponent(h(ServingsModal, { onClose: noop, onSave: noop }));
+
+    // monday/breakfast セルには保存済みの 1 が表示される (デフォルト 5 ではない)
+    expect(container.textContent).toContain('1');
+  });
+});

--- a/src/__tests__/app/menus/weekly/state/formDraftStore.test.ts
+++ b/src/__tests__/app/menus/weekly/state/formDraftStore.test.ts
@@ -81,10 +81,10 @@ describe('useFormDraftStore', () => {
     expect(s.newFridgeExpiry).toBe('');
     expect(s.newShoppingName).toBe('');
     expect(s.newShoppingAmount).toBe('');
-    // formDraftStore の初期値は '' (AddShoppingModal の <select> は明示選択待ち)。
-    // page.tsx 旧 local useState のデフォルト "食材" とは異なるが、store 側の
-    // initialState は本 refactor (#1031) 対象外のため変更しない。
-    expect(s.newShoppingCategory).toBe('');
+    // #1031 round-2: formDraftStore の初期値/リセット値は旧 page.tsx local
+    // useState のデフォルト "食材" と一致させる (AddShoppingModal の <select>
+    // に空文字値の <option> は無く、catch-all の value は "食材" のため)。
+    expect(s.newShoppingCategory).toBe('食材');
   });
 
   it('resetPhotoEdit / resetImageGenerate で File 系 state が初期値に戻る', () => {

--- a/src/__tests__/app/menus/weekly/state/formDraftStore.test.ts
+++ b/src/__tests__/app/menus/weekly/state/formDraftStore.test.ts
@@ -1,0 +1,129 @@
+// src/__tests__/app/menus/weekly/state/formDraftStore.test.ts
+// Issue #1031: page.tsx の aiChatInput/addMealKey/addMealDayIndex/selectedConditions/
+// editMealName/editMealMode/newFridge*/newShopping*/manualDishes/manualMode/catalog*/
+// photoFiles/photoPreviews/imageGenerationPrompt/imageReferenceFiles/imageReferencePreviews
+// local useState を useFormDraftStore に一本化。
+// 一本化後の store 単体動作 (reset 系 + manualDishes の LegacyDishDetail 型) を固定する。
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useFormDraftStore } from '@/app/(main)/menus/weekly/_state/formDraftStore';
+import type { LegacyDishDetail } from '@/app/(main)/menus/weekly/_state/types';
+
+const initialState = useFormDraftStore.getState();
+
+describe('useFormDraftStore', () => {
+  beforeEach(() => {
+    useFormDraftStore.setState(initialState, true);
+  });
+
+  it('manualDishes は LegacyDishDetail[] (旧 cal/protein 短縮キー) を受け付ける', () => {
+    const legacyDish: LegacyDishDetail = {
+      name: 'カレーライス',
+      role: 'main',
+      calories_kcal: 0, // 新形式キーが無い旧データを模す
+      cal: 650,
+      protein: 20,
+    };
+    useFormDraftStore.getState().setManualDishes([legacyDish]);
+    const [dish] = useFormDraftStore.getState().manualDishes;
+    // page.tsx saveManualEdit の `d.calories_kcal ?? d.cal ?? 0` パターンが機能することを検証
+    const totalCal = dish.calories_kcal ?? dish.cal ?? 0;
+    expect(totalCal || dish.cal).toBe(650);
+    expect(dish.cal).toBe(650);
+  });
+
+  it('resetManual で manualDishes/manualMode/catalog* が初期値に戻る', () => {
+    useFormDraftStore.getState().setManualDishes([{ name: 'X', role: 'main', calories_kcal: 100 }]);
+    useFormDraftStore.getState().setManualMode('buy');
+    useFormDraftStore.getState().setCatalogQuery('から揚げ');
+    useFormDraftStore.getState().setCatalogResults([{ id: 'p1', name: 'から揚げ弁当' } as any]);
+    useFormDraftStore.getState().setSelectedCatalogProduct({ id: 'p1', name: 'から揚げ弁当' } as any);
+    useFormDraftStore.getState().setIsCatalogSearching(true);
+    useFormDraftStore.getState().setCatalogSearchError('エラー');
+
+    useFormDraftStore.getState().resetManual();
+
+    const s = useFormDraftStore.getState();
+    expect(s.manualDishes).toEqual([]);
+    expect(s.manualMode).toBe('cook');
+    expect(s.catalogQuery).toBe('');
+    expect(s.catalogResults).toEqual([]);
+    expect(s.selectedCatalogProduct).toBeNull();
+    expect(s.isCatalogSearching).toBe(false);
+    expect(s.catalogSearchError).toBe('');
+  });
+
+  it('resetEditMeal で editMealName/editMealMode が初期値に戻る', () => {
+    useFormDraftStore.getState().setEditMealName('麻婆豆腐');
+    useFormDraftStore.getState().setEditMealMode('quick');
+
+    useFormDraftStore.getState().resetEditMeal();
+
+    const s = useFormDraftStore.getState();
+    expect(s.editMealName).toBe('');
+    expect(s.editMealMode).toBe('cook');
+  });
+
+  it('resetFridgeForm / resetShoppingForm で追加フォームが初期値に戻る', () => {
+    useFormDraftStore.getState().setNewFridgeName('にんじん');
+    useFormDraftStore.getState().setNewFridgeAmount('2本');
+    useFormDraftStore.getState().setNewFridgeExpiry('2026-08-01');
+    useFormDraftStore.getState().setNewShoppingName('牛乳');
+    useFormDraftStore.getState().setNewShoppingAmount('1本');
+    useFormDraftStore.getState().setNewShoppingCategory('乳製品・卵');
+
+    useFormDraftStore.getState().resetFridgeForm();
+    useFormDraftStore.getState().resetShoppingForm();
+
+    const s = useFormDraftStore.getState();
+    expect(s.newFridgeName).toBe('');
+    expect(s.newFridgeAmount).toBe('');
+    expect(s.newFridgeExpiry).toBe('');
+    expect(s.newShoppingName).toBe('');
+    expect(s.newShoppingAmount).toBe('');
+    // formDraftStore の初期値は '' (AddShoppingModal の <select> は明示選択待ち)。
+    // page.tsx 旧 local useState のデフォルト "食材" とは異なるが、store 側の
+    // initialState は本 refactor (#1031) 対象外のため変更しない。
+    expect(s.newShoppingCategory).toBe('');
+  });
+
+  it('resetPhotoEdit / resetImageGenerate で File 系 state が初期値に戻る', () => {
+    const fakeFile = { name: 'a.png' } as unknown as File;
+    useFormDraftStore.getState().setPhotoFiles([fakeFile]);
+    useFormDraftStore.getState().setPhotoPreviews(['data:image/png;base64,xxx']);
+    useFormDraftStore.getState().setImageGenerationPrompt('美味しそうな唐揚げ');
+    useFormDraftStore.getState().setImageReferenceFiles([fakeFile]);
+    useFormDraftStore.getState().setImageReferencePreviews(['data:image/png;base64,yyy']);
+
+    useFormDraftStore.getState().resetPhotoEdit();
+    useFormDraftStore.getState().resetImageGenerate();
+
+    const s = useFormDraftStore.getState();
+    expect(s.photoFiles).toEqual([]);
+    expect(s.photoPreviews).toEqual([]);
+    expect(s.imageGenerationPrompt).toBe('');
+    expect(s.imageReferenceFiles).toEqual([]);
+    expect(s.imageReferencePreviews).toEqual([]);
+  });
+
+  it('resetAddMeal で addMealKey/addMealDayIndex が初期値に戻る', () => {
+    useFormDraftStore.getState().setAddMealKey('lunch');
+    useFormDraftStore.getState().setAddMealDayIndex(3);
+
+    useFormDraftStore.getState().resetAddMeal();
+
+    const s = useFormDraftStore.getState();
+    expect(s.addMealKey).toBeNull();
+    expect(s.addMealDayIndex).toBe(0);
+  });
+
+  it('aiChatInput/selectedConditions は page.tsx ハンドラの getState() 都度読み取りパターンに対応する', () => {
+    useFormDraftStore.getState().setAiChatInput('魚料理がいい');
+    useFormDraftStore.getState().setSelectedConditions(['冷蔵庫の食材を優先', 'ヘルシーに']);
+
+    // page.tsx handleGenerateWeekly 相当の読み取り
+    const { aiChatInput, selectedConditions } = useFormDraftStore.getState();
+    expect(aiChatInput).toBe('魚料理がいい');
+    expect(selectedConditions).toEqual(['冷蔵庫の食材を優先', 'ヘルシーに']);
+  });
+});

--- a/src/__tests__/app/menus/weekly/state/pantryStore.test.ts
+++ b/src/__tests__/app/menus/weekly/state/pantryStore.test.ts
@@ -1,0 +1,54 @@
+// src/__tests__/app/menus/weekly/state/pantryStore.test.ts
+// Issue #1031: page.tsx の fridgeItems local useState を usePantryStore に一本化。
+// 一本化後の store 単体動作 (add/remove/update/reset 相当) を回帰防止として固定する。
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePantryStore } from '@/app/(main)/menus/weekly/_state/pantryStore';
+import type { PantryItem } from '@/types/domain';
+
+const makeItem = (overrides: Partial<PantryItem> = {}): PantryItem => ({
+  id: overrides.id ?? 'item-1',
+  name: overrides.name ?? 'にんじん',
+  amount: overrides.amount ?? '2本',
+  category: overrides.category ?? 'other',
+  expirationDate: overrides.expirationDate ?? null,
+  ...overrides,
+} as PantryItem);
+
+describe('usePantryStore', () => {
+  beforeEach(() => {
+    usePantryStore.setState({ fridgeItems: [] });
+  });
+
+  it('初期状態は空配列', () => {
+    expect(usePantryStore.getState().fridgeItems).toEqual([]);
+  });
+
+  it('setFridgeItems で一括置換できる', () => {
+    const items = [makeItem({ id: 'a' }), makeItem({ id: 'b' })];
+    usePantryStore.getState().setFridgeItems(items);
+    expect(usePantryStore.getState().fridgeItems).toEqual(items);
+  });
+
+  it('addFridgeItem で既存配列に追加される (page.tsx addPantryItem 相当)', () => {
+    usePantryStore.getState().setFridgeItems([makeItem({ id: 'a' })]);
+    usePantryStore.getState().addFridgeItem(makeItem({ id: 'b', name: 'たまねぎ' }));
+    const { fridgeItems } = usePantryStore.getState();
+    expect(fridgeItems).toHaveLength(2);
+    expect(fridgeItems[1].name).toBe('たまねぎ');
+  });
+
+  it('removeFridgeItem で指定 id のみ除去される (page.tsx deletePantryItem 相当)', () => {
+    usePantryStore.getState().setFridgeItems([makeItem({ id: 'a' }), makeItem({ id: 'b' })]);
+    usePantryStore.getState().removeFridgeItem('a');
+    const { fridgeItems } = usePantryStore.getState();
+    expect(fridgeItems).toHaveLength(1);
+    expect(fridgeItems[0].id).toBe('b');
+  });
+
+  it('updateFridgeItem で部分更新できる', () => {
+    usePantryStore.getState().setFridgeItems([makeItem({ id: 'a', amount: '1本' })]);
+    usePantryStore.getState().updateFridgeItem('a', { amount: '3本' });
+    expect(usePantryStore.getState().fridgeItems[0].amount).toBe('3本');
+  });
+});

--- a/src/__tests__/app/menus/weekly/state/servingsConfigStore.test.ts
+++ b/src/__tests__/app/menus/weekly/state/servingsConfigStore.test.ts
@@ -1,0 +1,36 @@
+// src/__tests__/app/menus/weekly/state/servingsConfigStore.test.ts
+// Issue #1031: page.tsx の servingsConfig/isLoadingServingsConfig local useState を
+// useServingsConfigStore に一本化。旧実装は fetchUserSettings の結果を local state に
+// しか書かず、ServingsModal が読む store は常に null のままだった (#1031 の症状)。
+// この回帰を防ぐため、store への書き込みが正しく読み出せることを固定する。
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useServingsConfigStore } from '@/app/(main)/menus/weekly/_state/servingsConfigStore';
+
+describe('useServingsConfigStore', () => {
+  beforeEach(() => {
+    useServingsConfigStore.setState({ servingsConfig: null, isLoadingServingsConfig: false });
+  });
+
+  it('初期状態は null / false', () => {
+    const s = useServingsConfigStore.getState();
+    expect(s.servingsConfig).toBeNull();
+    expect(s.isLoadingServingsConfig).toBe(false);
+  });
+
+  it('setServingsConfig で書き込んだ値が getState() で読み出せる (page.tsx fetchUserSettings 相当)', () => {
+    useServingsConfigStore.getState().setIsLoadingServingsConfig(true);
+    useServingsConfigStore.getState().setServingsConfig({ default: 4, byDayMeal: {} });
+    useServingsConfigStore.getState().setIsLoadingServingsConfig(false);
+
+    const s = useServingsConfigStore.getState();
+    expect(s.servingsConfig).toEqual({ default: 4, byDayMeal: {} });
+    expect(s.isLoadingServingsConfig).toBe(false);
+  });
+
+  it('ServingsModal onSave 相当: getState().servingsConfig を都度読む', () => {
+    useServingsConfigStore.getState().setServingsConfig({ default: 2, byDayMeal: { monday: { breakfast: 3 } } });
+    const currentServingsConfig = useServingsConfigStore.getState().servingsConfig;
+    expect(currentServingsConfig?.byDayMeal?.monday?.breakfast).toBe(3);
+  });
+});

--- a/src/__tests__/app/menus/weekly/state/shoppingStore.test.ts
+++ b/src/__tests__/app/menus/weekly/state/shoppingStore.test.ts
@@ -1,0 +1,94 @@
+// src/__tests__/app/menus/weekly/state/shoppingStore.test.ts
+// Issue #1031: page.tsx の shoppingList/activeShoppingList/isRegeneratingShoppingList/
+// shoppingListProgress/shoppingListRequestId/shoppingListTotalServings/shoppingRange/
+// shoppingRangeStep local useState を useShoppingStore に一本化。
+// 一本化後の store 単体動作 (関数型更新の機械展開を含む) を回帰防止として固定する。
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useShoppingStore } from '@/app/(main)/menus/weekly/_state/shoppingStore';
+import type { ShoppingListItem } from '@/types/domain';
+
+const initialState = useShoppingStore.getState();
+
+const makeItem = (overrides: Partial<ShoppingListItem> = {}): ShoppingListItem => ({
+  id: overrides.id ?? 'item-1',
+  itemName: overrides.itemName ?? 'にんじん',
+  quantity: overrides.quantity ?? '2本',
+  category: overrides.category ?? '青果（野菜・果物）',
+  isChecked: overrides.isChecked ?? false,
+  ...overrides,
+} as ShoppingListItem);
+
+describe('useShoppingStore', () => {
+  beforeEach(() => {
+    useShoppingStore.setState(initialState, true);
+  });
+
+  it('初期状態は空/デフォルト値', () => {
+    const s = useShoppingStore.getState();
+    expect(s.shoppingList).toEqual([]);
+    expect(s.activeShoppingList).toBeNull();
+    expect(s.isRegeneratingShoppingList).toBe(false);
+    expect(s.shoppingListProgress).toBeNull();
+    expect(s.shoppingListRequestId).toBeNull();
+    expect(s.shoppingListTotalServings).toBeNull();
+    expect(s.shoppingRange).toEqual({
+      type: 'week',
+      todayMeals: ['breakfast', 'lunch', 'dinner'],
+      daysCount: 3,
+    });
+    expect(s.shoppingRangeStep).toBe('range');
+  });
+
+  it('setShoppingList は素の値のみ受け取る (page.tsx の getState() 展開パターンを検証)', () => {
+    useShoppingStore.getState().setShoppingList([makeItem({ id: 'a' })]);
+    // page.tsx addShoppingItem 相当: getState().shoppingList を都度読んでから展開する
+    const cur = useShoppingStore.getState().shoppingList;
+    useShoppingStore.getState().setShoppingList([...cur, makeItem({ id: 'b' })]);
+    expect(useShoppingStore.getState().shoppingList.map((i) => i.id)).toEqual(['a', 'b']);
+  });
+
+  it('toggleShoppingItem 相当の楽観的更新+ロールバックが getState() 経由で機械展開できる', () => {
+    useShoppingStore.getState().setShoppingList([makeItem({ id: 'a', isChecked: false })]);
+
+    // page.tsx toggleShoppingItem の楽観的更新
+    const before = useShoppingStore.getState().shoppingList;
+    useShoppingStore.getState().setShoppingList(
+      before.map((i) => (i.id === 'a' ? { ...i, isChecked: true } : i))
+    );
+    expect(useShoppingStore.getState().shoppingList[0].isChecked).toBe(true);
+
+    // ロールバック
+    const after = useShoppingStore.getState().shoppingList;
+    useShoppingStore.getState().setShoppingList(
+      after.map((i) => (i.id === 'a' ? { ...i, isChecked: false } : i))
+    );
+    expect(useShoppingStore.getState().shoppingList[0].isChecked).toBe(false);
+  });
+
+  it('resetShoppingState で初期状態に戻る', () => {
+    useShoppingStore.getState().setShoppingList([makeItem()]);
+    useShoppingStore.getState().setIsRegeneratingShoppingList(true);
+    useShoppingStore.getState().setShoppingRangeStep('servings');
+
+    useShoppingStore.getState().resetShoppingState();
+
+    const s = useShoppingStore.getState();
+    expect(s.shoppingList).toEqual([]);
+    expect(s.isRegeneratingShoppingList).toBe(false);
+    expect(s.shoppingRangeStep).toBe('range');
+  });
+
+  it('setShoppingRangeStep / setShoppingRange は素の値を反映する (ShoppingRangeModal からの書き込みを想定)', () => {
+    useShoppingStore.getState().setShoppingRange({
+      type: 'today',
+      todayMeals: ['breakfast'],
+      daysCount: 3,
+    });
+    useShoppingStore.getState().setShoppingRangeStep('servings');
+
+    const s = useShoppingStore.getState();
+    expect(s.shoppingRange.type).toBe('today');
+    expect(s.shoppingRangeStep).toBe('servings');
+  });
+});

--- a/src/__tests__/app/menus/weekly/static-guard.test.ts
+++ b/src/__tests__/app/menus/weekly/static-guard.test.ts
@@ -1,0 +1,100 @@
+// src/__tests__/app/menus/weekly/static-guard.test.ts
+// Issue #1031: 「週間献立の状態二重管理 (Refactor B 途中停止)」の静的ガードテスト。
+//
+// page.tsx はこの refactor で pantryStore/shoppingStore/formDraftStore/
+// servingsConfigStore を canonical にし、旧来の local useState 群を全廃した。
+// モーダル 13 個は store を直接 read/write するため、page.tsx 側で同名の
+// useState が「復活」すると再び split-brain (同名 state の二重管理) が発生し、
+// モーダルの表示・保存が壊れる (#1031 の症状が再発する)。
+//
+// このテストは page.tsx をソースとして grep し、設計書 §1 の表に列挙された
+// 変数名が `useState(` で再宣言されていないことを機械的に検知する。
+// 片側 (page.tsx か、モーダル/store のどちらか一方) だけを直す修正が
+// 将来再発した場合に、このテストが red になることを期待する。
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const PAGE_TSX_PATH = path.resolve(
+  __dirname,
+  '../../../../app/(main)/menus/weekly/page.tsx'
+);
+
+const pageSource = fs.readFileSync(PAGE_TSX_PATH, 'utf-8');
+
+// Issue #1031 設計書 §1 の表: page.tsx から全廃対象だった local useState 変数名
+// (canonical ストア: pantryStore / shoppingStore / formDraftStore / servingsConfigStore)
+const CANONICALIZED_VARIABLE_NAMES = [
+  // formDraftStore
+  'aiChatInput',
+  'addMealKey',
+  'addMealDayIndex',
+  'selectedConditions',
+  'editMealName',
+  'editMealMode',
+  'newFridgeName',
+  'newFridgeAmount',
+  'newFridgeExpiry',
+  'newShoppingName',
+  'newShoppingAmount',
+  'newShoppingCategory',
+  'manualDishes',
+  'manualMode',
+  'catalogQuery',
+  'catalogResults',
+  'selectedCatalogProduct',
+  'isCatalogSearching',
+  'catalogSearchError',
+  'photoFiles',
+  'photoPreviews',
+  'imageGenerationPrompt',
+  'imageReferenceFiles',
+  'imageReferencePreviews',
+  // pantryStore
+  'fridgeItems',
+  // shoppingStore
+  'shoppingList',
+  'activeShoppingList',
+  'isRegeneratingShoppingList',
+  'shoppingListProgress',
+  'shoppingListRequestId',
+  'shoppingListTotalServings',
+  'shoppingRange',
+  'shoppingRangeStep',
+  // servingsConfigStore
+  'servingsConfig',
+  'isLoadingServingsConfig',
+] as const;
+
+describe('page.tsx static guard (#1031 split-brain regression)', () => {
+  it('page.tsx が存在し、空でないこと (前提条件)', () => {
+    expect(pageSource.length).toBeGreaterThan(1000);
+  });
+
+  it.each(CANONICALIZED_VARIABLE_NAMES)(
+    '%s が useState( で再宣言されていないこと (store 一本化を維持)',
+    (varName) => {
+      // `const [varName, setVarName] = useState(...)` 形式の再宣言を検知する。
+      // 変数名の前後に単語境界を要求し、部分一致 (例: shoppingList vs shoppingListItem) を避ける。
+      const destructurePattern = new RegExp(
+        `const\\s*\\[\\s*${varName}\\s*,`,
+        'g'
+      );
+      const matches = pageSource.match(destructurePattern) ?? [];
+      expect(
+        matches,
+        `page.tsx に "${varName}" の useState 再宣言が見つかりました。` +
+          ` ${varName} は store (pantryStore/shoppingStore/formDraftStore/servingsConfigStore) の` +
+          ` selector 購読または getState() 参照に一本化すること (#1031)。`
+      ).toHaveLength(0);
+    }
+  );
+
+  it('page.tsx が pantryStore/shoppingStore/formDraftStore/servingsConfigStore を import していること', () => {
+    expect(pageSource).toMatch(/usePantryStore/);
+    expect(pageSource).toMatch(/useShoppingStore/);
+    expect(pageSource).toMatch(/useFormDraftStore/);
+    expect(pageSource).toMatch(/useServingsConfigStore/);
+  });
+});

--- a/src/app/(main)/menus/weekly/_state/formDraftStore.ts
+++ b/src/app/(main)/menus/weekly/_state/formDraftStore.ts
@@ -103,7 +103,11 @@ const initialState: FormDraftState = {
   newFridgeExpiry: '',
   newShoppingName: '',
   newShoppingAmount: '',
-  newShoppingCategory: '',
+  // #1031 round-2: 旧 page.tsx local useState の既定値 "食材" と一致させる。
+  // AddShoppingModal の <select> に空文字値の <option> は無く (catch-all は
+  // value="食材" のため)、'' のままだとフルリロード直後にカテゴリ未選択で
+  // 追加した場合に API へ category: "" が送られる退行が発生する。
+  newShoppingCategory: '食材',
   aiChatInput: '',
   selectedConditions: [],
   addMealKey: null,

--- a/src/app/(main)/menus/weekly/_state/formDraftStore.ts
+++ b/src/app/(main)/menus/weekly/_state/formDraftStore.ts
@@ -1,7 +1,8 @@
 // Refactor B Phase B-1: モーダル内編集 state 集約 store
 import { create } from 'zustand';
-import type { MealMode, DishDetail, MealType } from '@/types/domain';
+import type { MealMode, MealType } from '@/types/domain';
 import type { CatalogProductSummary } from '@/types/catalog';
+import type { LegacyDishDetail } from './types';
 
 interface FormDraftState {
   // 食事名・モード
@@ -9,7 +10,10 @@ interface FormDraftState {
   editMealMode: MealMode;
 
   // 手動入力
-  manualDishes: DishDetail[];
+  // #1031: page.tsx の manualDishes は旧形式(cal/protein等の短縮キー)との
+  // 後方互換のため LegacyDishDetail[] を使う。DishDetail[] に狭めると
+  // saveManualEdit 等の d.cal 参照が型エラーになる。
+  manualDishes: LegacyDishDetail[];
   manualMode: MealMode;
 
   // カタログ検索
@@ -52,7 +56,7 @@ interface FormDraftState {
 interface FormDraftActions {
   setEditMealName: (name: string) => void;
   setEditMealMode: (mode: MealMode) => void;
-  setManualDishes: (dishes: DishDetail[]) => void;
+  setManualDishes: (dishes: LegacyDishDetail[]) => void;
   setManualMode: (mode: MealMode) => void;
   setCatalogQuery: (query: string) => void;
   setCatalogResults: (results: CatalogProductSummary[]) => void;

--- a/src/app/(main)/menus/weekly/_state/index.ts
+++ b/src/app/(main)/menus/weekly/_state/index.ts
@@ -5,6 +5,9 @@ export { useShoppingStore } from './shoppingStore';
 export type { ShoppingRangeType, ShoppingRangeSelection } from './shoppingStore';
 export { useServingsConfigStore } from './servingsConfigStore';
 
+// Issue #1031 Step 0: page.tsx / formDraftStore 共有型
+export type { LegacyDishDetail } from './types';
+
 // Refactor B Phase B-2: useReducer 群
 export { weekViewReducer, initialWeekViewState } from './reducers/weekViewReducer';
 export type { WeekViewState, WeekViewAction } from './reducers/weekViewReducer';

--- a/src/app/(main)/menus/weekly/_state/types.ts
+++ b/src/app/(main)/menus/weekly/_state/types.ts
@@ -1,0 +1,32 @@
+// Refactor B / Issue #1031 Step 0: page.tsx から移設した共有型
+// LegacyDishDetail は page.tsx と formDraftStore の両方から参照されるため、
+// どちらにも依存しない _state 配下に置く。
+import type { DishDetail } from '@/types/domain';
+
+// 旧形式（cal/protein/fat/carbs 等の短縮キー）との後方互換のための型拡張
+// dish データが古いスキーマで保存されている可能性があるため
+export type LegacyDishDetail = DishDetail & {
+  cal?: number;
+  protein?: number;
+  fat?: number;
+  carbs?: number;
+  fiber?: number;
+  sugar?: number;
+  sodium?: number;
+  potassium?: number;
+  calcium?: number;
+  phosphorus?: number;
+  iron?: number;
+  zinc?: number;
+  cholesterol?: number;
+  vitaminA?: number;
+  vitaminB1?: number;
+  vitaminB2?: number;
+  vitaminB6?: number;
+  vitaminB12?: number;
+  vitaminC?: number;
+  vitaminD?: number;
+  vitaminE?: number;
+  vitaminK?: number;
+  folicAcid?: number;
+};

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -1033,11 +1033,14 @@ export default function WeeklyMenuPage() {
     loadFamilyData();
   }, []);
 
-  // Form States (aiChat/addMeal/conditions は Phase B-3 で formDraftStore に移行予定)
-  const [aiChatInput, setAiChatInput] = useState("");
-  const [addMealKey, setAddMealKey] = useState<MealType | null>(null);
-  const [addMealDayIndex, setAddMealDayIndex] = useState<number>(0);
-  const [selectedConditions, setSelectedConditions] = useState<string[]>([]);
+  // Form States (#1031: formDraftStore に一本化。
+  // aiChatInput/addMealKey/addMealDayIndex/selectedConditions はハンドラ内でのみ読むため
+  // 各ハンドラ冒頭で useFormDraftStore.getState() から都度読む (§2 方針)。
+  // setter だけはここで selector 購読して呼び出し側を変更せずに済ませる。
+  const setAiChatInput = useFormDraftStore((s) => s.setAiChatInput);
+  const setAddMealKey = useFormDraftStore((s) => s.setAddMealKey);
+  const setAddMealDayIndex = useFormDraftStore((s) => s.setAddMealDayIndex);
+  const setSelectedConditions = useFormDraftStore((s) => s.setSelectedConditions);
   // isGenerating / generatingMeal / generationProgress / generationFailedError / generationFailedRequestId
   // → aiGenerationReducer 管理 (Phase B-2 で移行済み)
 
@@ -1865,14 +1868,16 @@ export default function WeeklyMenuPage() {
   const [newShoppingCategory, setNewShoppingCategory] = useState("食材");
 
   // Recipe / AI / manualEdit / photo / imageGenerate → reducers 管理 (Phase B-2 移行済み)
-  // formDraft 系 (manualDishes/mode/catalogQuery 等) → Phase B-3 formDraftStore 予定
+  // formDraft 系 (#1031: formDraftStore に一本化)
   const [manualDishes, setManualDishes] = useState<LegacyDishDetail[]>([]);
   const [manualMode, setManualMode] = useState<MealMode>('cook');
-  const [catalogQuery, setCatalogQuery] = useState('');
-  const [catalogResults, setCatalogResults] = useState<CatalogProductSummary[]>([]);
-  const [selectedCatalogProduct, setSelectedCatalogProduct] = useState<CatalogProductSummary | null>(null);
-  const [isCatalogSearching, setIsCatalogSearching] = useState(false);
-  const [catalogSearchError, setCatalogSearchError] = useState('');
+  // catalogQuery は検索 effect の deps で参照するため selector 購読が必要
+  const catalogQuery = useFormDraftStore((s) => s.catalogQuery);
+  const setCatalogQuery = useFormDraftStore((s) => s.setCatalogQuery);
+  const setCatalogResults = useFormDraftStore((s) => s.setCatalogResults);
+  const setSelectedCatalogProduct = useFormDraftStore((s) => s.setSelectedCatalogProduct);
+  const setIsCatalogSearching = useFormDraftStore((s) => s.setIsCatalogSearching);
+  const setCatalogSearchError = useFormDraftStore((s) => s.setCatalogSearchError);
 
   // Photo edit files (reducer に移せない File[] は Phase B-3 まで維持)
   const [photoFiles, setPhotoFiles] = useState<File[]>([]);
@@ -3496,8 +3501,9 @@ export default function WeeklyMenuPage() {
     const weekStartDate = formatLocalDate(weekStart);
     setIsGenerating(true);
     setActiveModal(null); // モーダルを閉じて一覧画面に戻る
-    
+
     try {
+      const { aiChatInput, selectedConditions } = useFormDraftStore.getState();
       const preferences = {
         useFridgeFirst: selectedConditions.includes('冷蔵庫の食材を優先'),
         quickMeals: selectedConditions.includes('時短メニュー中心'),
@@ -3508,8 +3514,8 @@ export default function WeeklyMenuPage() {
       const response = await fetch("/api/ai/menu/weekly/request", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ 
-          startDate: weekDates[0]?.dateStr, 
+        body: JSON.stringify({
+          startDate: weekDates[0]?.dateStr,
           note: aiChatInput + (selectedConditions.length > 0 ? `\n【条件】${selectedConditions.join('、')}` : ''),
           preferences,
         }),
@@ -3547,20 +3553,21 @@ export default function WeeklyMenuPage() {
 
   // Generate single meal with AI
   const handleGenerateSingleMeal = async () => {
+    const { addMealKey, addMealDayIndex, selectedConditions, aiChatInput } = useFormDraftStore.getState();
     if (!addMealKey) return;
-    
+
     const dayDate = weekDates[addMealDayIndex]?.dateStr;
-    
+
     // 生成開始前の該当食事タイプの数を記録
     const currentDay = currentPlan?.days?.find((d: any) => d.dayDate === dayDate);
     const initialMealCount = currentDay?.meals?.filter((m: any) => m.mealType === addMealKey).length || 0;
-    
+
     setGeneratingMeal({ dayIndex: addMealDayIndex, mealType: addMealKey });
     setActiveModal(null);
-    
+
     try {
       const preferences: Record<string, boolean> = {};
-      selectedConditions.forEach(c => {
+      selectedConditions.forEach((c: string) => {
         if (c === '冷蔵庫の食材を優先') preferences.useFridgeFirst = true;
         if (c === '時短メニュー中心') preferences.quickMeals = true;
         if (c === '和食多め') preferences.japaneseStyle = true;
@@ -3618,8 +3625,9 @@ export default function WeeklyMenuPage() {
 
   // Add meal with specific mode
   const handleAddMealWithMode = async (mode: MealMode) => {
+    const { addMealKey, addMealDayIndex, selectedCatalogProduct } = useFormDraftStore.getState();
     if (!addMealKey) return;
-    
+
     const dayDate = weekDates[addMealDayIndex]?.dateStr;
     const defaultNames: Record<MealMode, string> = {
       cook: '自炊メニュー',
@@ -3687,10 +3695,11 @@ export default function WeeklyMenuPage() {
     
     setIsRegenerating(true);
     setRegeneratingMealId(regeneratingMeal.id);
-    
+
     try {
+      const { selectedConditions, aiChatInput } = useFormDraftStore.getState();
       const preferences: Record<string, boolean> = {};
-      selectedConditions.forEach(c => {
+      selectedConditions.forEach((c: string) => {
         if (c === '冷蔵庫の食材を優先') preferences.useFridgeFirst = true;
         if (c === '時短メニュー中心') preferences.quickMeals = true;
         if (c === '和食多め') preferences.japaneseStyle = true;
@@ -3959,7 +3968,8 @@ export default function WeeklyMenuPage() {
     
     const totalCal = validDishes.reduce((sum, d) => sum + (d.calories_kcal ?? d.cal ?? 0), 0);
     const dishName = validDishes.map(d => d.name).join('、');
-    
+    const { selectedCatalogProduct } = useFormDraftStore.getState();
+
     try {
       await fetch(`/api/meal-plans/meals/${manualEditMeal.id}`, {
         method: 'PATCH',

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -20,7 +20,8 @@ import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import type { RealtimeChannel } from "@supabase/supabase-js";
-import type { DailyMeal, PlannedMeal, PantryItem, ShoppingListItem, ShoppingList, MealMode, MealDishes, DishDetail, TargetSlot, MenuGenerationConstraints, ServingsConfig, DayOfWeek, MealServings, WeekStartDay } from "@/types/domain";
+// #1031: PantryItem/ShoppingList は store selector 経由の型推論に一本化したため import 不要になった
+import type { DailyMeal, PlannedMeal, ShoppingListItem, MealMode, MealDishes, DishDetail, TargetSlot, MenuGenerationConstraints, ServingsConfig, DayOfWeek, MealServings, WeekStartDay } from "@/types/domain";
 import type { CatalogProductSummary } from "@/types/catalog";
 import ReactMarkdown from "react-markdown";
 import { useV4MenuGeneration } from "@/hooks/useV4MenuGeneration";
@@ -126,18 +127,7 @@ interface WeekPlan {
   days: MealPlanDay[];
 }
 
-// 買い物リスト範囲選択の型
-type ShoppingRangeType = 'today' | 'tomorrow' | 'dayAfterTomorrow' | 'week' | 'days' | 'custom';
-interface ShoppingRangeSelection {
-  type: ShoppingRangeType;
-  // today選択時の食事タイプ
-  todayMeals: ('breakfast' | 'lunch' | 'dinner')[];
-  // days選択時の日数
-  daysCount: number;
-  // custom選択時の開始・終了日
-  customStartDate?: string;
-  customEndDate?: string;
-}
+// 買い物リスト範囲選択の型は #1031 で shoppingStore (_state/shoppingStore.ts) に一本化
 
 // 全ての食事タイプ
 const ALL_MEAL_TYPES: MealType[] = ['breakfast', 'lunch', 'dinner', 'snack', 'midnight_snack'];

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -9,6 +9,10 @@ import {
   recipeReducer, initialRecipeState,
   uiFlagReducer, initialUiFlagState,
   useServingsConfigStore,
+  usePantryStore,
+  useShoppingStore,
+  useFormDraftStore,
+  type LegacyDishDetail,
 } from './_state';
 import dynamic from "next/dynamic";
 import { motion, AnimatePresence } from "framer-motion";
@@ -138,33 +142,7 @@ interface ShoppingRangeSelection {
 // 全ての食事タイプ
 const ALL_MEAL_TYPES: MealType[] = ['breakfast', 'lunch', 'dinner', 'snack', 'midnight_snack'];
 
-// 旧形式（cal/protein/fat/carbs 等の短縮キー）との後方互換のための型拡張
-// dish データが古いスキーマで保存されている可能性があるため
-type LegacyDishDetail = DishDetail & {
-  cal?: number;
-  protein?: number;
-  fat?: number;
-  carbs?: number;
-  fiber?: number;
-  sugar?: number;
-  sodium?: number;
-  potassium?: number;
-  calcium?: number;
-  phosphorus?: number;
-  iron?: number;
-  zinc?: number;
-  cholesterol?: number;
-  vitaminA?: number;
-  vitaminB1?: number;
-  vitaminB2?: number;
-  vitaminB6?: number;
-  vitaminB12?: number;
-  vitaminC?: number;
-  vitaminD?: number;
-  vitaminE?: number;
-  vitaminK?: number;
-  folicAcid?: number;
-};
+// LegacyDishDetail は _state/types.ts (Issue #1031 Step 0 で移設、formDraftStore と共有)
 
 // Reference UI Color Palette
 const colors = {

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -1885,10 +1885,10 @@ export default function WeeklyMenuPage() {
   const setPhotoPreviews = useFormDraftStore((s) => s.setPhotoPreviews);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Image generation files
-  const [imageGenerationPrompt, setImageGenerationPrompt] = useState('');
-  const [imageReferenceFiles, setImageReferenceFiles] = useState<File[]>([]);
-  const [imageReferencePreviews, setImageReferencePreviews] = useState<string[]>([]);
+  // Image generation files (#1031: formDraftStore に一本化。ハンドラ内でのみ読む)
+  const setImageGenerationPrompt = useFormDraftStore((s) => s.setImageGenerationPrompt);
+  const setImageReferenceFiles = useFormDraftStore((s) => s.setImageReferenceFiles);
+  const setImageReferencePreviews = useFormDraftStore((s) => s.setImageReferencePreviews);
   const imageGenerateInputRef = useRef<HTMLInputElement>(null);
 
   // レシピモーダルが開いたとき、お気に入り状態を取得
@@ -4147,12 +4147,12 @@ export default function WeeklyMenuPage() {
     if (!files || files.length === 0) return;
 
     const newFiles = Array.from(files);
-    setImageReferenceFiles((prev) => [...prev, ...newFiles]);
+    setImageReferenceFiles([...useFormDraftStore.getState().imageReferenceFiles, ...newFiles]);
 
     newFiles.forEach((file) => {
       const reader = new FileReader();
       reader.onloadend = () => {
-        setImageReferencePreviews((prev) => [...prev, reader.result as string]);
+        setImageReferencePreviews([...useFormDraftStore.getState().imageReferencePreviews, reader.result as string]);
       };
       reader.readAsDataURL(file);
     });
@@ -4161,13 +4161,14 @@ export default function WeeklyMenuPage() {
   };
 
   const removeImageReference = (index: number) => {
-    setImageReferenceFiles((prev) => prev.filter((_, i) => i !== index));
-    setImageReferencePreviews((prev) => prev.filter((_, i) => i !== index));
+    setImageReferenceFiles(useFormDraftStore.getState().imageReferenceFiles.filter((_, i) => i !== index));
+    setImageReferencePreviews(useFormDraftStore.getState().imageReferencePreviews.filter((_, i) => i !== index));
   };
 
   const generateMealImage = async () => {
     if (!imageGenerateMeal || !currentPlan) return;
 
+    const { imageGenerationPrompt, imageReferenceFiles } = useFormDraftStore.getState();
     const prompt = imageGenerationPrompt.trim();
     if (!prompt) {
       alert('生成したい料理の説明を入力してください');
@@ -5838,12 +5839,12 @@ export default function WeeklyMenuPage() {
                 onClose={() => closeImageGenerateModal(true)}
                 onAddReferenceImages={(files: FileList) => {
                   const newFiles = Array.from(files);
-                  setImageReferenceFiles(prev => [...prev, ...newFiles]);
+                  setImageReferenceFiles([...useFormDraftStore.getState().imageReferenceFiles, ...newFiles]);
                   newFiles.forEach(file => {
                     const reader = new FileReader();
                     reader.onload = (e) => {
                       if (e.target?.result) {
-                        setImageReferencePreviews(prev => [...prev, e.target!.result as string]);
+                        setImageReferencePreviews([...useFormDraftStore.getState().imageReferencePreviews, e.target!.result as string]);
                       }
                     };
                     reader.readAsDataURL(file);

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -1776,9 +1776,9 @@ export default function WeeklyMenuPage() {
     restoreShoppingListRegeneration();
   }, []);
   
-  // Edit meal state (editingMeal → modalReducer, editMealName/Mode → Phase B-3 formDraftStore)
-  const [editMealName, setEditMealName] = useState("");
-  const [editMealMode, setEditMealMode] = useState<MealMode>('cook');
+  // Edit meal state (editingMeal → modalReducer, editMealName/Mode → #1031 formDraftStore に一本化)
+  const setEditMealName = useFormDraftStore((s) => s.setEditMealName);
+  const setEditMealMode = useFormDraftStore((s) => s.setEditMealMode);
 
   // Pantry & Shopping (#1031: pantryStore/shoppingStore に一本化。page は selector 購読のみ)
   const fridgeItems = usePantryStore((s) => s.fridgeItems);
@@ -3825,7 +3825,9 @@ export default function WeeklyMenuPage() {
 
   const saveEditMeal = async () => {
     if (!editingMeal || !currentPlan) return;
-    
+
+    const { editMealName, editMealMode } = useFormDraftStore.getState();
+
     try {
       await fetch(`/api/meal-plans/meals/${editingMeal.id}`, {
         method: 'PATCH',
@@ -3835,12 +3837,12 @@ export default function WeeklyMenuPage() {
           mode: editMealMode
         })
       });
-      
+
       // Update local state
       const updatedDays = currentPlan.days?.map(day => ({
         ...day,
-        meals: day.meals?.map(m => 
-          m.id === editingMeal.id 
+        meals: day.meals?.map(m =>
+          m.id === editingMeal.id
             ? { ...m, dishName: editMealName, mode: editMealMode }
             : m
         )

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -1777,8 +1777,8 @@ export default function WeeklyMenuPage() {
   const [editMealName, setEditMealName] = useState("");
   const [editMealMode, setEditMealMode] = useState<MealMode>('cook');
 
-  // Pantry & Shopping (fridgeItems/shoppingList 等 → Phase B-3 pantryStore/shoppingStore)
-  const [fridgeItems, setFridgeItems] = useState<PantryItem[]>([]);
+  // Pantry & Shopping (#1031: pantryStore/shoppingStore に一本化。page は selector 購読のみ)
+  const fridgeItems = usePantryStore((s) => s.fridgeItems);
   const [shoppingList, setShoppingList] = useState<ShoppingListItem[]>([]);
   const [activeShoppingList, setActiveShoppingList] = useState<ShoppingList | null>(null);
   const [isRegeneratingShoppingList, setIsRegeneratingShoppingList] = useState(false);
@@ -2512,7 +2512,7 @@ export default function WeeklyMenuPage() {
         const res = await fetch('/api/pantry');
         if (res.ok) {
           const data = await res.json();
-          setFridgeItems(data.items || []);
+          usePantryStore.getState().setFridgeItems(data.items || []);
         }
       } catch (e) {
         console.error("Failed to fetch pantry:", e);
@@ -2946,9 +2946,9 @@ export default function WeeklyMenuPage() {
       });
       if (res.ok) {
         const { item } = await res.json();
-        setFridgeItems(prev => [...prev, item]);
-        setNewFridgeName(""); 
-        setNewFridgeAmount(""); 
+        usePantryStore.getState().addFridgeItem(item);
+        setNewFridgeName("");
+        setNewFridgeAmount("");
         setNewFridgeExpiry("");
         setActiveModal('fridge');
       }
@@ -2958,7 +2958,7 @@ export default function WeeklyMenuPage() {
   const deletePantryItem = async (id: string) => {
     try {
       await fetch(`/api/pantry/${id}`, { method: 'DELETE' });
-      setFridgeItems(prev => prev.filter(i => i.id !== id));
+      usePantryStore.getState().removeFridgeItem(id);
     } catch (e) { alert("削除に失敗しました"); }
   };
 

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -1880,9 +1880,9 @@ export default function WeeklyMenuPage() {
   const setIsCatalogSearching = useFormDraftStore((s) => s.setIsCatalogSearching);
   const setCatalogSearchError = useFormDraftStore((s) => s.setCatalogSearchError);
 
-  // Photo edit files (reducer に移せない File[] は Phase B-3 まで維持)
-  const [photoFiles, setPhotoFiles] = useState<File[]>([]);
-  const [photoPreviews, setPhotoPreviews] = useState<string[]>([]);
+  // Photo edit files (#1031: formDraftStore に一本化。photoFiles はハンドラ内でのみ読む)
+  const setPhotoFiles = useFormDraftStore((s) => s.setPhotoFiles);
+  const setPhotoPreviews = useFormDraftStore((s) => s.setPhotoPreviews);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Image generation files
@@ -4026,31 +4026,32 @@ export default function WeeklyMenuPage() {
     const files = e.target.files;
     if (files && files.length > 0) {
       const newFiles = Array.from(files);
-      setPhotoFiles(prev => [...prev, ...newFiles]);
-      
+      setPhotoFiles([...useFormDraftStore.getState().photoFiles, ...newFiles]);
+
       // プレビュー画像を生成
       newFiles.forEach(file => {
         const reader = new FileReader();
         reader.onloadend = () => {
-          setPhotoPreviews(prev => [...prev, reader.result as string]);
+          setPhotoPreviews([...useFormDraftStore.getState().photoPreviews, reader.result as string]);
         };
         reader.readAsDataURL(file);
       });
     }
   };
-  
+
   // 写真を削除
   const removePhoto = (index: number) => {
-    setPhotoFiles(prev => prev.filter((_, i) => i !== index));
-    setPhotoPreviews(prev => prev.filter((_, i) => i !== index));
+    setPhotoFiles(useFormDraftStore.getState().photoFiles.filter((_, i) => i !== index));
+    setPhotoPreviews(useFormDraftStore.getState().photoPreviews.filter((_, i) => i !== index));
   };
 
   // Analyze photo with AI（複数枚対応）
   const analyzePhotoWithAI = async () => {
+    const { photoFiles } = useFormDraftStore.getState();
     if (photoFiles.length === 0 || !photoEditMeal || !currentPlan) return;
-    
+
     setIsAnalyzingPhoto(true);
-    
+
     try {
       // 複数枚の写真をBase64に変換して送信
       const imageDataArray = await Promise.all(photoFiles.map(async (file) => {
@@ -5860,12 +5861,12 @@ export default function WeeklyMenuPage() {
                 onClose={() => { setActiveModal(null); setPhotoEditMeal(null); setPhotoFiles([]); setPhotoPreviews([]); }}
                 onPhotoSelect={(files: FileList) => {
                   const newFiles = Array.from(files);
-                  setPhotoFiles(prev => [...prev, ...newFiles]);
+                  setPhotoFiles([...useFormDraftStore.getState().photoFiles, ...newFiles]);
                   newFiles.forEach(file => {
                     const reader = new FileReader();
                     reader.onload = (e) => {
                       if (e.target?.result) {
-                        setPhotoPreviews(prev => [...prev, e.target!.result as string]);
+                        setPhotoPreviews([...useFormDraftStore.getState().photoPreviews, e.target!.result as string]);
                       }
                     };
                     reader.readAsDataURL(file);

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -1779,28 +1779,33 @@ export default function WeeklyMenuPage() {
 
   // Pantry & Shopping (#1031: pantryStore/shoppingStore に一本化。page は selector 購読のみ)
   const fridgeItems = usePantryStore((s) => s.fridgeItems);
-  const [shoppingList, setShoppingList] = useState<ShoppingListItem[]>([]);
-  const [activeShoppingList, setActiveShoppingList] = useState<ShoppingList | null>(null);
-  const [isRegeneratingShoppingList, setIsRegeneratingShoppingList] = useState(false);
-  const [shoppingListProgress, setShoppingListProgress] = useState<{ phase: string; message: string; percentage: number } | null>(null);
-  const [shoppingListRequestId, setShoppingListRequestId] = useState<string | null>(null);
-  const [shoppingListTotalServings, setShoppingListTotalServings] = useState<number | null>(null);
+  const shoppingList = useShoppingStore((s) => s.shoppingList);
+  // setShoppingList はストアの素の setter (関数型更新非対応)。
+  // prev => の呼び出し箇所は getState().shoppingList を都度読んで機械展開する (#1031 §2)。
+  const setShoppingList = useShoppingStore((s) => s.setShoppingList);
+  const activeShoppingList = useShoppingStore((s) => s.activeShoppingList);
+  const setActiveShoppingList = useShoppingStore((s) => s.setActiveShoppingList);
+  const isRegeneratingShoppingList = useShoppingStore((s) => s.isRegeneratingShoppingList);
+  const setIsRegeneratingShoppingList = useShoppingStore((s) => s.setIsRegeneratingShoppingList);
+  const shoppingListProgress = useShoppingStore((s) => s.shoppingListProgress);
+  const setShoppingListProgress = useShoppingStore((s) => s.setShoppingListProgress);
+  const shoppingListRequestId = useShoppingStore((s) => s.shoppingListRequestId);
+  const setShoppingListRequestId = useShoppingStore((s) => s.setShoppingListRequestId);
+  const shoppingListTotalServings = useShoppingStore((s) => s.shoppingListTotalServings);
+  const setShoppingListTotalServings = useShoppingStore((s) => s.setShoppingListTotalServings);
 
-  // 曜日別人数設定 (servingsConfig → Phase B-3 servingsConfigStore)
-  const [servingsConfig, setServingsConfig] = useState<ServingsConfig | null>(null);
-  const [isLoadingServingsConfig, setIsLoadingServingsConfig] = useState(false);
+  // 曜日別人数設定 (#1031: servingsConfigStore に一本化)
+  const servingsConfig = useServingsConfigStore((s) => s.servingsConfig);
+  const setServingsConfig = useServingsConfigStore((s) => s.setServingsConfig);
+  const setIsLoadingServingsConfig = useServingsConfigStore((s) => s.setIsLoadingServingsConfig);
 
   // feedbackChannelRef (nutrition 系は nutritionReducer 管理)
   // RealtimeChannel か、ポーリング用のカスタムクリーンアップオブジェクトのどちらかを保持する
   const feedbackChannelRef = useRef<RealtimeChannel | { unsubscribe: () => void } | null>(null);
 
-  // 買い物リスト範囲選択 (Phase B-3 shoppingStore 予定)
-  const [shoppingRange, setShoppingRange] = useState<ShoppingRangeSelection>({
-    type: 'week',
-    todayMeals: ['breakfast', 'lunch', 'dinner'],
-    daysCount: 3,
-  });
-  const [shoppingRangeStep, setShoppingRangeStep] = useState<'range' | 'servings'>('range');
+  // 買い物リスト範囲選択 (#1031: shoppingStore に一本化)
+  const shoppingRange = useShoppingStore((s) => s.shoppingRange);
+  const setShoppingRangeStep = useShoppingStore((s) => s.setShoppingRangeStep);
 
   // スーパーの動線に合わせたカテゴリ順序
   const CATEGORY_ORDER = [
@@ -2978,8 +2983,8 @@ export default function WeeklyMenuPage() {
       });
       if (res.ok) {
         const { item } = await res.json();
-        setShoppingList(prev => [...prev, item]);
-        setNewShoppingName(""); 
+        setShoppingList([...useShoppingStore.getState().shoppingList, item]);
+        setNewShoppingName("");
         setNewShoppingAmount(""); 
         setNewShoppingCategory("食材");
         setActiveModal('shopping');
@@ -2990,24 +2995,24 @@ export default function WeeklyMenuPage() {
   // チェックボックスのトグル（楽観的更新）
   const toggleShoppingItem = (id: string, currentChecked: boolean) => {
     // 即座にUIを更新
-    setShoppingList(prev => prev.map(i => i.id === id ? { ...i, isChecked: !currentChecked } : i));
-    
+    setShoppingList(useShoppingStore.getState().shoppingList.map(i => i.id === id ? { ...i, isChecked: !currentChecked } : i));
+
     // 裏でAPI呼び出し（永続化）- レスポンスを待たない
-    fetch(`/api/shopping-list/${id}`, { 
-        method: 'PATCH', 
-        headers: { 'Content-Type': 'application/json' }, 
-        body: JSON.stringify({ isChecked: !currentChecked }) 
-    }).catch(e => { 
+    fetch(`/api/shopping-list/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ isChecked: !currentChecked })
+    }).catch(e => {
       console.error('Failed to save check state:', e);
       // エラー時はロールバック
-      setShoppingList(prev => prev.map(i => i.id === id ? { ...i, isChecked: currentChecked } : i)); 
+      setShoppingList(useShoppingStore.getState().shoppingList.map(i => i.id === id ? { ...i, isChecked: currentChecked } : i));
     });
   };
 
   const deleteShoppingItem = async (id: string) => {
     // 楽観的UI更新
-    const previousList = shoppingList;
-    setShoppingList(prev => prev.filter(i => i.id !== id));
+    const previousList = useShoppingStore.getState().shoppingList;
+    setShoppingList(previousList.filter(i => i.id !== id));
     try {
       const res = await fetch(`/api/shopping-list/${id}`, { method: 'DELETE' });
       if (!res.ok) throw new Error('Delete failed');
@@ -3378,12 +3383,12 @@ export default function WeeklyMenuPage() {
     const newQuantity = item.quantityVariants[nextIndex]?.display || item.quantity;
     
     // 即座にUIを更新（楽観的更新）
-    setShoppingList(prev => prev.map(i => 
-      i.id === itemId 
+    setShoppingList(useShoppingStore.getState().shoppingList.map(i =>
+      i.id === itemId
         ? { ...i, selectedVariantIndex: nextIndex, quantity: newQuantity }
         : i
     ));
-    
+
     // 裏でAPIを呼び出し（永続化）- レスポンスを待たない
     fetch(`/api/shopping-list/${itemId}`, {
       method: 'PATCH',
@@ -3392,8 +3397,8 @@ export default function WeeklyMenuPage() {
     }).catch(e => {
       console.error('Failed to save variant change:', e);
       // エラー時はロールバック
-      setShoppingList(prev => prev.map(i => 
-        i.id === itemId 
+      setShoppingList(useShoppingStore.getState().shoppingList.map(i =>
+        i.id === itemId
           ? { ...i, selectedVariantIndex: item.selectedVariantIndex, quantity: item.quantity }
           : i
       ));
@@ -3470,7 +3475,7 @@ export default function WeeklyMenuPage() {
       });
       if (res.ok) {
         const { items } = await res.json();
-        setShoppingList(prev => [...prev, ...items]);
+        setShoppingList([...useShoppingStore.getState().shoppingList, ...items]);
         setActiveModal(null);
         setSuccessMessage({ 
           title: '買い物リストに追加しました ✓', 

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -1859,13 +1859,13 @@ export default function WeeklyMenuPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shoppingList]);  // CATEGORY_ORDER はコンポーネント内定数配列のため deps に含めるとメモ化が無効になる。本来はモジュールスコープに移動すべきだが挙動変更を避けるため個別 disable
   
-  // Add fridge/shopping form (Phase B-3 で formDraftStore 予定、今は useState 維持)
-  const [newFridgeName, setNewFridgeName] = useState("");
-  const [newFridgeAmount, setNewFridgeAmount] = useState("");
-  const [newFridgeExpiry, setNewFridgeExpiry] = useState("");
-  const [newShoppingName, setNewShoppingName] = useState("");
-  const [newShoppingAmount, setNewShoppingAmount] = useState("");
-  const [newShoppingCategory, setNewShoppingCategory] = useState("食材");
+  // Add fridge/shopping form (#1031: formDraftStore に一本化。ハンドラ内でのみ読む)
+  const setNewFridgeName = useFormDraftStore((s) => s.setNewFridgeName);
+  const setNewFridgeAmount = useFormDraftStore((s) => s.setNewFridgeAmount);
+  const setNewFridgeExpiry = useFormDraftStore((s) => s.setNewFridgeExpiry);
+  const setNewShoppingName = useFormDraftStore((s) => s.setNewShoppingName);
+  const setNewShoppingAmount = useFormDraftStore((s) => s.setNewShoppingAmount);
+  const setNewShoppingCategory = useFormDraftStore((s) => s.setNewShoppingCategory);
 
   // Recipe / AI / manualEdit / photo / imageGenerate → reducers 管理 (Phase B-2 移行済み)
   // formDraft 系 (#1031: formDraftStore に一本化)
@@ -2943,16 +2943,17 @@ export default function WeeklyMenuPage() {
 
   // Add pantry item
   const addPantryItem = async () => {
+    const { newFridgeName, newFridgeAmount, newFridgeExpiry } = useFormDraftStore.getState();
     if (!newFridgeName) return;
     try {
       const res = await fetch('/api/pantry', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ 
-          name: newFridgeName, 
-          amount: newFridgeAmount, 
-          category: "other", 
-          expirationDate: newFridgeExpiry || null 
+        body: JSON.stringify({
+          name: newFridgeName,
+          amount: newFridgeAmount,
+          category: "other",
+          expirationDate: newFridgeExpiry || null
         })
       });
       if (res.ok) {
@@ -2975,15 +2976,16 @@ export default function WeeklyMenuPage() {
 
   // Add shopping item
   const addShoppingItem = async () => {
+    const { newShoppingName, newShoppingAmount, newShoppingCategory } = useFormDraftStore.getState();
     if (!newShoppingName || !currentPlan) return;
     try {
       const res = await fetch('/api/shopping-list', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ 
+        body: JSON.stringify({
           shoppingListId: activeShoppingList?.id,
-          itemName: newShoppingName, 
-          quantity: newShoppingAmount, 
+          itemName: newShoppingName,
+          quantity: newShoppingAmount,
           category: newShoppingCategory
         })
       });

--- a/src/app/(main)/menus/weekly/page.tsx
+++ b/src/app/(main)/menus/weekly/page.tsx
@@ -1869,8 +1869,9 @@ export default function WeeklyMenuPage() {
 
   // Recipe / AI / manualEdit / photo / imageGenerate → reducers 管理 (Phase B-2 移行済み)
   // formDraft 系 (#1031: formDraftStore に一本化)
-  const [manualDishes, setManualDishes] = useState<LegacyDishDetail[]>([]);
-  const [manualMode, setManualMode] = useState<MealMode>('cook');
+  // manualDishes/manualMode はハンドラ内でのみ読むため useFormDraftStore.getState() を都度参照
+  const setManualDishes = useFormDraftStore((s) => s.setManualDishes);
+  const setManualMode = useFormDraftStore((s) => s.setManualMode);
   // catalogQuery は検索 effect の deps で参照するため selector 購読が必要
   const catalogQuery = useFormDraftStore((s) => s.catalogQuery);
   const setCatalogQuery = useFormDraftStore((s) => s.setCatalogQuery);
@@ -3920,26 +3921,27 @@ export default function WeeklyMenuPage() {
   // Add dish to manual edit
   const addManualDish = () => {
     setSelectedCatalogProduct(null);
-    setManualDishes(prev => [...prev, { name: '', calories_kcal: 0, role: 'side' }]);
+    setManualDishes([...useFormDraftStore.getState().manualDishes, { name: '', calories_kcal: 0, role: 'side' }]);
   };
 
   // Remove dish from manual edit
   const removeManualDish = (index: number) => {
     setSelectedCatalogProduct(null);
-    setManualDishes(prev => prev.filter((_, i) => i !== index));
+    setManualDishes(useFormDraftStore.getState().manualDishes.filter((_, i) => i !== index));
   };
 
   // Update dish in manual edit
   const updateManualDish = (index: number, field: keyof DishDetail, value: string | number) => {
     setSelectedCatalogProduct(null);
-    setManualDishes(prev => prev.map((dish, i) => 
+    setManualDishes(useFormDraftStore.getState().manualDishes.map((dish, i) =>
       i === index ? { ...dish, [field]: value } : dish
     ));
   };
 
   const applyCatalogProductToManualEdit = (product: CatalogProductSummary) => {
     setSelectedCatalogProduct(product);
-    setManualMode((prev) => (prev === 'out' ? 'out' : 'buy'));
+    const prevManualMode = useFormDraftStore.getState().manualMode;
+    setManualMode(prevManualMode === 'out' ? 'out' : 'buy');
     setCatalogQuery(product.name);
     setManualDishes([
       {
@@ -3959,16 +3961,16 @@ export default function WeeklyMenuPage() {
   // Save manual edit
   const saveManualEdit = async () => {
     if (!manualEditMeal || !currentPlan) return;
-    
+
+    const { manualDishes, manualMode, selectedCatalogProduct } = useFormDraftStore.getState();
     const validDishes = manualDishes.filter(d => d.name.trim());
     if (validDishes.length === 0) {
       alert('少なくとも1つの料理名を入力してください');
       return;
     }
-    
+
     const totalCal = validDishes.reduce((sum, d) => sum + (d.calories_kcal ?? d.cal ?? 0), 0);
     const dishName = validDishes.map(d => d.name).join('、');
-    const { selectedCatalogProduct } = useFormDraftStore.getState();
 
     try {
       await fetch(`/api/meal-plans/meals/${manualEditMeal.id}`, {
@@ -4122,7 +4124,7 @@ export default function WeeklyMenuPage() {
   const openImageGenerate = () => {
     if (!manualEditMeal) return;
 
-    const promptSource = manualDishes
+    const promptSource = useFormDraftStore.getState().manualDishes
       .map((dish) => dish.name.trim())
       .filter(Boolean)
       .join('、');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,6 +39,15 @@ export default defineConfig({
       ),
     },
   },
+  // tsconfig.json は Next.js の SWC コンパイラ向けに jsx: "preserve" を指定しているが、
+  // このバージョンの Vite (rolldown-vite, oxc ベース) は tsconfig の jsx: "preserve" を
+  // そのまま引き継いでしまい .tsx の変換に失敗する
+  // ("Failed to parse source... jsx to preserve" エラー)。
+  // tsconfig.json 自体は Next.js ビルド/tsc の都合で変更せず、Vitest 専用の
+  // oxc 設定だけを上書きしてコンポーネントの render テストを可能にする (#1031)。
+  oxc: {
+    jsx: { runtime: "automatic" },
+  },
   test: {
     exclude: [
       "**/node_modules/**",


### PR DESCRIPTION
## 概要
週間献立ページ(menus/weekly/page.tsx, 6170行)で page 側 local useState と各モーダルが read/write する zustand ストアが二重管理(split-brain)になり、13モーダルの操作(冷蔵庫追加・買い物リスト・AI条件・手動編集・写真/画像生成・買い物範囲・人数設定)が page 状態へ反映されない不具合を解消。

## 修正内容
- page.tsx の対象35 useState を全廃し canonical な zustand ストア(pantry/shopping/formDraft/servingsConfig)へ一本化。描画/memo/effect 依存値は selector 購読、ハンドラ専用値は getState() 参照。
- 関数型更新は getState() ライブ読みへ機械展開。
- #1032(互換 setter 層)/#1033 の領域は不可侵。
- 買い物追加カテゴリ既定値を '食材' に統一(round-2)。

## 検証
- 新規テスト63件 PASS(static-guard/modal-contracts/store単体)。tsc エラー0。退行スイート0。
- 2モデル敵対レビュー(Sonnet5+Fable)round-1/round-2 とも double-PASS。

## follow-up(別Issue)
- AddFridge/AddShopping モーダル open 時リセット未配線 / §5 Step10 reset 配線 / exhaustive-deps warning(実害なし)