### PR TITLE
fix(health): 健康・設定ページの UX 不具合を修正 (#1055)

### DIFF
--- a/src/app/(main)/badges/page.tsx
+++ b/src/app/(main)/badges/page.tsx
@@ -73,7 +73,9 @@ function BadgesPageInner() {
   const [badges, setBadges] = useState<BadgeWithStatus[]>([]);
   const [loading, setLoading] = useState(true);
   const [earnedCount, setEarnedCount] = useState(0);
-  const [newEarned, setNewEarned] = useState(false);
+  // #1055 (wave-3b): 「新しいバッジを獲得！」だけでどのバッジか分からなかったため、
+  // 直近獲得したバッジ本体を保持し、お祝い表示・カードハイライトの両方に使う
+  const [newlyEarnedBadges, setNewlyEarnedBadges] = useState<BadgeWithStatus[]>([]);
   const [selectedBadge, setSelectedBadge] = useState<BadgeWithStatus | null>(null);
 
   useEffect(() => {
@@ -90,10 +92,14 @@ function BadgesPageInner() {
 
         setBadges(mappedBadges);
         setEarnedCount(mappedBadges.filter((b: any) => b.earned).length);
-        
-        if (data.newEarnedCount > 0) {
-          setNewEarned(true);
-          setTimeout(() => setNewEarned(false), 5000); // 5秒後に非表示
+
+        // #1055 (wave-3b): どのバッジを新規獲得したか (code) を使ってお祝い表示・
+        // カードハイライトの対象を特定する
+        const newCodes: string[] = data.newEarnedBadgeCodes ?? [];
+        if (newCodes.length > 0) {
+          const newlyEarned = mappedBadges.filter((b: BadgeWithStatus) => newCodes.includes(b.code));
+          setNewlyEarnedBadges(newlyEarned);
+          setTimeout(() => setNewlyEarnedBadges([]), 5000); // 5秒後に非表示
         }
       } catch (e) {
         console.error(e);
@@ -136,19 +142,30 @@ function BadgesPageInner() {
       )}
 
       {/* お祝いエフェクト（新規獲得時） */}
+      {/* #1055 (wave-3b): 「新しいバッジを獲得！」だけでは匿名で何を取ったか分からなかったため、
+          直近獲得バッジのアイコン・名前・取得条件を表示する（該当カードは下のグリッドでハイライト） */}
       <AnimatePresence>
-        {newEarned && (
-          <motion.div 
+        {newlyEarnedBadges.length > 0 && (
+          <motion.div
             initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
             className="fixed inset-0 pointer-events-none z-[60] flex items-center justify-center"
           >
             <div className="absolute inset-0 bg-black/20" />
-            <motion.div 
+            <motion.div
               initial={{ scale: 0.5, y: 50 }} animate={{ scale: 1, y: 0 }}
-              className="bg-white p-8 rounded-3xl shadow-2xl text-center"
+              className="bg-white p-8 rounded-3xl shadow-2xl text-center max-w-xs"
             >
-              <div className="text-6xl mb-4">🎊</div>
+              <div className="text-6xl mb-4">{newlyEarnedBadges[0].icon}</div>
               <h2 className="text-2xl font-bold text-gray-900">新しいバッジを獲得！</h2>
+              <p className="text-lg font-bold text-[#FF8A65] mt-2">{newlyEarnedBadges[0].name}</p>
+              {newlyEarnedBadges[0].description && (
+                <p className="text-sm text-gray-500 mt-1">{newlyEarnedBadges[0].description}</p>
+              )}
+              {newlyEarnedBadges.length > 1 && (
+                <p className="text-xs text-gray-400 mt-3">
+                  他 {newlyEarnedBadges.length - 1} 個のバッジも獲得しました
+                </p>
+              )}
             </motion.div>
           </motion.div>
         )}
@@ -197,7 +214,9 @@ function BadgesPageInner() {
       ) : (
         <div className="px-6 grid grid-cols-2 md:grid-cols-3 gap-4">
           {badges.map((badge, i) => {
-            const isHighlighted = tutorialMode && highlightCodes.includes(badge.code);
+            // #1055 (wave-3b): 新規獲得バッジのカードも既存のハイライトスタイルを流用して目立たせる
+            const isHighlighted = (tutorialMode && highlightCodes.includes(badge.code))
+              || newlyEarnedBadges.some((b) => b.code === badge.code);
             return (
             <motion.button
               key={badge.code}

--- a/src/app/(main)/health/blood-tests/page.tsx
+++ b/src/app/(main)/health/blood-tests/page.tsx
@@ -131,6 +131,13 @@ export default function BloodTestsPage() {
         <p className="text-sm mt-1" style={{ color: colors.textMuted }}>
           過去の血液検査データを一覧で確認できます
         </p>
+        {sex !== 'male' && sex !== 'female' && (
+          // #1055 (wave-3b): 性別未設定時は男女どちらでも確定的に異常と言える場合のみ
+          // フラグする一般基準であることを明示する
+          <p className="text-xs mt-1" style={{ color: colors.textMuted }}>
+            ※ 性別未設定のため一般基準で判定しています
+          </p>
+        )}
       </div>
 
       {error && (

--- a/src/app/(main)/health/blood-tests/page.tsx
+++ b/src/app/(main)/health/blood-tests/page.tsx
@@ -7,6 +7,10 @@ import {
   Droplet, ChevronRight, Activity, AlertTriangle, CheckCircle2,
   Calendar, TrendingUp, TrendingDown, Minus,
 } from "lucide-react";
+import {
+  BLOOD_METRIC_DEFS, evaluateStatus, formatRangeText, getRangeForSex,
+  type BiologicalSex,
+} from "@/lib/health-blood-test-reference";
 
 const colors = {
   bg: "#FAF9F7",
@@ -48,20 +52,12 @@ interface BloodTestResult {
   uric_acid?: number;
 }
 
-const METRICS: { key: keyof BloodTestResult; label: string; unit: string; normalRange?: string }[] = [
-  { key: "hemoglobin",       label: "ヘモグロビン",       unit: "g/dL",  normalRange: "12.0–16.0" },
-  { key: "hba1c",            label: "HbA1c",             unit: "%",     normalRange: "4.6–6.2" },
-  { key: "fasting_glucose",  label: "空腹時血糖",         unit: "mg/dL", normalRange: "70–109" },
-  { key: "total_cholesterol",label: "総コレステロール",   unit: "mg/dL", normalRange: "120–219" },
-  { key: "ldl_cholesterol",  label: "LDLコレステロール",  unit: "mg/dL", normalRange: "60–119" },
-  { key: "hdl_cholesterol",  label: "HDLコレステロール",  unit: "mg/dL", normalRange: "40–96" },
-  { key: "triglycerides",    label: "中性脂肪",           unit: "mg/dL", normalRange: "30–149" },
-  { key: "ast",              label: "AST (GOT)",          unit: "U/L",   normalRange: "10–40" },
-  { key: "alt",              label: "ALT (GPT)",          unit: "U/L",   normalRange: "5–45" },
-  { key: "gamma_gtp",        label: "γ-GTP",             unit: "U/L",   normalRange: "0–80" },
-  { key: "creatinine",       label: "クレアチニン",       unit: "mg/dL", normalRange: "0.46–1.04" },
-  { key: "egfr",             label: "eGFR",               unit: "mL/min/1.73m²" },
-  { key: "uric_acid",        label: "尿酸",               unit: "mg/dL", normalRange: "2.1–7.0" },
+// #1055 UX3-24: METRICS のキー一覧は BLOOD_METRIC_DEFS (性別依存・checkups詳細画面と共通) から生成する
+type NumericMetricKey = Exclude<keyof BloodTestResult, 'id' | 'test_date' | 'facility_name'>;
+const METRIC_KEYS: NumericMetricKey[] = [
+  "hemoglobin", "hba1c", "fasting_glucose",
+  "total_cholesterol", "ldl_cholesterol", "hdl_cholesterol", "triglycerides",
+  "ast", "alt", "gamma_gtp", "creatinine", "egfr", "uric_acid",
 ];
 
 function formatDate(dateStr: string): string {
@@ -74,6 +70,8 @@ export default function BloodTestsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<string | null>(null);
+  // #1055 UX3-24: 基準値をプロフィールの性別で分岐させる
+  const [sex, setSex] = useState<BiologicalSex>(null);
 
   const fetchResults = useCallback(async () => {
     setLoading(true);
@@ -93,6 +91,20 @@ export default function BloodTestsPage() {
   useEffect(() => {
     void fetchResults();
   }, [fetchResults]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/profile", { cache: "no-store" });
+        if (res.ok) {
+          const data = await res.json();
+          setSex(data?.gender ?? null);
+        }
+      } catch (e) {
+        console.error("Failed to fetch profile for reference ranges:", e);
+      }
+    })();
+  }, []);
 
   if (loading) {
     return (
@@ -150,7 +162,7 @@ export default function BloodTestsPage() {
           {results.map((result, idx) => {
             const isOpen = expanded === result.id;
             // 記録済み項目数
-            const filledCount = METRICS.filter((m) => result[m.key] != null).length;
+            const filledCount = METRIC_KEYS.filter((key) => result[key] != null).length;
 
             return (
               <motion.div
@@ -200,21 +212,36 @@ export default function BloodTestsPage() {
                   >
                     <div className="border-t pt-3" style={{ borderColor: colors.border }}>
                       <div className="grid grid-cols-2 gap-2">
-                        {METRICS.map((m) => {
-                          const value = result[m.key];
+                        {/* #1055 UX3-24: checkups詳細画面と同じ基準値モジュールで異常値をハイライトする (従来は範囲表示のみで判定が無かった) */}
+                        {METRIC_KEYS.map((key) => {
+                          const value = result[key];
                           if (value == null) return null;
+                          const def = BLOOD_METRIC_DEFS[key];
+                          const status = evaluateStatus(key, value, sex);
+                          const isAbnormal = status === "high" || status === "low";
+                          const rangeText = formatRangeText(getRangeForSex(key, sex));
                           return (
-                            <div key={m.key} className="p-3 rounded-xl" style={{ backgroundColor: colors.bg }}>
-                              <p className="text-xs mb-1" style={{ color: colors.textMuted }}>{m.label}</p>
-                              <p className="font-bold text-base" style={{ color: colors.text }}>
-                                {String(value)}
-                                <span className="text-xs font-normal ml-1" style={{ color: colors.textMuted }}>{m.unit}</span>
-                              </p>
-                              {m.normalRange && (
-                                <p className="text-xs mt-0.5" style={{ color: colors.textMuted }}>
-                                  基準: {m.normalRange}
+                            <div
+                              key={key}
+                              className="p-3 rounded-xl"
+                              style={{ backgroundColor: isAbnormal ? colors.errorLight : colors.bg }}
+                            >
+                              <p className="text-xs mb-1" style={{ color: colors.textMuted }}>{def.label}</p>
+                              <div className="flex items-center gap-1.5">
+                                <p
+                                  className="font-bold text-base"
+                                  style={{ color: isAbnormal ? colors.error : colors.text }}
+                                >
+                                  {String(value)}
+                                  <span className="text-xs font-normal ml-1" style={{ color: colors.textMuted }}>{def.unit}</span>
                                 </p>
-                              )}
+                                {isAbnormal && (
+                                  <span className="w-2 h-2 rounded-full" style={{ backgroundColor: colors.error }} />
+                                )}
+                              </div>
+                              <p className="text-xs mt-0.5" style={{ color: colors.textMuted }}>
+                                基準: {rangeText}
+                              </p>
                             </div>
                           );
                         })}

--- a/src/app/(main)/health/challenges/page.tsx
+++ b/src/app/(main)/health/challenges/page.tsx
@@ -113,6 +113,8 @@ export default function HealthChallengesPage() {
 
   const activeChallenges = challenges.filter(c => c.status === 'active');
   const completedChallenges = challenges.filter(c => c.status === 'completed');
+  // #1055 UX3-16: 獲得ptの行き先が無かったため、達成したチャレンジの合計を表示する
+  const totalEarnedPoints = completedChallenges.reduce((sum, c) => sum + (c.reward_points || 0), 0);
 
   const getDaysRemaining = (endDate: string) => {
     const end = new Date(endDate);
@@ -161,6 +163,22 @@ export default function HealthChallengesPage() {
         </div>
       ) : (
         <>
+          {/* #1055 UX3-16: 獲得ptの行き先表示 */}
+          {totalEarnedPoints > 0 && (
+            <div className="px-4 mb-4">
+              <div
+                className="p-3 rounded-xl flex items-center gap-3"
+                style={{ backgroundColor: colors.warningLight }}
+              >
+                <Star size={20} style={{ color: colors.warning }} />
+                <div>
+                  <p className="text-xs" style={{ color: colors.textMuted }}>累計獲得ポイント</p>
+                  <p className="text-lg font-bold" style={{ color: colors.warning }}>{totalEarnedPoints} pt</p>
+                </div>
+              </div>
+            </div>
+          )}
+
           {/* アクティブなチャレンジ */}
           <div className="px-4 mb-6">
             <h2 className="font-semibold mb-3" style={{ color: colors.text }}>
@@ -191,13 +209,18 @@ export default function HealthChallengesPage() {
               <div className="space-y-3">
                 {activeChallenges.map((challenge) => {
                   const daysRemaining = getDaysRemaining(challenge.end_date);
+                  // #1055 UX3-16: 期限切れの場合「残り-3日」のような負数表示にせず、期限切れバッジ+グレーアウトにする
+                  const isExpired = daysRemaining < 0;
                   const progress = getProgressPercentage(challenge);
-                  
+
                   return (
                     <motion.div
                       key={challenge.id}
                       className="p-4 rounded-2xl"
-                      style={{ backgroundColor: colors.card }}
+                      style={{
+                        backgroundColor: colors.card,
+                        opacity: isExpired ? 0.6 : 1,
+                      }}
                     >
                       <div className="flex items-start justify-between mb-3">
                         <div>
@@ -208,12 +231,21 @@ export default function HealthChallengesPage() {
                             {challenge.description}
                           </p>
                         </div>
-                        <div className="flex items-center gap-1 px-2 py-1 rounded-full" style={{ backgroundColor: colors.warningLight }}>
-                          <Clock size={12} style={{ color: colors.warning }} />
-                          <span className="text-xs font-medium" style={{ color: colors.warning }}>
-                            残り{daysRemaining}日
-                          </span>
-                        </div>
+                        {isExpired ? (
+                          <div className="flex items-center gap-1 px-2 py-1 rounded-full" style={{ backgroundColor: colors.border }}>
+                            <Clock size={12} style={{ color: colors.textMuted }} />
+                            <span className="text-xs font-medium" style={{ color: colors.textMuted }}>
+                              期限切れ
+                            </span>
+                          </div>
+                        ) : (
+                          <div className="flex items-center gap-1 px-2 py-1 rounded-full" style={{ backgroundColor: colors.warningLight }}>
+                            <Clock size={12} style={{ color: colors.warning }} />
+                            <span className="text-xs font-medium" style={{ color: colors.warning }}>
+                              残り{daysRemaining}日
+                            </span>
+                          </div>
+                        )}
                       </div>
 
                       {/* 進捗バー */}

--- a/src/app/(main)/health/checkups/[id]/CheckupDetailClient.tsx
+++ b/src/app/(main)/health/checkups/[id]/CheckupDetailClient.tsx
@@ -365,6 +365,13 @@ export default function CheckupDetailClient({ id }: Props) {
           style={{ backgroundColor: colors.card }}
         >
           <h3 className="font-bold mb-4" style={{ color: colors.text }}>検査値</h3>
+          {sex !== 'male' && sex !== 'female' && (
+            // #1055 (wave-3b): 性別未設定時は男女どちらでも確定的に異常と言える場合のみ
+            // フラグする一般基準であることを明示する
+            <p className="text-xs mb-3" style={{ color: colors.textMuted }}>
+              ※ 性別未設定のため一般基準で判定しています
+            </p>
+          )}
 
           {/* 血圧・代謝 */}
           <div className="mb-4">

--- a/src/app/(main)/health/checkups/[id]/CheckupDetailClient.tsx
+++ b/src/app/(main)/health/checkups/[id]/CheckupDetailClient.tsx
@@ -8,6 +8,10 @@ import {
   ArrowLeft, Trash2, Activity, Heart, Droplet, AlertTriangle,
   CheckCircle2, Sparkles, Calendar, MapPin, Loader2
 } from 'lucide-react';
+import {
+  BLOOD_METRIC_DEFS, evaluateStatus, formatRangeText, getRangeForSex,
+  type BiologicalSex, type MetricStatus,
+} from '@/lib/health-blood-test-reference';
 
 const colors = {
   bg: '#FAF9F7',
@@ -64,23 +68,7 @@ interface HealthCheckup {
   };
 }
 
-// 基準値の定義
-const referenceValues: Record<string, { label: string; unit: string; normal: string; low?: number; high?: number }> = {
-  blood_pressure_systolic: { label: '収縮期血圧', unit: 'mmHg', normal: '<130', high: 130 },
-  blood_pressure_diastolic: { label: '拡張期血圧', unit: 'mmHg', normal: '<85', high: 85 },
-  hba1c: { label: 'HbA1c', unit: '%', normal: '<5.6', high: 5.6 },
-  fasting_glucose: { label: '空腹時血糖', unit: 'mg/dL', normal: '<100', high: 100 },
-  total_cholesterol: { label: '総コレステロール', unit: 'mg/dL', normal: '<220', high: 220 },
-  ldl_cholesterol: { label: 'LDL', unit: 'mg/dL', normal: '<140', high: 140 },
-  hdl_cholesterol: { label: 'HDL', unit: 'mg/dL', normal: '≥40', low: 40 },
-  triglycerides: { label: '中性脂肪', unit: 'mg/dL', normal: '<150', high: 150 },
-  ast: { label: 'AST(GOT)', unit: 'U/L', normal: '≤30', high: 30 },
-  alt: { label: 'ALT(GPT)', unit: 'U/L', normal: '≤30', high: 30 },
-  gamma_gtp: { label: 'γ-GTP', unit: 'U/L', normal: '≤50', high: 50 },
-  creatinine: { label: 'クレアチニン', unit: 'mg/dL', normal: '0.6-1.1', low: 0.6, high: 1.1 },
-  egfr: { label: 'eGFR', unit: '', normal: '≥60', low: 60 },
-  uric_acid: { label: '尿酸', unit: 'mg/dL', normal: '≤7.0', high: 7.0 },
-};
+// #1055 UX3-24: 基準値は @/lib/health-blood-test-reference (性別依存・blood-tests画面と共通) を単一ソースにする
 
 interface Props {
   id: string;
@@ -92,6 +80,8 @@ export default function CheckupDetailClient({ id }: Props) {
   const [checkup, setCheckup] = useState<HealthCheckup | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  // #1055 UX3-24: 基準値をプロフィールの性別で分岐させる
+  const [sex, setSex] = useState<BiologicalSex>(null);
 
   const fetchCheckup = useCallback(async () => {
     setLoading(true);
@@ -110,6 +100,20 @@ export default function CheckupDetailClient({ id }: Props) {
   useEffect(() => {
     void fetchCheckup();
   }, [fetchCheckup]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch('/api/profile', { cache: 'no-store' });
+        if (res.ok) {
+          const data = await res.json();
+          setSex(data?.gender ?? null);
+        }
+      } catch (error) {
+        console.error('Failed to fetch profile for reference ranges:', error);
+      }
+    })();
+  }, []);
 
   const handleDelete = async () => {
     setDeleting(true);
@@ -131,22 +135,11 @@ export default function CheckupDetailClient({ id }: Props) {
     return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
   };
 
-  const getValueStatus = (key: string, value: number | undefined): 'normal' | 'warning' | 'danger' => {
-    if (value === undefined) return 'normal';
-    const ref = referenceValues[key];
-    if (!ref) return 'normal';
-
-    if (ref.high && value > ref.high) return 'danger';
-    if (ref.low && value < ref.low) return 'danger';
-    return 'normal';
-  };
-
-  const getStatusStyle = (status: 'normal' | 'warning' | 'danger') => {
+  const getStatusStyle = (status: MetricStatus) => {
     switch (status) {
-      case 'danger':
+      case 'high':
+      case 'low':
         return { bg: colors.errorLight, text: colors.error };
-      case 'warning':
-        return { bg: colors.warningLight, text: colors.warning };
       default:
         return { bg: colors.successLight, text: colors.success };
     }
@@ -154,24 +147,28 @@ export default function CheckupDetailClient({ id }: Props) {
 
   const renderMetricRow = (key: string, value: number | undefined) => {
     if (value === undefined) return null;
-    const ref = referenceValues[key];
-    if (!ref) return null;
+    const def = BLOOD_METRIC_DEFS[key];
+    if (!def) return null;
 
-    const status = getValueStatus(key, value);
+    const status = evaluateStatus(key, value, sex);
     const statusStyle = getStatusStyle(status);
+    const rangeText = formatRangeText(getRangeForSex(key, sex));
 
     return (
       <div key={key} className="flex items-center justify-between py-2 border-b" style={{ borderColor: colors.border }}>
-        <span className="text-sm" style={{ color: colors.textLight }}>{ref.label}</span>
+        <div>
+          <span className="text-sm" style={{ color: colors.textLight }}>{def.label}</span>
+          <p className="text-xs" style={{ color: colors.textMuted }}>基準: {rangeText}</p>
+        </div>
         <div className="flex items-center gap-2">
           <span
             className="font-bold"
-            style={{ color: status === 'normal' ? colors.text : statusStyle.text }}
+            style={{ color: status === 'normal' || status === 'unknown' ? colors.text : statusStyle.text }}
           >
             {value}
           </span>
-          <span className="text-xs" style={{ color: colors.textMuted }}>{ref.unit}</span>
-          {status !== 'normal' && (
+          <span className="text-xs" style={{ color: colors.textMuted }}>{def.unit}</span>
+          {(status === 'high' || status === 'low') && (
             <div
               className="w-2 h-2 rounded-full"
               style={{ backgroundColor: statusStyle.text }}
@@ -379,6 +376,8 @@ export default function CheckupDetailClient({ id }: Props) {
             {renderMetricRow('blood_pressure_diastolic', checkup.blood_pressure_diastolic)}
             {renderMetricRow('hba1c', checkup.hba1c)}
             {renderMetricRow('fasting_glucose', checkup.fasting_glucose)}
+            {/* #1055 UX3-24: hemoglobin は従来この画面で一切表示されていなかった */}
+            {renderMetricRow('hemoglobin', checkup.hemoglobin)}
           </div>
 
           {/* 脂質 */}

--- a/src/app/(main)/health/checkups/new/page.tsx
+++ b/src/app/(main)/health/checkups/new/page.tsx
@@ -110,7 +110,9 @@ export default function NewHealthCheckupPage() {
   const [savedCheckup, setSavedCheckup] = useState<any>(null);
   const [error, setError] = useState<string | null>(null);
   // #1055 UX3-10: OCR失敗を無告知にせず、confirm画面でバナー表示する
-  const [ocrStatus, setOcrStatus] = useState<'idle' | 'success' | 'failed' | 'skipped'>('idle');
+  // #1055 (wave-3b): OCR API が 200 を返しても抽出項目が0件の場合は
+  // 「success」ではなく「empty」として扱い、偽の成功表示を避ける
+  const [ocrStatus, setOcrStatus] = useState<'idle' | 'success' | 'empty' | 'failed' | 'skipped'>('idle');
   const [ocrFilledCount, setOcrFilledCount] = useState(0);
   // #1055 UX3-11: upload/confirm から離脱する際、入力済みデータがあれば確認する
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
@@ -202,8 +204,11 @@ export default function NewHealthCheckupPage() {
         // camelCase → snake_case マッピングで formData に反映
         setFormData(prev => ({ ...prev, ...patch }));
         // #1055 UX3-10: OCR成功時は「N項目を自動入力」と分かるようにする
-        setOcrFilledCount(Object.keys(patch).length);
-        setOcrStatus('success');
+        // #1055 (wave-3b): 抽出項目が0件なら「読み取れる項目がありませんでした」の
+        // 警告扱いにし、「0項目を自動入力しました」という偽の成功表示を出さない
+        const filledCount = Object.keys(patch).length;
+        setOcrFilledCount(filledCount);
+        setOcrStatus(filledCount === 0 ? 'empty' : 'success');
       } else {
         // #1055 UX3-10: OCR失敗を無告知にせず、confirm画面でバナー表示する
         console.warn('OCR failed, proceeding to manual entry');
@@ -553,6 +558,16 @@ export default function NewHealthCheckupPage() {
                 <AlertTriangle size={18} className="flex-shrink-0 mt-0.5" style={{ color: colors.warning }} />
                 <p className="text-sm" style={{ color: colors.warning }}>
                   ⚠ 自動読み取りできませんでした。内容を確認し、手動で入力してください。
+                </p>
+              </div>
+            )}
+            {/* #1055 (wave-3b): OCRは成功したが抽出できた項目が0件のケース。
+                「success」バナーで「0項目を自動入力しました」と表示するのは偽の成功表示なので分離する */}
+            {ocrStatus === 'empty' && (
+              <div className="flex items-start gap-2 p-3 rounded-lg" style={{ backgroundColor: colors.warningLight }}>
+                <AlertTriangle size={18} className="flex-shrink-0 mt-0.5" style={{ color: colors.warning }} />
+                <p className="text-sm" style={{ color: colors.warning }}>
+                  ⚠ 読み取れる項目がありませんでした。内容を確認し、手動で入力してください。
                 </p>
               </div>
             )}

--- a/src/app/(main)/health/checkups/new/page.tsx
+++ b/src/app/(main)/health/checkups/new/page.tsx
@@ -8,7 +8,8 @@ import { createClient } from "@/lib/supabase/client";
 import { todayLocal } from "@/lib/date-utils";
 import {
   Camera, Upload, X, ChevronDown, ChevronUp, Loader2,
-  CheckCircle2, AlertTriangle, Sparkles, ArrowLeft, Activity
+  CheckCircle2, AlertTriangle, Sparkles, ArrowLeft, Activity,
+  Heart, Scale, Droplet, Filter, Info
 } from 'lucide-react';
 
 const colors = {
@@ -108,6 +109,11 @@ export default function NewHealthCheckupPage() {
   const [saving, setSaving] = useState(false);
   const [savedCheckup, setSavedCheckup] = useState<any>(null);
   const [error, setError] = useState<string | null>(null);
+  // #1055 UX3-10: OCR失敗を無告知にせず、confirm画面でバナー表示する
+  const [ocrStatus, setOcrStatus] = useState<'idle' | 'success' | 'failed' | 'skipped'>('idle');
+  const [ocrFilledCount, setOcrFilledCount] = useState(0);
+  // #1055 UX3-11: upload/confirm から離脱する際、入力済みデータがあれば確認する
+  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
 
   const supabase = createClient();
 
@@ -168,9 +174,7 @@ export default function NewHealthCheckupPage() {
         const ocrData = await ocrRes.json();
         const extracted = ocrData.extractedData ?? {};
 
-        // camelCase → snake_case マッピングで formData に反映
-        setFormData(prev => ({
-          ...prev,
+        const patch = {
           ...(extracted.checkupDate ? { checkup_date: extracted.checkupDate } : {}),
           ...(extracted.facilityName ? { facility_name: extracted.facilityName } : {}),
           ...(extracted.checkupType ? { checkup_type: extracted.checkupType } : {}),
@@ -193,17 +197,25 @@ export default function NewHealthCheckupPage() {
           ...(extracted.creatinine != null ? { creatinine: String(extracted.creatinine) } : {}),
           ...(extracted.egfr != null ? { egfr: String(extracted.egfr) } : {}),
           ...(extracted.uricAcid != null ? { uric_acid: String(extracted.uricAcid) } : {}),
-        }));
+        };
+
+        // camelCase → snake_case マッピングで formData に反映
+        setFormData(prev => ({ ...prev, ...patch }));
+        // #1055 UX3-10: OCR成功時は「N項目を自動入力」と分かるようにする
+        setOcrFilledCount(Object.keys(patch).length);
+        setOcrStatus('success');
       } else {
-        // OCR 失敗は非致命的。手動入力で続行
+        // #1055 UX3-10: OCR失敗を無告知にせず、confirm画面でバナー表示する
         console.warn('OCR failed, proceeding to manual entry');
+        setOcrStatus('failed');
       }
 
       setStep('confirm');
 
     } catch (err: any) {
-      // OCR エラーは非致命的。手動入力で続行
+      // #1055 UX3-10: OCRエラーも無告知にせず、confirm画面でバナー表示する
       console.warn('OCR error:', err);
+      setOcrStatus('failed');
       setStep('confirm');
     } finally {
       setUploading(false);
@@ -212,7 +224,36 @@ export default function NewHealthCheckupPage() {
   };
 
   const handleSkipUpload = () => {
+    setOcrStatus('skipped');
     setStep('confirm');
+  };
+
+  // #1055 UX3-11: 画像選択済み・入力済みの状態があるかどうか
+  const hasUnsavedInput = () => {
+    if (imageFile) return true;
+    return (Object.keys(initialFormData) as (keyof FormData)[]).some((key) => {
+      if (key === 'checkup_date') return false; // 常に初期値が入っているため対象外
+      if (key === 'checkup_type') return formData.checkup_type !== initialFormData.checkup_type;
+      return !!formData[key];
+    });
+  };
+
+  // #1055 UX3-11: 健診確認ステップの ← が router.back() で入力・OCR結果を全損していた問題を修正。
+  // confirm は upload ステップに戻すだけにし、実際にページを離れる時だけ確認する。
+  const handleBack = () => {
+    if (step === 'confirm') {
+      setStep('upload');
+      return;
+    }
+    if (step === 'review') {
+      router.back();
+      return;
+    }
+    if (hasUnsavedInput()) {
+      setShowLeaveConfirm(true);
+      return;
+    }
+    router.back();
   };
 
   const handleSave = async () => {
@@ -349,7 +390,7 @@ export default function NewHealthCheckupPage() {
       {/* ヘッダー */}
       <div className="sticky top-0 z-10 px-4 py-4" style={{ backgroundColor: colors.bg }}>
         <div className="flex items-center gap-3">
-          <button onClick={() => router.back()}>
+          <button onClick={handleBack}>
             <ArrowLeft size={24} style={{ color: colors.text }} />
           </button>
           <h1 className="text-xl font-bold" style={{ color: colors.text }}>
@@ -371,6 +412,13 @@ export default function NewHealthCheckupPage() {
             <p className="text-sm" style={{ color: colors.textLight }}>
               健康診断の結果票を撮影またはPDFをアップロードすると、AIが自動で数値を読み取ります。
             </p>
+            {/* #1055 UX3-12: 撮影した画像は現状 Storage に保存されず image_url が常に null になるため、明示しておく */}
+            <div className="flex items-start gap-2 p-3 rounded-lg" style={{ backgroundColor: colors.purpleLight }}>
+              <Info size={16} className="flex-shrink-0 mt-0.5" style={{ color: colors.purple }} />
+              <p className="text-xs leading-relaxed" style={{ color: colors.purple }}>
+                撮影・アップロードした画像は数値の自動読み取りにのみ使用され、記録には保存されません。
+              </p>
+            </div>
 
             {/* 画像プレビュー or アップロードエリア */}
             {imagePreview === '__pdf__' ? (
@@ -499,6 +547,24 @@ export default function NewHealthCheckupPage() {
             animate={{ opacity: 1, y: 0 }}
             className="space-y-4"
           >
+            {/* #1055 UX3-10: OCR結果を無告知にしない */}
+            {ocrStatus === 'failed' && (
+              <div className="flex items-start gap-2 p-3 rounded-lg" style={{ backgroundColor: colors.warningLight }}>
+                <AlertTriangle size={18} className="flex-shrink-0 mt-0.5" style={{ color: colors.warning }} />
+                <p className="text-sm" style={{ color: colors.warning }}>
+                  ⚠ 自動読み取りできませんでした。内容を確認し、手動で入力してください。
+                </p>
+              </div>
+            )}
+            {ocrStatus === 'success' && (
+              <div className="flex items-start gap-2 p-3 rounded-lg" style={{ backgroundColor: colors.successLight }}>
+                <CheckCircle2 size={18} className="flex-shrink-0 mt-0.5" style={{ color: colors.success }} />
+                <p className="text-sm" style={{ color: colors.success }}>
+                  {ocrFilledCount}項目を自動入力しました。内容を確認してください。
+                </p>
+              </div>
+            )}
+
             {/* 基本情報 */}
             <div className="p-4 rounded-xl space-y-3" style={{ backgroundColor: colors.card }}>
               <div className="flex items-center gap-2">
@@ -544,8 +610,8 @@ export default function NewHealthCheckupPage() {
               </div>
             </div>
 
-            {/* 血圧・代謝 */}
-            {renderSection('basic', '血圧・代謝', <Activity size={20} style={{ color: colors.accent }} />, (
+            {/* 血圧・代謝 (#1055 UX3-35: セクションごとに異なるアイコンにして見分けやすくする) */}
+            {renderSection('basic', '血圧・代謝', <Heart size={20} style={{ color: colors.accent }} />, (
               <>
                 {renderInput('blood_pressure_systolic', '収縮期血圧', 'mmHg', '120')}
                 {renderInput('blood_pressure_diastolic', '拡張期血圧', 'mmHg', '80')}
@@ -555,7 +621,7 @@ export default function NewHealthCheckupPage() {
             ))}
 
             {/* 身体測定 */}
-            {renderSection('blood', '身体測定', <Camera size={20} style={{ color: colors.accent }} />, (
+            {renderSection('blood', '身体測定', <Scale size={20} style={{ color: colors.accent }} />, (
               <>
                 {renderInput('height', '身長', 'cm', '170')}
                 {renderInput('weight', '体重', 'kg', '65')}
@@ -565,7 +631,7 @@ export default function NewHealthCheckupPage() {
             ))}
 
             {/* 脂質 */}
-            {renderSection('lipid', '脂質', <Activity size={20} style={{ color: colors.accent }} />, (
+            {renderSection('lipid', '脂質', <Droplet size={20} style={{ color: colors.accent }} />, (
               <>
                 {renderInput('total_cholesterol', '総コレステロール', 'mg/dL', '200')}
                 {renderInput('ldl_cholesterol', 'LDL', 'mg/dL', '120')}
@@ -584,7 +650,7 @@ export default function NewHealthCheckupPage() {
             ))}
 
             {/* 腎機能 */}
-            {renderSection('kidney', '腎機能・尿酸', <Activity size={20} style={{ color: colors.accent }} />, (
+            {renderSection('kidney', '腎機能・尿酸', <Filter size={20} style={{ color: colors.accent }} />, (
               <>
                 {renderInput('creatinine', 'クレアチニン', 'mg/dL', '0.8')}
                 {renderInput('egfr', 'eGFR', '', '90')}
@@ -714,6 +780,48 @@ export default function NewHealthCheckupPage() {
           </motion.div>
         )}
       </div>
+
+      {/* #1055 UX3-11: 入力・OCR結果があるまま離脱しようとした時の確認モーダル */}
+      <AnimatePresence>
+        {showLeaveConfirm && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/50 z-[70] flex items-center justify-center px-4"
+            onClick={() => setShowLeaveConfirm(false)}
+          >
+            <motion.div
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              className="bg-white rounded-2xl p-6 w-full max-w-sm shadow-xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h3 className="font-bold text-lg mb-2" style={{ color: colors.text }}>入力内容を破棄しますか？</h3>
+              <p className="text-sm mb-6" style={{ color: colors.textMuted }}>
+                ここまでの入力・読み取り結果は保存されていません。このまま離れると失われます。
+              </p>
+              <div className="flex gap-3">
+                <button
+                  onClick={() => setShowLeaveConfirm(false)}
+                  className="flex-1 py-3 rounded-xl font-medium"
+                  style={{ backgroundColor: colors.border, color: colors.textLight }}
+                >
+                  入力に戻る
+                </button>
+                <button
+                  onClick={() => router.back()}
+                  className="flex-1 py-3 rounded-xl font-bold text-white"
+                  style={{ backgroundColor: colors.error }}
+                >
+                  破棄して戻る
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/app/(main)/health/goals/page.tsx
+++ b/src/app/(main)/health/goals/page.tsx
@@ -7,6 +7,7 @@ import {
   ArrowLeft, Target, Plus, Scale, Percent, Footprints,
   Trophy, Calendar, CheckCircle2, X, Trash2, Edit2
 } from 'lucide-react';
+import { GOAL_TYPE_DEFS } from '@/lib/health-goal-types';
 
 const colors = {
   bg: '#FAF9F7',
@@ -42,11 +43,19 @@ interface HealthGoal {
   note?: string;
 }
 
-const GOAL_TYPES = [
-  { type: 'weight', label: '体重', unit: 'kg', icon: Scale, color: colors.accent },
-  { type: 'body_fat', label: '体脂肪率', unit: '%', icon: Percent, color: colors.purple },
-  { type: 'steps', label: '1日の歩数', unit: '歩', icon: Footprints, color: colors.blue },
-];
+// 表示名・単位は @/lib/health-goal-types が単一ソース (health/page.tsx ダッシュボードと共通化)。
+// アイコン・色は本画面固有の見た目情報のみここで補う。
+const GOAL_TYPE_VISUALS: Record<string, { icon: typeof Scale; color: string }> = {
+  weight: { icon: Scale, color: colors.accent },
+  body_fat: { icon: Percent, color: colors.purple },
+  steps: { icon: Footprints, color: colors.blue },
+};
+
+const GOAL_TYPES = GOAL_TYPE_DEFS.map((def) => ({
+  ...def,
+  icon: GOAL_TYPE_VISUALS[def.type]?.icon ?? Scale,
+  color: GOAL_TYPE_VISUALS[def.type]?.color ?? colors.accent,
+}));
 
 export default function HealthGoalsPage() {
   const router = useRouter();
@@ -60,6 +69,11 @@ export default function HealthGoalsPage() {
   });
   const [creating, setCreating] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null); // #87: window.confirm 廃止
+  // #1055 UX3-15: 目標を編集できるようにする
+  const [editGoal, setEditGoal] = useState<HealthGoal | null>(null);
+  const [editForm, setEditForm] = useState({ target_value: '', target_date: '' });
+  const [savingEdit, setSavingEdit] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
 
   useEffect(() => {
     fetchGoals();
@@ -110,6 +124,53 @@ export default function HealthGoalsPage() {
   const handleDeleteGoal = async (id: string) => {
     // #87: window.confirm を React modal に置換（PWA/headless 対応）
     setDeleteConfirm(id);
+  };
+
+  const openEditGoal = (goal: HealthGoal) => {
+    setEditError(null);
+    setEditGoal(goal);
+    setEditForm({
+      target_value: String(goal.target_value ?? ''),
+      target_date: goal.target_date ? goal.target_date.slice(0, 10) : '',
+    });
+  };
+
+  const closeEditGoal = () => {
+    setEditGoal(null);
+    setEditError(null);
+  };
+
+  const handleSaveEditGoal = async () => {
+    if (!editGoal) return;
+    if (!editForm.target_value || Number.isNaN(parseFloat(editForm.target_value))) {
+      setEditError('目標値を入力してください');
+      return;
+    }
+
+    setSavingEdit(true);
+    setEditError(null);
+    try {
+      const res = await fetch(`/api/health/goals/${editGoal.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          target_value: parseFloat(editForm.target_value),
+          target_date: editForm.target_date || null,
+        }),
+      });
+
+      if (res.ok) {
+        closeEditGoal();
+        fetchGoals();
+      } else {
+        const data = await res.json().catch(() => null);
+        setEditError(data?.error || '更新に失敗しました');
+      }
+    } catch (error) {
+      console.error('Failed to update goal:', error);
+      setEditError('更新に失敗しました');
+    }
+    setSavingEdit(false);
   };
 
   const confirmDelete = async () => {
@@ -215,12 +276,22 @@ export default function HealthGoalsPage() {
                             </p>
                           </div>
                         </div>
-                        <button
-                          onClick={() => handleDeleteGoal(goal.id)}
-                          className="p-2"
-                        >
-                          <Trash2 size={18} style={{ color: colors.textMuted }} />
-                        </button>
+                        <div className="flex items-center gap-1">
+                          <button
+                            onClick={() => openEditGoal(goal)}
+                            className="p-2"
+                            aria-label="目標を編集"
+                          >
+                            <Edit2 size={18} style={{ color: colors.textMuted }} />
+                          </button>
+                          <button
+                            onClick={() => handleDeleteGoal(goal.id)}
+                            className="p-2"
+                            aria-label="目標を削除"
+                          >
+                            <Trash2 size={18} style={{ color: colors.textMuted }} />
+                          </button>
+                        </div>
                       </div>
 
                       {/* 進捗バー */}
@@ -295,20 +366,39 @@ export default function HealthGoalsPage() {
                       className="p-4 rounded-2xl"
                       style={{ backgroundColor: colors.successLight }}
                     >
-                      <div className="flex items-center gap-3">
-                        <div 
-                          className="w-10 h-10 rounded-lg flex items-center justify-center"
-                          style={{ backgroundColor: colors.success }}
-                        >
-                          <Trophy size={20} color="white" />
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="flex items-center gap-3">
+                          <div
+                            className="w-10 h-10 rounded-lg flex items-center justify-center"
+                            style={{ backgroundColor: colors.success }}
+                          >
+                            <Trophy size={20} color="white" />
+                          </div>
+                          <div>
+                            <p className="font-semibold" style={{ color: colors.success }}>
+                              {config.label} 目標達成！
+                            </p>
+                            <p className="text-sm" style={{ color: colors.success }}>
+                              {goal.target_value}{goal.target_unit} を達成
+                            </p>
+                          </div>
                         </div>
-                        <div>
-                          <p className="font-semibold" style={{ color: colors.success }}>
-                            {config.label} 目標達成！
-                          </p>
-                          <p className="text-sm" style={{ color: colors.success }}>
-                            {goal.target_value}{goal.target_unit} を達成
-                          </p>
+                        {/* #1055 UX3-15: 達成済みでも編集・削除できるようにする */}
+                        <div className="flex items-center gap-1">
+                          <button
+                            onClick={() => openEditGoal(goal)}
+                            className="p-2"
+                            aria-label="目標を編集"
+                          >
+                            <Edit2 size={18} style={{ color: colors.success }} />
+                          </button>
+                          <button
+                            onClick={() => handleDeleteGoal(goal.id)}
+                            className="p-2"
+                            aria-label="目標を削除"
+                          >
+                            <Trash2 size={18} style={{ color: colors.success }} />
+                          </button>
                         </div>
                       </div>
                     </div>
@@ -360,6 +450,88 @@ export default function HealthGoalsPage() {
                   style={{ backgroundColor: colors.error }}
                 >
                   削除する
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* 目標編集モーダル (#1055 UX3-15: 削除しか出来なかった目標を編集可能に) */}
+      <AnimatePresence>
+        {editGoal && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/50 z-[70] flex items-center justify-center px-4"
+            onClick={closeEditGoal}
+          >
+            <motion.div
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              className="bg-white rounded-2xl p-6 w-full max-w-sm shadow-xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="font-bold text-lg" style={{ color: colors.text }}>目標を編集</h3>
+                <button onClick={closeEditGoal} className="p-1">
+                  <X size={20} style={{ color: colors.textMuted }} />
+                </button>
+              </div>
+
+              <div className="mb-4">
+                <label className="block text-sm font-medium mb-2" style={{ color: colors.textLight }}>
+                  {getGoalConfig(editGoal.goal_type).label} の目標値
+                </label>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="number"
+                    step="0.1"
+                    value={editForm.target_value}
+                    onChange={(e) => setEditForm({ ...editForm, target_value: e.target.value })}
+                    className="flex-1 p-4 rounded-xl text-xl font-bold"
+                    style={{ backgroundColor: colors.bg, color: colors.text }}
+                  />
+                  <span className="text-lg" style={{ color: colors.textMuted }}>
+                    {editGoal.target_unit}
+                  </span>
+                </div>
+              </div>
+
+              <div className="mb-6">
+                <label className="block text-sm font-medium mb-2" style={{ color: colors.textLight }}>
+                  期限（オプション）
+                </label>
+                <input
+                  type="date"
+                  value={editForm.target_date}
+                  onChange={(e) => setEditForm({ ...editForm, target_date: e.target.value })}
+                  className="w-full p-4 rounded-xl"
+                  style={{ backgroundColor: colors.bg, color: colors.text }}
+                />
+              </div>
+
+              {editError && (
+                <p className="text-sm mb-4" style={{ color: colors.error }}>{editError}</p>
+              )}
+
+              <div className="flex gap-3">
+                <button
+                  onClick={closeEditGoal}
+                  className="flex-1 py-3 rounded-xl font-medium"
+                  style={{ backgroundColor: colors.border, color: colors.textLight }}
+                >
+                  キャンセル
+                </button>
+                <button
+                  onClick={handleSaveEditGoal}
+                  disabled={savingEdit}
+                  className="flex-1 py-3 rounded-xl font-bold text-white disabled:opacity-50"
+                  style={{ backgroundColor: colors.accent }}
+                >
+                  {savingEdit ? '保存中...' : '保存する'}
                 </button>
               </div>
             </motion.div>

--- a/src/app/(main)/health/graphs/page.tsx
+++ b/src/app/(main)/health/graphs/page.tsx
@@ -210,6 +210,12 @@ export default function HealthGraphsPage() {
   const { data: graphData, min, max, avg } = getGraphData();
   const formatStat = (v: number | null) => (v === null ? '-' : v.toFixed(1));
 
+  // #1055 (wave-3b): 血圧は最小=拡張期/最大=収縮期/平均=収縮期の系列混在のまま
+  // 無ラベルで表示されていたため、どの系列の統計かを明示する
+  const statLabels = metric === 'bp'
+    ? { min: '最小（拡張期）', avg: '平均（収縮期）', max: '最大（収縮期）' }
+    : { min: '最小', avg: '平均', max: '最大' };
+
   // 変化を計算
   const getChange = () => {
     const validData = graphData.filter(d => d.value !== null);
@@ -550,7 +556,7 @@ export default function HealthGraphsPage() {
             className="p-4 rounded-xl text-center"
             style={{ backgroundColor: colors.card }}
           >
-            <p className="text-xs mb-1" style={{ color: colors.textMuted }}>最小</p>
+            <p className="text-xs mb-1" style={{ color: colors.textMuted }}>{statLabels.min}</p>
             <p className="text-lg font-bold" style={{ color: colors.text }}>
               {formatStat(min)}
             </p>
@@ -559,7 +565,7 @@ export default function HealthGraphsPage() {
             className="p-4 rounded-xl text-center"
             style={{ backgroundColor: colors.card }}
           >
-            <p className="text-xs mb-1" style={{ color: colors.textMuted }}>平均</p>
+            <p className="text-xs mb-1" style={{ color: colors.textMuted }}>{statLabels.avg}</p>
             <p className="text-lg font-bold" style={{ color: colors.text }}>
               {formatStat(avg)}
             </p>
@@ -568,7 +574,7 @@ export default function HealthGraphsPage() {
             className="p-4 rounded-xl text-center"
             style={{ backgroundColor: colors.card }}
           >
-            <p className="text-xs mb-1" style={{ color: colors.textMuted }}>最大</p>
+            <p className="text-xs mb-1" style={{ color: colors.textMuted }}>{statLabels.max}</p>
             <p className="text-lg font-bold" style={{ color: colors.text }}>
               {formatStat(max)}
             </p>

--- a/src/app/(main)/health/graphs/page.tsx
+++ b/src/app/(main)/health/graphs/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { motion } from "framer-motion";
 import { formatLocalDate } from "@/lib/date-utils";
 import { createClient } from "@/lib/supabase/client";
@@ -148,15 +149,16 @@ export default function HealthGraphsPage() {
   }, [fetchData]);
 
   // グラフデータを生成
+  // #1055 UX3-13/14: 血圧は収縮期のみ描画されていたため、拡張期 (value2) も持たせて2系列描画する
   const getGraphData = (): {
-    data: { date: string; value: number | null; fromCheckup?: boolean }[];
+    data: { date: string; value: number | null; value2?: number | null; fromCheckup?: boolean }[];
     min: number | null;
     max: number | null;
     avg: number | null;
   } => {
     if (records.length === 0) return { data: [], min: null, max: null, avg: null };
 
-    let values: { date: string; value: number | null; fromCheckup?: boolean }[] = [];
+    let values: { date: string; value: number | null; value2?: number | null; fromCheckup?: boolean }[] = [];
 
     // 期間内の全日付を生成
     const days = period === 'week' ? 7 : period === 'month' ? 30 : period === '3months' ? 90 : 365;
@@ -169,6 +171,7 @@ export default function HealthGraphsPage() {
       const record = records.find(r => r.record_date === dateStr);
 
       let value: number | null = null;
+      let value2: number | null = null;
       if (record) {
         switch (metric) {
           case 'weight':
@@ -179,21 +182,27 @@ export default function HealthGraphsPage() {
             break;
           case 'bp':
             value = record.systolic_bp || null;
+            value2 = record.diastolic_bp || null;
             break;
           case 'sleep':
             value = record.sleep_hours || null;
             break;
         }
       }
-      values.push({ date: dateStr, value, fromCheckup: record?.fromCheckup });
+      values.push({ date: dateStr, value, value2, fromCheckup: record?.fromCheckup });
     }
 
     const validValues = values.filter(v => v.value !== null).map(v => v.value as number);
-    if (validValues.length === 0) return { data: values, min: null, max: null, avg: null };
+    const validValues2 = metric === 'bp' ? values.filter(v => v.value2 != null).map(v => v.value2 as number) : [];
+    const allValues = [...validValues, ...validValues2];
+    if (allValues.length === 0) return { data: values, min: null, max: null, avg: null };
 
-    const min = Math.min(...validValues);
-    const max = Math.max(...validValues);
-    const avg = validValues.reduce((a, b) => a + b, 0) / validValues.length;
+    const min = Math.min(...allValues);
+    const max = Math.max(...allValues);
+    // 平均は主系列 (体重/体脂肪率/収縮期血圧/睡眠時間) のみで算出する
+    const avg = validValues.length > 0
+      ? validValues.reduce((a, b) => a + b, 0) / validValues.length
+      : null;
 
     return { data: values, min, max, avg };
   };
@@ -244,6 +253,20 @@ export default function HealthGraphsPage() {
       ? `M ${validPoints.map(p => `${p.x},${p.y}`).join(' L ')}`
       : '';
 
+    // #1055 UX3-13/14: 血圧は拡張期 (value2) も同じスケールで第2系列として描画する
+    const points2 = metric === 'bp'
+      ? graphData.map((d, i) => ({
+          x: padding.left + (i / (graphData.length - 1)) * graphWidth,
+          y: d.value2 != null
+            ? padding.top + graphHeight - ((d.value2 - yMin) / (yMax - yMin)) * graphHeight
+            : -1,
+        }))
+      : [];
+    const validPoints2 = points2.filter(p => p.y >= 0);
+    const pathD2 = validPoints2.length > 1
+      ? `M ${validPoints2.map(p => `${p.x},${p.y}`).join(' L ')}`
+      : '';
+
     // 目標ラインのY座標
     const targetY = targetWeight && metric === 'weight'
       ? padding.top + graphHeight - ((targetWeight - yMin) / (yMax - yMin)) * graphHeight
@@ -287,7 +310,7 @@ export default function HealthGraphsPage() {
           </>
         )}
 
-        {/* グラフ線 */}
+        {/* グラフ線 (収縮期血圧 or 体重/体脂肪率/睡眠) */}
         <path
           d={pathD}
           fill="none"
@@ -296,6 +319,19 @@ export default function HealthGraphsPage() {
           strokeLinecap="round"
           strokeLinejoin="round"
         />
+
+        {/* 拡張期血圧 (血圧選択時のみ第2系列として描画) */}
+        {metric === 'bp' && (
+          <path
+            d={pathD2}
+            fill="none"
+            stroke={colors.blue}
+            strokeWidth={2.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeDasharray="5,3"
+          />
+        )}
 
         {/* データポイント (健診由来は菱形で区別) */}
         {validPoints.map((p, i) =>
@@ -320,12 +356,25 @@ export default function HealthGraphsPage() {
           )
         )}
 
-        {/* Y軸ラベル */}
+        {/* 拡張期血圧のデータポイント */}
+        {metric === 'bp' && validPoints2.map((p, i) => (
+          <circle
+            key={`d-${i}`}
+            cx={p.x}
+            cy={p.y}
+            r={3.5}
+            fill={colors.card}
+            stroke={colors.blue}
+            strokeWidth={2}
+          />
+        ))}
+
+        {/* Y軸ラベル (単位付き) */}
         <text x={padding.left - 5} y={padding.top + 5} fontSize={10} fill={colors.textMuted} textAnchor="end">
-          {yMax.toFixed(1)}
+          {yMax.toFixed(1)}{currentMetric.unit}
         </text>
         <text x={padding.left - 5} y={padding.top + graphHeight} fontSize={10} fill={colors.textMuted} textAnchor="end">
-          {yMin.toFixed(1)}
+          {yMin.toFixed(1)}{currentMetric.unit}
         </text>
 
         {/* X軸ラベル */}
@@ -416,7 +465,8 @@ export default function HealthGraphsPage() {
           <div className="flex items-center justify-between mb-4">
             <div>
               <p className="text-sm" style={{ color: colors.textMuted }}>
-                {currentMetric.label}の推移
+                {/* #1055 UX3-13/14: 血圧は収縮期のみのラベルにせず両方を明示する */}
+                {metric === 'bp' ? '血圧(収縮期/拡張期)の推移' : `${currentMetric.label}の推移`}
               </p>
               <div className="flex items-baseline gap-2">
                 <span className="text-3xl font-bold" style={{ color: colors.text }}>
@@ -424,6 +474,9 @@ export default function HealthGraphsPage() {
                 </span>
                 <span className="text-sm" style={{ color: colors.textMuted }}>
                   {currentMetric.unit}
+                  {metric === 'bp' && (
+                    <> / {graphData.filter(d => d.value2 != null).slice(-1)[0]?.value2?.toFixed(1) ?? '-'} {currentMetric.unit}</>
+                  )}
                 </span>
               </div>
             </div>
@@ -449,6 +502,20 @@ export default function HealthGraphsPage() {
             )}
           </div>
 
+          {/* #1055 UX3-13/14: 血圧選択時は収縮期/拡張期の凡例を表示する */}
+          {metric === 'bp' && (
+            <div className="flex items-center gap-4 mb-2">
+              <div className="flex items-center gap-1.5">
+                <span className="w-3 h-0.5 rounded-full" style={{ backgroundColor: colors.accent }} />
+                <span className="text-xs" style={{ color: colors.textLight }}>収縮期</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <span className="w-3 h-0.5 rounded-full border-t-2 border-dashed" style={{ borderColor: colors.blue }} />
+                <span className="text-xs" style={{ color: colors.textLight }}>拡張期</span>
+              </div>
+            </div>
+          )}
+
           {/* グラフ */}
           <div className="h-48">
             {loading ? (
@@ -458,10 +525,18 @@ export default function HealthGraphsPage() {
             ) : graphData.filter(d => d.value !== null).length > 0 ? (
               renderGraph()
             ) : (
-              <div className="h-full flex items-center justify-center">
+              // #1055 UX3-36: 空状態に次アクションが無かったため、記録への導線を追加
+              <div className="h-full flex flex-col items-center justify-center gap-3">
                 <p className="text-sm" style={{ color: colors.textMuted }}>
                   データがありません
                 </p>
+                <Link
+                  href="/health/record"
+                  className="px-4 py-2 rounded-lg text-sm font-medium text-white"
+                  style={{ backgroundColor: colors.accent }}
+                >
+                  今日の記録をつける
+                </Link>
               </div>
             )}
           </div>

--- a/src/app/(main)/health/page.tsx
+++ b/src/app/(main)/health/page.tsx
@@ -9,6 +9,7 @@ import {
   Target, Flame, Calendar, ChevronRight, Plus, Camera, Sparkles,
   Award, Clock, Smile, Frown, Meh, AlertTriangle, CheckCircle2
 } from 'lucide-react';
+import { getGoalTypeLabel } from "@/lib/health-goal-types";
 
 // カラーパレット
 const colors = {
@@ -571,8 +572,8 @@ export default function HealthDashboardPage() {
                   <div className="flex items-center gap-2">
                     <Target size={18} style={{ color: colors.accent }} />
                     <span className="font-medium" style={{ color: colors.text }}>
-                      {goal.goal_type === 'weight' ? '目標体重' : 
-                       goal.goal_type === 'body_fat' ? '目標体脂肪率' : goal.goal_type}
+                      {goal.goal_type === 'weight' ? '目標体重' :
+                       goal.goal_type === 'body_fat' ? '目標体脂肪率' : getGoalTypeLabel(goal.goal_type)}
                     </span>
                   </div>
                   <span className="text-sm font-bold" style={{ color: colors.accent }}>

--- a/src/app/(main)/health/settings/page.tsx
+++ b/src/app/(main)/health/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import {
   ArrowLeft, Bell, BellOff, Clock, Moon, Smile, Brain,
   Trophy, Zap, Heart, Save, ChevronRight, Calendar
@@ -58,23 +58,32 @@ interface Preferences {
   vacation_until: string | null;
 }
 
+const DEFAULT_PREFERENCES: Preferences = {
+  enabled: true,
+  quiet_hours_start: '22:00',
+  quiet_hours_end: '07:00',
+  record_mode: 'standard',
+  personality_type: 'positive',
+  morning_reminder_enabled: true,
+  morning_reminder_time: '07:30',
+  evening_reminder_enabled: false,
+  evening_reminder_time: '21:00',
+  vacation_mode: false,
+  vacation_until: null,
+};
+
 export default function HealthSettingsPage() {
   const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [preferences, setPreferences] = useState<Preferences>({
-    enabled: true,
-    quiet_hours_start: '22:00',
-    quiet_hours_end: '07:00',
-    record_mode: 'standard',
-    personality_type: 'positive',
-    morning_reminder_enabled: true,
-    morning_reminder_time: '07:30',
-    evening_reminder_enabled: false,
-    evening_reminder_time: '21:00',
-    vacation_mode: false,
-    vacation_until: null,
-  });
+  const [preferences, setPreferences] = useState<Preferences>(DEFAULT_PREFERENCES);
+  // #1055 UX3-26: 保存成功が無言 back になっていた・戻るで未保存破棄されていた問題への対応
+  const [initialPreferences, setInitialPreferences] = useState<Preferences>(DEFAULT_PREFERENCES);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
+
+  const isDirty = JSON.stringify(preferences) !== JSON.stringify(initialPreferences);
 
   useEffect(() => {
     fetchPreferences();
@@ -88,6 +97,7 @@ export default function HealthSettingsPage() {
         const data = await res.json();
         if (data.preferences) {
           setPreferences(data.preferences);
+          setInitialPreferences(data.preferences);
         }
       }
     } catch (error) {
@@ -98,6 +108,8 @@ export default function HealthSettingsPage() {
 
   const handleSave = async () => {
     setSaving(true);
+    setSaveError(null);
+    setSaveMessage(null);
     try {
       const res = await fetch('/api/health/notifications/preferences', {
         method: 'PUT',
@@ -106,12 +118,26 @@ export default function HealthSettingsPage() {
       });
 
       if (res.ok) {
-        router.back();
+        // #1055 UX3-26: 保存成功を無言で back せず、メッセージを見せてから戻る
+        setInitialPreferences(preferences);
+        setSaveMessage('設定を保存しました');
+        window.setTimeout(() => router.back(), 900);
+      } else {
+        setSaveError('保存に失敗しました。時間をおいて再度お試しください。');
       }
     } catch (error) {
       console.error('Failed to save preferences:', error);
+      setSaveError('保存に失敗しました。時間をおいて再度お試しください。');
     }
     setSaving(false);
+  };
+
+  const handleBackClick = () => {
+    if (isDirty) {
+      setShowLeaveConfirm(true);
+    } else {
+      router.back();
+    }
   };
 
   if (loading) {
@@ -127,7 +153,7 @@ export default function HealthSettingsPage() {
       {/* ヘッダー */}
       <div className="sticky top-0 z-10 px-4 py-4 flex items-center justify-between" style={{ backgroundColor: colors.bg }}>
         <div className="flex items-center">
-          <button onClick={() => router.back()} className="p-2 -ml-2">
+          <button onClick={handleBackClick} className="p-2 -ml-2">
             <ArrowLeft size={24} style={{ color: colors.text }} />
           </button>
           <h1 className="font-bold ml-2" style={{ color: colors.text }}>記録設定</h1>
@@ -135,13 +161,28 @@ export default function HealthSettingsPage() {
         <motion.button
           whileTap={{ scale: 0.95 }}
           onClick={handleSave}
-          disabled={saving}
-          className="px-4 py-2 rounded-lg font-medium text-white"
+          disabled={saving || !isDirty}
+          className="px-4 py-2 rounded-lg font-medium text-white disabled:opacity-50"
           style={{ backgroundColor: colors.accent }}
         >
           {saving ? '保存中...' : '保存'}
         </motion.button>
       </div>
+
+      {/* #1055 UX3-26: 保存結果を無言にしないためのメッセージ */}
+      {(saveMessage || saveError) && (
+        <div className="px-4 mb-2">
+          <div
+            className="p-3 rounded-lg text-sm"
+            style={{
+              backgroundColor: saveMessage ? colors.successLight : colors.warningLight,
+              color: saveMessage ? colors.success : colors.warning,
+            }}
+          >
+            {saveMessage ?? saveError}
+          </div>
+        </div>
+      )}
 
       {/* 記録モード */}
       <div className="px-4 mb-6">
@@ -408,6 +449,48 @@ export default function HealthSettingsPage() {
           </div>
         </div>
       </div>
+
+      {/* #1055 UX3-26: 未保存の変更があるまま戻ろうとした時の確認モーダル */}
+      <AnimatePresence>
+        {showLeaveConfirm && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/50 z-[70] flex items-center justify-center px-4"
+            onClick={() => setShowLeaveConfirm(false)}
+          >
+            <motion.div
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              className="bg-white rounded-2xl p-6 w-full max-w-sm shadow-xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h3 className="font-bold text-lg mb-2" style={{ color: colors.text }}>変更を破棄しますか？</h3>
+              <p className="text-sm mb-6" style={{ color: colors.textMuted }}>
+                保存していない変更があります。このまま戻ると変更内容は失われます。
+              </p>
+              <div className="flex gap-3">
+                <button
+                  onClick={() => setShowLeaveConfirm(false)}
+                  className="flex-1 py-3 rounded-xl font-medium"
+                  style={{ backgroundColor: colors.border, color: colors.textLight }}
+                >
+                  編集に戻る
+                </button>
+                <button
+                  onClick={() => router.back()}
+                  className="flex-1 py-3 rounded-xl font-bold text-white"
+                  style={{ backgroundColor: colors.accent }}
+                >
+                  破棄して戻る
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/app/(main)/health/streaks/page.tsx
+++ b/src/app/(main)/health/streaks/page.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import {
-  Flame, Award, ChevronRight, Activity, CheckCircle2, Calendar,
+  Flame, Award, ChevronRight, Activity, CheckCircle2, Calendar, X,
 } from "lucide-react";
 
 const colors = {
@@ -41,9 +41,17 @@ interface StreakData {
 
 const BADGE_MILESTONES = [7, 14, 30, 60, 100];
 
-function BadgeCard({ days, achieved }: { days: number; achieved: boolean }) {
+// #1055 UX3-25: 未獲得の条件がホバー依存にならないよう、タップで常に見えるモーダルにする
+function getBadgeCondition(days: number): string {
+  return `${days}日連続で記録を続けると獲得できます`;
+}
+
+function BadgeCard({ days, achieved, onSelect }: { days: number; achieved: boolean; onSelect: () => void }) {
   return (
-    <motion.div
+    <motion.button
+      type="button"
+      whileTap={{ scale: 0.95 }}
+      onClick={onSelect}
       className="p-3 rounded-xl flex flex-col items-center gap-1"
       style={{
         backgroundColor: achieved ? colors.accentLight : colors.bg,
@@ -59,7 +67,7 @@ function BadgeCard({ days, achieved }: { days: number; achieved: boolean }) {
       ) : (
         <p className="text-xs" style={{ color: colors.textMuted }}>未達成</p>
       )}
-    </motion.div>
+    </motion.button>
   );
 }
 
@@ -70,6 +78,8 @@ export default function StreaksPage() {
   const [weeklyRecords, setWeeklyRecords] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // #1055 UX3-25: タップでバッジ詳細 (アイコン+名前+条件) を確認できるようにする
+  const [selectedBadgeDays, setSelectedBadgeDays] = useState<number | null>(null);
 
   const fetchStreak = useCallback(async () => {
     setLoading(true);
@@ -225,6 +235,7 @@ export default function StreaksPage() {
               key={days}
               days={days}
               achieved={(streak?.achieved_badges ?? []).includes(`${days}_days`)}
+              onSelect={() => setSelectedBadgeDays(days)}
             />
           ))}
         </div>
@@ -251,6 +262,65 @@ export default function StreaksPage() {
           </motion.div>
         </Link>
       </div>
+
+      {/* #1055 UX3-25: バッジ詳細モーダル (アイコン+名前+条件をタップで確認できるようにする) */}
+      <AnimatePresence>
+        {selectedBadgeDays !== null && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/50 z-[70] flex items-center justify-center px-4"
+            onClick={() => setSelectedBadgeDays(null)}
+          >
+            {(() => {
+              const achieved = (streak?.achieved_badges ?? []).includes(`${selectedBadgeDays}_days`);
+              return (
+                <motion.div
+                  initial={{ scale: 0.9, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  exit={{ scale: 0.9, opacity: 0 }}
+                  className="relative bg-white rounded-2xl p-6 w-full max-w-sm shadow-xl text-center"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button
+                    onClick={() => setSelectedBadgeDays(null)}
+                    className="absolute top-4 right-4"
+                  >
+                    <X size={20} style={{ color: colors.textMuted }} />
+                  </button>
+                  <div
+                    className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-3"
+                    style={{ backgroundColor: achieved ? colors.accentLight : colors.bg, border: `2px solid ${achieved ? colors.accent : colors.border}` }}
+                  >
+                    <Award size={32} style={{ color: achieved ? colors.accent : colors.textMuted }} />
+                  </div>
+                  <h3 className="font-bold text-lg mb-1" style={{ color: colors.text }}>
+                    {selectedBadgeDays}日連続記録バッジ
+                  </h3>
+                  <p className="text-sm mb-4" style={{ color: colors.textMuted }}>
+                    {getBadgeCondition(selectedBadgeDays)}
+                  </p>
+                  {achieved ? (
+                    <div className="flex items-center justify-center gap-2 py-2 px-4 rounded-xl" style={{ backgroundColor: colors.successLight }}>
+                      <CheckCircle2 size={18} style={{ color: colors.success }} />
+                      <span className="text-sm font-medium" style={{ color: colors.success }}>達成しました！</span>
+                    </div>
+                  ) : (
+                    <div className="py-2 px-4 rounded-xl" style={{ backgroundColor: colors.bg }}>
+                      <span className="text-sm font-medium" style={{ color: colors.textLight }}>
+                        {streak && streak.current_streak > 0
+                          ? `現在 ${streak.current_streak}日目 (あと${Math.max(0, selectedBadgeDays - streak.current_streak)}日)`
+                          : '未達成'}
+                      </span>
+                    </div>
+                  )}
+                </motion.div>
+              );
+            })()}
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/app/api/badges/route.ts
+++ b/src/app/api/badges/route.ts
@@ -124,9 +124,16 @@ export async function GET(request: Request) {
                   (newEarnedBadges.includes(badge.id) ? new Date().toISOString() : null)
     }));
 
-    return NextResponse.json({ 
-      badges, 
+    // #1055 (wave-3b): 新規獲得バッジの匿名性を解消するため、
+    // 件数だけでなくどのバッジを獲得したか (code) をレスポンスに含める
+    const newEarnedBadgeCodes = allBadges
+      .filter(badge => newEarnedBadges.includes(badge.id))
+      .map(badge => badge.code);
+
+    return NextResponse.json({
+      badges,
       newEarnedCount: newEarnedBadges.length,
+      newEarnedBadgeCodes,
       stats: {
         completedMeals: mealCount,
         cookMeals: cookCount || 0,

--- a/src/components/nutrition/nutrition-target-planner.tsx
+++ b/src/components/nutrition/nutrition-target-planner.tsx
@@ -5,6 +5,9 @@ import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { deriveMacroTargets, estimateGoalProjection, type MacroRatios } from "@/lib/nutrition-target-planner";
+import {
+  MAX_MANUAL_CALORIES, MIN_MANUAL_CALORIES, getBmrWarning, getManualCalorieError,
+} from "@/lib/nutrition-target-validation";
 import type { CalculationBasis } from "@homegohan/core";
 
 type PlannerMode = "default" | "onboarding";
@@ -147,6 +150,17 @@ export function NutritionTargetPlanner({ mode = "default" }: { mode?: PlannerMod
     ? targets?.dailyCalories ?? 0
     : manualCaloriesNumber;
 
+  // #1055 UX3-19: 手動カロリー調整に範囲検証が無く 500kcal 等でも保存できてしまっていたための対応
+  const manualCalorieError = useMemo(() => {
+    if (autoCalculate) return null;
+    return getManualCalorieError(manualCalories, manualCaloriesNumber);
+  }, [autoCalculate, manualCalories, manualCaloriesNumber]);
+
+  const bmrWarning = useMemo(() => {
+    if (autoCalculate || manualCalorieError) return null;
+    return getBmrWarning(manualCaloriesNumber, targets?.calculationBasis?.energy?.bmr?.result_kcal);
+  }, [autoCalculate, manualCalorieError, manualCaloriesNumber, targets?.calculationBasis?.energy?.bmr?.result_kcal]);
+
   const previewMacros = useMemo(() => {
     if (!targets) return null;
     return deriveMacroTargets({
@@ -169,6 +183,8 @@ export function NutritionTargetPlanner({ mode = "default" }: { mode?: PlannerMod
 
   const handleSave = async () => {
     if (!targets || !previewMacros) return;
+    // #1055 UX3-19: 手動カロリー調整の範囲外保存を拒否する
+    if (manualCalorieError) return;
 
     setSaving(true);
     setSavedMessage(null);
@@ -382,13 +398,20 @@ export function NutritionTargetPlanner({ mode = "default" }: { mode?: PlannerMod
               <span className="text-sm font-medium text-gray-700">目標カロリー (kcal)</span>
               <Input
                 type="number"
-                min="1000"
-                max="5000"
+                min={MIN_MANUAL_CALORIES}
+                max={MAX_MANUAL_CALORIES}
                 step="1"
                 value={autoCalculate ? String(targets.dailyCalories) : manualCalories}
                 onChange={(event) => setManualCalories(event.target.value)}
                 disabled={autoCalculate}
               />
+              {/* #1055 UX3-19: HTML min/max だけでは保存を防げていなかったため、明示的なエラー・警告を表示する */}
+              {!autoCalculate && manualCalorieError && (
+                <p className="text-xs font-medium text-red-600">{manualCalorieError}</p>
+              )}
+              {!autoCalculate && !manualCalorieError && bmrWarning && (
+                <p className="text-xs font-medium text-amber-600">{bmrWarning}</p>
+              )}
             </label>
           </div>
 
@@ -414,7 +437,7 @@ export function NutritionTargetPlanner({ mode = "default" }: { mode?: PlannerMod
           </div>
 
           <div className="mt-5 flex flex-wrap items-center gap-3">
-            <Button onClick={() => void handleSave()} disabled={saving}>
+            <Button onClick={() => void handleSave()} disabled={saving || !!manualCalorieError}>
               {saving ? "保存中..." : autoCalculate ? "自動計算に戻す" : "この設定を保存する"}
             </Button>
             <p className="text-xs text-gray-500">

--- a/src/lib/health-blood-test-reference.ts
+++ b/src/lib/health-blood-test-reference.ts
@@ -49,7 +49,12 @@ function normalizeSex(sex: BiologicalSex): 'male' | 'female' | null {
   return null;
 }
 
-/** 性別が未設定の場合は男女どちらでも異常を見逃さないよう、範囲を合成 (低いlow, 高いhigh) して返す。 */
+/**
+ * 性別が未設定の場合は、男女どちらの基準で見ても正常範囲内という値まで
+ * 誤って異常扱い(誤警報)しないよう、範囲を合成 (低い方のlow, 高い方のhigh) して返す。
+ * ＝ 性別不明時は「どちらの性別であっても確定的に異常と言える場合」のみ high/low とフラグする設計。
+ * (代わりに、実際の性別なら異常と判定されたはずの値を見逃す可能性はある)
+ */
 function combinedRange(def: MetricDef): SexRange {
   const low =
     def.male.low != null && def.female.low != null

--- a/src/lib/health-blood-test-reference.ts
+++ b/src/lib/health-blood-test-reference.ts
@@ -1,0 +1,99 @@
+/**
+ * 血液検査・健診値の基準値 (性別依存) の単一ソース。
+ *
+ * 従来は checkups/[id] (CheckupDetailClient) と blood-tests/page.tsx で
+ * それぞれ別の基準値表・別の見せ方 (前者はハイライトのみ・後者は範囲テキストのみで
+ * 判定なし) を持っており、かつ性別非依存 (実質女性寄り) の固定値だった。
+ * (#1055 UX3-24)
+ *
+ * NOTE: ここでの数値は一般的な人間ドック学会の基準範囲を参考にした目安であり、
+ * 医学的診断を目的としたものではない。個人差・持病により正常範囲は異なる。
+ */
+
+export type BiologicalSex = 'male' | 'female' | string | null | undefined;
+
+interface SexRange {
+  low?: number;
+  high?: number;
+}
+
+interface MetricDef {
+  label: string;
+  unit: string;
+  male: SexRange;
+  female: SexRange;
+}
+
+export const BLOOD_METRIC_DEFS: Record<string, MetricDef> = {
+  blood_pressure_systolic: { label: '収縮期血圧', unit: 'mmHg', male: { high: 130 }, female: { high: 130 } },
+  blood_pressure_diastolic: { label: '拡張期血圧', unit: 'mmHg', male: { high: 85 }, female: { high: 85 } },
+  hemoglobin: { label: 'ヘモグロビン', unit: 'g/dL', male: { low: 13.5, high: 17.6 }, female: { low: 11.3, high: 15.2 } },
+  hba1c: { label: 'HbA1c', unit: '%', male: { high: 5.6 }, female: { high: 5.6 } },
+  fasting_glucose: { label: '空腹時血糖', unit: 'mg/dL', male: { high: 100 }, female: { high: 100 } },
+  total_cholesterol: { label: '総コレステロール', unit: 'mg/dL', male: { high: 220 }, female: { high: 220 } },
+  ldl_cholesterol: { label: 'LDLコレステロール', unit: 'mg/dL', male: { high: 140 }, female: { high: 140 } },
+  hdl_cholesterol: { label: 'HDLコレステロール', unit: 'mg/dL', male: { low: 40 }, female: { low: 40 } },
+  triglycerides: { label: '中性脂肪', unit: 'mg/dL', male: { high: 150 }, female: { high: 150 } },
+  ast: { label: 'AST(GOT)', unit: 'U/L', male: { low: 13, high: 30 }, female: { low: 9, high: 25 } },
+  alt: { label: 'ALT(GPT)', unit: 'U/L', male: { low: 10, high: 42 }, female: { low: 7, high: 23 } },
+  gamma_gtp: { label: 'γ-GTP', unit: 'U/L', male: { low: 13, high: 64 }, female: { low: 9, high: 32 } },
+  creatinine: { label: 'クレアチニン', unit: 'mg/dL', male: { low: 0.65, high: 1.07 }, female: { low: 0.46, high: 0.79 } },
+  egfr: { label: 'eGFR', unit: 'mL/min/1.73m²', male: { low: 60 }, female: { low: 60 } },
+  uric_acid: { label: '尿酸', unit: 'mg/dL', male: { low: 3.7, high: 7.8 }, female: { low: 2.6, high: 5.5 } },
+};
+
+export type MetricKey = keyof typeof BLOOD_METRIC_DEFS;
+
+function normalizeSex(sex: BiologicalSex): 'male' | 'female' | null {
+  if (sex === 'male' || sex === 'female') return sex;
+  return null;
+}
+
+/** 性別が未設定の場合は男女どちらでも異常を見逃さないよう、範囲を合成 (低いlow, 高いhigh) して返す。 */
+function combinedRange(def: MetricDef): SexRange {
+  const low =
+    def.male.low != null && def.female.low != null
+      ? Math.min(def.male.low, def.female.low)
+      : def.male.low ?? def.female.low;
+  const high =
+    def.male.high != null && def.female.high != null
+      ? Math.max(def.male.high, def.female.high)
+      : def.male.high ?? def.female.high;
+  return { low, high };
+}
+
+export function getRangeForSex(key: string, sex?: BiologicalSex): SexRange | null {
+  const def = BLOOD_METRIC_DEFS[key];
+  if (!def) return null;
+  const normalized = normalizeSex(sex);
+  if (normalized === 'male') return def.male;
+  if (normalized === 'female') return def.female;
+  return combinedRange(def);
+}
+
+export function formatRangeText(range: SexRange | null): string {
+  if (!range) return '-';
+  if (range.low != null && range.high != null) return `${range.low}〜${range.high}`;
+  if (range.high != null) return `${range.high}以下`;
+  if (range.low != null) return `${range.low}以上`;
+  return '-';
+}
+
+export type MetricStatus = 'normal' | 'low' | 'high' | 'unknown';
+
+export function evaluateStatus(key: string, value: number | null | undefined, sex?: BiologicalSex): MetricStatus {
+  if (value == null) return 'unknown';
+  const range = getRangeForSex(key, sex);
+  if (!range) return 'unknown';
+  if (range.high != null && value > range.high) return 'high';
+  if (range.low != null && value < range.low) return 'low';
+  return 'normal';
+}
+
+export function getMetricLabel(key: string): string | null {
+  return BLOOD_METRIC_DEFS[key]?.label ?? null;
+}
+
+export function getMetricUnit(key: string): string | null {
+  return BLOOD_METRIC_DEFS[key]?.unit ?? null;
+}

--- a/src/lib/health-goal-types.ts
+++ b/src/lib/health-goal-types.ts
@@ -1,0 +1,31 @@
+/**
+ * 健康目標 (health_goals.goal_type) の表示名・単位の単一ソース。
+ *
+ * goals/page.tsx と health/page.tsx (ダッシュボード) の両方が参照することで、
+ * goal_type の英語生値 (例: "steps") がそのまま画面に漏れることを防ぐ。
+ * (#1055 UX3-15)
+ */
+export interface GoalTypeDef {
+  type: string;
+  label: string;
+  unit: string;
+}
+
+export const GOAL_TYPE_DEFS: GoalTypeDef[] = [
+  { type: 'weight', label: '体重', unit: 'kg' },
+  { type: 'body_fat', label: '体脂肪率', unit: '%' },
+  { type: 'steps', label: '1日の歩数', unit: '歩' },
+];
+
+const GOAL_TYPE_MAP: Record<string, GoalTypeDef> = Object.fromEntries(
+  GOAL_TYPE_DEFS.map((def) => [def.type, def]),
+);
+
+/** goal_type から表示ラベルを取得。未知の type は goal_type をそのまま返さず、汎用ラベルにフォールバックする。 */
+export function getGoalTypeLabel(goalType: string): string {
+  return GOAL_TYPE_MAP[goalType]?.label ?? 'その他の目標';
+}
+
+export function getGoalTypeDef(goalType: string): GoalTypeDef {
+  return GOAL_TYPE_MAP[goalType] ?? GOAL_TYPE_DEFS[0];
+}

--- a/src/lib/nutrition-target-validation.ts
+++ b/src/lib/nutrition-target-validation.ts
@@ -1,0 +1,29 @@
+/**
+ * 手動カロリー調整の範囲検証 (#1055 UX3-19)
+ *
+ * nutrition-target-planner.tsx:383 付近で、HTML の min/max 属性だけでは
+ * 500kcal のような極端な値の保存を防げていなかったための対応。
+ * ロジックをコンポーネントから切り出し、単体テスト可能にする。
+ */
+
+export const MIN_MANUAL_CALORIES = 1000;
+export const MAX_MANUAL_CALORIES = 5000;
+
+export function getManualCalorieError(
+  rawValue: string,
+  numericValue: number,
+): string | null {
+  if (!rawValue) return '目標カロリーを入力してください。';
+  if (numericValue < MIN_MANUAL_CALORIES || numericValue > MAX_MANUAL_CALORIES) {
+    return `目標カロリーは ${MIN_MANUAL_CALORIES}〜${MAX_MANUAL_CALORIES}kcal の範囲で入力してください。`;
+  }
+  return null;
+}
+
+export function getBmrWarning(numericValue: number, bmrKcal: number | null | undefined): string | null {
+  if (bmrKcal == null) return null;
+  if (numericValue < bmrKcal) {
+    return `基礎代謝 (BMR: ${bmrKcal}kcal) を下回っています。長期間続けると体調を崩す可能性があります。`;
+  }
+  return null;
+}

--- a/tests/badges-route.test.ts
+++ b/tests/badges-route.test.ts
@@ -1,0 +1,146 @@
+/**
+ * tests/badges-route.test.ts
+ *
+ * #1055 (wave-3b): /api/badges の GET が、新規獲得バッジの code 一覧
+ * (newEarnedBadgeCodes) を返すことを検証する。
+ * バッジページの「新しいバッジを獲得！」オーバーレイがどのバッジか示せない
+ * 匿名性の問題を修正するための契約テスト。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+const { GET } = await import('@/app/api/badges/route');
+
+const user = { id: 'user-1' };
+
+interface SetupOptions {
+  allBadges: Array<{ id: string; code: string; name: string; description: string }>;
+  userBadges: Array<{ badge_id: string; obtained_at: string }>;
+  completedMealCount: number;
+  cookCount: number;
+  completedDays: Array<{ day_date: string }>;
+}
+
+function setupSupabaseMocks(opts: SetupOptions) {
+  let plannedMealsCallCount = 0;
+  const insertMock = vi.fn().mockResolvedValue({ data: null, error: null });
+
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'badges') {
+      return {
+        select: () => Promise.resolve({ data: opts.allBadges }),
+      };
+    }
+
+    if (table === 'user_badges') {
+      return {
+        select: () => ({
+          eq: () => Promise.resolve({ data: opts.userBadges }),
+        }),
+        insert: insertMock,
+      };
+    }
+
+    if (table === 'planned_meals') {
+      plannedMealsCallCount += 1;
+      const isFirstCall = plannedMealsCallCount === 1; // 完了食事数（.eq().eq() で確定）
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () =>
+              isFirstCall
+                ? Promise.resolve({ count: opts.completedMealCount })
+                : {
+                    in: () => Promise.resolve({ count: opts.cookCount }),
+                  },
+          }),
+        }),
+      };
+    }
+
+    if (table === 'user_daily_meals') {
+      return {
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              order: () => ({
+                limit: () => Promise.resolve({ data: opts.completedDays }),
+              }),
+            }),
+          }),
+        }),
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  });
+
+  return { insertMock };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /api/badges', () => {
+  it('未認証なら 401 を返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') });
+
+    const res = await GET(new Request('http://localhost/api/badges'));
+    expect(res.status).toBe(401);
+  });
+
+  it('新規に条件を満たしたバッジがある場合、newEarnedBadgeCodes にその code を含める', async () => {
+    mockGetUser.mockResolvedValue({ data: { user }, error: null });
+
+    setupSupabaseMocks({
+      allBadges: [
+        { id: 'b-first-bite', code: 'first_bite', name: '最初の一口', description: '1回記録する' },
+        { id: 'b-streak-7', code: 'streak_7', name: '7日連続', description: '7日連続で記録する' },
+      ],
+      userBadges: [], // まだ何も獲得していない
+      completedMealCount: 1, // first_bite の条件を満たす
+      cookCount: 0,
+      completedDays: [], // streak_7 の条件は満たさない
+    });
+
+    const res = await GET(new Request('http://localhost/api/badges'));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.newEarnedCount).toBe(1);
+    expect(json.newEarnedBadgeCodes).toEqual(['first_bite']);
+    // streak_7 は条件未達のため含まれない
+    expect(json.newEarnedBadgeCodes).not.toContain('streak_7');
+  });
+
+  it('新規獲得バッジが無い場合、newEarnedBadgeCodes は空配列', async () => {
+    mockGetUser.mockResolvedValue({ data: { user }, error: null });
+
+    setupSupabaseMocks({
+      allBadges: [
+        { id: 'b-first-bite', code: 'first_bite', name: '最初の一口', description: '1回記録する' },
+      ],
+      userBadges: [{ badge_id: 'b-first-bite', obtained_at: '2026-01-01T00:00:00.000Z' }], // 既に獲得済み
+      completedMealCount: 5,
+      cookCount: 0,
+      completedDays: [],
+    });
+
+    const res = await GET(new Request('http://localhost/api/badges'));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.newEarnedCount).toBe(0);
+    expect(json.newEarnedBadgeCodes).toEqual([]);
+  });
+});

--- a/tests/e2e/.exploration/checkup-graphs-explore.spec.ts
+++ b/tests/e2e/.exploration/checkup-graphs-explore.spec.ts
@@ -350,7 +350,9 @@ test.describe("5-7. /health/graphs — 4 タブ + Bug-17 回帰", () => {
 
       if (hasEmpty) {
         // 統計カード「最大」に "100.0" が表示されてはいけない
-        const maxLabel = page.getByText("最大", { exact: true }).first();
+        // #1055 (wave-3b): 血圧タブは系列混在を避けるため「最大（収縮期）」等の
+        // ラベルになるため、前方一致で取得する（exact ではなくなる）
+        const maxLabel = page.getByText(/^最大/).first();
         const maxCard = maxLabel.locator("..");
         const cardText = (await maxCard.innerText()).trim();
         expect(cardText, `[Bug-17 回帰] タブ「${tabLabel}」: 最大値に 100.0 が表示されている`).not.toMatch(/100\.0/);
@@ -358,7 +360,7 @@ test.describe("5-7. /health/graphs — 4 タブ + Bug-17 回帰", () => {
         console.log(`✓ [${tabLabel}] データなし: 最大 = ${cardText}`);
       } else {
         // データあり: 統計値が数値であること
-        const maxLabel = page.getByText("最大", { exact: true }).first();
+        const maxLabel = page.getByText(/^最大/).first();
         const maxCard = maxLabel.locator("..");
         const cardText = (await maxCard.innerText()).trim();
         console.log(`✓ [${tabLabel}] データあり: 最大 = ${cardText}`);

--- a/tests/e2e/bug-17-graph-empty-state.spec.ts
+++ b/tests/e2e/bug-17-graph-empty-state.spec.ts
@@ -34,7 +34,9 @@ test.describe("health graphs empty state", () => {
       if (hasEmptyMessage) {
         // データなし: 「最大 100.0」が表示されてはいけない
         // 統計カードは「最大」ラベルの直後に値テキストが入っている
-        const maxLabel = tourPendingUser.getByText("最大", { exact: true }).first();
+        // #1055 (wave-3b): 血圧タブは系列混在を避けるため「最大（収縮期）」等の
+        // ラベルになるため、前方一致で取得する（exact ではなくなる）
+        const maxLabel = tourPendingUser.getByText(/^最大/).first();
         await expect(maxLabel).toBeVisible();
 
         // 親カード内の値テキストを取得

--- a/tests/health-blood-test-reference.test.ts
+++ b/tests/health-blood-test-reference.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BLOOD_METRIC_DEFS,
+  evaluateStatus,
+  formatRangeText,
+  getRangeForSex,
+} from '../src/lib/health-blood-test-reference';
+
+// #1055 UX3-24: checkups詳細画面とblood-tests一覧画面が共通で参照する基準値モジュールの契約テスト。
+// 従来は性別非依存 (実質女性寄り) の固定値だったため、性別で分岐することを保証する。
+describe('health-blood-test-reference', () => {
+  it('uses different hemoglobin ranges for male and female', () => {
+    const male = getRangeForSex('hemoglobin', 'male');
+    const female = getRangeForSex('hemoglobin', 'female');
+    expect(male).not.toEqual(female);
+    expect(male?.low).toBeGreaterThan(female?.low ?? 0);
+  });
+
+  it('flags a male-normal hemoglobin value as low when evaluated against the female range but normal for male', () => {
+    // 12.5 g/dL: 女性の正常範囲内だが、男性の下限 (13.5) を下回る
+    expect(evaluateStatus('hemoglobin', 12.5, 'male')).toBe('low');
+    expect(evaluateStatus('hemoglobin', 12.5, 'female')).toBe('normal');
+  });
+
+  it('falls back to a combined (widened) range when sex is unknown, avoiding false negatives', () => {
+    const combined = getRangeForSex('hemoglobin', null);
+    const male = getRangeForSex('hemoglobin', 'male');
+    const female = getRangeForSex('hemoglobin', 'female');
+    expect(combined?.low).toBe(Math.min(male!.low!, female!.low!));
+    expect(combined?.high).toBe(Math.max(male!.high!, female!.high!));
+  });
+
+  it('evaluates high/low/normal/unknown correctly', () => {
+    expect(evaluateStatus('ldl_cholesterol', 200, 'male')).toBe('high');
+    expect(evaluateStatus('hdl_cholesterol', 20, 'female')).toBe('low');
+    expect(evaluateStatus('egfr', 90, 'male')).toBe('normal');
+    expect(evaluateStatus('egfr', undefined, 'male')).toBe('unknown');
+    expect(evaluateStatus('not_a_real_metric', 100, 'male')).toBe('unknown');
+  });
+
+  it('formats range text for both single-bound and double-bound ranges', () => {
+    expect(formatRangeText({ low: 40 })).toBe('40以上');
+    expect(formatRangeText({ high: 130 })).toBe('130以下');
+    expect(formatRangeText({ low: 13.5, high: 17.6 })).toBe('13.5〜17.6');
+    expect(formatRangeText(null)).toBe('-');
+  });
+
+  it('every metric def has a label and unit usable in both consuming screens', () => {
+    for (const key of Object.keys(BLOOD_METRIC_DEFS)) {
+      const def = BLOOD_METRIC_DEFS[key];
+      expect(def.label.length).toBeGreaterThan(0);
+      expect(typeof def.unit).toBe('string');
+    }
+  });
+});

--- a/tests/health-blood-test-reference.test.ts
+++ b/tests/health-blood-test-reference.test.ts
@@ -22,12 +22,21 @@ describe('health-blood-test-reference', () => {
     expect(evaluateStatus('hemoglobin', 12.5, 'female')).toBe('normal');
   });
 
-  it('falls back to a combined (widened) range when sex is unknown, avoiding false negatives', () => {
+  it('falls back to a combined (widened) range when sex is unknown, flagging only values that are definitively abnormal for either sex (avoiding false positives)', () => {
     const combined = getRangeForSex('hemoglobin', null);
     const male = getRangeForSex('hemoglobin', 'male');
     const female = getRangeForSex('hemoglobin', 'female');
     expect(combined?.low).toBe(Math.min(male!.low!, female!.low!));
     expect(combined?.high).toBe(Math.max(male!.high!, female!.high!));
+  });
+
+  // #1055 (wave-3b): combinedRange のコメント/テスト名が「見逃さない」設計だと誤って
+  // 逆方向に説明していたのを修正。実際の挙動 = 性別不明時は widened range により、
+  // 「片方の性別なら異常」という値でも誤って異常フラグを立てない (false positive 回避)。
+  // その代わり、実際の性別を知っていれば異常と判定できたはずの値を見逃す (false negative) 余地はある。
+  it('does not flag a value that is normal for one sex but low for the other when sex is unknown (avoids a false alarm)', () => {
+    // 12.5 g/dL は男性なら low、女性なら normal。性別不明時は誤警報を避け normal 扱いにする。
+    expect(evaluateStatus('hemoglobin', 12.5, null)).toBe('normal');
   });
 
   it('evaluates high/low/normal/unknown correctly', () => {

--- a/tests/health-goal-types.test.ts
+++ b/tests/health-goal-types.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { GOAL_TYPE_DEFS, getGoalTypeDef, getGoalTypeLabel } from '../src/lib/health-goal-types';
+
+// #1055 UX3-15: goals/page.tsx と health/page.tsx (ダッシュボード) が共通で参照する
+// 表示名マッピングの契約テスト。goal_type の英語生値がそのまま画面に漏れないことを保証する。
+describe('health-goal-types', () => {
+  it('returns Japanese labels for all known goal types', () => {
+    expect(getGoalTypeLabel('weight')).toBe('体重');
+    expect(getGoalTypeLabel('body_fat')).toBe('体脂肪率');
+    expect(getGoalTypeLabel('steps')).toBe('1日の歩数');
+  });
+
+  it('never falls back to the raw goal_type value for unknown types', () => {
+    const label = getGoalTypeLabel('some_future_goal_type');
+    expect(label).not.toBe('some_future_goal_type');
+    expect(label).toBe('その他の目標');
+  });
+
+  it('getGoalTypeDef falls back to the first def for unknown types', () => {
+    const def = getGoalTypeDef('unknown');
+    expect(def).toEqual(GOAL_TYPE_DEFS[0]);
+  });
+
+  it('every def has a non-empty label and unit', () => {
+    for (const def of GOAL_TYPE_DEFS) {
+      expect(def.label.length).toBeGreaterThan(0);
+      expect(def.unit.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/nutrition-target-validation.test.ts
+++ b/tests/nutrition-target-validation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_MANUAL_CALORIES,
+  MIN_MANUAL_CALORIES,
+  getBmrWarning,
+  getManualCalorieError,
+} from '../src/lib/nutrition-target-validation';
+
+// #1055 UX3-19: nutrition-target-planner.tsx の手動カロリー調整が範囲検証なしで
+// 保存できてしまっていた (500kcal 等) バグの契約テスト。
+describe('nutrition-target-validation', () => {
+  it('rejects empty input', () => {
+    expect(getManualCalorieError('', 0)).toBeTruthy();
+  });
+
+  it('rejects values below the minimum (e.g. 500kcal from the bug report)', () => {
+    expect(getManualCalorieError('500', 500)).toBeTruthy();
+  });
+
+  it('rejects values above the maximum', () => {
+    expect(getManualCalorieError('6000', 6000)).toBeTruthy();
+  });
+
+  it('accepts values within the allowed range', () => {
+    expect(getManualCalorieError('1800', 1800)).toBeNull();
+    expect(getManualCalorieError(String(MIN_MANUAL_CALORIES), MIN_MANUAL_CALORIES)).toBeNull();
+    expect(getManualCalorieError(String(MAX_MANUAL_CALORIES), MAX_MANUAL_CALORIES)).toBeNull();
+  });
+
+  it('warns (non-blocking) when the value is below BMR', () => {
+    expect(getBmrWarning(1200, 1500)).toBeTruthy();
+  });
+
+  it('does not warn when the value is at or above BMR', () => {
+    expect(getBmrWarning(1500, 1500)).toBeNull();
+    expect(getBmrWarning(1800, 1500)).toBeNull();
+  });
+
+  it('does not warn when BMR is unknown', () => {
+    expect(getBmrWarning(1200, null)).toBeNull();
+    expect(getBmrWarning(1200, undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要
健康・設定ページの中〜低優先 UX 不具合を修正(#1055)。ページ/コンポーネントのみ(`api/health/**` は #1048=PR #1078 管轄のため不変更)。

## 修正内容
- health の goals/challenges/graphs/checkups/settings ページ、nutrition-target-planner、checkup/blood-test 基準値、badges 表示の UX 不具合(Issue 記載分)。
- **バッジお祝いの匿名性解消**: 「新しいバッジを獲得!」だけだった演出に、獲得バッジのアイコン/名前を表示し該当カードをハイライト。
- **OCR 偽成功表示の解消**: 抽出 0 項目なのに「0項目を自動入力しました」と緑バナーを出していた問題を、warning 扱い(「読み取れる項目がありませんでした」)に。
- **血圧統計の系列混在**: 最大(収縮期)/最小(拡張期)/平均(収縮期)のラベルを付与。
- 血液検査の性別未設定時基準(combinedRange)のコメント/テスト名を実装の意図(誤警報回避)に一致させ、UI に「性別未設定のため一般基準」注記。

## スコープ外(理由付き)
- チャレンジ中断導線: 対応 API が存在せず(API 側は別 Issue 管轄)、報告のみ。
- `settings/membership`(#1051/#1037 管轄)、`health/record/quick`(#1035 管轄)、体系的 a11y(#1052 管轄)。

## 検証
- 追加/更新テスト全 PASS。tsc/eslint クリーン。
- 2モデル敵対レビュー(Sonnet5+Fable)**double-PASS ×2回**(本修正+Warning 解消 delta。Issue 名指しのバッジお祝い演出の未修正を round で検出→解消済み)。
