### PR TITLE
fix(health): 健康記録・パフォーマンス系APIの入力検証と集計不具合を修正 (#1048)

### DIFF
--- a/packages/core/src/nutrition/adaptive-loop.test.ts
+++ b/packages/core/src/nutrition/adaptive-loop.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { applyRecommendations } from './adaptive-loop';
+
+/**
+ * #1048 F2-18: performance/analyze の POST が recommendations をクライアントから
+ * 信頼して適用しており、delta を捏造されると nutrition_targets を無制限に
+ * 書き換えられた。applyRecommendations 側にも防御的な delta クランプを追加した
+ * ので、その挙動を検証する。
+ */
+describe('applyRecommendations', () => {
+  const baseTargets = { calories: 2000, protein: 100, fat: 60, carbs: 250 };
+
+  it('applies a normal, small delta unchanged', () => {
+    const result = applyRecommendations(
+      baseTargets,
+      [{ type: 'calories', delta: -150, reason: 'test', confidence: 'high', priority: 1 }],
+      { applyTop: 1 },
+    );
+    expect(result.calories).toBe(1850);
+    expect(result.appliedRecommendations[0].delta).toBe(-150);
+  });
+
+  it('clamps an oversized calories delta to maxCalorieChange', () => {
+    const result = applyRecommendations(
+      baseTargets,
+      [{ type: 'calories', delta: 999999, reason: 'malicious', confidence: 'high', priority: 1 }],
+      { applyTop: 1 },
+    );
+    expect(result.calories).toBe(2000 + 200); // default maxCalorieChange = 200
+    expect(result.appliedRecommendations[0].delta).toBe(200);
+  });
+
+  it('clamps an oversized protein delta (previously unbounded)', () => {
+    const result = applyRecommendations(
+      baseTargets,
+      [{ type: 'protein', delta: 999999, reason: 'malicious', confidence: 'high', priority: 1 }],
+      { applyTop: 1 },
+    );
+    expect(result.protein).toBe(100 + 60); // default maxProteinChange = 60
+    expect(result.appliedRecommendations[0].delta).toBe(60);
+  });
+
+  it('clamps an oversized carbs delta (previously unbounded)', () => {
+    const result = applyRecommendations(
+      baseTargets,
+      [{ type: 'carbs', delta: -999999, reason: 'malicious', confidence: 'high', priority: 1 }],
+      { applyTop: 1 },
+    );
+    expect(result.carbs).toBe(150); // 250 - 100 (clamped from -999999)
+    expect(result.appliedRecommendations[0].delta).toBe(-100);
+  });
+
+  it('clamps an oversized fat delta (previously unbounded)', () => {
+    const result = applyRecommendations(
+      baseTargets,
+      [{ type: 'fat', delta: 999999, reason: 'malicious', confidence: 'high', priority: 1 }],
+      { applyTop: 1 },
+    );
+    expect(result.fat).toBe(60 + 50); // default maxFatChange = 50
+    expect(result.appliedRecommendations[0].delta).toBe(50);
+  });
+
+  it('still respects the floor values (calories>=1200, protein>=40, carbs>=50, fat>=20)', () => {
+    const tiny = { calories: 1250, protein: 45, fat: 25, carbs: 55 };
+    const result = applyRecommendations(
+      tiny,
+      [
+        { type: 'calories', delta: -999999, reason: 'x', confidence: 'high', priority: 1 },
+      ],
+      { applyTop: 1 },
+    );
+    expect(result.calories).toBe(1200);
+  });
+
+  it('only applies the top N recommendations', () => {
+    const result = applyRecommendations(
+      baseTargets,
+      [
+        { type: 'calories', delta: -100, reason: 'a', confidence: 'high', priority: 1 },
+        { type: 'protein', delta: 15, reason: 'b', confidence: 'medium', priority: 2 },
+      ],
+      { applyTop: 1 },
+    );
+    expect(result.appliedRecommendations).toHaveLength(1);
+    expect(result.protein).toBe(100); // 未適用のまま
+  });
+});

--- a/packages/core/src/nutrition/adaptive-loop.ts
+++ b/packages/core/src/nutrition/adaptive-loop.ts
@@ -427,6 +427,12 @@ export function applyRecommendations(
   recommendations: AdjustmentRecommendation[],
   options: {
     maxCalorieChange?: number; // デフォルト200
+    // #1048 F2-18: calories 以外は delta の上限が無く、
+    // recommendations の出所（呼び出し元）が信頼できない場合に
+    // nutrition_targets が無制限に変更され得た。安全弁として上限を設ける。
+    maxProteinChange?: number; // デフォルト60g（analyzeCheckinLoop の想定最大は15g）
+    maxCarbsChange?: number;   // デフォルト100g（想定最大は40g）
+    maxFatChange?: number;     // デフォルト50g（想定最大は0g、将来拡張の余地を残す）
     applyTop?: number; // 上位N件のみ適用（デフォルト1）
   } = {}
 ): {
@@ -436,7 +442,13 @@ export function applyRecommendations(
   carbs: number;
   appliedRecommendations: AdjustmentRecommendation[];
 } {
-  const { maxCalorieChange = 200, applyTop = 1 } = options;
+  const {
+    maxCalorieChange = 200,
+    maxProteinChange = 60,
+    maxCarbsChange = 100,
+    maxFatChange = 50,
+    applyTop = 1,
+  } = options;
 
   let { calories, protein, fat, carbs } = currentTargets;
   const appliedRecommendations: AdjustmentRecommendation[] = [];
@@ -454,18 +466,24 @@ export function applyRecommendations(
         appliedRecommendations.push({ ...rec, delta: clampedDelta });
         break;
       }
-      case 'protein':
-        protein = Math.max(40, protein + rec.delta);
-        appliedRecommendations.push(rec);
+      case 'protein': {
+        const clampedDelta = Math.max(-maxProteinChange, Math.min(maxProteinChange, rec.delta));
+        protein = Math.max(40, protein + clampedDelta);
+        appliedRecommendations.push({ ...rec, delta: clampedDelta });
         break;
-      case 'carbs':
-        carbs = Math.max(50, carbs + rec.delta);
-        appliedRecommendations.push(rec);
+      }
+      case 'carbs': {
+        const clampedDelta = Math.max(-maxCarbsChange, Math.min(maxCarbsChange, rec.delta));
+        carbs = Math.max(50, carbs + clampedDelta);
+        appliedRecommendations.push({ ...rec, delta: clampedDelta });
         break;
-      case 'fat':
-        fat = Math.max(20, fat + rec.delta);
-        appliedRecommendations.push(rec);
+      }
+      case 'fat': {
+        const clampedDelta = Math.max(-maxFatChange, Math.min(maxFatChange, rec.delta));
+        fat = Math.max(20, fat + clampedDelta);
+        appliedRecommendations.push({ ...rec, delta: clampedDelta });
         break;
+      }
     }
   }
 

--- a/src/app/api/ai/consultation/actions/[actionId]/execute/route.ts
+++ b/src/app/api/ai/consultation/actions/[actionId]/execute/route.ts
@@ -2,9 +2,13 @@ import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 import type { TargetSlot } from '@/types/domain';
 import {
+  RECORD_DATE_PATTERN,
   sanitizeHealthGoalUpdate,
   sanitizeHealthRecordPayload,
+  stripUndefined,
 } from '@/lib/health-payloads';
+import { updateHealthStreak } from '@/lib/health-streaks';
+import { todayLocal } from '@/lib/date-utils';
 import { invokeGenerateMenuV4WithRetry, markWeeklyMenuRequestFailed } from '@/lib/generate-menu-v4-retry';
 import { loadFeatureFlags } from '@/lib/menu-generation-feature-flags';
 import type { MealImageJobSeed } from '../../../../../../../lib/meal-image';
@@ -20,6 +24,13 @@ import { createLogger } from '@/lib/db-logger';
 
 // セキュリティ上禁止されたフィールド
 const FORBIDDEN_PROFILE_FIELDS = ['email', 'avatar_url', 'is_banned', 'role', 'auth_provider'];
+
+// #1048 F2-23: planned_meals.meal_type / meals.meal_type には
+// CHECK (meal_type IN ('breakfast','lunch','dinner','snack')) が存在し、
+// 'midnight_snack' を挿入すると DB 制約違反で 500 になる
+// (supabase/migrations/20260430160000_db_audit_fixes.sql #221)。
+// AI 生成アクション経由でこの不整合値が渡らないようホワイトリストで防御する。
+const AI_ALLOWED_MEAL_TYPES = ['breakfast', 'lunch', 'dinner', 'snack'] as const;
 
 // ==================== mass assignment 対策: サニタイザ ====================
 // AIが生成した action_params は信頼できない入力（プロンプトインジェクションの
@@ -510,6 +521,14 @@ export async function POST(
 
         if (!date || !mealType) {
           result = { error: 'date と mealType は必須です' };
+          break;
+        }
+
+        // #1048 F2-23: DB CHECK 制約と矛盾する mealType(例: 'midnight_snack')を
+        // 拒否する。プロンプトからは既に除去済みだが、AI 出力は信頼できないため
+        // 実行時にも二重で防御する。
+        if (!AI_ALLOWED_MEAL_TYPES.includes(mealType)) {
+          result = { error: `mealType は ${AI_ALLOWED_MEAL_TYPES.join('/')} のいずれかである必要があります` };
           break;
         }
 
@@ -1257,17 +1276,21 @@ export async function POST(
       // ==================== 健康記録関連 ====================
       // health_recordsカラム: daily_note (notesではない)
       case 'add_health_record': {
-        const { date, weight, bodyFatPercentage, systolicBp, diastolicBp, sleepHours, 
+        const { date, weight, bodyFatPercentage, systolicBp, diastolicBp, sleepHours,
                 overallCondition, moodScore, stressLevel, stepCount, dailyNote, notes } = action.action_params;
-        
-        const recordDate = date || new Date().toISOString().split('T')[0];
-        
-        // 既存レコードがあればupsert
-        const { error: upsertError } = await supabase
-          .from('health_records')
-          .upsert({
-            user_id: user.id,
-            record_date: recordDate,
+
+        const recordDate = typeof date === 'string' && date.trim() ? date.trim() : todayLocal();
+        if (!RECORD_DATE_PATTERN.test(recordDate)) {
+          result = { error: 'date must be in YYYY-MM-DD format' };
+          break;
+        }
+
+        // #1048 F2-08: AI が生成した値をそのまま保存すると、レンジ検証（体重の異常値等）や
+        // streak・user_profiles 同期がバイパスされる（update_health_record は既に
+        // sanitizeHealthRecordPayload を通しているが、こちらは未対応だった）。
+        // stripUndefined で未送信キーを除去してから既存のサニタイザに通す。
+        const { data: safeRecord, errors: recordErrors } = sanitizeHealthRecordPayload(
+          stripUndefined({
             weight,
             body_fat_percentage: bodyFatPercentage,
             systolic_bp: systolicBp,
@@ -1277,13 +1300,45 @@ export async function POST(
             mood_score: moodScore,
             stress_level: stressLevel,
             step_count: stepCount,
-            daily_note: dailyNote || notes, // 後方互換性のためnotesもサポート
+            daily_note: dailyNote,
+            notes,
+          }),
+          { acceptLegacyNotes: true },
+        );
+
+        if (recordErrors.length > 0) {
+          result = { error: recordErrors.join(', ') };
+          break;
+        }
+        if (Object.keys(safeRecord).length === 0) {
+          result = { error: '保存可能な健康記録項目がありません' };
+          break;
+        }
+
+        // 既存レコードがあればupsert
+        const { error: upsertError } = await supabase
+          .from('health_records')
+          .upsert({
+            user_id: user.id,
+            record_date: recordDate,
+            ...safeRecord,
           }, { onConflict: 'user_id,record_date' });
         success = !upsertError;
         if (upsertError) {
           console.error('add_health_record error:', upsertError);
           result = { error: upsertError.message };
         } else {
+          // #1048 F2-08: update_health_record 同様、streak・user_profiles も同期する
+          await updateHealthStreak(supabase, user.id, recordDate);
+          if (typeof safeRecord.weight === 'number') {
+            const today = todayLocal();
+            if (recordDate === today) {
+              await supabase
+                .from('user_profiles')
+                .update({ weight: safeRecord.weight })
+                .eq('id', user.id);
+            }
+          }
           result = { date: recordDate, saved: success };
         }
         break;

--- a/src/app/api/ai/consultation/important-messages/route.ts
+++ b/src/app/api/ai/consultation/important-messages/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
+import { clampIntParam } from '@/lib/http-params';
 
 // ユーザーの全重要メッセージを取得
 export async function GET(request: Request) {
@@ -8,7 +9,8 @@ export async function GET(request: Request) {
   if (userError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const { searchParams } = new URL(request.url);
-  const limit = parseInt(searchParams.get('limit') || '50');
+  // #1048 F2-16: limit が未クランプで DoS/意図しない大量取得が可能だった。
+  const limit = clampIntParam(searchParams.get('limit'), { min: 1, max: 200, default: 50 });
 
   try {
     // ユーザーの全セッションから重要メッセージを取得

--- a/src/app/api/ai/consultation/sessions/[sessionId]/messages/route.ts
+++ b/src/app/api/ai/consultation/sessions/[sessionId]/messages/route.ts
@@ -593,7 +593,7 @@ ${importantMessagesInfo}
 - generate_single_meal: AIが栄養計算付きで1食を生成（推奨）
   params: {
     date: "YYYY-MM-DD",
-    mealType: "breakfast|lunch|dinner|snack|midnight_snack",
+    mealType: "breakfast|lunch|dinner|snack",
     specificDish?: "希望の料理名（例: 肉じゃが、カレー）",
     recipeId?: "uuid",              // レシピDB検索結果のUUID（search_recipesで取得）
     recipeExternalId?: "external_id", // レシピDBの外部ID（search_recipesで取得）

--- a/src/app/api/health/checkups/route.ts
+++ b/src/app/api/health/checkups/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/supabase/server';
 import { sanitizeHealthCheckupPayload } from '@/lib/health-payloads';
 import { getFastLLMClient, getFastLLMModel } from '@/lib/ai/fast-llm';
 import { checkRateLimit, rateLimitExceededResponse } from '@/lib/rate-limit';
+import { clampIntParam } from '@/lib/http-params';
 
 // 健康診断一覧を取得
 export async function GET(request: NextRequest) {
@@ -14,7 +15,9 @@ export async function GET(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url);
-  const limit = parseInt(searchParams.get('limit') || '20');
+  // #1048 F2-16: limit が未クランプで DoS/意図しない大量取得が可能だった。
+  // グラフの「1年」表示（limit=365 リクエスト）も許容するため上限は400。
+  const limit = clampIntParam(searchParams.get('limit'), { min: 1, max: 400, default: 20 });
 
   const { data, error } = await supabase
     .from('health_checkups')
@@ -76,12 +79,17 @@ export async function POST(request: NextRequest) {
   }
 
   // #264: 健康診断を保存（UNIQUE 制約に対応するため upsert を使用）
+  // #1048 F2-26: 同じ checkup_date への再アップロード（数値の再OCR等）で upsert すると、
+  // individual_review を明示しない限り前回の古いレビューが残留し、新しい数値と
+  // 矛盾した内容が表示され続けてしまう。ここで一旦 null にリセットし、
+  // 生成成功時のみ下で書き戻す。
   const { data: checkup, error: insertError } = await supabase
     .from('health_checkups')
     .upsert(
       {
         user_id: user.id,
         ...checkupData,
+        individual_review: null,
       },
       { onConflict: 'user_id,checkup_date' },
     )

--- a/src/app/api/health/insights/route.ts
+++ b/src/app/api/health/insights/route.ts
@@ -2,18 +2,20 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { generateGeminiJson } from '@/lib/ai/gemini-json';
 import { checkRateLimit, rateLimitExceededResponse } from '@/lib/rate-limit';
+import { clampIntParam } from '@/lib/http-params';
 
 // AI分析結果の取得
 export async function GET(request: NextRequest) {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
-  
+
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const { searchParams } = new URL(request.url);
-  const limit = parseInt(searchParams.get('limit') || '20');
+  // #1048 F2-16: limit が未クランプで DoS/意図しない大量取得が可能だった。
+  const limit = clampIntParam(searchParams.get('limit'), { min: 1, max: 200, default: 20 });
   const unreadOnly = searchParams.get('unread') === 'true';
   const alertsOnly = searchParams.get('alerts') === 'true';
 

--- a/src/app/api/health/records/[date]/route.ts
+++ b/src/app/api/health/records/[date]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { sanitizeHealthRecordPayload } from '@/lib/health-payloads';
+import { RECORD_DATE_PATTERN, sanitizeHealthRecordPayload } from '@/lib/health-payloads';
 
 // 特定日の健康記録を取得
 export async function GET(
@@ -9,12 +9,18 @@ export async function GET(
 ) {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
-  
+
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const { date } = await params;
+
+  // #1048 F2-16: 不正な date パラメータは DB 側の型キャストエラー(500)や
+  // 意図しないクエリになり得るため、事前にフォーマット検証して400を返す。
+  if (!RECORD_DATE_PATTERN.test(date)) {
+    return NextResponse.json({ error: 'date must be in YYYY-MM-DD format' }, { status: 400 });
+  }
 
   const { data, error } = await supabase
     .from('health_records')
@@ -58,6 +64,13 @@ export async function PUT(
   }
 
   const { date } = await params;
+
+  // #1048 F2-16: 不正な date パラメータは DB 側の型キャストエラー(500)になり得るため
+  // 事前にフォーマット検証して400を返す。
+  if (!RECORD_DATE_PATTERN.test(date)) {
+    return NextResponse.json({ error: 'date must be in YYYY-MM-DD format' }, { status: 400 });
+  }
+
   const body = await request.json().catch(() => null);
   const { data: recordData, errors } = sanitizeHealthRecordPayload(body, {
     acceptLegacyNotes: true,
@@ -71,37 +84,21 @@ export async function PUT(
     return NextResponse.json({ error: 'No valid health record fields were provided' }, { status: 400 });
   }
 
-  // 既存レコードを確認
-  const { data: existing } = await supabase
+  // #1048 F2-19: 確認してから insert/update する check-then-act は同時リクエストで
+  // UNIQUE(user_id, record_date) 違反 500 を起こし得るため upsert に統一する。
+  const result = await supabase
     .from('health_records')
-    .select('id')
-    .eq('user_id', user.id)
-    .eq('record_date', date)
-    .single();
-
-  let result;
-  
-  if (existing) {
-    result = await supabase
-      .from('health_records')
-      .update({
-        ...recordData,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', existing.id)
-      .select()
-      .single();
-  } else {
-    result = await supabase
-      .from('health_records')
-      .insert({
+    .upsert(
+      {
         user_id: user.id,
         record_date: date,
         ...recordData,
-      })
-      .select()
-      .single();
-  }
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,record_date' },
+    )
+    .select()
+    .single();
 
   if (result.error) {
     return NextResponse.json({ error: result.error.message }, { status: 500 });
@@ -123,6 +120,10 @@ export async function DELETE(
   }
 
   const { date } = await params;
+
+  if (!RECORD_DATE_PATTERN.test(date)) {
+    return NextResponse.json({ error: 'date must be in YYYY-MM-DD format' }, { status: 400 });
+  }
 
   const { error } = await supabase
     .from('health_records')

--- a/src/app/api/health/records/history/route.ts
+++ b/src/app/api/health/records/history/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { addDays, formatLocalDate } from '@/lib/date-utils';
+import { clampIntParam } from '@/lib/http-params';
 
 // 体重履歴を取得（直近N日間）
 export async function GET(request: NextRequest) {
@@ -11,15 +13,13 @@ export async function GET(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url);
-  const days = parseInt(searchParams.get('days') || '7');
-
-  // 日数の制限（最大90日）
-  const limitedDays = Math.min(Math.max(days, 1), 90);
+  // #1048 F2-16: days=abc 等の不正値は parseInt が NaN を返し、
+  // 後続の Date 演算で RangeError（未処理例外→500）になっていた。
+  // clampIntParam で安全にフォールバック・クランプする（日数の制限は最大90日）。
+  const limitedDays = clampIntParam(searchParams.get('days'), { min: 1, max: 90, default: 7 });
 
   // N日前の日付を計算
-  const startDate = new Date();
-  startDate.setDate(startDate.getDate() - limitedDays);
-  const startDateStr = startDate.toISOString().split('T')[0];
+  const startDateStr = formatLocalDate(addDays(new Date(), -limitedDays));
 
   const { data, error } = await supabase
     .from('health_records')

--- a/src/app/api/health/records/quick/route.ts
+++ b/src/app/api/health/records/quick/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { sanitizeHealthRecordPayload } from '@/lib/health-payloads';
+import { RECORD_DATE_PATTERN, sanitizeHealthRecordPayload, stripUndefined } from '@/lib/health-payloads';
 import { todayLocal, formatLocalDate } from '@/lib/date-utils';
+import { updateHealthStreak } from '@/lib/health-streaks';
 
-const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const DATE_PATTERN = RECORD_DATE_PATTERN;
 
 // クイック記録（体重・気分・睡眠のみ）
 export async function POST(request: NextRequest) {
@@ -33,20 +34,28 @@ export async function POST(request: NextRequest) {
   }
 
   const dataSource = body.source === 'photo' ? 'photo' : 'quick';
-  const { data: sanitizedRecord, errors } = sanitizeHealthRecordPayload({
+  // #1048 F2-19: `{ weight: body.weight }` のように未送信フィールドを undefined のまま
+  // 詰め替えると、オブジェクトにキー自体は残ってしまい sanitizeHealthRecordPayload の
+  // hasOwn 判定で「null が送られた」と誤認され、未送信の項目まで null 上書きされる
+  // （例: mood_score のみのクイック記録で weight が null に巻き戻る）。
+  // stripUndefined で未送信キーを事前に除去してから渡す。
+  const { data: sanitizedRecord, errors } = sanitizeHealthRecordPayload(stripUndefined({
     weight: body.weight,
     body_fat_percentage: body.bodyFat ?? body.body_fat_percentage,
     muscle_mass: body.muscleMass ?? body.muscle_mass,
     mood_score: body.mood_score,
     sleep_quality: body.sleep_quality,
-  });
+  }));
 
   if (errors.length > 0) {
     return NextResponse.json({ error: errors.join(', ') }, { status: 400 });
   }
 
+  // #1048 F2-19: キー存在(`in`)だけで判定すると、値が null の項目しか
+  // 送られなかった場合でも「記録あり」扱いになり、streak が誤加算される。
+  // 実際に値が入っている（null でない）項目があるかどうかで判定する。
   const hasMetric = ['weight', 'body_fat_percentage', 'muscle_mass', 'mood_score', 'sleep_quality'].some(
-    (field) => field in sanitizedRecord,
+    (field) => sanitizedRecord[field as keyof typeof sanitizedRecord] != null,
   );
 
   if (!hasMetric) {
@@ -55,49 +64,33 @@ export async function POST(request: NextRequest) {
     }, { status: 400 });
   }
 
-  // 既存レコードを確認
-  const { data: existing } = await supabase
-    .from('health_records')
-    .select('*')
-    .eq('user_id', user.id)
-    .eq('record_date', recordDate)
-    .single();
-
   const updateData: Record<string, unknown> = {
     ...sanitizedRecord,
     data_source: dataSource,
     updated_at: new Date().toISOString(),
   };
 
-  let result;
-  
-  if (existing) {
-    // 更新（既存データを保持しつつ新しいデータをマージ）
-    result = await supabase
-      .from('health_records')
-      .update(updateData)
-      .eq('id', existing.id)
-      .select()
-      .single();
-  } else {
-    // 新規作成
-    result = await supabase
-      .from('health_records')
-      .insert({
+  // #1048 F2-19: 確認してから insert/update する check-then-act は同時リクエストで
+  // UNIQUE(user_id, record_date) 違反 500 を起こし得るため upsert に統一する。
+  const result = await supabase
+    .from('health_records')
+    .upsert(
+      {
         user_id: user.id,
         record_date: recordDate,
         ...updateData,
-      })
-      .select()
-      .single();
-  }
+      },
+      { onConflict: 'user_id,record_date' },
+    )
+    .select()
+    .single();
 
   if (result.error) {
     return NextResponse.json({ error: result.error.message }, { status: 500 });
   }
 
   // 連続記録を更新
-  await updateStreak(supabase, user.id, recordDate);
+  await updateHealthStreak(supabase, user.id, recordDate);
 
   // 前日との比較データを取得
   const yesterday = new Date(recordDate);
@@ -151,76 +144,6 @@ export async function POST(request: NextRequest) {
     streak: streak || { current_streak: 1, longest_streak: 1 },
     message: getEncouragementMessage(changes, streak?.current_streak || 1),
   });
-}
-
-// 連続記録の更新
-async function updateStreak(supabase: any, userId: string, recordDate: string) {
-  const streakType = 'daily_record';
-  
-  const { data: streak } = await supabase
-    .from('health_streaks')
-    .select('*')
-    .eq('user_id', userId)
-    .eq('streak_type', streakType)
-    .single();
-
-  const today = new Date(recordDate);
-  const yesterday = new Date(today);
-  yesterday.setDate(yesterday.getDate() - 1);
-  const yesterdayStr = formatLocalDate(yesterday);
-
-  if (streak) {
-    const lastDate = streak.last_activity_date;
-    
-    if (lastDate === recordDate) return;
-    
-    let newStreak = streak.current_streak;
-    let newStreakStart = streak.streak_start_date;
-    
-    if (lastDate === yesterdayStr) {
-      newStreak += 1;
-    } else {
-      newStreak = 1;
-      newStreakStart = recordDate;
-    }
-    
-    const longestStreak = Math.max(streak.longest_streak, newStreak);
-    const achievedBadges = streak.achieved_badges || [];
-    
-    const badgeMilestones = [7, 14, 30, 60, 100];
-    for (const milestone of badgeMilestones) {
-      const badgeCode = `${milestone}_days`;
-      if (newStreak >= milestone && !achievedBadges.includes(badgeCode)) {
-        achievedBadges.push(badgeCode);
-      }
-    }
-    
-    await supabase
-      .from('health_streaks')
-      .update({
-        current_streak: newStreak,
-        longest_streak: longestStreak,
-        last_activity_date: recordDate,
-        streak_start_date: newStreakStart,
-        achieved_badges: achievedBadges,
-        total_records: streak.total_records + 1,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', streak.id);
-  } else {
-    await supabase
-      .from('health_streaks')
-      .insert({
-        user_id: userId,
-        streak_type: streakType,
-        current_streak: 1,
-        longest_streak: 1,
-        last_activity_date: recordDate,
-        streak_start_date: recordDate,
-        achieved_badges: [],
-        total_records: 1,
-      });
-  }
 }
 
 // 励ましメッセージを生成

--- a/src/app/api/health/records/route.ts
+++ b/src/app/api/health/records/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { sanitizeHealthRecordPayload } from '@/lib/health-payloads';
+import { RECORD_DATE_PATTERN, sanitizeHealthRecordPayload } from '@/lib/health-payloads';
 import { todayLocal } from '@/lib/date-utils';
-
-const RECORD_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+import { updateHealthStreak } from '@/lib/health-streaks';
+import { clampIntParam } from '@/lib/http-params';
 
 // 健康記録の取得
 export async function GET(request: NextRequest) {
@@ -18,7 +18,9 @@ export async function GET(request: NextRequest) {
   const startDate = searchParams.get('start_date');
   const endDate = searchParams.get('end_date');
   // #265: limit に上限を設けて DoS を防ぐ
-  const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '30'), 1), 200);
+  // #1048 F2-11: 1年グラフ(365日)が start_date + limit=365 で取得するため、
+  // 200 では末尾約165日が欠落していた。集計用途を考慮し上限を400に緩和。
+  const limit = clampIntParam(searchParams.get('limit'), { min: 1, max: 400, default: 30 });
 
   let query = supabase
     .from('health_records')
@@ -80,46 +82,28 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'No valid health record fields were provided' }, { status: 400 });
   }
 
-  // 既存レコードを確認
-  const { data: existing } = await supabase
+  // #1048 F2-19: 確認してから insert/update する check-then-act は同時リクエストで
+  // UNIQUE(user_id, record_date) 違反 500 を起こし得るため upsert に統一する。
+  const result = await supabase
     .from('health_records')
-    .select('id')
-    .eq('user_id', user.id)
-    .eq('record_date', record_date)
-    .single();
-
-  let result;
-  
-  if (existing) {
-    // 更新
-    result = await supabase
-      .from('health_records')
-      .update({
-        ...sanitizedRecordData,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', existing.id)
-      .select()
-      .single();
-  } else {
-    // 新規作成
-    result = await supabase
-      .from('health_records')
-      .insert({
+    .upsert(
+      {
         user_id: user.id,
         record_date,
         ...sanitizedRecordData,
-      })
-      .select()
-      .single();
-  }
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,record_date' },
+    )
+    .select()
+    .single();
 
   if (result.error) {
     return NextResponse.json({ error: result.error.message }, { status: 500 });
   }
 
   // 連続記録を更新
-  await updateStreak(supabase, user.id, record_date);
+  await updateHealthStreak(supabase, user.id, record_date);
 
   // user_profilesの体重も更新（最新の記録の場合）
   if ('weight' in sanitizedRecordData && sanitizedRecordData.weight !== null) {
@@ -134,83 +118,4 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json({ record: result.data });
-}
-
-// 連続記録の更新
-async function updateStreak(supabase: any, userId: string, recordDate: string) {
-  const streakType = 'daily_record';
-  
-  // 現在の連続記録を取得
-  const { data: streak } = await supabase
-    .from('health_streaks')
-    .select('*')
-    .eq('user_id', userId)
-    .eq('streak_type', streakType)
-    .single();
-
-  const today = new Date(recordDate);
-  const yesterday = new Date(today);
-  yesterday.setDate(yesterday.getDate() - 1);
-  const yesterdayStr = yesterday.toISOString().split('T')[0];
-
-  if (streak) {
-    // 既存の連続記録がある場合
-    const lastDate = streak.last_activity_date;
-    
-    if (lastDate === recordDate) {
-      // 同じ日の記録は無視
-      return;
-    }
-    
-    let newStreak = streak.current_streak;
-    let newStreakStart = streak.streak_start_date;
-    
-    if (lastDate === yesterdayStr) {
-      // 連続している
-      newStreak += 1;
-    } else {
-      // 連続が途切れた
-      newStreak = 1;
-      newStreakStart = recordDate;
-    }
-    
-    const longestStreak = Math.max(streak.longest_streak, newStreak);
-    
-    // バッジ判定
-    const achievedBadges = streak.achieved_badges || [];
-    const badgeMilestones = [7, 14, 30, 60, 100];
-    for (const milestone of badgeMilestones) {
-      const badgeCode = `${milestone}_days`;
-      if (newStreak >= milestone && !achievedBadges.includes(badgeCode)) {
-        achievedBadges.push(badgeCode);
-      }
-    }
-    
-    await supabase
-      .from('health_streaks')
-      .update({
-        current_streak: newStreak,
-        longest_streak: longestStreak,
-        last_activity_date: recordDate,
-        streak_start_date: newStreakStart,
-        achieved_badges: achievedBadges,
-        total_records: streak.total_records + 1,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', streak.id);
-  } else {
-    // 新規作成
-    await supabase
-      .from('health_streaks')
-      .insert({
-        user_id: userId,
-        streak_type: streakType,
-        current_streak: 1,
-        longest_streak: 1,
-        last_activity_date: recordDate,
-        streak_start_date: recordDate,
-        achieved_badges: [],
-        total_records: 1,
-      });
-  }
 }

--- a/src/app/api/performance/analyze/route.ts
+++ b/src/app/api/performance/analyze/route.ts
@@ -1,8 +1,119 @@
 import { createClient } from '@/lib/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
 import { toPerformancePlan, fromPerformancePlan, toUserProfile, toPerformanceProfile } from '@/lib/converter'
-import { analyzeCheckinLoop, applyRecommendations, type CheckinAverages as CoreCheckinAverages } from '@homegohan/core'
+import {
+  analyzeCheckinLoop,
+  applyRecommendations,
+  type AdjustmentRecommendation,
+  type CheckinAverages as CoreCheckinAverages,
+} from '@homegohan/core'
 import type { NutritionGoal } from '@homegohan/core'
+import { RECORD_DATE_PATTERN } from '@/lib/health-payloads'
+
+type SupabaseLike = Awaited<ReturnType<typeof createClient>>
+
+type AnalysisRunResult =
+  | {
+      ok: true
+      eligible: boolean
+      eligibilityReason?: string
+      recommendations: AdjustmentRecommendation[]
+      trends: ReturnType<typeof analyzeCheckinLoop>['trends'] | null
+      nextAction: ReturnType<typeof analyzeCheckinLoop>['nextAction']
+      currentTargets: { calories: number; protein: number; fat: number; carbs: number }
+    }
+  | { ok: false; status: number; error: string }
+
+/**
+ * #1048 F2-18: GET/POST 双方で同じ「プロフィール→栄養目標→7日平均→分析」の
+ * 手順を共有する。POST はこの結果のみを信頼し、クライアントが送った
+ * recommendations は使用しない（サーバー側で再計算した提案だけを適用する）。
+ */
+async function runAnalysis(supabase: SupabaseLike, userId: string, date: string): Promise<AnalysisRunResult> {
+  // 1. ユーザープロフィールを取得（nutrition_goal含む）
+  const { data: profileData, error: profileError } = await supabase
+    .from('user_profiles')
+    .select('weight, nutrition_goal, performance_profile')
+    .eq('id', userId)
+    .single()
+
+  if (profileError || !profileData) {
+    return { ok: false, status: 404, error: 'Profile not found' }
+  }
+
+  // 2. 現在の栄養目標を取得
+  const { data: targetsData, error: targetsError } = await supabase
+    .from('nutrition_targets')
+    .select('daily_calories, protein_g, fat_g, carbs_g')
+    .eq('user_id', userId)
+    .single()
+
+  if (targetsError || !targetsData) {
+    return { ok: false, status: 404, error: 'Nutrition targets not found' }
+  }
+
+  const currentTargets = {
+    calories: targetsData.daily_calories,
+    protein: targetsData.protein_g,
+    fat: targetsData.fat_g,
+    carbs: targetsData.carbs_g,
+  }
+
+  // 3. 7日移動平均を取得
+  const { data: avgData, error: avgError } = await supabase.rpc('get_7d_checkin_averages', {
+    p_user_id: userId,
+    p_date: date,
+  })
+
+  if (avgError) {
+    console.error('Checkin averages error:', avgError)
+    return { ok: false, status: 500, error: avgError.message }
+  }
+
+  const rawAvg = avgData?.[0] || null
+  if (!rawAvg) {
+    return {
+      ok: true,
+      eligible: false,
+      eligibilityReason: 'チェックインデータがありません',
+      recommendations: [],
+      trends: null,
+      nextAction: null,
+      currentTargets,
+    }
+  }
+
+  // RPC結果をcore用の型に変換
+  const averages: CoreCheckinAverages = {
+    sleepHoursAvg: rawAvg.avg_sleep_hours ?? null,
+    sleepQualityAvg: rawAvg.avg_sleep_quality ?? null,
+    fatigueAvg: rawAvg.avg_fatigue ?? null,
+    focusAvg: rawAvg.avg_focus ?? null,
+    trainingLoadAvg: rawAvg.avg_training_rpe ?? null,
+    hungerAvg: rawAvg.avg_hunger ?? null,
+    weightStart: rawAvg.weight_start ?? null,
+    weightEnd: rawAvg.weight_end ?? null,
+    checkinCount: rawAvg.checkin_count ?? 0,
+  }
+
+  // 4. 分析を実行
+  const performanceProfile = toPerformanceProfile(profileData.performance_profile)
+  const analysis = analyzeCheckinLoop(averages, currentTargets, {
+    nutritionGoal: (profileData.nutrition_goal as NutritionGoal) || 'maintain',
+    weight: profileData.weight || 60,
+    performanceProfile,
+  })
+
+  return {
+    ok: true,
+    eligible: analysis.eligible,
+    eligibilityReason: analysis.eligibilityReason,
+    recommendations: analysis.recommendations,
+    trends: analysis.trends,
+    nextAction: analysis.nextAction,
+    currentTargets,
+  }
+}
 
 /**
  * GET /api/performance/analyze
@@ -21,95 +132,31 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = new URL(request.url)
-    const date = searchParams.get('date') || new Date().toISOString().split('T')[0]
+    const rawDate = searchParams.get('date')
+    const date = rawDate && RECORD_DATE_PATTERN.test(rawDate) ? rawDate : new Date().toISOString().split('T')[0]
 
-    // 1. ユーザープロフィールを取得（nutrition_goal含む）
-    const { data: profileData, error: profileError } = await supabase
-      .from('user_profiles')
-      .select('weight, nutrition_goal, performance_profile')
-      .eq('id', user.id)
-      .single()
-
-    if (profileError || !profileData) {
-      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+    const run = await runAnalysis(supabase, user.id, date)
+    if (!run.ok) {
+      return NextResponse.json({ error: run.error }, { status: run.status })
     }
 
-    // 2. 現在の栄養目標を取得
-    const { data: targetsData, error: targetsError } = await supabase
-      .from('nutrition_targets')
-      .select('daily_calories, protein_g, fat_g, carbs_g')
-      .eq('user_id', user.id)
-      .single()
-
-    if (targetsError || !targetsData) {
-      return NextResponse.json({ error: 'Nutrition targets not found' }, { status: 404 })
-    }
-
-    // 3. 7日移動平均を取得
-    const { data: avgData, error: avgError } = await supabase.rpc('get_7d_checkin_averages', {
-      p_user_id: user.id,
-      p_date: date,
-    })
-
-    if (avgError) {
-      console.error('Checkin averages error:', avgError)
-      return NextResponse.json({ error: avgError.message }, { status: 500 })
-    }
-
-    const rawAvg = avgData?.[0] || null
-    if (!rawAvg) {
+    if (!run.eligible) {
       return NextResponse.json({
         eligible: false,
-        eligibilityReason: 'チェックインデータがありません',
+        eligibilityReason: run.eligibilityReason,
         analysis: null,
         date,
       })
     }
 
-    // RPC結果をcore用の型に変換
-    const averages: CoreCheckinAverages = {
-      sleepHoursAvg: rawAvg.avg_sleep_hours ?? null,
-      sleepQualityAvg: rawAvg.avg_sleep_quality ?? null,
-      fatigueAvg: rawAvg.avg_fatigue ?? null,
-      focusAvg: rawAvg.avg_focus ?? null,
-      trainingLoadAvg: rawAvg.avg_training_rpe ?? null,
-      hungerAvg: rawAvg.avg_hunger ?? null,
-      weightStart: rawAvg.weight_start ?? null,
-      weightEnd: rawAvg.weight_end ?? null,
-      checkinCount: rawAvg.checkin_count ?? 0,
-    }
-
-    // 4. 分析を実行
-    const performanceProfile = toPerformanceProfile(profileData.performance_profile)
-    const analysis = analyzeCheckinLoop(
-      averages,
-      {
-        calories: targetsData.daily_calories,
-        protein: targetsData.protein_g,
-        fat: targetsData.fat_g,
-        carbs: targetsData.carbs_g,
-      },
-      {
-        nutritionGoal: (profileData.nutrition_goal as NutritionGoal) || 'maintain',
-        weight: profileData.weight || 60,
-        performanceProfile,
-      }
-    )
-
     return NextResponse.json({
-      eligible: analysis.eligible,
-      eligibilityReason: analysis.eligibilityReason,
+      eligible: true,
       analysis: {
-        trends: analysis.trends,
-        recommendations: analysis.recommendations,
-        nextAction: analysis.nextAction,
+        trends: run.trends,
+        recommendations: run.recommendations,
+        nextAction: run.nextAction,
       },
-      currentTargets: {
-        calories: targetsData.daily_calories,
-        protein: targetsData.protein_g,
-        fat: targetsData.fat_g,
-        carbs: targetsData.carbs_g,
-      },
+      currentTargets: run.currentTargets,
       date,
     })
   } catch (error: any) {
@@ -122,6 +169,12 @@ export async function GET(request: NextRequest) {
  * POST /api/performance/analyze
  *
  * 分析結果に基づいて調整を適用し、performance_planを作成
+ *
+ * #1048 F2-18: 従来はクライアントが送った `recommendations`（delta を含む）を
+ * そのまま `applyRecommendations` に渡しており、クライアントが任意の delta を
+ * 捏造すれば nutrition_targets を無制限に書き換えられた。
+ * date のみを受け取り、GET と同じロジックでサーバー側が recommendations を
+ * 再計算し、その結果だけを適用する。
  */
 export async function POST(request: NextRequest) {
   try {
@@ -132,35 +185,30 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const body = await request.json()
-    const { recommendations, applyTop = 1 } = body
+    const body = await request.json().catch(() => ({}))
+    const rawDate = typeof body?.date === 'string' ? body.date : null
+    const date = rawDate && RECORD_DATE_PATTERN.test(rawDate) ? rawDate : new Date().toISOString().split('T')[0]
 
-    if (!recommendations || !Array.isArray(recommendations) || recommendations.length === 0) {
-      return NextResponse.json({ error: 'recommendations are required' }, { status: 400 })
+    const rawApplyTop = body?.applyTop
+    const applyTop =
+      typeof rawApplyTop === 'number' && Number.isInteger(rawApplyTop)
+        ? Math.min(Math.max(rawApplyTop, 1), 5)
+        : 1
+
+    // 1. サーバー側で分析を再計算する（クライアント入力の recommendations は使用しない）
+    const run = await runAnalysis(supabase, user.id, date)
+    if (!run.ok) {
+      return NextResponse.json({ error: run.error }, { status: run.status })
     }
-
-    // 1. 現在の栄養目標を取得
-    const { data: targetsData, error: targetsError } = await supabase
-      .from('nutrition_targets')
-      .select('daily_calories, protein_g, fat_g, carbs_g')
-      .eq('user_id', user.id)
-      .single()
-
-    if (targetsError || !targetsData) {
-      return NextResponse.json({ error: 'Nutrition targets not found' }, { status: 404 })
+    if (!run.eligible || run.recommendations.length === 0) {
+      return NextResponse.json(
+        { error: run.eligibilityReason || '調整可能な提案がありません' },
+        { status: 400 },
+      )
     }
 
     // 2. 調整を適用
-    const adjusted = applyRecommendations(
-      {
-        calories: targetsData.daily_calories,
-        protein: targetsData.protein_g,
-        fat: targetsData.fat_g,
-        carbs: targetsData.carbs_g,
-      },
-      recommendations,
-      { applyTop }
-    )
+    const adjusted = applyRecommendations(run.currentTargets, run.recommendations, { applyTop })
 
     // 3. 調整があれば栄養目標を更新
     if (adjusted.appliedRecommendations.length > 0) {

--- a/src/app/api/performance/checkins/route.ts
+++ b/src/app/api/performance/checkins/route.ts
@@ -1,6 +1,8 @@
 import { createClient } from '@/lib/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
 import { toPerformanceCheckin, fromPerformanceCheckin, toCheckinAverages } from '@/lib/converter'
+import { RECORD_DATE_PATTERN } from '@/lib/health-payloads'
+import { sanitizePerformanceCheckinPayload } from '@/lib/performance-payloads'
 
 /**
  * GET /api/performance/checkins
@@ -120,15 +122,22 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const { checkinDate, ...checkinData } = body
 
-    if (!checkinDate) {
-      return NextResponse.json({ error: 'checkinDate is required' }, { status: 400 })
+    if (typeof checkinDate !== 'string' || !RECORD_DATE_PATTERN.test(checkinDate.trim())) {
+      return NextResponse.json({ error: 'checkinDate must be in YYYY-MM-DD format' }, { status: 400 })
+    }
+
+    // #1048 F2-18: weight や resting_heart_rate 等は DB に CHECK 制約が無く、
+    // 異常値がそのまま保存され user_profiles.weight にも汚染が伝播していた。
+    const { data: safeCheckinData, errors: checkinErrors } = sanitizePerformanceCheckinPayload(checkinData)
+    if (checkinErrors.length > 0) {
+      return NextResponse.json({ error: checkinErrors.join(', ') }, { status: 400 })
     }
 
     // DBフォーマットに変換
     const dbData = fromPerformanceCheckin({
       userId: user.id,
-      checkinDate,
-      ...checkinData,
+      checkinDate: checkinDate.trim(),
+      ...safeCheckinData,
     })
 
     // Upsert（日付でユニーク制約あり）
@@ -146,11 +155,11 @@ export async function POST(request: NextRequest) {
     }
 
     // 体重が更新された場合、user_profiles.weightも更新
-    if (checkinData.weight !== undefined) {
+    if (typeof safeCheckinData.weight === 'number') {
       await supabase
         .from('user_profiles')
         .update({
-          weight: checkinData.weight,
+          weight: safeCheckinData.weight,
           updated_at: new Date().toISOString(),
         })
         .eq('id', user.id)

--- a/src/lib/health-payloads.ts
+++ b/src/lib/health-payloads.ts
@@ -5,6 +5,28 @@ type ValidationResult<T extends object> = {
 
 type PlainObject = Record<string, unknown>;
 
+/**
+ * #1048 F2-19: 呼び出し側が `{ weight: body.weight, ... }` のように別名フィールドから
+ * 値を詰め替えるとき、元の値が `undefined`（＝クライアントが送らなかった）でも
+ * オブジェクトリテラルには **キー自体は存在してしまう**
+ * （`Object.prototype.hasOwnProperty.call({ foo: undefined }, 'foo')` は true）。
+ *
+ * sanitizeHealthRecordPayload 等は「キーが存在するか」で送信有無を判定するため、
+ * これを素通しすると「未送信」が「null を送信」と誤認され、
+ * 既存の保存値を意図せず null で上書きしてしまう（例: mood のみのクイック記録が
+ * weight を null に巻き戻す）。値を詰め替える呼び出し側は、渡す前に本関数で
+ * `undefined` のキーを除去すること。
+ */
+export function stripUndefined<T extends PlainObject>(input: T): Partial<T> {
+  const result: Partial<T> = {};
+  for (const key of Object.keys(input) as (keyof T)[]) {
+    if (input[key] !== undefined) {
+      result[key] = input[key];
+    }
+  }
+  return result;
+}
+
 export interface NotificationPreferencesPayload {
   enabled: boolean;
   quiet_hours_start: string;
@@ -110,6 +132,8 @@ export const DEFAULT_NOTIFICATION_PREFERENCES = {
 
 const TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+// #1048 F2-16: health/records/[date] 等、複数ルートで YYYY-MM-DD 検証を共有するため export する
+export const RECORD_DATE_PATTERN = DATE_PATTERN;
 const NOTIFICATION_RECORD_MODES = new Set(['standard', 'minimal', 'weekly', 'off']);
 const NOTIFICATION_PERSONALITY_TYPES = new Set(['positive', 'logical', 'gentle', 'competitive']);
 

--- a/src/lib/health-streaks.ts
+++ b/src/lib/health-streaks.ts
@@ -1,0 +1,107 @@
+import { addDays, formatLocalDate, parseLocalDate } from '@/lib/date-utils';
+
+/**
+ * #1048 F2-03: health_records の連続記録(streak)更新を共通化する。
+ *
+ * records/route.ts と records/quick/route.ts に同一ロジックが重複していたため、
+ * ここに一本化する。あわせて「過去日付のバックフィルで streak が壊れる」バグを修正する。
+ *
+ * 修正内容:
+ *   - recordDate が last_activity_date と同じ日 → 何もしない（重複カウント防止、既存動作を維持）
+ *   - recordDate が last_activity_date より過去（バックフィル）
+ *     → current_streak / longest_streak / last_activity_date / streak_start_date /
+ *       achieved_badges は一切変更せず、total_records のみ加算する。
+ *       （前進済みの streak を過去日の登録で巻き戻さないため）
+ *   - recordDate が last_activity_date より未来（通常の新規記録）
+ *     → 従来通り、連続日数の前進 / リセットを判定する。
+ */
+
+const STREAK_TYPE = 'daily_record';
+const BADGE_MILESTONES = [7, 14, 30, 60, 100] as const;
+
+type SupabaseLike = any;
+
+export async function updateHealthStreak(
+  supabase: SupabaseLike,
+  userId: string,
+  recordDate: string,
+): Promise<void> {
+  const { data: streak } = await supabase
+    .from('health_streaks')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('streak_type', STREAK_TYPE)
+    .single();
+
+  if (!streak) {
+    await supabase
+      .from('health_streaks')
+      .insert({
+        user_id: userId,
+        streak_type: STREAK_TYPE,
+        current_streak: 1,
+        longest_streak: 1,
+        last_activity_date: recordDate,
+        streak_start_date: recordDate,
+        achieved_badges: [],
+        total_records: 1,
+      });
+    return;
+  }
+
+  const lastDate: string | null = streak.last_activity_date;
+
+  if (lastDate && recordDate === lastDate) {
+    // 同じ日の記録は無視（streak・total_records とも変更なし）
+    return;
+  }
+
+  if (lastDate && recordDate < lastDate) {
+    // #1048 F2-03: 過去日付のバックフィル。既に前進済みの streak を巻き戻さない。
+    await supabase
+      .from('health_streaks')
+      .update({
+        total_records: streak.total_records + 1,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', streak.id);
+    return;
+  }
+
+  const yesterdayStr = formatLocalDate(addDays(parseLocalDate(recordDate), -1));
+
+  let newStreak = streak.current_streak;
+  let newStreakStart = streak.streak_start_date;
+
+  if (lastDate === yesterdayStr) {
+    // 連続している
+    newStreak += 1;
+  } else {
+    // 連続が途切れた
+    newStreak = 1;
+    newStreakStart = recordDate;
+  }
+
+  const longestStreak = Math.max(streak.longest_streak, newStreak);
+
+  const achievedBadges: string[] = streak.achieved_badges || [];
+  for (const milestone of BADGE_MILESTONES) {
+    const badgeCode = `${milestone}_days`;
+    if (newStreak >= milestone && !achievedBadges.includes(badgeCode)) {
+      achievedBadges.push(badgeCode);
+    }
+  }
+
+  await supabase
+    .from('health_streaks')
+    .update({
+      current_streak: newStreak,
+      longest_streak: longestStreak,
+      last_activity_date: recordDate,
+      streak_start_date: newStreakStart,
+      achieved_badges: achievedBadges,
+      total_records: streak.total_records + 1,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', streak.id);
+}

--- a/src/lib/http-params.ts
+++ b/src/lib/http-params.ts
@@ -1,0 +1,26 @@
+/**
+ * #1048 F2-16: クエリパラメータの数値検証を共通化する。
+ *
+ * `parseInt` は不正な文字列 (例: "abc") に対して NaN を返し、それを
+ * そのまま日付演算等に渡すと RangeError 等の未処理例外→500 につながる。
+ * また limit 系パラメータは DoS 防止のため必ず上限でクランプする。
+ *
+ * この関数は不正な入力（NaN・空文字・非数値文字列）を例外にせず、
+ * 安全に `opts.default` へフォールバックさせた上で [min, max] にクランプする。
+ */
+export function clampIntParam(
+  raw: string | null | undefined,
+  opts: { min: number; max: number; default: number },
+): number {
+  if (raw == null || raw.trim() === '') {
+    return opts.default;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return opts.default;
+  }
+
+  const rounded = Math.trunc(parsed);
+  return Math.min(Math.max(rounded, opts.min), opts.max);
+}

--- a/src/lib/performance-payloads.ts
+++ b/src/lib/performance-payloads.ts
@@ -1,0 +1,184 @@
+/**
+ * #1048 F2-18: performance 系 POST の入力検証。
+ *
+ * user_performance_checkins テーブルは sleep_quality/fatigue/focus/hunger/mood/
+ * soreness/training_load_rpe に DB CHECK 制約があるが、weight / body_fat_percentage /
+ * resting_heart_rate / sleep_hours / training_minutes には制約が無く、
+ * 異常値（例: weight=5000）がそのまま保存され user_profiles.weight にも
+ * 汚染が伝播していた。ここでアプリ層のレンジ検証を一本化する。
+ */
+
+type ValidationResult<T extends object> = {
+  data: Partial<T>;
+  errors: string[];
+};
+
+type PlainObject = Record<string, unknown>;
+
+// PerformanceCheckin (types/domain.ts) の各フィールドは null を許容しないため、
+// このペイロードも同じ形（値 or 未設定＝undefined）に揃える。
+// 空値/null が送られた場合は「未設定」（フィールドを省略しキーごと保存しない）として扱う。
+export interface PerformanceCheckinInputPayload {
+  sleepHours: number;
+  sleepQuality: number;
+  fatigue: number;
+  focus: number;
+  hunger: number;
+  trainingLoadRpe: number;
+  trainingMinutes: number;
+  weight: number;
+  bodyFatPercentage: number;
+  restingHeartRate: number;
+  mood: number;
+  soreness: number;
+  note: string;
+}
+
+function isPlainObject(value: unknown): value is PlainObject {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasOwn(input: PlainObject, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(input, key);
+}
+
+function parseNullableNumber(
+  input: PlainObject,
+  key: string,
+  errors: string[],
+  opts: { integer?: boolean; min?: number; max?: number; label?: string } = {},
+): number | undefined {
+  if (!hasOwn(input, key)) return undefined;
+
+  const value = input[key];
+  // PerformanceCheckin は null を許容しないため、null/空文字は「未設定」として扱う
+  // （フィールド自体を省略し、既存値を変更しない）。
+  if (value == null || value === '') return undefined;
+
+  if (typeof value === 'string' && !/^-?\d+(\.\d+)?$/.test(value.trim())) {
+    errors.push(`${key} must be a finite number or null`);
+    return undefined;
+  }
+
+  const numeric =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim()
+        ? Number(value)
+        : Number.NaN;
+
+  if (!Number.isFinite(numeric)) {
+    errors.push(`${key} must be a finite number or null`);
+    return undefined;
+  }
+
+  if (opts.integer && !Number.isInteger(numeric)) {
+    errors.push(`${key} must be an integer or null`);
+    return undefined;
+  }
+
+  const label = opts.label ?? key;
+  if (opts.min !== undefined && numeric < opts.min) {
+    errors.push(`${label} は ${opts.min} 以上の値を入力してください`);
+    return undefined;
+  }
+  if (opts.max !== undefined && numeric > opts.max) {
+    errors.push(`${label} は ${opts.max} 以下の値を入力してください`);
+    return undefined;
+  }
+
+  return numeric;
+}
+
+function parseNullableString(input: PlainObject, key: string, errors: string[], maxLen = 2000): string | undefined {
+  if (!hasOwn(input, key)) return undefined;
+
+  const value = input[key];
+  if (value == null) return undefined;
+  if (typeof value !== 'string') {
+    errors.push(`${key} must be a string or null`);
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length > maxLen) {
+    errors.push(`${key} は ${maxLen} 文字以内で入力してください`);
+    return undefined;
+  }
+
+  return trimmed || undefined;
+}
+
+// DB CHECK 済みの 1-5 尺度項目 (sleep_quality/fatigue/focus/hunger/mood/soreness)
+const SCALE_1_5_FIELDS: Record<string, string> = {
+  sleepQuality: '睡眠の質 (1-5)',
+  fatigue: '疲労度 (1-5)',
+  focus: '集中力 (1-5)',
+  hunger: '空腹感 (1-5)',
+  mood: '気分 (1-5)',
+  soreness: '筋肉痛 (1-5)',
+};
+
+export function sanitizePerformanceCheckinPayload(input: unknown): ValidationResult<PerformanceCheckinInputPayload> {
+  if (!isPlainObject(input)) {
+    return { data: {}, errors: ['Body must be a JSON object'] };
+  }
+
+  const errors: string[] = [];
+  const data: Record<string, unknown> = {};
+
+  for (const [field, label] of Object.entries(SCALE_1_5_FIELDS)) {
+    const value = parseNullableNumber(input, field, errors, { integer: true, min: 1, max: 5, label });
+    if (value !== undefined) data[field] = value;
+  }
+
+  const trainingLoadRpe = parseNullableNumber(input, 'trainingLoadRpe', errors, {
+    integer: true,
+    min: 1,
+    max: 10,
+    label: 'トレーニング負荷RPE (1-10)',
+  });
+  if (trainingLoadRpe !== undefined) data.trainingLoadRpe = trainingLoadRpe;
+
+  const trainingMinutes = parseNullableNumber(input, 'trainingMinutes', errors, {
+    integer: true,
+    min: 0,
+    max: 1440,
+    label: 'トレーニング時間 (分)',
+  });
+  if (trainingMinutes !== undefined) data.trainingMinutes = trainingMinutes;
+
+  const sleepHours = parseNullableNumber(input, 'sleepHours', errors, {
+    min: 0,
+    max: 24,
+    label: '睡眠時間 (h)',
+  });
+  if (sleepHours !== undefined) data.sleepHours = sleepHours;
+
+  const weight = parseNullableNumber(input, 'weight', errors, {
+    min: 20,
+    max: 300,
+    label: '体重 (kg)',
+  });
+  if (weight !== undefined) data.weight = weight;
+
+  const bodyFatPercentage = parseNullableNumber(input, 'bodyFatPercentage', errors, {
+    min: 1,
+    max: 70,
+    label: '体脂肪率 (%)',
+  });
+  if (bodyFatPercentage !== undefined) data.bodyFatPercentage = bodyFatPercentage;
+
+  const restingHeartRate = parseNullableNumber(input, 'restingHeartRate', errors, {
+    integer: true,
+    min: 20,
+    max: 300,
+    label: '安静時心拍数 (bpm)',
+  });
+  if (restingHeartRate !== undefined) data.restingHeartRate = restingHeartRate;
+
+  const note = parseNullableString(input, 'note', errors);
+  if (note !== undefined) data.note = note;
+
+  return { data, errors };
+}

--- a/tests/health-payloads.test.ts
+++ b/tests/health-payloads.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_NOTIFICATION_PREFERENCES,
   mergeNotificationPreferences,
+  RECORD_DATE_PATTERN,
   sanitizeBloodTestPayload,
   sanitizeHealthCheckupPayload,
   sanitizeHealthGoalUpdate,
   sanitizeHealthRecordPayload,
   sanitizeNotificationPreferences,
+  stripUndefined,
 } from '../src/lib/health-payloads';
 
 describe('health payload sanitizers', () => {
@@ -87,5 +89,82 @@ describe('health payload sanitizers', () => {
       test_date: '2026-03-01',
       hba1c: 5.4,
     });
+  });
+
+  // #1048 F2-08: AI 経由 add_health_record がレンジ検証をバイパスしていた
+  // (weight:5000 がそのまま保存される) の回帰テスト。
+  it('rejects out-of-range health record values (e.g. weight=5000)', () => {
+    const result = sanitizeHealthRecordPayload({ weight: 5000 });
+    expect(result.data.weight).toBeUndefined();
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a negative/zero weight', () => {
+    expect(sanitizeHealthRecordPayload({ weight: 0 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizeHealthRecordPayload({ weight: -5 }).errors.length).toBeGreaterThan(0);
+  });
+
+  it('accepts the health record weight boundary values (20 and 300)', () => {
+    expect(sanitizeHealthRecordPayload({ weight: 20 }).errors).toEqual([]);
+    expect(sanitizeHealthRecordPayload({ weight: 300 }).errors).toEqual([]);
+    expect(sanitizeHealthRecordPayload({ weight: 19.9 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizeHealthRecordPayload({ weight: 300.1 }).errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects out-of-range blood pressure (systolic_bp)', () => {
+    expect(sanitizeHealthRecordPayload({ systolic_bp: 500 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizeHealthRecordPayload({ systolic_bp: 10 }).errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('RECORD_DATE_PATTERN', () => {
+  it('accepts a valid YYYY-MM-DD date', () => {
+    expect(RECORD_DATE_PATTERN.test('2026-01-15')).toBe(true);
+  });
+
+  it('rejects malformed / non-date strings (e.g. records/[date] path param)', () => {
+    expect(RECORD_DATE_PATTERN.test('abc')).toBe(false);
+    expect(RECORD_DATE_PATTERN.test('2026/01/15')).toBe(false);
+    expect(RECORD_DATE_PATTERN.test('2026-1-5')).toBe(false);
+    expect(RECORD_DATE_PATTERN.test('')).toBe(false);
+    expect(RECORD_DATE_PATTERN.test("'; DROP TABLE health_records; --")).toBe(false);
+  });
+});
+
+describe('stripUndefined', () => {
+  // #1048 F2-19: `{ weight: body.weight }` のように詰め替えると、body.weight が
+  // undefined でもキー自体は残る（hasOwnProperty は true）。これを事前に除去しないと
+  // sanitizeHealthRecordPayload の hasOwn 判定で「null 送信」と誤認され、
+  // 未送信フィールドが null で上書きされてしまう。
+  it('removes keys whose value is undefined', () => {
+    const input: Record<string, unknown> = { a: 1, b: undefined, c: null, d: 'x' };
+    expect(stripUndefined(input)).toEqual({ a: 1, c: null, d: 'x' });
+  });
+
+  it('keeps explicit null values (distinct from "not provided")', () => {
+    expect(stripUndefined({ weight: null })).toEqual({ weight: null });
+  });
+
+  it('prevents a mood-only quick record from wiping out weight/sleep_quality to null', () => {
+    // records/quick/route.ts が行っていた詰め替えを再現
+    const body: { mood_score: number; weight?: number; sleep_quality?: number } = { mood_score: 4 };
+    const merged = {
+      weight: body.weight,
+      sleep_quality: body.sleep_quality,
+      mood_score: body.mood_score,
+    };
+
+    // 修正前: stripUndefined を挟まないと weight/sleep_quality キーが
+    // undefined のまま残り、sanitizeHealthRecordPayload が null を返してしまう。
+    const buggy = sanitizeHealthRecordPayload(merged);
+    expect(buggy.data.weight).toBeNull();
+    expect(buggy.data.sleep_quality).toBeNull();
+
+    // 修正後: stripUndefined で未送信キーを除去してから渡す
+    const fixed = sanitizeHealthRecordPayload(stripUndefined(merged));
+    expect(fixed.errors).toEqual([]);
+    expect(fixed.data).toEqual({ mood_score: 4 });
+    expect(fixed.data.weight).toBeUndefined();
+    expect(fixed.data.sleep_quality).toBeUndefined();
   });
 });

--- a/tests/health-streaks.test.ts
+++ b/tests/health-streaks.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from 'vitest';
+import { updateHealthStreak } from '../src/lib/health-streaks';
+
+/**
+ * #1048 F2-03: 過去日付のバックフィルで streak(連続記録)が破壊される不具合の回帰テスト。
+ *
+ * updateHealthStreak は supabase クライアントのメソッドチェーンを呼び出すだけなので、
+ * ここでは `.from('health_streaks')` 呼び出しを最小限のスタブで再現し、
+ * 呼び出し引数（update/insert に渡された値）を検証する。
+ */
+
+interface FakeStreakRow {
+  id: string;
+  user_id: string;
+  streak_type: string;
+  current_streak: number;
+  longest_streak: number;
+  total_records: number;
+  last_activity_date: string | null;
+  streak_start_date: string | null;
+  achieved_badges: string[];
+}
+
+function createFakeSupabase(initialStreak: FakeStreakRow | null) {
+  let streak = initialStreak;
+  const updateCalls: any[] = [];
+  const insertCalls: any[] = [];
+
+  const supabase = {
+    from(table: string) {
+      expect(table).toBe('health_streaks');
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              single: async () => ({ data: streak, error: streak ? null : { code: 'PGRST116' } }),
+            }),
+          }),
+        }),
+        update: (payload: any) => {
+          updateCalls.push(payload);
+          if (streak) streak = { ...streak, ...payload };
+          return {
+            eq: async () => ({ data: null, error: null }),
+          };
+        },
+        insert: (payload: any) => {
+          insertCalls.push(payload);
+          streak = { id: 'new-streak', ...payload };
+          return Promise.resolve({ data: null, error: null });
+        },
+      };
+    },
+  };
+
+  return { supabase, updateCalls, insertCalls, getStreak: () => streak };
+}
+
+describe('updateHealthStreak', () => {
+  it('creates a new streak row on first record', async () => {
+    const { supabase, insertCalls } = createFakeSupabase(null);
+
+    await updateHealthStreak(supabase, 'user-1', '2026-01-10');
+
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0]).toMatchObject({
+      user_id: 'user-1',
+      current_streak: 1,
+      longest_streak: 1,
+      last_activity_date: '2026-01-10',
+      streak_start_date: '2026-01-10',
+      total_records: 1,
+    });
+  });
+
+  it('increments the streak when the record continues from yesterday', async () => {
+    const { supabase, updateCalls } = createFakeSupabase({
+      id: 's1',
+      user_id: 'user-1',
+      streak_type: 'daily_record',
+      current_streak: 5,
+      longest_streak: 5,
+      total_records: 5,
+      last_activity_date: '2026-01-09',
+      streak_start_date: '2026-01-05',
+      achieved_badges: [],
+    });
+
+    await updateHealthStreak(supabase, 'user-1', '2026-01-10');
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]).toMatchObject({
+      current_streak: 6,
+      longest_streak: 6,
+      last_activity_date: '2026-01-10',
+      streak_start_date: '2026-01-05',
+      total_records: 6,
+    });
+  });
+
+  it('resets the streak when there is a forward gap (missed days)', async () => {
+    const { supabase, updateCalls } = createFakeSupabase({
+      id: 's1',
+      user_id: 'user-1',
+      streak_type: 'daily_record',
+      current_streak: 5,
+      longest_streak: 5,
+      total_records: 5,
+      last_activity_date: '2026-01-01',
+      streak_start_date: '2025-12-28',
+      achieved_badges: [],
+    });
+
+    // 2026-01-10 は 2026-01-01 の翌日ではないため、通常のリセットロジックが働く
+    await updateHealthStreak(supabase, 'user-1', '2026-01-10');
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]).toMatchObject({
+      current_streak: 1,
+      last_activity_date: '2026-01-10',
+      streak_start_date: '2026-01-10',
+    });
+  });
+
+  it('does not touch streak fields when the same day is recorded twice (no double count)', async () => {
+    const { supabase, updateCalls, insertCalls } = createFakeSupabase({
+      id: 's1',
+      user_id: 'user-1',
+      streak_type: 'daily_record',
+      current_streak: 5,
+      longest_streak: 5,
+      total_records: 5,
+      last_activity_date: '2026-01-10',
+      streak_start_date: '2026-01-06',
+      achieved_badges: [],
+    });
+
+    await updateHealthStreak(supabase, 'user-1', '2026-01-10');
+
+    expect(updateCalls).toHaveLength(0);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('#1048 F2-03: backdating (past date) does not roll back an already-advanced streak', async () => {
+    const { supabase, updateCalls, getStreak } = createFakeSupabase({
+      id: 's1',
+      user_id: 'user-1',
+      streak_type: 'daily_record',
+      current_streak: 30,
+      longest_streak: 30,
+      total_records: 30,
+      last_activity_date: '2026-01-30',
+      streak_start_date: '2026-01-01',
+      achieved_badges: ['7_days', '14_days', '30_days'],
+    });
+
+    // 過去日 (2026-01-15) を後からバックフィル
+    await updateHealthStreak(supabase, 'user-1', '2026-01-15');
+
+    expect(updateCalls).toHaveLength(1);
+    // total_records だけ加算され、streak 系は一切変更されない
+    expect(updateCalls[0]).toEqual({
+      total_records: 31,
+      updated_at: expect.any(String),
+    });
+
+    const streak = getStreak();
+    expect(streak?.current_streak).toBe(30);
+    expect(streak?.longest_streak).toBe(30);
+    expect(streak?.last_activity_date).toBe('2026-01-30');
+    expect(streak?.streak_start_date).toBe('2026-01-01');
+  });
+
+  it('#1048 F2-03: backdating exactly one day before last_activity_date still preserves the streak', async () => {
+    const { supabase, updateCalls } = createFakeSupabase({
+      id: 's1',
+      user_id: 'user-1',
+      streak_type: 'daily_record',
+      current_streak: 10,
+      longest_streak: 10,
+      total_records: 10,
+      last_activity_date: '2026-01-10',
+      streak_start_date: '2026-01-01',
+      achieved_badges: ['7_days'],
+    });
+
+    // 2026-01-09 は last_activity_date (2026-01-10) より過去 → バックフィル扱い
+    await updateHealthStreak(supabase, 'user-1', '2026-01-09');
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]).toEqual({
+      total_records: 11,
+      updated_at: expect.any(String),
+    });
+  });
+
+  it('awards badge milestones on forward progress', async () => {
+    const { supabase, updateCalls } = createFakeSupabase({
+      id: 's1',
+      user_id: 'user-1',
+      streak_type: 'daily_record',
+      current_streak: 6,
+      longest_streak: 6,
+      total_records: 6,
+      last_activity_date: '2026-01-09',
+      streak_start_date: '2026-01-04',
+      achieved_badges: [],
+    });
+
+    await updateHealthStreak(supabase, 'user-1', '2026-01-10');
+
+    expect(updateCalls[0].achieved_badges).toEqual(['7_days']);
+  });
+});

--- a/tests/http-params.test.ts
+++ b/tests/http-params.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { clampIntParam } from '../src/lib/http-params';
+
+/**
+ * #1048 F2-16: クエリの NaN・不正日付で未処理例外500 / limit 未クランプ の回帰テスト。
+ */
+describe('clampIntParam', () => {
+  it('returns the default when the param is missing', () => {
+    expect(clampIntParam(null, { min: 1, max: 90, default: 7 })).toBe(7);
+    expect(clampIntParam(undefined, { min: 1, max: 90, default: 7 })).toBe(7);
+    expect(clampIntParam('', { min: 1, max: 90, default: 7 })).toBe(7);
+  });
+
+  it('falls back to the default instead of throwing on non-numeric input (e.g. days=abc)', () => {
+    expect(clampIntParam('abc', { min: 1, max: 90, default: 7 })).toBe(7);
+    expect(() => clampIntParam('abc', { min: 1, max: 90, default: 7 })).not.toThrow();
+  });
+
+  it('rejects loosely-numeric strings that parseInt would have accepted (e.g. "20abc")', () => {
+    // parseInt("20abc") === 20 (permissive); Number("20abc") === NaN (strict).
+    // ここでは NaN 扱い→デフォルトへのフォールバックになることを確認する。
+    expect(clampIntParam('20abc', { min: 1, max: 90, default: 7 })).toBe(7);
+  });
+
+  it('clamps values below the minimum', () => {
+    expect(clampIntParam('0', { min: 1, max: 90, default: 7 })).toBe(1);
+    expect(clampIntParam('-5', { min: 1, max: 90, default: 7 })).toBe(1);
+  });
+
+  it('clamps values above the maximum (DoS 防止)', () => {
+    expect(clampIntParam('99999', { min: 1, max: 400, default: 30 })).toBe(400);
+  });
+
+  it('accepts valid in-range values', () => {
+    expect(clampIntParam('365', { min: 1, max: 400, default: 30 })).toBe(365);
+    expect(clampIntParam('30', { min: 1, max: 90, default: 7 })).toBe(30);
+  });
+
+  it('truncates non-integer numeric input', () => {
+    expect(clampIntParam('7.9', { min: 1, max: 90, default: 7 })).toBe(7);
+  });
+
+  it('rejects Infinity / -Infinity safely', () => {
+    expect(clampIntParam('Infinity', { min: 1, max: 90, default: 7 })).toBe(7);
+    expect(clampIntParam('-Infinity', { min: 1, max: 90, default: 7 })).toBe(7);
+  });
+});

--- a/tests/performance-payloads.test.ts
+++ b/tests/performance-payloads.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizePerformanceCheckinPayload } from '../src/lib/performance-payloads';
+
+/**
+ * #1048 F2-18: performance 系 POST の入力検証欠如(weight 汚染・nutrition_targets 無制限変更)
+ * の回帰テスト。user_performance_checkins には weight 等に DB CHECK が無いため、
+ * アプリ層のレンジ検証が唯一の防波堤になる。
+ */
+describe('sanitizePerformanceCheckinPayload', () => {
+  it('accepts a fully valid payload', () => {
+    const result = sanitizePerformanceCheckinPayload({
+      sleepHours: 7.5,
+      sleepQuality: 4,
+      fatigue: 2,
+      focus: 4,
+      hunger: 3,
+      trainingLoadRpe: 6,
+      trainingMinutes: 60,
+      weight: 65.5,
+      bodyFatPercentage: 18.2,
+      restingHeartRate: 55,
+      mood: 4,
+      soreness: 2,
+      note: 'いい感じ',
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.data).toEqual({
+      sleepHours: 7.5,
+      sleepQuality: 4,
+      fatigue: 2,
+      focus: 4,
+      hunger: 3,
+      trainingLoadRpe: 6,
+      trainingMinutes: 60,
+      weight: 65.5,
+      bodyFatPercentage: 18.2,
+      restingHeartRate: 55,
+      mood: 4,
+      soreness: 2,
+      note: 'いい感じ',
+    });
+  });
+
+  it('rejects an out-of-range weight (weight pollution, e.g. 5000kg)', () => {
+    const result = sanitizePerformanceCheckinPayload({ weight: 5000 });
+    expect(result.data.weight).toBeUndefined();
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a negative or zero weight', () => {
+    const result = sanitizePerformanceCheckinPayload({ weight: -10 });
+    expect(result.data.weight).toBeUndefined();
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('accepts the weight boundary values (20 and 300)', () => {
+    expect(sanitizePerformanceCheckinPayload({ weight: 20 }).errors).toEqual([]);
+    expect(sanitizePerformanceCheckinPayload({ weight: 300 }).errors).toEqual([]);
+  });
+
+  it('rejects values just outside the weight boundary', () => {
+    expect(sanitizePerformanceCheckinPayload({ weight: 19.9 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizePerformanceCheckinPayload({ weight: 300.1 }).errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects 1-5 scale fields outside their range (mirrors the DB CHECK constraint)', () => {
+    expect(sanitizePerformanceCheckinPayload({ mood: 0 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizePerformanceCheckinPayload({ mood: 6 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizePerformanceCheckinPayload({ fatigue: 10 }).errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects non-integer values for integer-only fields', () => {
+    expect(sanitizePerformanceCheckinPayload({ mood: 3.5 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizePerformanceCheckinPayload({ trainingMinutes: 30.5 }).errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects trainingLoadRpe outside 1-10', () => {
+    expect(sanitizePerformanceCheckinPayload({ trainingLoadRpe: 0 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizePerformanceCheckinPayload({ trainingLoadRpe: 11 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizePerformanceCheckinPayload({ trainingLoadRpe: 10 }).errors).toEqual([]);
+  });
+
+  it('rejects an absurd trainingMinutes value (> 1 day)', () => {
+    expect(sanitizePerformanceCheckinPayload({ trainingMinutes: 100000 }).errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects an out-of-range restingHeartRate', () => {
+    expect(sanitizePerformanceCheckinPayload({ restingHeartRate: 500 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizePerformanceCheckinPayload({ restingHeartRate: 0 }).errors.length).toBeGreaterThan(0);
+  });
+
+  it('strips unknown/forbidden keys (mass assignment protection)', () => {
+    const result = sanitizePerformanceCheckinPayload({
+      mood: 4,
+      user_id: 'blocked',
+      isAdmin: true,
+    } as any);
+    expect(result.errors).toEqual([]);
+    expect(result.data).toEqual({ mood: 4 });
+  });
+
+  it('treats null/empty values as "not provided" rather than erroring', () => {
+    const result = sanitizePerformanceCheckinPayload({ weight: null, note: '' });
+    expect(result.errors).toEqual([]);
+    expect(result.data.weight).toBeUndefined();
+    expect(result.data.note).toBeUndefined();
+  });
+
+  it('rejects NaN-producing strings instead of silently coercing', () => {
+    const result = sanitizePerformanceCheckinPayload({ weight: 'abc' });
+    expect(result.data.weight).toBeUndefined();
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 概要
健康記録/パフォーマンス/AIコンサル系の入力検証・集計・データ整合の不具合を修正(#1048、F2-03/08/11/16/18/19/23/26)。

## 修正内容
- **F2-03 streak破壊**: 過去日(バックフィル)記録では total_records のみ加算し streak 系(current/last_activity/start/badges)を不変に。updateHealthStreak を新設し records/quick の重複実装を統合。
- **F2-19 同時実行race + データ消失**: check-then-insert を upsert(onConflict:user_id,record_date)に統一。**mood のみのクイック記録が weight 等を null 上書きする消失バグ**を stripUndefined で修正(undefined のみ除去・明示 null は保持)。
- **F2-08 AI経由の検証バイパス**: execute route の add_health_record を sanitizeHealthRecordPayload + streak + プロフィール同期経由に。
- **F2-16 NaN/limit**: clampIntParam を新設し records/history/checkups/insights/important-messages に適用。[date] に RECORD_DATE_PATTERN 検証。
- **F2-18 performance検証欠如**: sanitizePerformanceCheckinPayload でレンジ検証。analyze POST はクライアント recommendations を信用せずサーバ側 runAnalysis で再計算。adaptive-loop に delta クランプ(多層防御)。
- **F2-11 1年グラフ欠落**: limit 上限 200→400。
- **F2-26 健診レビュー残留**: upsert で individual_review を null リセット→生成成功時のみ書き戻し。
- **F2-23**: AI 経路の midnight_snack を CHECK 制約(breakfast/lunch/dinner/snack)に合わせ拒否(500 回避)。

## 検証
- 新規テスト49件+回帰29件、全PASS。tsc(root+packages/core)/eslint クリーン。全体テスト差分ゼロ(退行なし)。
- 2モデル敵対レビュー(Sonnet5+Fable)= **double-PASS**。stripUndefined/upsert のデータ整合・performance 再計算の契約互換(POST 呼び出し元は存在せず GET のみ)を確認。

## follow-up(別issue・スコープ外/既存バグ)
- **F2-23 アプリ全体版**: meal_type CHECK が midnight_snack を弾く一方 UI/menu生成は一級で提示→手動追加でも500になる既存バグ。CHECK に追加(migration)か UI 全体から除去かの製品判断が必要。
- streak 更新の RPC 化(read-then-write の非アトミック性、UNIQUE違反レース)。
- execute route の update_health_record にも RECORD_DATE_PATTERN 検証を(add_health_record と非一貫)。
- F2-25 streak DELETE(正規のリセット機能・sandbox/env ガード検討)。