### PR TITLE
fix(infra): PostHog CSPブロック・認証ページ誤キャッシュ・ログ/問い合わせAPIの未検証入力を修正 (#1044)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,8 @@ import { dirname, join } from 'path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf8'));
 const isDev = process.env.NODE_ENV === 'development';
+// #1044 (F6-09): PostHog の api_host は src/lib/posthog.ts のデフォルトと合わせる
+const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -15,7 +17,10 @@ const nextConfig = {
   async headers() {
     return [
       {
-        source: '/handson-tour/(.*)',
+        // #1044 (F6-08): '/handson-tour/(.*)' は認証必須ページ (例: /handson-tour/photo) にも
+        // マッチしてしまい、CDN が認証済み HTML を1年キャッシュする恐れがあった。
+        // public/handson-tour 配下の静的アセットのみに限定する。
+        source: '/handson-tour/sample-meal.webp',
         headers: [
           {
             key: 'Cache-Control',
@@ -51,7 +56,8 @@ const nextConfig = {
               `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''} *.vercel-scripts.com`,
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: blob: *.supabase.co images.unsplash.com",
-              "connect-src 'self' *.supabase.co *.vercel.app wss://*.supabase.co",
+              // #1044 (F6-09): PostHog の capture/identify 送信先を許可 (未設定だと全ブロックされていた)
+              `connect-src 'self' *.supabase.co *.vercel.app wss://*.supabase.co ${posthogHost}`,
               "frame-ancestors 'none'",
               "font-src 'self'",
               "object-src 'none'",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -57,7 +57,8 @@ const nextConfig = {
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: blob: *.supabase.co images.unsplash.com",
               // #1044 (F6-09): PostHog の capture/identify 送信先を許可 (未設定だと全ブロックされていた)
-              `connect-src 'self' *.supabase.co *.vercel.app wss://*.supabase.co ${posthogHost}`,
+              // #1044 round-2: session replay 等で使う PostHog アセットホストも予防的に許可
+              `connect-src 'self' *.supabase.co *.vercel.app wss://*.supabase.co ${posthogHost} https://us-assets.i.posthog.com`,
               "frame-ancestors 'none'",
               "font-src 'self'",
               "object-src 'none'",

--- a/src/__tests__/api/contact.test.ts
+++ b/src/__tests__/api/contact.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetUser = vi.fn();
+const mockSingle = vi.fn();
+const mockSelectAfterInsert = vi.fn(() => ({ single: mockSingle }));
+const mockInsert = vi.fn(() => ({ select: mockSelectAfterInsert }));
+
+const mockOrder = vi.fn();
+const mockEq = vi.fn(() => ({ order: mockOrder }));
+const mockSelect = vi.fn((_columns?: string) => ({ eq: mockEq }));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+    from: () => ({
+      insert: mockInsert,
+      select: mockSelect,
+    }),
+  }),
+}));
+
+const { POST, GET } = await import('@/app/api/contact/route');
+
+const validBody = {
+  inquiryType: 'general',
+  email: 'user@example.com',
+  subject: 'テスト件名',
+  message: 'テストメッセージ',
+};
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/contact', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-forwarded-for': '203.0.113.1' },
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+  mockSingle.mockResolvedValue({
+    data: { id: 'inquiry-1', inquiry_type: 'general', email: 'user@example.com', subject: 's', message: 'm' },
+    error: null,
+  });
+  mockOrder.mockResolvedValue({ data: [], error: null });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('POST /api/contact (#1044 F6-19)', () => {
+  it('正常なリクエストは成功する', async () => {
+    const res = await POST(makeRequest(validBody));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+  });
+
+  it('不正な inquiryType は 400 を返す', async () => {
+    const res = await POST(makeRequest({ ...validBody, inquiryType: 'not-a-real-type' }));
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('不正なメールアドレスは 400 を返す', async () => {
+    const res = await POST(makeRequest({ ...validBody, email: 'not-an-email' }));
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('100文字を超える subject は 400 を返す', async () => {
+    const res = await POST(makeRequest({ ...validBody, subject: 'a'.repeat(101) }));
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('5000文字を超える message は 400 を返す', async () => {
+    const res = await POST(makeRequest({ ...validBody, message: 'a'.repeat(5001) }));
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('5000文字ちょうどの message は許可される', async () => {
+    const res = await POST(makeRequest({ ...validBody, message: 'a'.repeat(5000) }));
+    expect(res.status).toBe(200);
+  });
+
+  it('本番環境で Upstash 未設定 (テスト環境の常態) の場合は 503 を返す', async () => {
+    // このテストスイートは UPSTASH_REDIS_REST_URL/TOKEN を設定していないため
+    // upstashRatelimiter は null のまま。NODE_ENV を production に切り替えると
+    // in-memory フォールバックへの依存を許さず 503 で拒否するはず (F6-19)。
+    vi.stubEnv('NODE_ENV', 'production');
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(503);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/contact (#1044 F6-19)', () => {
+  it('未認証は 401 を返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('必要な列のみを select する (admin_notes 等を含めない)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    const selectedColumns = mockSelect.mock.calls[0][0] as string;
+    expect(selectedColumns).not.toContain('*');
+    expect(selectedColumns).not.toContain('admin_notes');
+    expect(selectedColumns).toContain('inquiry_type');
+  });
+});

--- a/src/__tests__/api/contact.test.ts
+++ b/src/__tests__/api/contact.test.ts
@@ -87,14 +87,18 @@ describe('POST /api/contact (#1044 F6-19)', () => {
     expect(res.status).toBe(200);
   });
 
-  it('本番環境で Upstash 未設定 (テスト環境の常態) の場合は 503 を返す', async () => {
+  it('本番環境で Upstash 未設定 (テスト環境の常態) でも in-memory フォールバックで受け付ける', async () => {
     // このテストスイートは UPSTASH_REDIS_REST_URL/TOKEN を設定していないため
-    // upstashRatelimiter は null のまま。NODE_ENV を production に切り替えると
-    // in-memory フォールバックへの依存を許さず 503 で拒否するはず (F6-19)。
+    // upstashRatelimiter は null のまま。#1044 round-2: Upstash 未設定を理由に
+    // hard 503 で拒否すると本番で問い合わせフォームが全壊するため、
+    // src/lib/rate-limit.ts と同じ canonical 方針 (in-memory フォールバック + warn ログ)
+    // に揃え、NODE_ENV=production でもリクエストを通す。
     vi.stubEnv('NODE_ENV', 'production');
     const res = await POST(makeRequest(validBody));
-    expect(res.status).toBe(503);
-    expect(mockInsert).not.toHaveBeenCalled();
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockInsert).toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/api/cron/process-menu-queue.test.ts
+++ b/src/__tests__/api/cron/process-menu-queue.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockRpc = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    rpc: mockRpc,
+    from: () => ({
+      update: () => ({ eq: () => ({ eq: () => ({ in: vi.fn() }) }) }),
+    }),
+  })),
+}));
+
+const { GET } = await import('@/app/api/cron/process-menu-queue/route');
+
+function makeRequest(authorization?: string) {
+  return new Request('http://localhost/api/cron/process-menu-queue', {
+    headers: authorization ? { authorization } : {},
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('CRON_SECRET', 'my-cron-secret-value');
+  vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co');
+  vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-role-key');
+  mockRpc.mockResolvedValue({ data: null, error: null }); // idle
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('GET /api/cron/process-menu-queue (#1044 cron timing-safe suggestion)', () => {
+  it('CRON_SECRET 未設定時は 503 を返す', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co');
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-role-key');
+    const res = await GET(makeRequest('Bearer anything'));
+    expect(res.status).toBe(503);
+  });
+
+  it('Authorization ヘッダなしは 401 を返す', async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('誤った secret (同じ長さ) は 401 を返す', async () => {
+    const res = await GET(makeRequest('Bearer my-cron-secret-XXXXX'));
+    expect(res.status).toBe(401);
+  });
+
+  it('誤った secret (異なる長さ) は 401 を返す', async () => {
+    const res = await GET(makeRequest('Bearer short'));
+    expect(res.status).toBe(401);
+  });
+
+  it('正しい secret は認可され idle を返す', async () => {
+    const res = await GET(makeRequest('Bearer my-cron-secret-value'));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.idle).toBe(true);
+  });
+});

--- a/src/__tests__/api/log.test.ts
+++ b/src/__tests__/api/log.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Supabase (認証チェック用) クライアントのモック
+const mockGetUser = vi.fn();
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+// service_role クライアント (app_logs への insert) のモック
+const mockInsert = vi.fn();
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: () => ({ insert: mockInsert }),
+  })),
+}));
+
+const { POST } = await import('@/app/api/log/route');
+
+const validUser = { id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' };
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/log', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockInsert.mockResolvedValue({ error: null });
+  mockGetUser.mockResolvedValue({ data: { user: validUser }, error: null });
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+});
+
+describe('POST /api/log (#1044 F6-20)', () => {
+  it('正常なリクエストは 200 を返す', async () => {
+    const res = await POST(makeRequest({ level: 'info', message: 'hello' }));
+    expect(res.status).toBe(200);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('level 未指定は 400 を返す', async () => {
+    const res = await POST(makeRequest({ message: 'hello' }));
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('不正な level (enum 外) は 400 を返す', async () => {
+    const res = await POST(makeRequest({ level: 'critical', message: 'hello' }));
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('2000文字を超える message は 400 を返す', async () => {
+    const res = await POST(makeRequest({ level: 'info', message: 'a'.repeat(2001) }));
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('2000文字ちょうどの message は許可される', async () => {
+    const res = await POST(makeRequest({ level: 'info', message: 'a'.repeat(2000) }));
+    expect(res.status).toBe(200);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('metadata 内の秘密キーは *** でマスクされて保存される', async () => {
+    const res = await POST(
+      makeRequest({
+        level: 'info',
+        message: 'login attempt',
+        metadata: { password: 'p@ssw0rd', token: 'abc', note: 'ok' },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const insertedArg = mockInsert.mock.calls[0][0];
+    expect(insertedArg.metadata.password).toBe('***');
+    expect(insertedArg.metadata.token).toBe('***');
+    expect(insertedArg.metadata.note).toBe('ok');
+  });
+
+  it('巨大な metadata は切り詰められて保存される', async () => {
+    const res = await POST(
+      makeRequest({
+        level: 'info',
+        message: 'huge payload',
+        metadata: { blob: 'x'.repeat(20_000) },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const insertedArg = mockInsert.mock.calls[0][0];
+    expect(insertedArg.metadata._truncated).toBe(true);
+  });
+
+  it('未認証リクエストは 401 を返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') });
+    const res = await POST(makeRequest({ level: 'info', message: 'hello' }));
+    expect(res.status).toBe(401);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/config/next-config-headers.test.ts
+++ b/src/__tests__/config/next-config-headers.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+// next.config.mjs は import 時に process.env を読むため、テストごとに
+// クエリ文字列付きで動的 import してフレッシュな評価を行う。
+async function loadNextConfig() {
+  vi.resetModules();
+  const mod = await import(/* @vite-ignore */ `../../../next.config.mjs?t=${Date.now()}-${Math.random()}`);
+  return mod.default;
+}
+
+async function getSecurityHeaders(config: any) {
+  const headerGroups = await config.headers();
+  const securityGroup = headerGroups.find((g: any) => g.source === '/(.*)');
+  const csp = securityGroup.headers.find((h: any) => h.key === 'Content-Security-Policy').value as string;
+  return { headerGroups, csp };
+}
+
+describe('next.config.mjs headers (#1044)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('F6-09: connect-src にデフォルトの PostHog ホストを含む', async () => {
+    const config = await loadNextConfig();
+    const { csp } = await getSecurityHeaders(config);
+
+    expect(csp).toContain('connect-src');
+    expect(csp).toContain('https://us.i.posthog.com');
+  });
+
+  it('F6-09: NEXT_PUBLIC_POSTHOG_HOST が設定されている場合はそのホストを使う', async () => {
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_HOST', 'https://eu.i.posthog.com');
+    const config = await loadNextConfig();
+    const { csp } = await getSecurityHeaders(config);
+
+    expect(csp).toContain('https://eu.i.posthog.com');
+  });
+
+  it('F6-09: 既存の許可済みドメイン (supabase/vercel) は壊れていない', async () => {
+    const config = await loadNextConfig();
+    const { csp } = await getSecurityHeaders(config);
+
+    expect(csp).toContain('*.supabase.co');
+    expect(csp).toContain('*.vercel.app');
+    expect(csp).toContain("wss://*.supabase.co");
+    expect(csp).toContain("script-src 'self' 'unsafe-inline'");
+    expect(csp).toContain('*.vercel-scripts.com');
+    expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    expect(csp).toContain('img-src');
+    expect(csp).toContain('images.unsplash.com');
+    expect(csp).toContain("font-src 'self'");
+  });
+
+  it('F6-08: 長期キャッシュ設定は静的アセット (sample-meal.webp) のみを対象にする', async () => {
+    const config = await loadNextConfig();
+    const { headerGroups } = await getSecurityHeaders(config);
+
+    const cacheRule = headerGroups.find((g: any) =>
+      g.headers.some((h: any) => h.key === 'Cache-Control'),
+    );
+
+    expect(cacheRule.source).toBe('/handson-tour/sample-meal.webp');
+    // ワイルドカードパターンでないこと (認証必須ページにマッチしないことの確認)
+    expect(cacheRule.source).not.toBe('/handson-tour/(.*)');
+    expect(cacheRule.source).not.toMatch(/\(.*\)/);
+
+    const cacheControl = cacheRule.headers.find((h: any) => h.key === 'Cache-Control').value;
+    expect(cacheControl).toContain('immutable');
+  });
+});

--- a/src/__tests__/lib/db-logger.test.ts
+++ b/src/__tests__/lib/db-logger.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { maskSecrets, truncateMetadata, sanitizeMetadata } from '@/lib/db-logger';
+
+describe('maskSecrets (#1044 F6-20)', () => {
+  it('password/token/secret/authorization/api_key を含むキーをマスクする', () => {
+    const input = {
+      password: 'p@ssw0rd',
+      token: 'abc123',
+      secret: 'shh',
+      authorization: 'Bearer xyz',
+      api_key: 'sk-xxx',
+      apiKey: 'sk-yyy',
+      'api-key': 'sk-zzz',
+      safe_field: 'keep me',
+    };
+
+    const result = maskSecrets(input);
+
+    expect(result.password).toBe('***');
+    expect(result.token).toBe('***');
+    expect(result.secret).toBe('***');
+    expect(result.authorization).toBe('***');
+    expect(result.api_key).toBe('***');
+    expect(result.apiKey).toBe('***');
+    expect(result['api-key']).toBe('***');
+    expect(result.safe_field).toBe('keep me');
+  });
+
+  it('ネストしたオブジェクト内の秘密情報も再帰的にマスクする', () => {
+    const input = {
+      user: {
+        name: 'taro',
+        credentials: { password: 'secret-pass', note: 'ok' },
+      },
+    };
+
+    const result = maskSecrets(input) as any;
+
+    expect(result.user.name).toBe('taro');
+    expect(result.user.credentials.password).toBe('***');
+    expect(result.user.credentials.note).toBe('ok');
+  });
+
+  it('配列内のオブジェクトもマスクする', () => {
+    const input = { items: [{ token: 'a' }, { safe: 'b' }] };
+    const result = maskSecrets(input) as any;
+
+    expect(result.items[0].token).toBe('***');
+    expect(result.items[1].safe).toBe('b');
+  });
+
+  it('無関係のキー名は変更しない', () => {
+    const input = { message: 'hello', count: 3 };
+    const result = maskSecrets(input);
+    expect(result).toEqual({ message: 'hello', count: 3 });
+  });
+});
+
+describe('truncateMetadata (#1044 F6-20)', () => {
+  it('8KB 以下の metadata はそのまま返す', () => {
+    const metadata = { foo: 'bar' };
+    expect(truncateMetadata(metadata)).toEqual(metadata);
+  });
+
+  it('8KB を超える metadata は切り詰められる', () => {
+    const huge = { data: 'x'.repeat(20_000) };
+    const result = truncateMetadata(huge)!;
+
+    expect(result._truncated).toBe(true);
+    expect(typeof result._original_bytes).toBe('number');
+    expect((result._original_bytes as number)).toBeGreaterThan(8 * 1024);
+    expect(typeof result._preview).toBe('string');
+    // 切り詰め後のオブジェクト自体は 8KB を大きく超えない
+    const serializedSize = new TextEncoder().encode(JSON.stringify(result)).length;
+    expect(serializedSize).toBeLessThan(8.5 * 1024);
+  });
+
+  it('undefined はそのまま undefined を返す', () => {
+    expect(truncateMetadata(undefined)).toBeUndefined();
+  });
+});
+
+describe('sanitizeMetadata (#1044 F6-20)', () => {
+  it('マスキングと切り詰めを両方適用する', () => {
+    const input = { password: 'secret', data: 'x'.repeat(20_000) };
+    const result = sanitizeMetadata(input)!;
+
+    // サイズ超過時は切り詰め結果が優先される (マスク済みJSONの一部がpreviewに含まれる)
+    expect(result._truncated).toBe(true);
+    expect(result._preview).toContain('***');
+  });
+
+  it('サイズが小さければマスキングのみ適用される', () => {
+    const input = { password: 'secret', note: 'ok' };
+    const result = sanitizeMetadata(input)!;
+
+    expect(result.password).toBe('***');
+    expect(result.note).toBe('ok');
+  });
+});

--- a/src/__tests__/lib/db-logger.test.ts
+++ b/src/__tests__/lib/db-logger.test.ts
@@ -54,6 +54,21 @@ describe('maskSecrets (#1044 F6-20)', () => {
     const result = maskSecrets(input);
     expect(result).toEqual({ message: 'hello', count: 3 });
   });
+
+  it('#1044 round-2: 深さ上限を超えるネストは値ごとマスクされる (生値を返さない fail-safe)', () => {
+    // MAX_MASK_DEPTH = 6 を超える深さでネストされたオブジェクトを作る
+    let nested: any = { leaked_password: 'super-secret-at-the-bottom' };
+    for (let i = 0; i < 8; i++) {
+      nested = { level: i, child: nested };
+    }
+
+    const result = maskSecrets(nested) as any;
+    const serialized = JSON.stringify(result);
+
+    // 生の秘密値が結果のどこにも残っていないこと
+    expect(serialized).not.toContain('super-secret-at-the-bottom');
+    expect(serialized).toContain('***');
+  });
 });
 
 describe('truncateMetadata (#1044 F6-20)', () => {

--- a/src/__tests__/lib/posthog.test.ts
+++ b/src/__tests__/lib/posthog.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockInit = vi.fn();
+const mockOptIn = vi.fn();
+const mockOptOut = vi.fn();
+
+const mockPosthog: any = {
+  __loaded: false,
+  init: mockInit,
+  opt_in_capturing: mockOptIn,
+  opt_out_capturing: mockOptOut,
+  identify: vi.fn(),
+  capture: vi.fn(),
+};
+
+vi.mock('posthog-js', () => ({
+  default: mockPosthog,
+}));
+
+const {
+  initPostHog,
+  optInPostHog,
+  optOutPostHog,
+  getAnalyticsConsent,
+  ANALYTICS_CONSENT_KEY,
+  ANALYTICS_CONSENT_EVENT,
+} = await import('@/lib/posthog');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPosthog.__loaded = false;
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('getAnalyticsConsent', () => {
+  it('localStorage が true でない場合は false を返す', () => {
+    expect(getAnalyticsConsent()).toBe(false);
+  });
+
+  it('localStorage が "true" の場合は true を返す', () => {
+    localStorage.setItem(ANALYTICS_CONSENT_KEY, 'true');
+    expect(getAnalyticsConsent()).toBe(true);
+  });
+});
+
+describe('initPostHog (#1044 F6-15: 冒頭の同意ガード)', () => {
+  it('同意なしの場合は本番環境・キー設定済みでも init しない', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', 'phc_test_key');
+    // 同意なし (localStorage 未設定)
+
+    initPostHog();
+
+    expect(mockInit).not.toHaveBeenCalled();
+  });
+
+  it('同意ありかつ本番環境・キー設定済みの場合は init する', () => {
+    localStorage.setItem(ANALYTICS_CONSENT_KEY, 'true');
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', 'phc_test_key');
+
+    initPostHog();
+
+    expect(mockInit).toHaveBeenCalledTimes(1);
+  });
+
+  it('同意ありでも開発環境では init しない (既存の graceful degradation を維持)', () => {
+    localStorage.setItem(ANALYTICS_CONSENT_KEY, 'true');
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', 'phc_test_key');
+
+    initPostHog();
+
+    expect(mockInit).not.toHaveBeenCalled();
+  });
+});
+
+describe('optInPostHog / optOutPostHog (#1044 F6-15: 同一タブ通知)', () => {
+  it('optInPostHog は同意状態を保存し、同一タブ向け CustomEvent を発火する', () => {
+    const handler = vi.fn();
+    window.addEventListener(ANALYTICS_CONSENT_EVENT, handler);
+
+    optInPostHog();
+
+    expect(localStorage.getItem(ANALYTICS_CONSENT_KEY)).toBe('true');
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    window.removeEventListener(ANALYTICS_CONSENT_EVENT, handler);
+  });
+
+  it('optOutPostHog は同意状態を保存し、同一タブ向け CustomEvent を発火する', () => {
+    const handler = vi.fn();
+    window.addEventListener(ANALYTICS_CONSENT_EVENT, handler);
+
+    optOutPostHog();
+
+    expect(localStorage.getItem(ANALYTICS_CONSENT_KEY)).toBe('false');
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    window.removeEventListener(ANALYTICS_CONSENT_EVENT, handler);
+  });
+});

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -2,6 +2,21 @@ import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 import { createClient } from '@/lib/supabase/server';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+// #1044 (F6-19): 入力を Zod で厳密検証する
+const contactInquirySchema = z.object({
+  inquiryType: z.enum(['general', 'support', 'bug', 'feature'], {
+    message: 'inquiryType の値が不正です',
+  }),
+  email: z.string().email('有効なメールアドレスを入力してください'),
+  subject: z.string().min(1, '件名は必須です').max(100, '件名は100文字以内です'),
+  message: z.string().min(1, 'お問い合わせ内容は必須です').max(5000, 'お問い合わせ内容は5000文字以内です'),
+});
+
+// GET で返す列は必要最小限に限定する (admin_notes 等の内部情報は返さない)
+const INQUIRY_SAFE_COLUMNS =
+  'id, inquiry_type, subject, message, status, created_at, updated_at, resolved_at';
 
 async function sendAdminNotification(inquiry: {
   id: string;
@@ -53,7 +68,7 @@ async function sendAdminNotification(inquiry: {
 }
 
 // #274 レートリミット: Upstash Redis があれば分散 ratelimit、なければ in-memory フォールバック
-// TODO: env 設定後 ratelimit 有効化 — UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN を設定すること
+// #1044 (F6-19): 本番環境では in-memory フォールバックを許容せず、Upstash env 未設定時は POST を 503 で拒否する
 
 const RATE_LIMIT_MAX = 10;
 const RATE_LIMIT_WINDOW_SEC = 60;
@@ -106,6 +121,16 @@ async function checkRateLimit(ip: string): Promise<boolean> {
 }
 
 export async function POST(request: NextRequest) {
+  // #1044 (F6-19): 本番環境では分散レートリミット (Upstash) を必須とする。
+  // 未設定のまま in-memory フォールバックで動かすと Vercel サーバーレス環境では実質無効化されるため。
+  if (process.env.NODE_ENV === 'production' && !upstashRatelimiter) {
+    console.error('[contact] 本番環境で Upstash Redis が未設定のためリクエストを拒否します。');
+    return NextResponse.json(
+      { error: 'サービスが一時的に利用できません。しばらくしてから再度お試しください。' },
+      { status: 503 },
+    );
+  }
+
   // レートリミットチェック
   const ip =
     request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
@@ -122,24 +147,16 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { inquiryType, email, subject, message } = body;
 
-    // バリデーション
-    if (!inquiryType || !email || !subject || !message) {
+    // #1044 (F6-19): Zod による厳密バリデーション
+    const parseResult = contactInquirySchema.safeParse(body);
+    if (!parseResult.success) {
       return NextResponse.json(
-        { error: '必須項目が入力されていません' },
+        { error: '入力内容を確認してください', details: parseResult.error.flatten() },
         { status: 400 },
       );
     }
-
-    // メールアドレスの簡易バリデーション
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
-      return NextResponse.json(
-        { error: '有効なメールアドレスを入力してください' },
-        { status: 400 },
-      );
-    }
+    const { inquiryType, email, subject, message } = parseResult.data;
 
     // ユーザーIDを取得（ログイン中の場合）
     const { data: { user } } = await supabase.auth.getUser();
@@ -197,7 +214,7 @@ export async function GET() {
   try {
     const { data, error } = await supabase
       .from('inquiries')
-      .select('*')
+      .select(INQUIRY_SAFE_COLUMNS)
       .eq('user_id', user.id)
       .order('created_at', { ascending: false });
 

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -68,7 +68,12 @@ async function sendAdminNotification(inquiry: {
 }
 
 // #274 レートリミット: Upstash Redis があれば分散 ratelimit、なければ in-memory フォールバック
-// #1044 (F6-19): 本番環境では in-memory フォールバックを許容せず、Upstash env 未設定時は POST を 503 で拒否する
+// #1044 round-2: Upstash env 未設定時に POST を hard 503 で拒否すると、本番で Upstash が
+// 未接続の間 (docs/design/cross/06-perf-cache.md #549, .env.example, ENV_SETUP.md いずれも
+// 本番未設定を示す) 問い合わせフォームが全壊してしまう。同日実装の src/lib/rate-limit.ts が
+// 採用する canonical 方針 (fail-open は避けるが hard-block もしない = in-memory フォールバック
+// + warn ログ) に揃え、Upstash 未設定時も in-memory レートリミットで最低限の制限をかけつつ
+// リクエストは通す。
 
 const RATE_LIMIT_MAX = 10;
 const RATE_LIMIT_WINDOW_SEC = 60;
@@ -121,16 +126,6 @@ async function checkRateLimit(ip: string): Promise<boolean> {
 }
 
 export async function POST(request: NextRequest) {
-  // #1044 (F6-19): 本番環境では分散レートリミット (Upstash) を必須とする。
-  // 未設定のまま in-memory フォールバックで動かすと Vercel サーバーレス環境では実質無効化されるため。
-  if (process.env.NODE_ENV === 'production' && !upstashRatelimiter) {
-    console.error('[contact] 本番環境で Upstash Redis が未設定のためリクエストを拒否します。');
-    return NextResponse.json(
-      { error: 'サービスが一時的に利用できません。しばらくしてから再度お試しください。' },
-      { status: 503 },
-    );
-  }
-
   // レートリミットチェック
   const ip =
     request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??

--- a/src/app/api/cron/process-menu-queue/route.ts
+++ b/src/app/api/cron/process-menu-queue/route.ts
@@ -4,6 +4,23 @@ import { createClient } from '@supabase/supabase-js';
 export const runtime = 'edge';
 export const maxDuration = 60; // Vercel Pro: 60s OK
 
+// #1044 (cron timing suggestion): edge runtime では node:crypto の timingSafeEqual が
+// 使えないため、固定長で比較する簡易 constant-time 比較を実装する。
+function timingSafeEqualString(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  const maxLength = Math.max(aBytes.length, bBytes.length);
+
+  let diff = aBytes.length ^ bBytes.length;
+  for (let i = 0; i < maxLength; i++) {
+    const x = i < aBytes.length ? aBytes[i] : 0;
+    const y = i < bBytes.length ? bBytes[i] : 0;
+    diff |= x ^ y;
+  }
+  return diff === 0;
+}
+
 export async function GET(req: Request) {
   // CRON 認証 (Vercel Cron の Authorization header をチェック)
   const cronSecret = process.env.CRON_SECRET;
@@ -12,7 +29,7 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'cron_disabled' }, { status: 503 });
   }
   const auth = req.headers.get('authorization');
-  if (auth !== `Bearer ${cronSecret}`) {
+  if (!auth || !timingSafeEqualString(auth, `Bearer ${cronSecret}`)) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/log/route.ts
+++ b/src/app/api/log/route.ts
@@ -5,6 +5,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@/lib/supabase/server';
+import { sanitizeMetadata } from '@/lib/db-logger';
+
+// #1044 (F6-20): level は enum に限定、message は上限文字数を設ける
+const ALLOWED_LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const;
+const MAX_MESSAGE_LENGTH = 2000;
 
 export async function POST(request: NextRequest) {
   try {
@@ -13,6 +18,21 @@ export async function POST(request: NextRequest) {
     if (!message || !level) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
     }
+
+    if (typeof level !== 'string' || !ALLOWED_LOG_LEVELS.includes(level as (typeof ALLOWED_LOG_LEVELS)[number])) {
+      return NextResponse.json({ error: 'Invalid level' }, { status: 400 });
+    }
+
+    if (typeof message !== 'string' || message.length > MAX_MESSAGE_LENGTH) {
+      return NextResponse.json({ error: 'Invalid message' }, { status: 400 });
+    }
+
+    if (metadata !== undefined && metadata !== null && typeof metadata !== 'object') {
+      return NextResponse.json({ error: 'Invalid metadata' }, { status: 400 });
+    }
+
+    // 秘密情報マスキング + サイズ切り詰め (F6-20)
+    const sanitizedMetadata = sanitizeMetadata(metadata ?? undefined);
 
     // 認証チェック: 未認証リクエストは拒否 (fail-closed)
     const supabase = await createClient();
@@ -36,7 +56,7 @@ export async function POST(request: NextRequest) {
       level,
       source: 'client',
       message,
-      metadata,
+      metadata: sanitizedMetadata,
       user_id: userId,
     });
 

--- a/src/app/api/log/route.ts
+++ b/src/app/api/log/route.ts
@@ -31,16 +31,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid metadata' }, { status: 400 });
     }
 
-    // 秘密情報マスキング + サイズ切り詰め (F6-20)
-    const sanitizedMetadata = sanitizeMetadata(metadata ?? undefined);
-
     // 認証チェック: 未認証リクエストは拒否 (fail-closed)
+    // #1044 round-2: sanitizeMetadata (metadata 全体の JSON.stringify を伴う) より前に
+    // 認証チェックを行い、未認証者が巨大な metadata を送って CPU を消費させる DoS を軽減する。
     const supabase = await createClient();
     const { data: { user }, error: authError } = await supabase.auth.getUser();
     if (authError || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
     const userId = user.id;
+
+    // 秘密情報マスキング + サイズ切り詰め (F6-20)
+    const sanitizedMetadata = sanitizeMetadata(metadata ?? undefined);
 
     // service_roleでログを保存
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -101,7 +101,18 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       }
 
       // PostHog init (production + 同意あり、initPostHog 冒頭でも同意ガードあり)
-      initPostHog();
+      // #1044 round-2: すでに init 済み (__loaded) の場合、initPostHog() は no-op のため
+      // opt-out → opt-in を跨いだ際に capturing が再開されない。src/lib/posthog.ts の
+      // optInPostHog() と等価に、__loaded 済みなら opt_in_capturing を明示的に呼ぶ。
+      try {
+        if (posthog.__loaded) {
+          posthog.opt_in_capturing();
+        } else {
+          initPostHog();
+        }
+      } catch {
+        // ignore
+      }
       identifyAndTrackVitals();
     };
 

--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -6,7 +6,13 @@
 
 import { useEffect } from "react";
 import { createClient } from "@/lib/supabase/client";
-import { posthog, initPostHog, getAnalyticsConsent, ANALYTICS_CONSENT_KEY } from "@/lib/posthog";
+import {
+  posthog,
+  initPostHog,
+  getAnalyticsConsent,
+  ANALYTICS_CONSENT_KEY,
+  ANALYTICS_CONSENT_EVENT,
+} from "@/lib/posthog";
 import { setAnalyticsAdapter, fireAnalytics } from "@homegohan/handson-tour-shared";
 
 /**
@@ -15,21 +21,94 @@ import { setAnalyticsAdapter, fireAnalytics } from "@homegohan/handson-tour-shar
  * - Cookie 同意確認済みの場合のみ PostHog init を呼ぶ
  * - 認証ユーザー取得後に identify を呼ぶ (PII は含めない)
  * - setAnalyticsAdapter で共通 package に PostHog を接続する
+ *
+ * #1044 (F6-15): 同意状態は mount 時の 1 回だけでなく、
+ * 同意変更のたびに (同一タブ/別タブどちらでも) 再評価する。
+ * 同一タブでの opt-in は 'storage' イベントが発火しないため、
+ * CustomEvent (ANALYTICS_CONSENT_EVENT) も監視する。
  */
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
-    // Cookie 同意確認 (localStorage 代替)
-    const hasConsent = getAnalyticsConsent();
-    if (!hasConsent) {
-      return;
-    }
+    const supabase = createClient();
+    // identify / Web Vitals 登録は同意が有効な間に一度だけ行う
+    // (opt-out → opt-in を繰り返しても Web Vitals リスナーが多重登録されないようにする)
+    let identifyDone = false;
 
-    // PostHog init (production + 同意あり)
-    initPostHog();
+    // 認証ユーザーの identify + Web Vitals 計測 (PII 不可、operator/07 §15.5)
+    const identifyAndTrackVitals = () => {
+      if (identifyDone) return;
+      identifyDone = true;
+      supabase.auth.getUser().then(({ data }) => {
+        if (!data.user) return;
 
-    // AnalyticsAdapter を共通 package に注入
+        const userId = data.user.id;
+
+        // profile から非 PII 属性を取得
+        supabase
+          .from('user_profiles')
+          .select('created_at, plan_key_cached')
+          .eq('id', userId)
+          .single()
+          .then(({ data: profile }) => {
+            try {
+              posthog.identify(userId, {
+                signup_at: profile?.created_at ?? null,
+                platform: 'web',
+                plan_key_cached: profile?.plan_key_cached ?? null,
+              });
+            } catch {
+              // ignore
+            }
+
+            // Web Vitals 計測 (handson-tour 専用 analytics schema)
+            // web-vitals v4+ では onFID は削除され onINP (Interaction to Next Paint) に置き換わった
+            import('web-vitals').then(({ onLCP, onCLS, onINP }) => {
+              const page = typeof window !== 'undefined' ? window.location.pathname : '/';
+              const common = {
+                user_id: userId,
+                timestamp: new Date().toISOString(),
+                platform: 'web' as const,
+                app_version: '1.0.0',
+                page,
+              };
+              onLCP((metric) => {
+                fireAnalytics('web_vitals_lcp', { ...common, value_ms: metric.value });
+              });
+              onCLS((metric) => {
+                fireAnalytics('web_vitals_cls', { ...common, value: metric.value });
+              });
+              onINP((metric) => {
+                fireAnalytics('web_vitals_inp', { ...common, value_ms: metric.value });
+              });
+            }).catch(() => {
+              // web-vitals unavailable — ignore
+            });
+          });
+      });
+    };
+
+    // 現在の同意状態を反映する (mount 時・opt-in/opt-out 時の両方から呼ばれる)
+    const applyConsentState = () => {
+      if (!getAnalyticsConsent()) {
+        try {
+          if (posthog.__loaded) {
+            posthog.opt_out_capturing();
+          }
+        } catch {
+          // ignore
+        }
+        return;
+      }
+
+      // PostHog init (production + 同意あり、initPostHog 冒頭でも同意ガードあり)
+      initPostHog();
+      identifyAndTrackVitals();
+    };
+
+    // AnalyticsAdapter を共通 package に注入する (同意チェックは呼び出しの都度行う: F6-15)
     setAnalyticsAdapter({
       capture: (eventName, payload) => {
+        if (!getAnalyticsConsent()) return;
         try {
           posthog.capture(eventName, payload as Record<string, unknown>);
         } catch {
@@ -38,78 +117,23 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       },
     });
 
-    // 認証ユーザーの identify (PII 不可、operator/07 §15.5)
-    const supabase = createClient();
-    supabase.auth.getUser().then(({ data }) => {
-      if (!data.user) return;
+    // mount 時点の同意状態を反映
+    applyConsentState();
 
-      const userId = data.user.id;
-
-      // profile から非 PII 属性を取得
-      supabase
-        .from('user_profiles')
-        .select('created_at, plan_key_cached')
-        .eq('id', userId)
-        .single()
-        .then(({ data: profile }) => {
-          try {
-            posthog.identify(userId, {
-              signup_at: profile?.created_at ?? null,
-              platform: 'web',
-              plan_key_cached: profile?.plan_key_cached ?? null,
-            });
-          } catch {
-            // ignore
-          }
-
-          // Web Vitals 計測 (handson-tour 専用 analytics schema)
-          // web-vitals v4+ では onFID は削除され onINP (Interaction to Next Paint) に置き換わった
-          import('web-vitals').then(({ onLCP, onCLS, onINP }) => {
-            const page = typeof window !== 'undefined' ? window.location.pathname : '/';
-            const common = {
-              user_id: userId,
-              timestamp: new Date().toISOString(),
-              platform: 'web' as const,
-              app_version: '1.0.0',
-              page,
-            };
-            onLCP((metric) => {
-              fireAnalytics('web_vitals_lcp', { ...common, value_ms: metric.value });
-            });
-            onCLS((metric) => {
-              fireAnalytics('web_vitals_cls', { ...common, value: metric.value });
-            });
-            onINP((metric) => {
-              fireAnalytics('web_vitals_inp', { ...common, value_ms: metric.value });
-            });
-          }).catch(() => {
-            // web-vitals unavailable — ignore
-          });
-        });
-    });
-
-    // Cookie 同意変更を監視 (storage event)
+    // Cookie 同意変更を監視: 別タブ (storage event) + 同一タブ (CustomEvent) の両方に対応
     const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === ANALYTICS_CONSENT_KEY) {
-        if (e.newValue === 'false' || e.newValue === null) {
-          try {
-            posthog.opt_out_capturing();
-          } catch {
-            // ignore
-          }
-        } else if (e.newValue === 'true') {
-          try {
-            posthog.opt_in_capturing();
-          } catch {
-            // ignore
-          }
-        }
-      }
+      if (e.key !== ANALYTICS_CONSENT_KEY) return;
+      applyConsentState();
+    };
+    const handleConsentChangeEvent = () => {
+      applyConsentState();
     };
 
     window.addEventListener('storage', handleStorageChange);
+    window.addEventListener(ANALYTICS_CONSENT_EVENT, handleConsentChangeEvent);
     return () => {
       window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener(ANALYTICS_CONSENT_EVENT, handleConsentChangeEvent);
     };
   }, []);
 

--- a/src/lib/db-logger.ts
+++ b/src/lib/db-logger.ts
@@ -19,6 +19,66 @@ interface LogEntry {
   request_id?: string;
 }
 
+// #1044 (F6-20): metadata に混入した秘密情報をマスキングする
+const SECRET_KEY_PATTERN = /password|token|secret|authorization|api[_-]?key/i;
+const MASK_VALUE = '***';
+const MAX_MASK_DEPTH = 6;
+
+/**
+ * オブジェクト/配列を再帰的に走査し、キー名が秘密情報パターンに一致する値をマスクする。
+ * 循環参照や深いネストで無限ループしないよう深さ上限を設ける。
+ */
+export function maskSecrets<T>(value: T, depth = 0): T {
+  if (depth >= MAX_MASK_DEPTH) return value;
+
+  if (Array.isArray(value)) {
+    return value.map((item) => maskSecrets(item, depth + 1)) as unknown as T;
+  }
+
+  if (value !== null && typeof value === 'object' && !(value instanceof Date)) {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = SECRET_KEY_PATTERN.test(key) ? MASK_VALUE : maskSecrets(val, depth + 1);
+    }
+    return result as T;
+  }
+
+  return value;
+}
+
+const DEFAULT_MAX_METADATA_BYTES = 8 * 1024; // 8KB
+
+/**
+ * metadata のシリアライズ後サイズが上限を超える場合、プレビューのみを残して切り詰める。
+ */
+export function truncateMetadata(
+  metadata: Record<string, unknown> | undefined,
+  maxBytes: number = DEFAULT_MAX_METADATA_BYTES,
+): Record<string, unknown> | undefined {
+  if (!metadata) return metadata;
+
+  const json = JSON.stringify(metadata);
+  const byteLength = new TextEncoder().encode(json).length;
+  if (byteLength <= maxBytes) return metadata;
+
+  return {
+    _truncated: true,
+    _original_bytes: byteLength,
+    _preview: json.slice(0, Math.max(0, maxBytes - 200)),
+  };
+}
+
+/**
+ * metadata にマスキングとサイズ切り詰めをまとめて適用する。
+ */
+export function sanitizeMetadata(
+  metadata: Record<string, unknown> | undefined,
+  maxBytes: number = DEFAULT_MAX_METADATA_BYTES,
+): Record<string, unknown> | undefined {
+  if (!metadata) return metadata;
+  return truncateMetadata(maskSecrets(metadata), maxBytes);
+}
+
 // Supabase クライアント（service_role）
 function getSupabaseClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -39,8 +99,14 @@ async function saveLog(entry: LogEntry): Promise<void> {
   try {
     const supabase = getSupabaseClient();
     if (!supabase) return;
-    
-    const { error } = await supabase.from('app_logs').insert(entry);
+
+    // #1044 (F6-20): 保存前に秘密情報マスキング + サイズ切り詰め
+    const sanitizedEntry: LogEntry = {
+      ...entry,
+      metadata: sanitizeMetadata(entry.metadata),
+    };
+
+    const { error } = await supabase.from('app_logs').insert(sanitizedEntry);
     
     if (error) {
       console.error('Failed to save log to DB:', error);

--- a/src/lib/db-logger.ts
+++ b/src/lib/db-logger.ts
@@ -29,7 +29,9 @@ const MAX_MASK_DEPTH = 6;
  * 循環参照や深いネストで無限ループしないよう深さ上限を設ける。
  */
 export function maskSecrets<T>(value: T, depth = 0): T {
-  if (depth >= MAX_MASK_DEPTH) return value;
+  // #1044 round-2: 深さ上限に達した場合、生値をそのまま返すと上限より深いネストに
+  // 潜む秘密情報がマスクされずに漏洩する。fail-safe として値ごとマスクする。
+  if (depth >= MAX_MASK_DEPTH) return MASK_VALUE as unknown as T;
 
   if (Array.isArray(value)) {
     return value.map((item) => maskSecrets(item, depth + 1)) as unknown as T;
@@ -130,16 +132,19 @@ export function createLogger(routeName: string, requestId?: string) {
   const log = (level: LogLevel, message: string, metadata?: Record<string, unknown>) => {
     const timestamp = new Date().toISOString();
     const logLine = `[${timestamp}] [${level.toUpperCase()}] [${routeName}] ${message}`;
-    
+    // #1044 round-2: DB保存時と同様、コンソール出力にも秘密情報マスキングを適用する
+    // (Vercel の関数ログにも生の metadata が残らないようにする)
+    const sanitizedMetadata = sanitizeMetadata(metadata);
+
     // コンソール出力
     if (level === 'error') {
-      console.error(logLine, metadata || '');
+      console.error(logLine, sanitizedMetadata || '');
     } else if (level === 'warn') {
-      console.warn(logLine, metadata || '');
+      console.warn(logLine, sanitizedMetadata || '');
     } else {
-      console.log(logLine, metadata || '');
+      console.log(logLine, sanitizedMetadata || '');
     }
-    
+
     // DB保存（非同期、待たない）
     saveLog({
       ...baseEntry,
@@ -158,8 +163,8 @@ export function createLogger(routeName: string, requestId?: string) {
       const errorStack = error instanceof Error ? error.stack : undefined;
       
       const timestamp = new Date().toISOString();
-      console.error(`[${timestamp}] [ERROR] [${routeName}] ${message}`, error, metadata || '');
-      
+      console.error(`[${timestamp}] [ERROR] [${routeName}] ${message}`, error, sanitizeMetadata(metadata) || '');
+
       saveLog({
         ...baseEntry,
         level: 'error',
@@ -178,8 +183,8 @@ export function createLogger(routeName: string, requestId?: string) {
       
       const userLog = (level: LogLevel, message: string, metadata?: Record<string, unknown>) => {
         const timestamp = new Date().toISOString();
-        console.log(`[${timestamp}] [${level.toUpperCase()}] [${routeName}] [user:${userId}] ${message}`, metadata || '');
-        
+        console.log(`[${timestamp}] [${level.toUpperCase()}] [${routeName}] [user:${userId}] ${message}`, sanitizeMetadata(metadata) || '');
+
         saveLog({
           ...userEntry,
           level,
@@ -195,9 +200,9 @@ export function createLogger(routeName: string, requestId?: string) {
         error: (message: string, error?: Error | unknown, metadata?: Record<string, unknown>) => {
           const errorMessage = error instanceof Error ? error.message : String(error);
           const errorStack = error instanceof Error ? error.stack : undefined;
-          
-          console.error(`[${new Date().toISOString()}] [ERROR] [${routeName}] [user:${userId}] ${message}`, error, metadata || '');
-          
+
+          console.error(`[${new Date().toISOString()}] [ERROR] [${routeName}] [user:${userId}] ${message}`, error, sanitizeMetadata(metadata) || '');
+
           saveLog({
             ...userEntry,
             level: 'error',

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -22,6 +22,13 @@ const FORBIDDEN_KEYS = [
 export const ANALYTICS_CONSENT_KEY = 'cookie_consent_analytics';
 
 /**
+ * 同意状態変更を同一タブ内で通知するための CustomEvent 名。
+ * 'storage' イベントは同一タブでは発火しないため (F6-15)、
+ * 同一タブの opt-in/opt-out を即時反映するために使用する。
+ */
+export const ANALYTICS_CONSENT_EVENT = 'homegohan:analytics-consent-changed';
+
+/**
  * 計測 Cookie への同意状態を確認する
  */
 export function getAnalyticsConsent(): boolean {
@@ -39,6 +46,11 @@ export function getAnalyticsConsent(): boolean {
  * - Cookie 同意なしの場合は init を呼ばない (cross/08 §13)
  */
 export function initPostHog(): void {
+  // 同意ガード: 呼び出し元の状態に関わらず、同意なしでは init しない (F6-15)
+  if (!getAnalyticsConsent()) {
+    return;
+  }
+
   const key = process.env['NEXT_PUBLIC_POSTHOG_KEY'];
   const host = process.env['NEXT_PUBLIC_POSTHOG_HOST'] ?? 'https://us.i.posthog.com';
 
@@ -85,6 +97,8 @@ export function optOutPostHog(): void {
   } catch {
     // ignore
   }
+  // 同一タブ内の listener (PostHogProvider 等) に即時通知する (F6-15)
+  window.dispatchEvent(new CustomEvent(ANALYTICS_CONSENT_EVENT));
 }
 
 /**
@@ -103,4 +117,6 @@ export function optInPostHog(): void {
   } else {
     initPostHog();
   }
+  // 同一タブ内の listener (PostHogProvider 等) に即時通知する (F6-15)
+  window.dispatchEvent(new CustomEvent(ANALYTICS_CONSENT_EVENT));
 }


### PR DESCRIPTION
## 概要
インフラ層の複数不具合を修正(#1044)。CSP で PostHog(analytics)が全ブロック、認証必須ページの誤キャッシュ、/api/log・/api/contact の入力未検証・秘密露出、同意状態の再評価漏れ。

## 修正内容
- **CSP**: connect-src に PostHog(api_host + us-assets)を追加し analytics のブロックを解消。既存許可(Supabase/Vercel/unsplash 等)は全維持。
- **キャッシュ**: Cache-Control の immutable ルールを /handson-tour/(.*) から sample-meal.webp のみに限定し、認証ページの誤キャッシュを解消。
- **/api/log・/api/contact**: level enum・長さ上限・Zod 検証を追加。db-logger は秘密(password/token/secret/authorization/api_key)を再帰マスク+8KB切り詰め、console 出力にもマスク適用、深さ上限で丸ごとマスクの fail-safe。log route は認証を sanitize より前に。
- **contact GET**: select('*')→列限定で admin_notes 等を除外。
- **レート制限**: contact は Upstash 未設定時に in-memory フォールバック(rate-limit.ts の canonical パターンと一致)。**本番で Upstash 未設定でもフォーム全壊しない**(round-2 で hard-503 を撤廃)。
- **cron**: process-menu-queue の秘密比較を timing-safe に。
- **PostHog 同意**: opt-in/out を同一タブ即時反映+クロスタブ opt-in で opt_in_capturing 再開。

## 検証
- 新規テスト42件+round-2修正、全PASS。tsc/eslint クリーン、build で CSP/ヘッダ計算 OK。
- 2モデル敵対レビュー(Sonnet5+Fable): round-1 で本番 contact 503(フォーム全壊)Critical を両モデルが捕捉→round-2 で解消し **double-PASS**。

## follow-up(別issue候補)
- db-logger の error オブジェクト自体のマスク / log() の二重 sanitize 最適化 / PostHog asset host の region 連動