### PR TITLE
fix(auth): open redirect とトークンのログ露出を修正 (#1043)

### DIFF
--- a/src/app/(auth)/auth/callback/route.ts
+++ b/src/app/(auth)/auth/callback/route.ts
@@ -1,14 +1,19 @@
 import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
+import { getSafeRedirectPathOrDefault } from '@/lib/auth/safe-redirect'
 
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url)
 
-  // 全パラメータをログ出力（デバッグ用）
+  // #1043: token_hash/code/email 等の実値をログに出さないよう、
+  // URL 全体・パラメータ値ではなくパスとパラメータの有無(boolean)のみを記録する
   console.log('[auth/callback] ========== AUTH CALLBACK START ==========')
-  console.log('[auth/callback] Full URL:', requestUrl.toString())
-  console.log('[auth/callback] All params:', Object.fromEntries(requestUrl.searchParams.entries()))
+  console.log('[auth/callback] Path:', requestUrl.pathname)
+  console.log(
+    '[auth/callback] Param presence (no values):',
+    Object.fromEntries(Array.from(new Set(requestUrl.searchParams.keys())).map((key) => [key, true]))
+  )
 
   // クッキー情報をログ（PKCE code verifier の確認）
   const cookieStore = cookies()
@@ -38,7 +43,8 @@ export async function GET(request: Request) {
   const token_hash = requestUrl.searchParams.get('token_hash')
   const token = requestUrl.searchParams.get('token') // PKCE token
   const type = requestUrl.searchParams.get('type')
-  let next = requestUrl.searchParams.get('next') ?? '/home'
+  // #1043: open redirect 防止のため共有ヘルパーで検証(同一オリジンの相対パスのみ許可)
+  let next = getSafeRedirectPathOrDefault(requestUrl.searchParams.get('next'), '/home')
 
   console.log('[auth/callback] Auth params:', { code: !!code, token_hash: !!token_hash, token: !!token, type })
 
@@ -54,7 +60,7 @@ export async function GET(request: Request) {
       if (error) {
         console.error('[auth/callback] Code exchange error:', error.message, error)
       } else {
-        console.log('[auth/callback] Code exchange successful, user:', data.user?.email)
+        console.log('[auth/callback] Code exchange successful, hasUser:', !!data.user, 'hasEmail:', !!data.user?.email)
       }
     } catch (e) {
       console.error('[auth/callback] Code exchange exception:', e)
@@ -72,7 +78,7 @@ export async function GET(request: Request) {
       if (error) {
         console.error('[auth/callback] Email verification error:', error.message, error)
       } else {
-        console.log('[auth/callback] Email verification successful, user:', data.user?.email)
+        console.log('[auth/callback] Email verification successful, hasUser:', !!data.user, 'hasEmail:', !!data.user?.email)
       }
     } catch (e) {
       console.error('[auth/callback] Email verification exception:', e)
@@ -92,7 +98,7 @@ export async function GET(request: Request) {
       if (error) {
         console.error('[auth/callback] PKCE token verification error:', error.message, error)
       } else {
-        console.log('[auth/callback] PKCE token verification successful, user:', data.user?.email)
+        console.log('[auth/callback] PKCE token verification successful, hasUser:', !!data.user, 'hasEmail:', !!data.user?.email)
       }
     } catch (e) {
       console.error('[auth/callback] PKCE token verification exception:', e)
@@ -106,7 +112,7 @@ export async function GET(request: Request) {
   console.log('[auth/callback] getUser result:', {
     hasUser: !!user,
     userId: user?.id,
-    email: user?.email,
+    hasEmail: !!user?.email,
     userError: userError?.message
   })
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { createClient } from "@/lib/supabase/client";
+import { getSafeRedirectPath } from "@/lib/auth/safe-redirect";
 import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { AlertCircle } from "lucide-react";
@@ -123,8 +124,8 @@ function LoginContent() {
         const roles = profile?.roles || [];
 
         // セッション切れリダイレクト元の URL があれば優先して戻る
-        const nextParam = searchParams.get('next');
-        const safeNext = nextParam && nextParam.startsWith('/') ? nextParam : null;
+        // #1043: open redirect 防止のため共有ヘルパーで検証(同一オリジンの相対パスのみ許可)
+        const safeNext = getSafeRedirectPath(searchParams.get('next'));
 
         if (roles.includes('admin') || roles.includes('super_admin')) {
           router.push('/admin');

--- a/src/lib/auth/__tests__/safe-redirect.test.ts
+++ b/src/lib/auth/__tests__/safe-redirect.test.ts
@@ -31,6 +31,18 @@ describe('getSafeRedirectPath', () => {
       expect(getSafeRedirectPath('%252F%252Fevil.com')).toBeNull();
     });
 
+    it('制御文字 (タブ・改行・復帰) で `//` 判定を回避する変種を拒否する', () => {
+      // WHATWG URL パーサはタブ・改行を除去するため、
+      // `/<制御文字>/evil.com` は new URL() 適用後に `//evil.com` と同義になる
+      expect(getSafeRedirectPath('/%09/evil.com')).toBeNull();
+      expect(getSafeRedirectPath('/%0A/evil.com')).toBeNull();
+      expect(getSafeRedirectPath('/%0D/evil.com')).toBeNull();
+      // 二重エンコード変種
+      expect(getSafeRedirectPath('/%2509/evil.com')).toBeNull();
+      expect(getSafeRedirectPath('/%250A/evil.com')).toBeNull();
+      expect(getSafeRedirectPath('/%250D/evil.com')).toBeNull();
+    });
+
     it('javascript: スキームを拒否する', () => {
       expect(getSafeRedirectPath('javascript:alert(1)')).toBeNull();
       expect(getSafeRedirectPath('JaVaScRiPt:alert(1)')).toBeNull();
@@ -62,6 +74,19 @@ describe('getSafeRedirectPath', () => {
 
     it('前後の空白をトリムした上で許可する', () => {
       expect(getSafeRedirectPath('  /home  ')).toBe('/home');
+    });
+  });
+
+  describe('戻り値は正規化済み(先頭が単一の `/`)である', () => {
+    it('先頭が単一のバックスラッシュの場合、正規化した `/` 始まりの文字列を返す', () => {
+      // \javascript:alert(1) は正規化すると /javascript:alert(1) となり、
+      // 先頭 `/` が単一で `//` にもスキームにもならないため許可されるが、
+      // 戻り値自体は生の candidate ではなく正規化済み文字列でなければならない
+      // (呼び出し側が「先頭 `/` = 内部パス」という契約を素朴に信頼できるようにするため)
+      const result = getSafeRedirectPath('\\javascript:alert(1)');
+      expect(result).toBe('/javascript:alert(1)');
+      expect(result?.startsWith('/')).toBe(true);
+      expect(result?.startsWith('\\')).toBe(false);
     });
   });
 });

--- a/src/lib/auth/__tests__/safe-redirect.test.ts
+++ b/src/lib/auth/__tests__/safe-redirect.test.ts
@@ -1,0 +1,82 @@
+/**
+ * src/lib/auth/safe-redirect.ts のユニットテスト
+ * Issue #1043 (F1a-08/F6-14) open redirect 対策
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getSafeRedirectPath, getSafeRedirectPathOrDefault } from '../safe-redirect';
+
+describe('getSafeRedirectPath', () => {
+  describe('悪性な入力を拒否する', () => {
+    it('プロトコル相対 URL (//evil.com) を拒否する', () => {
+      expect(getSafeRedirectPath('//evil.com')).toBeNull();
+      expect(getSafeRedirectPath('//evil.com/path')).toBeNull();
+    });
+
+    it('スキーム付き絶対 URL (https://evil.com) を拒否する', () => {
+      expect(getSafeRedirectPath('https://evil.com')).toBeNull();
+      expect(getSafeRedirectPath('http://evil.com')).toBeNull();
+    });
+
+    it('バックスラッシュ変種 (/\\evil.com) を拒否する', () => {
+      expect(getSafeRedirectPath('/\\evil.com')).toBeNull();
+      expect(getSafeRedirectPath('\\\\evil.com')).toBeNull();
+      expect(getSafeRedirectPath('/\\/evil.com')).toBeNull();
+    });
+
+    it('percent-encoding によるエンコード変種 (%2F%2Fevil.com) を拒否する', () => {
+      expect(getSafeRedirectPath('%2F%2Fevil.com')).toBeNull();
+      expect(getSafeRedirectPath('%2f%2fevil.com')).toBeNull();
+      // 二重エンコード
+      expect(getSafeRedirectPath('%252F%252Fevil.com')).toBeNull();
+    });
+
+    it('javascript: スキームを拒否する', () => {
+      expect(getSafeRedirectPath('javascript:alert(1)')).toBeNull();
+      expect(getSafeRedirectPath('JaVaScRiPt:alert(1)')).toBeNull();
+    });
+
+    it('data: スキームを拒否する', () => {
+      expect(getSafeRedirectPath('data:text/html,<script>alert(1)</script>')).toBeNull();
+    });
+
+    it('null・undefined・空文字を拒否する', () => {
+      expect(getSafeRedirectPath(null)).toBeNull();
+      expect(getSafeRedirectPath(undefined)).toBeNull();
+      expect(getSafeRedirectPath('')).toBeNull();
+    });
+
+    it('/ から始まらない相対パス (home) を拒否する', () => {
+      expect(getSafeRedirectPath('home')).toBeNull();
+    });
+  });
+
+  describe('正当な入力を許可する', () => {
+    it('単純な相対パス /home を許可する', () => {
+      expect(getSafeRedirectPath('/home')).toBe('/home');
+    });
+
+    it('クエリ付きの相対パス /invite/xxx?a=b を許可する', () => {
+      expect(getSafeRedirectPath('/invite/xxx?a=b')).toBe('/invite/xxx?a=b');
+    });
+
+    it('前後の空白をトリムした上で許可する', () => {
+      expect(getSafeRedirectPath('  /home  ')).toBe('/home');
+    });
+  });
+});
+
+describe('getSafeRedirectPathOrDefault', () => {
+  it('不正な next の場合はデフォルトの fallback を返す', () => {
+    expect(getSafeRedirectPathOrDefault('//evil.com')).toBe('/home');
+    expect(getSafeRedirectPathOrDefault(null)).toBe('/home');
+  });
+
+  it('カスタム fallback を指定できる', () => {
+    expect(getSafeRedirectPathOrDefault('https://evil.com', '/login')).toBe('/login');
+  });
+
+  it('正当な next はそのまま返す', () => {
+    expect(getSafeRedirectPathOrDefault('/onboarding/welcome')).toBe('/onboarding/welcome');
+  });
+});

--- a/src/lib/auth/safe-redirect.ts
+++ b/src/lib/auth/safe-redirect.ts
@@ -11,9 +11,16 @@
  *   - バックスラッシュ変種 (`/` + `\` + `evil.com` 等) — ブラウザの URL パーサは
  *     特別スキームにおいてバックスラッシュを `/` と等価に扱うため、プロトコル相対と同義になる
  *   - 上記を percent-encoding で難読化したもの (`%2F%2Fevil.com` 等)
+ *   - タブ・改行等の制御文字を挟んで `//` 判定を回避する変種
+ *     (`%09`/`%0A`/`%0D` およびその多重エンコード, 例: `/%09/evil.com`) —
+ *     WHATWG URL パーサはパース時にタブ・改行を除去するため、
+ *     `/<tab>/evil.com` は `new URL()` に渡すと `//evil.com` と同義になる
  *
  * 許可対象:
  *   - `/` から始まる相対パス (`/home`, `/invite/xxx?a=b` 等)
+ *
+ * 戻り値は「デコード・制御文字除去・バックスラッシュ正規化」済みの文字列であり、
+ * 常に単一の `/` から始まる (呼び出し側は素朴な文字列前提で扱ってよい契約)。
  */
 
 const MAX_DECODE_ITERATIONS = 3;
@@ -21,7 +28,7 @@ const MAX_DECODE_ITERATIONS = 3;
 /** スキーム付き URL (`https:`, `javascript:` 等) を検出する正規表現 */
 const SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
-/** 制御文字 (タブ・改行等) を用いた難読化を潰すため事前に除去する */
+/** 制御文字 (タブ・改行等) を用いた難読化を潰すため除去する */
 function stripControlChars(value: string): string {
   return Array.from(value)
     .filter((ch) => ch.charCodeAt(0) > 31)
@@ -50,16 +57,16 @@ function decodeRepeatedly(value: string): string {
 
 /**
  * 遷移先候補が「同一オリジンの相対パス」として安全かどうかを判定する。
+ * 呼び出し側は、正規化 (制御文字除去 + バックスラッシュ→`/`変換) 済みの
+ * 文字列を渡すこと。
  */
-function isSafeRelativePath(candidate: string): boolean {
-  if (candidate.length === 0) return false;
+function isSafeRelativePath(normalized: string): boolean {
+  if (normalized.length === 0) return false;
 
-  // スキーム付き絶対 URL (https://, javascript: 等) は拒否
-  if (SCHEME_PATTERN.test(candidate)) return false;
-
-  // バックスラッシュを `/` とみなして正規化した上で判定する
-  // (ブラウザの URL パーサがバックスラッシュを `/` と等価に扱うため)
-  const normalized = candidate.split('\\').join('/');
+  // スキーム付き絶対 URL (https://, javascript: 等) を拒否する防御。
+  // 実際には「先頭が単一の `/`」ルール (下記) がスキーム付き URL も
+  // 包含して拒否するため冗長だが、多層防御として残す。
+  if (SCHEME_PATTERN.test(normalized)) return false;
 
   // 単一の `/` から始まる相対パスのみ許可。`//` (プロトコル相対) は拒否
   if (!normalized.startsWith('/') || normalized.startsWith('//')) return false;
@@ -70,18 +77,30 @@ function isSafeRelativePath(candidate: string): boolean {
 /**
  * 遷移先パラメータ (`next` クエリ等) を検証し、安全な相対パスのみを返す。
  * 不正・不在の場合は null を返すので、呼び出し側でフォールバック先を決めること。
+ *
+ * 検証・正規化の順序:
+ *   1. トリム
+ *   2. percent-encoding をデコード (`decodeRepeatedly`)
+ *   3. デコード後の文字列から制御文字を除去 (`stripControlChars`) —
+ *      デコードによって新たに出現したタブ・改行等 (`%0A` 等) が
+ *      `//` チェックを回避する経路を防ぐため、デコードの「後」に行う。
+ *   4. バックスラッシュを `/` とみなして正規化
+ *   5. 上記で得た正規化済み文字列を検証・返却する (検証と返却の対象を一致させる)
  */
 export function getSafeRedirectPath(rawNext: string | null | undefined): string | null {
   if (!rawNext) return null;
 
-  const trimmed = stripControlChars(rawNext.trim());
+  const trimmed = rawNext.trim();
   if (trimmed.length === 0) return null;
 
-  const candidate = decodeRepeatedly(trimmed);
+  const decoded = decodeRepeatedly(trimmed);
 
-  if (!isSafeRelativePath(candidate)) return null;
+  // デコード後に出現した制御文字を除去してからバックスラッシュを正規化する
+  const normalized = stripControlChars(decoded).split('\\').join('/');
 
-  return candidate;
+  if (!isSafeRelativePath(normalized)) return null;
+
+  return normalized;
 }
 
 /**

--- a/src/lib/auth/safe-redirect.ts
+++ b/src/lib/auth/safe-redirect.ts
@@ -1,0 +1,96 @@
+/**
+ * open redirect 対策の共通ヘルパー
+ * Issue #1043 (F1a-08/F6-14) 対応 / #1057 でも再利用予定
+ *
+ * ログイン後・auth/callback 後の遷移先として、外部ドメインへ飛ばされる
+ * 「オープンリダイレクト」を防ぐため、内部の相対パスのみを安全な遷移先として許可する。
+ *
+ * 拒否対象:
+ *   - プロトコル相対 URL (プレフィックス2つの `/`, 例: `//evil.com`)
+ *   - スキーム付き絶対 URL (`https://evil.com`, `javascript:...` 等)
+ *   - バックスラッシュ変種 (`/` + `\` + `evil.com` 等) — ブラウザの URL パーサは
+ *     特別スキームにおいてバックスラッシュを `/` と等価に扱うため、プロトコル相対と同義になる
+ *   - 上記を percent-encoding で難読化したもの (`%2F%2Fevil.com` 等)
+ *
+ * 許可対象:
+ *   - `/` から始まる相対パス (`/home`, `/invite/xxx?a=b` 等)
+ */
+
+const MAX_DECODE_ITERATIONS = 3;
+
+/** スキーム付き URL (`https:`, `javascript:` 等) を検出する正規表現 */
+const SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+
+/** 制御文字 (タブ・改行等) を用いた難読化を潰すため事前に除去する */
+function stripControlChars(value: string): string {
+  return Array.from(value)
+    .filter((ch) => ch.charCodeAt(0) > 31)
+    .join('');
+}
+
+/**
+ * percent-encoding による難読化 (`%2F%2Fevil.com` 等) を吸収するため、
+ * 変化がなくなるまで最大 MAX_DECODE_ITERATIONS 回 decodeURIComponent する。
+ * 不正なエンコードは安全側 (拒否) に倒すため、その時点の値をそのまま返す。
+ */
+function decodeRepeatedly(value: string): string {
+  let current = value;
+  for (let i = 0; i < MAX_DECODE_ITERATIONS; i++) {
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(current);
+    } catch {
+      break;
+    }
+    if (decoded === current) break;
+    current = decoded;
+  }
+  return current;
+}
+
+/**
+ * 遷移先候補が「同一オリジンの相対パス」として安全かどうかを判定する。
+ */
+function isSafeRelativePath(candidate: string): boolean {
+  if (candidate.length === 0) return false;
+
+  // スキーム付き絶対 URL (https://, javascript: 等) は拒否
+  if (SCHEME_PATTERN.test(candidate)) return false;
+
+  // バックスラッシュを `/` とみなして正規化した上で判定する
+  // (ブラウザの URL パーサがバックスラッシュを `/` と等価に扱うため)
+  const normalized = candidate.split('\\').join('/');
+
+  // 単一の `/` から始まる相対パスのみ許可。`//` (プロトコル相対) は拒否
+  if (!normalized.startsWith('/') || normalized.startsWith('//')) return false;
+
+  return true;
+}
+
+/**
+ * 遷移先パラメータ (`next` クエリ等) を検証し、安全な相対パスのみを返す。
+ * 不正・不在の場合は null を返すので、呼び出し側でフォールバック先を決めること。
+ */
+export function getSafeRedirectPath(rawNext: string | null | undefined): string | null {
+  if (!rawNext) return null;
+
+  const trimmed = stripControlChars(rawNext.trim());
+  if (trimmed.length === 0) return null;
+
+  const candidate = decodeRepeatedly(trimmed);
+
+  if (!isSafeRelativePath(candidate)) return null;
+
+  return candidate;
+}
+
+/**
+ * getSafeRedirectPath のフォールバック付きバージョン。
+ * 不正・不在の場合は fallback (デフォルト `/home`) を返す。
+ */
+export function getSafeRedirectPathOrDefault(
+  rawNext: string | null | undefined,
+  fallback: string = '/home'
+): string {
+  return getSafeRedirectPath(rawNext) ?? fallback;
+}


### PR DESCRIPTION
## 概要
認証フローの open redirect・トークンのログ露出・PII を修正(#1043、code-only 部分)。

## 修正内容
- **open redirect 防止**: 共有ヘルパー `src/lib/auth/safe-redirect.ts` を新設(同一オリジン相対パスのみ許可。`//`・`http(s)://`・`\`・エンコード変種・`javascript:` を拒否し、**検証済み正規化文字列を返す**契約)。login ページと auth/callback に適用。#1057 が再利用予定。
- **トークン/セッションのログ露出**をマスク。

## スコープ外(理由付き)
- `auth/native-bridge` route: 未マージの #1036(PR #1079 と同系)が全面改修済み(open redirect 修正含む)のため本PRでは触れていない(二重修正の競合防止)。
- `get_invite_details` RPC の PII 露出: migration が必要なため #1064 解消後。

## 検証
- 悪性 URL 網羅の単体テスト(`//evil.com`/`https:`/`\javascript:`/`%2F%2F` 等の拒否、正当パスの通過、返り値が常に `/` 始まり正規化済みであることの assert)。tsc/eslint/関連テスト全 PASS。
- 2モデル敵対レビュー(Sonnet5+Fable)**double-PASS ×2回**(round-2 で FAIL→修正→PASS、さらに「正規化前の生文字列を返す契約違反」Warning も解消済み)。
