### PR TITLE
fix(menu-generation): 破壊的献立操作のデータ消失を snapshot+rollback で防止 (#1042)

### DIFF
--- a/src/__tests__/api/ai/menu/day-regenerate.test.ts
+++ b/src/__tests__/api/ai/menu/day-regenerate.test.ts
@@ -1,0 +1,200 @@
+/**
+ * src/__tests__/api/ai/menu/day-regenerate.test.ts
+ *
+ * #1042 (F1a-14): day/regenerate が完食済み(is_completed)の食事も上書きし
+ * 摂取実績・ストリークが遡って壊れる問題の修正確認。
+ *
+ * - 完食済みの食事は targetSlots から除外され、上書きされないこと
+ * - 明示的に includeCompleted:true を指定した場合のみ上書き対象に含まれること
+ * - 全食事が完食済みの場合は Edge Function を呼ばずスキップを返すこと
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetUser = vi.fn();
+const mockUserDailyMealsSingle = vi.fn();
+const mockPlannedMealsEq = vi.fn();
+const mockWeeklyInsertSingle = vi.fn();
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'user_daily_meals') {
+    return {
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            single: mockUserDailyMealsSingle,
+          }),
+        }),
+      }),
+    };
+  }
+  if (table === 'planned_meals') {
+    return {
+      select: () => ({
+        eq: mockPlannedMealsEq,
+      }),
+    };
+  }
+  if (table === 'weekly_menu_requests') {
+    return {
+      insert: () => ({
+        select: () => ({
+          single: mockWeeklyInsertSingle,
+        }),
+      }),
+    };
+  }
+  throw new Error(`Unexpected table in test: ${table}`);
+});
+
+const mockSupabase = {
+  auth: { getUser: mockGetUser },
+  from: mockFrom,
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => mockSupabase),
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(async () => ({ success: true, limit: 10, remaining: 9, reset: Date.now() + 60_000 })),
+  rateLimitExceededResponse: vi.fn(),
+}));
+
+vi.mock('@/lib/menu-generation-feature-flags', () => ({
+  loadFeatureFlags: vi.fn(async () => ({ menu_generation_v5_wrapped: false })),
+}));
+
+const mockCallGenerateMenuV4WithRetry = vi.fn(async (..._args: any[]) => ({
+  ok: true,
+  attempts: 1,
+  response: new Response(),
+}));
+const mockMarkWeeklyMenuRequestFailed = vi.fn(async (..._args: any[]) => {});
+
+vi.mock('@/lib/generate-menu-v4-retry', () => ({
+  callGenerateMenuV4WithRetry: mockCallGenerateMenuV4WithRetry,
+  markWeeklyMenuRequestFailed: mockMarkWeeklyMenuRequestFailed,
+}));
+
+vi.mock('@/lib/generate-menu-v5-retry', () => ({
+  callGenerateMenuV5WithRetry: vi.fn(async () => ({ ok: true, attempts: 1, response: new Response() })),
+}));
+
+const waitUntilPromises: Promise<unknown>[] = [];
+vi.mock('@vercel/functions', () => ({
+  waitUntil: vi.fn((p: Promise<unknown>) => {
+    waitUntilPromises.push(p);
+  }),
+}));
+
+const { POST } = await import('@/app/api/ai/menu/day/regenerate/route');
+
+const user = { id: 'user-1' };
+const dailyMealId = 'day-1';
+const dayDate = '2026-07-10';
+
+const makeRequest = (body: Record<string, unknown>) =>
+  new Request('http://localhost/api/ai/menu/day/regenerate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+const flushBackground = async () => {
+  await Promise.all(waitUntilPromises);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  waitUntilPromises.length = 0;
+  mockGetUser.mockResolvedValue({ data: { user }, error: null });
+  mockUserDailyMealsSingle.mockResolvedValue({ data: { id: dailyMealId, day_date: dayDate }, error: null });
+  mockWeeklyInsertSingle.mockResolvedValue({ data: { id: 'request-1' }, error: null });
+});
+
+describe('POST /api/ai/menu/day/regenerate', () => {
+  it('未完食のみなら3スロット全てが再生成対象になる', async () => {
+    mockPlannedMealsEq.mockResolvedValue({
+      data: [
+        { id: 'meal-b', meal_type: 'breakfast', is_completed: false },
+        { id: 'meal-l', meal_type: 'lunch', is_completed: false },
+        { id: 'meal-d', meal_type: 'dinner', is_completed: false },
+      ],
+      error: null,
+    });
+
+    const res = await POST(makeRequest({ dailyMealId }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.mealsCount).toBe(3);
+    expect(mockCallGenerateMenuV4WithRetry).toHaveBeenCalledTimes(1);
+    const payload = mockCallGenerateMenuV4WithRetry.mock.calls[0][0].payload;
+    expect(payload.targetSlots.map((s: any) => s.mealType).sort()).toEqual(['breakfast', 'dinner', 'lunch']);
+    await flushBackground();
+  });
+
+  it('完食済みの朝食は除外され、上書き対象から外れる (includeCompleted未指定)', async () => {
+    mockPlannedMealsEq.mockResolvedValue({
+      data: [
+        { id: 'meal-b', meal_type: 'breakfast', is_completed: true },
+        { id: 'meal-l', meal_type: 'lunch', is_completed: false },
+        { id: 'meal-d', meal_type: 'dinner', is_completed: false },
+      ],
+      error: null,
+    });
+
+    const res = await POST(makeRequest({ dailyMealId }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.mealsCount).toBe(2);
+    const payload = mockCallGenerateMenuV4WithRetry.mock.calls[0][0].payload;
+    const mealTypes = payload.targetSlots.map((s: any) => s.mealType);
+    expect(mealTypes).not.toContain('breakfast');
+    expect(mealTypes.sort()).toEqual(['dinner', 'lunch']);
+    await flushBackground();
+  });
+
+  it('全食事が完食済みなら Edge Function を呼ばずスキップを返す', async () => {
+    mockPlannedMealsEq.mockResolvedValue({
+      data: [
+        { id: 'meal-b', meal_type: 'breakfast', is_completed: true },
+        { id: 'meal-l', meal_type: 'lunch', is_completed: true },
+        { id: 'meal-d', meal_type: 'dinner', is_completed: true },
+      ],
+      error: null,
+    });
+
+    const res = await POST(makeRequest({ dailyMealId }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.status).toBe('skipped');
+    expect(json.mealsCount).toBe(0);
+    expect(mockCallGenerateMenuV4WithRetry).not.toHaveBeenCalled();
+    // weekly_menu_requests への insert も発生しないこと（無駄なリクエスト行を作らない）
+    expect(mockWeeklyInsertSingle).not.toHaveBeenCalled();
+  });
+
+  it('includeCompleted:true を明示指定すれば完食済みも上書き対象に含まれる', async () => {
+    mockPlannedMealsEq.mockResolvedValue({
+      data: [
+        { id: 'meal-b', meal_type: 'breakfast', is_completed: true },
+        { id: 'meal-l', meal_type: 'lunch', is_completed: false },
+        { id: 'meal-d', meal_type: 'dinner', is_completed: false },
+      ],
+      error: null,
+    });
+
+    const res = await POST(makeRequest({ dailyMealId, includeCompleted: true }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.mealsCount).toBe(3);
+    const payload = mockCallGenerateMenuV4WithRetry.mock.calls[0][0].payload;
+    expect(payload.targetSlots.map((s: any) => s.mealType).sort()).toEqual(['breakfast', 'dinner', 'lunch']);
+    await flushBackground();
+  });
+});

--- a/src/__tests__/api/ai/menu/weekly-cleanup.test.ts
+++ b/src/__tests__/api/ai/menu/weekly-cleanup.test.ts
@@ -1,0 +1,120 @@
+/**
+ * src/__tests__/api/ai/menu/weekly-cleanup.test.ts
+ *
+ * #1042: stale sweeper (weekly/cleanup) が waitUntil 消失等で生成コールバックが
+ * 実行されず stuck になったリクエストを failed 化するだけで、削除済み献立の
+ * スナップショット (generated_data.snapshot) を復元しない問題の修正確認。
+ *
+ * - stuck リクエストが無い場合は復元を呼ばないこと
+ * - stuck リクエストのうち snapshot を持つものだけ復元し、結果を集計して response に含めること
+ * - failed への更新自体が失敗した場合は復元を呼ばず 500 を返すこと
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetUser = vi.fn();
+
+const fetchResultQueue: Array<{ data: any; error: any }> = [];
+const mockLt = vi.fn(() => Promise.resolve(fetchResultQueue.shift() ?? { data: [], error: null }));
+const mockSelectIn = vi.fn(() => ({ lt: mockLt }));
+const mockSelectEq = vi.fn(() => ({ in: mockSelectIn }));
+const mockSelect = vi.fn(() => ({ eq: mockSelectEq }));
+
+const updateResultQueue: Array<{ error: any }> = [];
+const mockUpdateIn = vi.fn(() => Promise.resolve(updateResultQueue.shift() ?? { error: null }));
+const mockUpdate = vi.fn(() => ({ in: mockUpdateIn }));
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'weekly_menu_requests') {
+    return { select: mockSelect, update: mockUpdate };
+  }
+  throw new Error(`Unexpected table in test: ${table}`);
+});
+
+const mockSupabase = {
+  auth: { getUser: mockGetUser },
+  from: mockFrom,
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => mockSupabase),
+}));
+
+const mockRestorePlannedMealsSnapshot = vi.fn(async (..._args: any[]) => ({ restored: 0, skipped: 0, failed: 0 }));
+vi.mock('@/lib/planned-meals-snapshot', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/planned-meals-snapshot')>();
+  return {
+    ...actual,
+    restorePlannedMealsSnapshot: mockRestorePlannedMealsSnapshot,
+  };
+});
+
+const { POST } = await import('@/app/api/ai/menu/weekly/cleanup/route');
+
+const user = { id: 'user-1' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchResultQueue.length = 0;
+  updateResultQueue.length = 0;
+  mockGetUser.mockResolvedValue({ data: { user }, error: null });
+});
+
+describe('POST /api/ai/menu/weekly/cleanup', () => {
+  it('stuck リクエストが無い場合は復元を呼ばず No stuck requests found を返す', async () => {
+    fetchResultQueue.push({ data: [], error: null });
+
+    const res = await POST();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.message).toBe('No stuck requests found');
+    expect(json.cleaned).toBe(0);
+    expect(mockRestorePlannedMealsSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('snapshot を持つ stuck リクエストのみ復元し、結果を集計して返す', async () => {
+    const snapshotRowA = { id: 'meal-a', daily_meal_id: 'day-a', meal_type: 'breakfast' };
+    fetchResultQueue.push({
+      data: [
+        { id: 'req-1', status: 'processing', created_at: '2026-07-06T00:00:00Z', generated_data: { snapshot: [snapshotRowA] } },
+        { id: 'req-2', status: 'pending', created_at: '2026-07-06T00:00:00Z', generated_data: null },
+      ],
+      error: null,
+    });
+    updateResultQueue.push({ error: null });
+    mockRestorePlannedMealsSnapshot.mockResolvedValueOnce({ restored: 1, skipped: 0, failed: 0 });
+
+    const res = await POST();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.cleaned).toBe(2);
+    expect(json.ids).toEqual(['req-1', 'req-2']);
+    expect(json.restoredMeals).toBe(1);
+    expect(json.skippedMeals).toBe(0);
+    expect(json.failedMeals).toBe(0);
+
+    // snapshot を持つ req-1 分のみ復元が呼ばれる
+    expect(mockRestorePlannedMealsSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockRestorePlannedMealsSnapshot).toHaveBeenCalledWith(mockSupabase, [snapshotRowA]);
+
+    // failed への一括更新が呼ばれていること
+    expect(mockUpdateIn).toHaveBeenCalledWith('id', ['req-1', 'req-2']);
+  });
+
+  it('failed への更新自体が失敗した場合は復元を呼ばず 500 を返す', async () => {
+    fetchResultQueue.push({
+      data: [{ id: 'req-1', status: 'processing', created_at: '2026-07-06T00:00:00Z', generated_data: { snapshot: [{ id: 'm', daily_meal_id: 'd', meal_type: 'lunch' }] } }],
+      error: null,
+    });
+    updateResultQueue.push({ error: { message: 'update failed' } });
+
+    const res = await POST();
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toBe('update failed');
+    expect(mockRestorePlannedMealsSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/api/ai/menu/weekly-pending.test.ts
+++ b/src/__tests__/api/ai/menu/weekly-pending.test.ts
@@ -1,0 +1,148 @@
+/**
+ * src/__tests__/api/ai/menu/weekly-pending.test.ts
+ *
+ * #1042: stale sweeper (weekly/pending) が waitUntil 消失等で生成コールバックが
+ * 実行されず stale になったリクエストを failed 化するだけで、削除済み献立の
+ * スナップショット (generated_data.snapshot) を復元しない問題の修正確認。
+ *
+ * - stale でない場合はそのまま hasPending を返し、復元は呼ばれないこと
+ * - stale かつ snapshot が残っている場合は復元を実行し、結果を response に含めること
+ * - stale だが snapshot がない場合は復元を呼ばず、response に restore を含めないこと
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetUser = vi.fn();
+
+const pendingResultQueue: Array<{ data: any; error: any }> = [];
+const mockSingle = vi.fn(() => Promise.resolve(pendingResultQueue.shift() ?? { data: null, error: null }));
+const mockLimit = vi.fn(() => ({ single: mockSingle }));
+const mockOrder = vi.fn(() => ({ limit: mockLimit }));
+const mockIn = vi.fn(() => ({ order: mockOrder }));
+const mockOr = vi.fn(() => ({ in: mockIn }));
+const mockEq = vi.fn(() => ({ or: mockOr }));
+const mockSelect = vi.fn(() => ({ eq: mockEq }));
+
+const updateEqQueue: Array<{ error: any }> = [];
+const mockUpdateEq2 = vi.fn(() => Promise.resolve(updateEqQueue.shift() ?? { error: null }));
+const mockUpdateEq1 = vi.fn(() => ({ eq: mockUpdateEq2 }));
+const mockUpdate = vi.fn(() => ({ eq: mockUpdateEq1 }));
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'weekly_menu_requests') {
+    return { select: mockSelect, update: mockUpdate };
+  }
+  throw new Error(`Unexpected table in test: ${table}`);
+});
+
+const mockSupabase = {
+  auth: { getUser: mockGetUser },
+  from: mockFrom,
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => mockSupabase),
+}));
+
+const mockRestorePlannedMealsSnapshot = vi.fn(async (..._args: any[]) => ({ restored: 0, skipped: 0, failed: 0 }));
+vi.mock('@/lib/planned-meals-snapshot', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/planned-meals-snapshot')>();
+  return {
+    ...actual,
+    restorePlannedMealsSnapshot: mockRestorePlannedMealsSnapshot,
+  };
+});
+
+const { GET } = await import('@/app/api/ai/menu/weekly/pending/route');
+
+const user = { id: 'user-1' };
+const date = '2026-07-06';
+
+const makeRequest = () => new Request(`http://localhost/api/ai/menu/weekly/pending?date=${date}`);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  pendingResultQueue.length = 0;
+  updateEqQueue.length = 0;
+  mockGetUser.mockResolvedValue({ data: { user }, error: null });
+});
+
+describe('GET /api/ai/menu/weekly/pending', () => {
+  it('stale でない processing リクエストは hasPending:true を返す(復元は呼ばない)', async () => {
+    pendingResultQueue.push({
+      data: {
+        id: 'req-1',
+        status: 'processing',
+        mode: 'v4',
+        start_date: date,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        generated_data: { snapshot: [] },
+      },
+      error: null,
+    });
+
+    const res = await GET(makeRequest());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.hasPending).toBe(true);
+    expect(mockRestorePlannedMealsSnapshot).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('stale なリクエストは failed 化し、snapshot があれば復元して response に反映する', async () => {
+    const snapshotRow = { id: 'meal-1', daily_meal_id: 'day-1', meal_type: 'breakfast' };
+    const staleDate = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    pendingResultQueue.push({
+      data: {
+        id: 'req-1',
+        status: 'processing',
+        mode: 'v4',
+        start_date: date,
+        created_at: staleDate,
+        updated_at: staleDate,
+        generated_data: { snapshot: [snapshotRow] },
+      },
+      error: null,
+    });
+    mockRestorePlannedMealsSnapshot.mockResolvedValueOnce({ restored: 1, skipped: 0, failed: 0 });
+
+    const res = await GET(makeRequest());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.hasPending).toBe(false);
+    expect(json.restore).toEqual({ restored: 1, skipped: 0, failed: 0 });
+
+    expect(mockRestorePlannedMealsSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockRestorePlannedMealsSnapshot).toHaveBeenCalledWith(mockSupabase, [snapshotRow]);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed', error_message: 'stale_request_timeout' }),
+    );
+  });
+
+  it('stale だが snapshot がない場合は復元を呼ばず response に restore を含めない', async () => {
+    const staleDate = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    pendingResultQueue.push({
+      data: {
+        id: 'req-1',
+        status: 'processing',
+        mode: 'v4',
+        start_date: date,
+        created_at: staleDate,
+        updated_at: staleDate,
+        generated_data: null,
+      },
+      error: null,
+    });
+
+    const res = await GET(makeRequest());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.hasPending).toBe(false);
+    expect(json.restore).toBeUndefined();
+    expect(mockRestorePlannedMealsSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/api/ai/menu/weekly-pending.test.ts
+++ b/src/__tests__/api/ai/menu/weekly-pending.test.ts
@@ -8,6 +8,11 @@
  * - stale でない場合はそのまま hasPending を返し、復元は呼ばれないこと
  * - stale かつ snapshot が残っている場合は復元を実行し、結果を response に含めること
  * - stale だが snapshot がない場合は復元を呼ばず、response に restore を含めないこと
+ *
+ * #1042 性能退行修正: 3秒間隔ポーリングの通常 select から生成中に肥大化する
+ * generated_data(jsonb) を外し、stale 判定成立時のみ二次クエリで取得することの確認。
+ * - 非 stale ポーリングでは generated_data を select しないこと
+ * - stale 判定成立時は generated_data のみを対象にした二次クエリを発行すること
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -20,8 +25,15 @@ const mockLimit = vi.fn(() => ({ single: mockSingle }));
 const mockOrder = vi.fn(() => ({ limit: mockLimit }));
 const mockIn = vi.fn(() => ({ order: mockOrder }));
 const mockOr = vi.fn(() => ({ in: mockIn }));
-const mockEq = vi.fn(() => ({ or: mockOr }));
-const mockSelect = vi.fn(() => ({ eq: mockEq }));
+
+// stale 判定成立時のみ発行される generated_data 専用の二次クエリ
+// (select('generated_data').eq('id', ...).eq('user_id', ...).maybeSingle())
+const snapshotResultQueue: Array<{ data: any; error: any }> = [];
+const mockMaybeSingle = vi.fn(() => Promise.resolve(snapshotResultQueue.shift() ?? { data: null, error: null }));
+const mockEq2 = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
+// 最初の .eq() は主問い合わせ( -> or)と二次クエリ( -> eq)の両方のチェーンをサポートする
+const mockEq = vi.fn(() => ({ or: mockOr, eq: mockEq2 }));
+const mockSelect = vi.fn((..._args: any[]) => ({ eq: mockEq }));
 
 const updateEqQueue: Array<{ error: any }> = [];
 const mockUpdateEq2 = vi.fn(() => Promise.resolve(updateEqQueue.shift() ?? { error: null }));
@@ -63,6 +75,7 @@ const makeRequest = () => new Request(`http://localhost/api/ai/menu/weekly/pendi
 beforeEach(() => {
   vi.clearAllMocks();
   pendingResultQueue.length = 0;
+  snapshotResultQueue.length = 0;
   updateEqQueue.length = 0;
   mockGetUser.mockResolvedValue({ data: { user }, error: null });
 });
@@ -77,7 +90,6 @@ describe('GET /api/ai/menu/weekly/pending', () => {
         start_date: date,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
-        generated_data: { snapshot: [] },
       },
       error: null,
     });
@@ -91,6 +103,27 @@ describe('GET /api/ai/menu/weekly/pending', () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
+  it('非 stale ポーリングでは generated_data を select しない(二次クエリも発行しない)', async () => {
+    pendingResultQueue.push({
+      data: {
+        id: 'req-1',
+        status: 'processing',
+        mode: 'v4',
+        start_date: date,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+      error: null,
+    });
+
+    await GET(makeRequest());
+
+    // 通常ポーリングでの select は1回のみで、generated_data を含まないこと
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    expect(mockSelect.mock.calls[0][0]).not.toContain('generated_data');
+    expect(mockMaybeSingle).not.toHaveBeenCalled();
+  });
+
   it('stale なリクエストは failed 化し、snapshot があれば復元して response に反映する', async () => {
     const snapshotRow = { id: 'meal-1', daily_meal_id: 'day-1', meal_type: 'breakfast' };
     const staleDate = new Date(Date.now() - 30 * 60 * 1000).toISOString();
@@ -102,8 +135,12 @@ describe('GET /api/ai/menu/weekly/pending', () => {
         start_date: date,
         created_at: staleDate,
         updated_at: staleDate,
-        generated_data: { snapshot: [snapshotRow] },
       },
+      error: null,
+    });
+    // stale 判定成立後に発行される generated_data 専用の二次クエリの結果
+    snapshotResultQueue.push({
+      data: { generated_data: { snapshot: [snapshotRow] } },
       error: null,
     });
     mockRestorePlannedMealsSnapshot.mockResolvedValueOnce({ restored: 1, skipped: 0, failed: 0 });
@@ -120,6 +157,11 @@ describe('GET /api/ai/menu/weekly/pending', () => {
     expect(mockUpdate).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'failed', error_message: 'stale_request_timeout' }),
     );
+
+    // stale 判定成立時のみ generated_data 専用の二次クエリが発行されること
+    expect(mockSelect).toHaveBeenCalledTimes(2);
+    expect(mockSelect.mock.calls[0][0]).not.toContain('generated_data');
+    expect(mockSelect.mock.calls[1][0]).toContain('generated_data');
   });
 
   it('stale だが snapshot がない場合は復元を呼ばず response に restore を含めない', async () => {
@@ -132,8 +174,12 @@ describe('GET /api/ai/menu/weekly/pending', () => {
         start_date: date,
         created_at: staleDate,
         updated_at: staleDate,
-        generated_data: null,
       },
+      error: null,
+    });
+    // stale 判定成立後に発行される generated_data 専用の二次クエリの結果(snapshot なし)
+    snapshotResultQueue.push({
+      data: { generated_data: null },
       error: null,
     });
 

--- a/src/__tests__/api/ai/menu/weekly-request.test.ts
+++ b/src/__tests__/api/ai/menu/weekly-request.test.ts
@@ -1,0 +1,247 @@
+/**
+ * src/__tests__/api/ai/menu/weekly-request.test.ts
+ *
+ * #1042 (F1a-03): weekly/request が生成前に既存献立を物理削除しロールバックなし
+ * だった問題の修正確認（失敗注入テスト）。
+ *
+ * - 既存献立の削除前にスナップショットを取得し weekly_menu_requests.generated_data に退避すること
+ * - Edge Function 呼び出しが失敗した場合、スナップショットからのロールバック復元
+ *   (restorePlannedMealsSnapshot) が実行されること
+ * - Edge Function が成功した場合はロールバックを実行しないこと
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetUser = vi.fn();
+
+// user_daily_meals.select('id').eq().eq().maybeSingle() のキュー（日毎に1回ずつ呼ばれる）
+const userDailyMealsQueue: Array<{ data: any; error: any }> = [];
+const mockUserDailyMealsMaybeSingle = vi.fn(() =>
+  Promise.resolve(userDailyMealsQueue.shift() ?? { data: null, error: null }),
+);
+
+// planned_meals.select('*').eq('daily_meal_id', ...) のキュー（スナップショット取得）
+const plannedMealsSelectQueue: Array<{ data: any; error: any }> = [];
+const mockPlannedMealsSelectEq = vi.fn(() =>
+  Promise.resolve(plannedMealsSelectQueue.shift() ?? { data: [], error: null }),
+);
+
+const mockPlannedMealsDeleteEq = vi.fn(() => Promise.resolve({ data: null, error: null }));
+
+const mockWeeklyInsertSingle = vi.fn();
+const mockWeeklyInsertCall = vi.fn((..._args: any[]) => ({
+  select: () => ({ single: mockWeeklyInsertSingle }),
+}));
+const mockWeeklyUpdateEq = vi.fn(() => Promise.resolve({ data: null, error: null }));
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'user_daily_meals') {
+    return {
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            maybeSingle: mockUserDailyMealsMaybeSingle,
+          }),
+        }),
+      }),
+    };
+  }
+  if (table === 'planned_meals') {
+    return {
+      select: () => ({
+        eq: mockPlannedMealsSelectEq,
+      }),
+      delete: () => ({
+        eq: mockPlannedMealsDeleteEq,
+      }),
+    };
+  }
+  if (table === 'weekly_menu_requests') {
+    return {
+      insert: mockWeeklyInsertCall,
+      update: () => ({
+        eq: mockWeeklyUpdateEq,
+      }),
+    };
+  }
+  throw new Error(`Unexpected table in test: ${table}`);
+});
+
+const mockSupabase = {
+  auth: { getUser: mockGetUser },
+  from: mockFrom,
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => mockSupabase),
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(async () => ({ success: true, limit: 10, remaining: 9, reset: Date.now() + 60_000 })),
+  rateLimitExceededResponse: vi.fn(),
+}));
+
+vi.mock('@/lib/menu-generation-feature-flags', () => ({
+  loadFeatureFlags: vi.fn(async () => ({ menu_generation_v5_wrapped: false })),
+}));
+
+vi.mock('@/lib/meal-image-jobs', () => ({
+  cancelPendingMealImageJobs: vi.fn(async () => {}),
+}));
+
+vi.mock('@/lib/db-logger', () => ({
+  createLogger: vi.fn(() => ({
+    withUser: vi.fn().mockReturnThis(),
+    error: vi.fn(),
+  })),
+}));
+
+const mockCallGenerateMenuV4WithRetry = vi.fn(async (..._args: any[]): Promise<
+  { ok: true; attempts: number; response: Response } | { ok: false; attempts: number; errorMessage: string }
+> => ({
+  ok: true,
+  attempts: 1,
+  response: new Response(),
+}));
+const mockMarkWeeklyMenuRequestFailed = vi.fn(async (..._args: any[]) => {});
+
+vi.mock('@/lib/generate-menu-v4-retry', () => ({
+  callGenerateMenuV4WithRetry: mockCallGenerateMenuV4WithRetry,
+  markWeeklyMenuRequestFailed: mockMarkWeeklyMenuRequestFailed,
+}));
+
+vi.mock('@/lib/generate-menu-v5-retry', () => ({
+  callGenerateMenuV5WithRetry: vi.fn(async () => ({ ok: true, attempts: 1, response: new Response() })),
+}));
+
+const waitUntilPromises: Promise<unknown>[] = [];
+vi.mock('@vercel/functions', () => ({
+  waitUntil: vi.fn((p: Promise<unknown>) => {
+    waitUntilPromises.push(p);
+  }),
+}));
+
+const mockRestorePlannedMealsSnapshot = vi.fn(async (..._args: any[]) => ({ restored: 0, skipped: 0, failed: 0 }));
+vi.mock('@/lib/planned-meals-snapshot', () => ({
+  restorePlannedMealsSnapshot: mockRestorePlannedMealsSnapshot,
+}));
+
+const { POST } = await import('@/app/api/ai/menu/weekly/request/route');
+
+const user = { id: 'user-1' };
+const startDate = '2026-07-06'; // 固定した「今日」= fake timer で使用
+
+const makeRequest = (body: Record<string, unknown>) =>
+  new Request('http://localhost/api/ai/menu/weekly/request', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+const flushBackground = async () => {
+  await Promise.all(waitUntilPromises);
+};
+
+const existingBreakfast = {
+  id: 'meal-breakfast-1',
+  daily_meal_id: 'day-1',
+  meal_type: 'breakfast',
+  dish_name: '元の朝食',
+};
+const existingLunch = {
+  id: 'meal-lunch-1',
+  daily_meal_id: 'day-1',
+  meal_type: 'lunch',
+  dish_name: '元の昼食',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  waitUntilPromises.length = 0;
+  userDailyMealsQueue.length = 0;
+  plannedMealsSelectQueue.length = 0;
+
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-07-06T09:00:00+09:00'));
+
+  mockGetUser.mockResolvedValue({ data: { user }, error: null });
+  mockWeeklyInsertSingle.mockResolvedValue({ data: { id: 'request-1' }, error: null });
+
+  // day0(startDate): 既存の献立あり（削除→スナップショット対象）
+  userDailyMealsQueue.push({ data: { id: 'day-1' }, error: null });
+  plannedMealsSelectQueue.push({ data: [existingBreakfast, existingLunch], error: null });
+  // day1〜day6: 既存の献立なし
+  for (let i = 0; i < 6; i++) {
+    userDailyMealsQueue.push({ data: null, error: null });
+  }
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('POST /api/ai/menu/weekly/request', () => {
+  it('Edge Function 失敗時、削除前スナップショットからロールバック復元する', async () => {
+    mockCallGenerateMenuV4WithRetry.mockResolvedValue({
+      ok: false,
+      attempts: 3,
+      errorMessage: 'generate-menu-v4 failed after 3/3 attempts',
+    });
+    mockRestorePlannedMealsSnapshot.mockResolvedValue({ restored: 2, skipped: 0, failed: 0 });
+
+    const res = await POST(makeRequest({ startDate }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.status).toBe('processing');
+
+    // weekly_menu_requests insert に削除前スナップショットが退避されていること
+    const insertPayload = mockWeeklyInsertCall.mock.calls[0][0];
+    expect(insertPayload.generated_data).toEqual({ snapshot: [existingBreakfast, existingLunch] });
+
+    await flushBackground();
+
+    // Edge Function 失敗 → ロールバック復元が呼ばれること
+    expect(mockRestorePlannedMealsSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockRestorePlannedMealsSnapshot).toHaveBeenCalledWith(
+      mockSupabase,
+      [existingBreakfast, existingLunch],
+    );
+
+    // markWeeklyMenuRequestFailed にロールバック結果が反映されたエラーメッセージが渡ること
+    expect(mockMarkWeeklyMenuRequestFailed).toHaveBeenCalledTimes(1);
+    const failedArgs = mockMarkWeeklyMenuRequestFailed.mock.calls[0][0];
+    expect(failedArgs.requestId).toBe('request-1');
+    expect(failedArgs.errorMessage).toContain('rollback: restored=2, skipped=0, failed=0');
+  });
+
+  it('Edge Function 成功時はロールバックを実行しない', async () => {
+    mockCallGenerateMenuV4WithRetry.mockResolvedValue({ ok: true, attempts: 1, response: new Response() });
+
+    const res = await POST(makeRequest({ startDate }));
+    expect(res.status).toBe(200);
+
+    await flushBackground();
+
+    expect(mockRestorePlannedMealsSnapshot).not.toHaveBeenCalled();
+    expect(mockMarkWeeklyMenuRequestFailed).not.toHaveBeenCalled();
+  });
+
+  it('削除対象の既存献立がない週は generated_data.snapshot を null にする', async () => {
+    userDailyMealsQueue.length = 0;
+    plannedMealsSelectQueue.length = 0;
+    for (let i = 0; i < 7; i++) {
+      userDailyMealsQueue.push({ data: null, error: null });
+    }
+    mockCallGenerateMenuV4WithRetry.mockResolvedValue({ ok: true, attempts: 1, response: new Response() });
+
+    const res = await POST(makeRequest({ startDate }));
+    expect(res.status).toBe(200);
+
+    const insertPayload = mockWeeklyInsertCall.mock.calls[0][0];
+    expect(insertPayload.generated_data).toBeNull();
+
+    await flushBackground();
+    expect(mockRestorePlannedMealsSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/api/ai/menu/weekly-status.test.ts
+++ b/src/__tests__/api/ai/menu/weekly-status.test.ts
@@ -1,0 +1,154 @@
+/**
+ * src/__tests__/api/ai/menu/weekly-status.test.ts
+ *
+ * #1042: stale sweeper (weekly/status) が waitUntil 消失等で生成コールバックが
+ * 実行されず stale になったリクエストを failed 化するだけで、削除済み献立の
+ * スナップショット (generated_data.snapshot) を復元しない問題の修正確認。
+ *
+ * - stale でない場合はそのまま状態を返し、復元は呼ばれないこと
+ * - stale かつ snapshot が残っている場合は復元を実行し、結果を response に含めること
+ * - stale だが snapshot がない場合は復元を呼ばず、response に restore を含めないこと
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetUser = vi.fn();
+
+const selectResultQueue: Array<{ data: any; error: any }> = [];
+const mockMaybeSingle = vi.fn(() => Promise.resolve(selectResultQueue.shift() ?? { data: null, error: null }));
+const mockSelectEq2 = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
+const mockSelectEq1 = vi.fn(() => ({ eq: mockSelectEq2 }));
+const mockSelect = vi.fn(() => ({ eq: mockSelectEq1 }));
+
+const updateEqQueue: Array<{ error: any }> = [];
+const mockUpdateEq2 = vi.fn(() => Promise.resolve(updateEqQueue.shift() ?? { error: null }));
+const mockUpdateEq1 = vi.fn(() => ({ eq: mockUpdateEq2 }));
+const mockUpdate = vi.fn(() => ({ eq: mockUpdateEq1 }));
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'weekly_menu_requests') {
+    return { select: mockSelect, update: mockUpdate };
+  }
+  throw new Error(`Unexpected table in test: ${table}`);
+});
+
+const mockSupabase = {
+  auth: { getUser: mockGetUser },
+  from: mockFrom,
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => mockSupabase),
+}));
+
+const mockRestorePlannedMealsSnapshot = vi.fn(async (..._args: any[]) => ({ restored: 0, skipped: 0, failed: 0 }));
+vi.mock('@/lib/planned-meals-snapshot', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/planned-meals-snapshot')>();
+  return {
+    ...actual,
+    restorePlannedMealsSnapshot: mockRestorePlannedMealsSnapshot,
+  };
+});
+
+const { GET } = await import('@/app/api/ai/menu/weekly/status/route');
+
+const user = { id: 'user-1' };
+
+const makeRequest = (requestId: string) =>
+  new Request(`http://localhost/api/ai/menu/weekly/status?requestId=${requestId}`);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectResultQueue.length = 0;
+  updateEqQueue.length = 0;
+  mockGetUser.mockResolvedValue({ data: { user }, error: null });
+});
+
+describe('GET /api/ai/menu/weekly/status', () => {
+  it('stale でない processing リクエストはそのまま状態を返す(復元は呼ばない)', async () => {
+    selectResultQueue.push({
+      data: {
+        id: 'req-1',
+        status: 'processing',
+        error_message: null,
+        updated_at: new Date().toISOString(),
+        mode: 'v4',
+        start_date: '2026-07-06',
+        target_meal_id: null,
+        progress: 5,
+        generated_data: { snapshot: [] },
+      },
+      error: null,
+    });
+
+    const res = await GET(makeRequest('req-1'));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.status).toBe('processing');
+    expect(mockRestorePlannedMealsSnapshot).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('stale な processing リクエストは failed 化し、snapshot があれば復元して response に反映する', async () => {
+    const snapshotRow = { id: 'meal-1', daily_meal_id: 'day-1', meal_type: 'breakfast' };
+    const staleDate = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    selectResultQueue.push({
+      data: {
+        id: 'req-1',
+        status: 'processing',
+        error_message: null,
+        updated_at: staleDate,
+        mode: 'v4',
+        start_date: '2026-07-06',
+        target_meal_id: null,
+        progress: 5,
+        generated_data: { snapshot: [snapshotRow] },
+      },
+      error: null,
+    });
+    mockRestorePlannedMealsSnapshot.mockResolvedValueOnce({ restored: 1, skipped: 0, failed: 0 });
+
+    const res = await GET(makeRequest('req-1'));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.status).toBe('failed');
+    expect(json.errorMessage).toBe('stale_request_timeout');
+    expect(json.restore).toEqual({ restored: 1, skipped: 0, failed: 0 });
+
+    expect(mockRestorePlannedMealsSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockRestorePlannedMealsSnapshot).toHaveBeenCalledWith(mockSupabase, [snapshotRow]);
+
+    // stale リクエストを failed に更新する呼び出しが行われていること
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed', error_message: 'stale_request_timeout' }),
+    );
+  });
+
+  it('stale だが snapshot がない場合は復元を呼ばず response に restore を含めない', async () => {
+    const staleDate = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    selectResultQueue.push({
+      data: {
+        id: 'req-1',
+        status: 'pending',
+        error_message: null,
+        updated_at: staleDate,
+        mode: 'v4',
+        start_date: '2026-07-06',
+        target_meal_id: null,
+        progress: null,
+        generated_data: null,
+      },
+      error: null,
+    });
+
+    const res = await GET(makeRequest('req-1'));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.status).toBe('failed');
+    expect(json.restore).toBeUndefined();
+    expect(mockRestorePlannedMealsSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/api/ai/menu/weekly-status.test.ts
+++ b/src/__tests__/api/ai/menu/weekly-status.test.ts
@@ -8,6 +8,11 @@
  * - stale でない場合はそのまま状態を返し、復元は呼ばれないこと
  * - stale かつ snapshot が残っている場合は復元を実行し、結果を response に含めること
  * - stale だが snapshot がない場合は復元を呼ばず、response に restore を含めないこと
+ *
+ * #1042 性能退行修正: 3秒間隔ポーリングの通常 select から生成中に肥大化する
+ * generated_data(jsonb) を外し、stale 判定成立時のみ二次クエリで取得することの確認。
+ * - 非 stale ポーリングでは generated_data を select しないこと
+ * - stale 判定成立時は generated_data のみを対象にした二次クエリを発行すること
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -18,7 +23,7 @@ const selectResultQueue: Array<{ data: any; error: any }> = [];
 const mockMaybeSingle = vi.fn(() => Promise.resolve(selectResultQueue.shift() ?? { data: null, error: null }));
 const mockSelectEq2 = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
 const mockSelectEq1 = vi.fn(() => ({ eq: mockSelectEq2 }));
-const mockSelect = vi.fn(() => ({ eq: mockSelectEq1 }));
+const mockSelect = vi.fn((..._args: any[]) => ({ eq: mockSelectEq1 }));
 
 const updateEqQueue: Array<{ error: any }> = [];
 const mockUpdateEq2 = vi.fn(() => Promise.resolve(updateEqQueue.shift() ?? { error: null }));
@@ -76,7 +81,6 @@ describe('GET /api/ai/menu/weekly/status', () => {
         start_date: '2026-07-06',
         target_meal_id: null,
         progress: 5,
-        generated_data: { snapshot: [] },
       },
       error: null,
     });
@@ -88,6 +92,29 @@ describe('GET /api/ai/menu/weekly/status', () => {
     expect(json.status).toBe('processing');
     expect(mockRestorePlannedMealsSnapshot).not.toHaveBeenCalled();
     expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('非 stale ポーリングでは generated_data を select しない(二次クエリも発行しない)', async () => {
+    selectResultQueue.push({
+      data: {
+        id: 'req-1',
+        status: 'processing',
+        error_message: null,
+        updated_at: new Date().toISOString(),
+        mode: 'v4',
+        start_date: '2026-07-06',
+        target_meal_id: null,
+        progress: 5,
+      },
+      error: null,
+    });
+
+    await GET(makeRequest('req-1'));
+
+    // 通常ポーリングでの select は1回のみで、generated_data を含まないこと
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    expect(mockSelect.mock.calls[0][0]).not.toContain('generated_data');
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(1);
   });
 
   it('stale な processing リクエストは failed 化し、snapshot があれば復元して response に反映する', async () => {
@@ -103,8 +130,12 @@ describe('GET /api/ai/menu/weekly/status', () => {
         start_date: '2026-07-06',
         target_meal_id: null,
         progress: 5,
-        generated_data: { snapshot: [snapshotRow] },
       },
+      error: null,
+    });
+    // stale 判定成立後に発行される generated_data 専用の二次クエリの結果
+    selectResultQueue.push({
+      data: { generated_data: { snapshot: [snapshotRow] } },
       error: null,
     });
     mockRestorePlannedMealsSnapshot.mockResolvedValueOnce({ restored: 1, skipped: 0, failed: 0 });
@@ -124,6 +155,11 @@ describe('GET /api/ai/menu/weekly/status', () => {
     expect(mockUpdate).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'failed', error_message: 'stale_request_timeout' }),
     );
+
+    // stale 判定成立時のみ generated_data 専用の二次クエリが発行されること
+    expect(mockSelect).toHaveBeenCalledTimes(2);
+    expect(mockSelect.mock.calls[0][0]).not.toContain('generated_data');
+    expect(mockSelect.mock.calls[1][0]).toContain('generated_data');
   });
 
   it('stale だが snapshot がない場合は復元を呼ばず response に restore を含めない', async () => {
@@ -138,8 +174,12 @@ describe('GET /api/ai/menu/weekly/status', () => {
         start_date: '2026-07-06',
         target_meal_id: null,
         progress: null,
-        generated_data: null,
       },
+      error: null,
+    });
+    // stale 判定成立後に発行される generated_data 専用の二次クエリの結果(snapshot なし)
+    selectResultQueue.push({
+      data: { generated_data: null },
       error: null,
     });
 

--- a/src/__tests__/api/pantry/from-photo.test.ts
+++ b/src/__tests__/api/pantry/from-photo.test.ts
@@ -1,0 +1,148 @@
+/**
+ * src/__tests__/api/pantry/from-photo.test.ts
+ *
+ * #1042 (F1a-15): pantry/from-photo の mode='replace' が「全削除→逐次insert」
+ * で部分失敗時に欠損する問題の修正確認（失敗注入テスト）。
+ *
+ * - replace モードで insert が部分的に失敗した場合、今回挿入した分をロールバックし
+ *   削除前の旧データを復元すること（既存データが無傷であること）
+ * - 全て成功した場合はロールバックが発生しないこと
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetUser = vi.fn();
+
+const selectEqQueue: Array<{ data: any; error: any }> = [];
+const mockPantryItemsSelect = vi.fn(() => ({
+  eq: vi.fn(() => Promise.resolve(selectEqQueue.shift() ?? { data: [], error: null })),
+}));
+
+const deleteEqQueue: Array<{ error: any }> = [];
+const deleteInQueue: Array<{ error: any }> = [];
+const mockPantryItemsDelete = vi.fn(() => ({
+  eq: vi.fn(() => Promise.resolve(deleteEqQueue.shift() ?? { error: null })),
+  in: vi.fn(() => Promise.resolve(deleteInQueue.shift() ?? { error: null })),
+}));
+
+const singleInsertQueue: Array<{ data: any; error: any }> = [];
+const bulkInsertQueue: Array<{ error: any }> = [];
+const mockPantryItemsInsert = vi.fn((payload: unknown) => {
+  if (Array.isArray(payload)) {
+    return Promise.resolve(bulkInsertQueue.shift() ?? { error: null });
+  }
+  return {
+    select: () => ({
+      single: () => Promise.resolve(singleInsertQueue.shift() ?? { data: null, error: null }),
+    }),
+  };
+});
+
+const mockFridgeSnapshotsInsert = vi.fn(() => Promise.resolve({ data: null, error: null }));
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'pantry_items') {
+    return {
+      select: mockPantryItemsSelect,
+      delete: mockPantryItemsDelete,
+      insert: mockPantryItemsInsert,
+    };
+  }
+  if (table === 'fridge_snapshots') {
+    return { insert: mockFridgeSnapshotsInsert };
+  }
+  throw new Error(`Unexpected table in test: ${table}`);
+});
+
+const mockSupabase = {
+  auth: { getUser: mockGetUser },
+  from: mockFrom,
+};
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => mockSupabase),
+}));
+
+const { POST } = await import('@/app/api/pantry/from-photo/route');
+
+const user = { id: 'user-1' };
+const previousPantryItems = [
+  { id: 'old-1', user_id: 'user-1', name: '既存の卵', category: 'dairy', amount: '6個', expiration_date: null, added_at: '2026-07-01', created_at: null, updated_at: null },
+];
+
+const makeRequest = (body: Record<string, unknown>) =>
+  new Request('http://localhost/api/pantry/from-photo', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectEqQueue.length = 0;
+  deleteEqQueue.length = 0;
+  deleteInQueue.length = 0;
+  singleInsertQueue.length = 0;
+  bulkInsertQueue.length = 0;
+
+  mockGetUser.mockResolvedValue({ data: { user }, error: null });
+});
+
+describe('POST /api/pantry/from-photo (mode=replace)', () => {
+  it('insertが部分的に失敗したら新規分を削除し旧データを復元してロールバックする', async () => {
+    selectEqQueue.push({ data: previousPantryItems, error: null }); // 削除前スナップショット
+    deleteEqQueue.push({ error: null }); // 全削除 成功
+    singleInsertQueue.push({ data: { id: 'new-1', name: 'にんじん' }, error: null }); // 1件目 成功
+    singleInsertQueue.push({ data: null, error: { message: 'insert failed' } }); // 2件目 失敗
+    deleteInQueue.push({ error: null }); // ロールバック削除 成功
+    bulkInsertQueue.push({ error: null }); // 旧データ復元 成功
+
+    const res = await POST(
+      makeRequest({
+        mode: 'replace',
+        ingredients: [{ name: 'にんじん' }, { name: 'たまねぎ' }],
+      }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toContain('ロールバック');
+    expect(json.results.created).toBe(1);
+    expect(json.results.skipped).toBe(1);
+
+    // ロールバック削除: 今回新規挿入した new-1 のみ対象
+    expect(mockPantryItemsDelete).toHaveBeenCalledTimes(2); // 1回目=全削除, 2回目=ロールバック削除
+    const rollbackDeleteCall = mockPantryItemsDelete.mock.results[1].value;
+    expect(rollbackDeleteCall.in).toHaveBeenCalledWith('id', ['new-1']);
+
+    // 旧データ復元: スナップショットした previousPantryItems がそのまま insert されること
+    const bulkInsertCall = mockPantryItemsInsert.mock.calls.find((call) => Array.isArray(call[0]));
+    expect(bulkInsertCall?.[0]).toEqual(previousPantryItems);
+
+    // 失敗時は fridge_snapshots への履歴保存は行わない
+    expect(mockFridgeSnapshotsInsert).not.toHaveBeenCalled();
+  });
+
+  it('全て成功すればロールバックせず通常のレスポンスを返す', async () => {
+    selectEqQueue.push({ data: previousPantryItems, error: null });
+    deleteEqQueue.push({ error: null });
+    singleInsertQueue.push({ data: { id: 'new-1', name: 'にんじん' }, error: null });
+    singleInsertQueue.push({ data: { id: 'new-2', name: 'たまねぎ' }, error: null });
+
+    const res = await POST(
+      makeRequest({
+        mode: 'replace',
+        ingredients: [{ name: 'にんじん' }, { name: 'たまねぎ' }],
+      }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.results.created).toBe(2);
+    // ロールバック用の delete().in(...) や 復元 insert(array) は呼ばれない
+    const bulkInsertCall = mockPantryItemsInsert.mock.calls.find((call) => Array.isArray(call[0]));
+    expect(bulkInsertCall).toBeUndefined();
+    expect(mockPantryItemsDelete).toHaveBeenCalledTimes(1); // 全削除のみ
+  });
+});

--- a/src/__tests__/api/pantry/from-photo.test.ts
+++ b/src/__tests__/api/pantry/from-photo.test.ts
@@ -9,7 +9,10 @@
  * - 全て成功した場合はロールバックが発生しないこと
  * - ロールバック（新規分の削除・旧データの復元）自体が失敗した場合は、
  *   「元のデータへロールバックしました」という誤ったメッセージを返さず、
- *   rollbackSucceeded=false とデータ消失の可能性を明示すること
+ *   rollbackSucceeded=false を明示すること
+ * - 旧データの復元insert自体が失敗した場合（データ消失の可能性）と、
+ *   新規分の削除ロールバックのみ失敗した場合（旧データは復元済みで新規分と
+ *   重複している可能性）とでメッセージを分岐すること
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -145,7 +148,8 @@ describe('POST /api/pantry/from-photo (mode=replace)', () => {
 
     expect(res.status).toBe(500);
     expect(json.rollbackSucceeded).toBe(false);
-    expect(json.error).toContain('ロールバックにも失敗');
+    expect(json.error).toContain('旧データの復元にも失敗');
+    expect(json.error).toContain('冷蔵庫データが失われた可能性があります');
     expect(json.error).not.toContain('元のデータへロールバックしました');
   });
 
@@ -167,7 +171,9 @@ describe('POST /api/pantry/from-photo (mode=replace)', () => {
 
     expect(res.status).toBe(500);
     expect(json.rollbackSucceeded).toBe(false);
-    expect(json.error).toContain('ロールバックにも失敗');
+    expect(json.error).toContain('削除ロールバックに失敗');
+    expect(json.error).toContain('重複している可能性');
+    expect(json.error).not.toContain('冷蔵庫データが失われた可能性');
     expect(json.error).not.toContain('元のデータへロールバックしました');
   });
 

--- a/src/__tests__/api/pantry/from-photo.test.ts
+++ b/src/__tests__/api/pantry/from-photo.test.ts
@@ -7,6 +7,9 @@
  * - replace モードで insert が部分的に失敗した場合、今回挿入した分をロールバックし
  *   削除前の旧データを復元すること（既存データが無傷であること）
  * - 全て成功した場合はロールバックが発生しないこと
+ * - ロールバック（新規分の削除・旧データの復元）自体が失敗した場合は、
+ *   「元のデータへロールバックしました」という誤ったメッセージを返さず、
+ *   rollbackSucceeded=false とデータ消失の可能性を明示すること
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -107,6 +110,7 @@ describe('POST /api/pantry/from-photo (mode=replace)', () => {
 
     expect(res.status).toBe(500);
     expect(json.error).toContain('ロールバック');
+    expect(json.rollbackSucceeded).toBe(true);
     expect(json.results.created).toBe(1);
     expect(json.results.skipped).toBe(1);
 
@@ -121,6 +125,50 @@ describe('POST /api/pantry/from-photo (mode=replace)', () => {
 
     // 失敗時は fridge_snapshots への履歴保存は行わない
     expect(mockFridgeSnapshotsInsert).not.toHaveBeenCalled();
+  });
+
+  it('旧データの復元insert自体が失敗したらロールバック失敗として rollbackSucceeded=false を返す', async () => {
+    selectEqQueue.push({ data: previousPantryItems, error: null }); // 削除前スナップショット
+    deleteEqQueue.push({ error: null }); // 全削除 成功
+    singleInsertQueue.push({ data: { id: 'new-1', name: 'にんじん' }, error: null }); // 1件目 成功
+    singleInsertQueue.push({ data: null, error: { message: 'insert failed' } }); // 2件目 失敗
+    deleteInQueue.push({ error: null }); // ロールバック削除(新規分) 成功
+    bulkInsertQueue.push({ error: { message: 'restore insert failed' } }); // 旧データ復元 失敗
+
+    const res = await POST(
+      makeRequest({
+        mode: 'replace',
+        ingredients: [{ name: 'にんじん' }, { name: 'たまねぎ' }],
+      }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.rollbackSucceeded).toBe(false);
+    expect(json.error).toContain('ロールバックにも失敗');
+    expect(json.error).not.toContain('元のデータへロールバックしました');
+  });
+
+  it('新規分のロールバック削除自体が失敗したらロールバック失敗として rollbackSucceeded=false を返す', async () => {
+    selectEqQueue.push({ data: previousPantryItems, error: null }); // 削除前スナップショット
+    deleteEqQueue.push({ error: null }); // 全削除 成功
+    singleInsertQueue.push({ data: { id: 'new-1', name: 'にんじん' }, error: null }); // 1件目 成功
+    singleInsertQueue.push({ data: null, error: { message: 'insert failed' } }); // 2件目 失敗
+    deleteInQueue.push({ error: { message: 'rollback delete failed' } }); // ロールバック削除(新規分) 失敗
+    bulkInsertQueue.push({ error: null }); // 旧データ復元 成功
+
+    const res = await POST(
+      makeRequest({
+        mode: 'replace',
+        ingredients: [{ name: 'にんじん' }, { name: 'たまねぎ' }],
+      }),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.rollbackSucceeded).toBe(false);
+    expect(json.error).toContain('ロールバックにも失敗');
+    expect(json.error).not.toContain('元のデータへロールバックしました');
   });
 
   it('全て成功すればロールバックせず通常のレスポンスを返す', async () => {

--- a/src/__tests__/lib/planned-meals-snapshot.test.ts
+++ b/src/__tests__/lib/planned-meals-snapshot.test.ts
@@ -1,0 +1,148 @@
+/**
+ * src/__tests__/lib/planned-meals-snapshot.test.ts
+ *
+ * #1042: 破壊的な献立操作 (削除→再生成) のデータ消失防止。
+ * restorePlannedMealsSnapshot の失敗注入テスト:
+ * - 生成失敗時、削除前スナップショットから旧データが復元されること
+ * - 既に新しいデータが書き込まれているスロットは上書きしない(スキップ)こと
+ * - 復元自体が失敗した行は failed としてカウントされ、他の行の復元を止めないこと
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { restorePlannedMealsSnapshot, type PlannedMealSnapshotRow } from '@/lib/planned-meals-snapshot';
+
+type LookupResult = { data: { id: string } | null; error: { message: string } | null };
+
+function buildMockSupabase(params: {
+  lookupResults: LookupResult[];
+  insertResults?: Array<{ error: { message: string } | null }>;
+}) {
+  const lookupQueue = [...params.lookupResults];
+  const insertQueue = [...(params.insertResults ?? [])];
+
+  const mockMaybeSingle = vi.fn(() => Promise.resolve(lookupQueue.shift() ?? { data: null, error: null }));
+  const mockEq2 = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
+  const mockEq1 = vi.fn(() => ({ eq: mockEq2 }));
+  const mockSelect = vi.fn(() => ({ eq: mockEq1 }));
+
+  const mockInsert = vi.fn(() => Promise.resolve(insertQueue.shift() ?? { error: null }));
+
+  const mockFrom = vi.fn(() => ({
+    select: mockSelect,
+    insert: mockInsert,
+  }));
+
+  return {
+    supabase: { from: mockFrom } as any,
+    mockFrom,
+    mockSelect,
+    mockEq1,
+    mockEq2,
+    mockMaybeSingle,
+    mockInsert,
+  };
+}
+
+const makeRow = (overrides: Partial<PlannedMealSnapshotRow> = {}): PlannedMealSnapshotRow => ({
+  id: 'meal-1',
+  daily_meal_id: 'day-1',
+  meal_type: 'breakfast',
+  dish_name: '元の朝食',
+  ...overrides,
+});
+
+describe('restorePlannedMealsSnapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('スロットが空いていれば旧データを復元する (restored++)', async () => {
+    const snapshot = [makeRow()];
+    const { supabase, mockInsert } = buildMockSupabase({
+      lookupResults: [{ data: null, error: null }], // 既存データなし = 空きスロット
+      insertResults: [{ error: null }],
+    });
+
+    const result = await restorePlannedMealsSnapshot(supabase, snapshot);
+
+    expect(result).toEqual({ restored: 1, skipped: 0, failed: 0 });
+    expect(mockInsert).toHaveBeenCalledWith(snapshot[0]);
+  });
+
+  it('生成処理が部分的に成功し既にスロットが埋まっていれば上書きせずスキップする (他者による更新の検知)', async () => {
+    const snapshot = [makeRow({ id: 'meal-old' })];
+    const { supabase, mockInsert } = buildMockSupabase({
+      lookupResults: [{ data: { id: 'meal-new' }, error: null }], // 既に新しいデータが書き込み済み
+    });
+
+    const result = await restorePlannedMealsSnapshot(supabase, snapshot);
+
+    expect(result).toEqual({ restored: 0, skipped: 1, failed: 0 });
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('復元insertが失敗した行は failed としてカウントし、他の行は継続処理する', async () => {
+    const snapshot = [makeRow({ id: 'meal-1', meal_type: 'breakfast' }), makeRow({ id: 'meal-2', meal_type: 'lunch' })];
+    const { supabase, mockInsert } = buildMockSupabase({
+      lookupResults: [
+        { data: null, error: null },
+        { data: null, error: null },
+      ],
+      insertResults: [{ error: { message: 'insert failed' } }, { error: null }],
+    });
+
+    const result = await restorePlannedMealsSnapshot(supabase, snapshot);
+
+    expect(result).toEqual({ restored: 1, skipped: 0, failed: 1 });
+    expect(mockInsert).toHaveBeenCalledTimes(2);
+  });
+
+  it('スロット確認(lookup)自体が失敗した行は failed としてカウントし、insertは行わない', async () => {
+    const snapshot = [makeRow()];
+    const { supabase, mockInsert } = buildMockSupabase({
+      lookupResults: [{ data: null, error: { message: 'lookup failed' } }],
+    });
+
+    const result = await restorePlannedMealsSnapshot(supabase, snapshot);
+
+    expect(result).toEqual({ restored: 0, skipped: 0, failed: 1 });
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('daily_meal_id / meal_type を欠いた行は failed としてカウントしクエリを発行しない', async () => {
+    const snapshot = [{ id: 'broken', daily_meal_id: '', meal_type: '' } as PlannedMealSnapshotRow];
+    const { supabase, mockFrom } = buildMockSupabase({ lookupResults: [] });
+
+    const result = await restorePlannedMealsSnapshot(supabase, snapshot);
+
+    expect(result).toEqual({ restored: 0, skipped: 0, failed: 1 });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('複数行を混在で処理し、restored/skipped/failed を正しく集計する', async () => {
+    const snapshot = [
+      makeRow({ id: 'meal-1', meal_type: 'breakfast' }),
+      makeRow({ id: 'meal-2', meal_type: 'lunch' }),
+      makeRow({ id: 'meal-3', meal_type: 'dinner' }),
+    ];
+    const { supabase } = buildMockSupabase({
+      lookupResults: [
+        { data: null, error: null }, // breakfast: 空き -> restore
+        { data: { id: 'meal-new' }, error: null }, // lunch: 既に埋まっている -> skip
+        { data: null, error: null }, // dinner: 空きだが insert 失敗 -> failed
+      ],
+      insertResults: [{ error: null }, { error: { message: 'insert failed' } }],
+    });
+
+    const result = await restorePlannedMealsSnapshot(supabase, snapshot);
+
+    expect(result).toEqual({ restored: 1, skipped: 1, failed: 1 });
+  });
+
+  it('空のスナップショットは何もせず全て0を返す', async () => {
+    const { supabase, mockFrom } = buildMockSupabase({ lookupResults: [] });
+    const result = await restorePlannedMealsSnapshot(supabase, []);
+    expect(result).toEqual({ restored: 0, skipped: 0, failed: 0 });
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/lib/planned-meals-snapshot.test.ts
+++ b/src/__tests__/lib/planned-meals-snapshot.test.ts
@@ -9,7 +9,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { restorePlannedMealsSnapshot, type PlannedMealSnapshotRow } from '@/lib/planned-meals-snapshot';
+import {
+  restorePlannedMealsSnapshot,
+  extractPlannedMealsSnapshot,
+  type PlannedMealSnapshotRow,
+} from '@/lib/planned-meals-snapshot';
 
 type LookupResult = { data: { id: string } | null; error: { message: string } | null };
 
@@ -144,5 +148,38 @@ describe('restorePlannedMealsSnapshot', () => {
     const result = await restorePlannedMealsSnapshot(supabase, []);
     expect(result).toEqual({ restored: 0, skipped: 0, failed: 0 });
     expect(mockFrom).not.toHaveBeenCalled();
+  });
+});
+
+describe('extractPlannedMealsSnapshot', () => {
+  // #1042: sweeper (status/pending/cleanup) が weekly_menu_requests.generated_data
+  // から復元用スナップショットを安全に取り出せることを確認する。
+
+  it('request/route.ts が保存する { snapshot: [...] } 形式から配列を取り出す', () => {
+    const snapshot = [makeRow()];
+    expect(extractPlannedMealsSnapshot({ snapshot })).toEqual(snapshot);
+  });
+
+  it('generated_data が null の場合は空配列を返す', () => {
+    expect(extractPlannedMealsSnapshot(null)).toEqual([]);
+  });
+
+  it('generated_data が snapshot を持たないオブジェクトの場合は空配列を返す', () => {
+    expect(extractPlannedMealsSnapshot({ version: 'v4', someOtherField: 1 })).toEqual([]);
+  });
+
+  it('snapshot が配列でない場合は空配列を返す', () => {
+    expect(extractPlannedMealsSnapshot({ snapshot: 'not-an-array' })).toEqual([]);
+  });
+
+  it('id/daily_meal_id/meal_type を欠いた不正な行は除外する', () => {
+    const validRow = makeRow({ id: 'valid-1' });
+    const invalidRow = { id: 'broken' }; // daily_meal_id / meal_type 欠如
+    expect(extractPlannedMealsSnapshot({ snapshot: [validRow, invalidRow] })).toEqual([validRow]);
+  });
+
+  it('generated_data がオブジェクトでない場合(文字列・数値等)は空配列を返す', () => {
+    expect(extractPlannedMealsSnapshot('unexpected-string')).toEqual([]);
+    expect(extractPlannedMealsSnapshot(42)).toEqual([]);
   });
 });

--- a/src/app/api/ai/menu/day/regenerate/route.ts
+++ b/src/app/api/ai/menu/day/regenerate/route.ts
@@ -13,7 +13,7 @@ export async function POST(request: Request) {
   const supabase = await createClient();
 
   try {
-    const { dailyMealId, dayDate, preferences } = await request.json();
+    const { dailyMealId, dayDate, preferences, includeCompleted } = await request.json();
 
     if (!dailyMealId && !dayDate) {
       return NextResponse.json({ error: 'Either dailyMealId or dayDate is required' }, { status: 400 });
@@ -60,7 +60,7 @@ export async function POST(request: Request) {
 
     const { data: meals, error: mealsError } = await supabase
       .from('planned_meals')
-      .select('id, meal_type')
+      .select('id, meal_type, is_completed')
       .eq('daily_meal_id', targetDayId);
 
     if (mealsError) {
@@ -68,15 +68,30 @@ export async function POST(request: Request) {
     }
 
     // 4. target_slotsを生成（その日の全食事）
+    // #1042: 完食済み(is_completed)の食事は、明示的な includeCompleted:true 指定が
+    // ない限り生成対象から除外する。摂取実績・ストリークを遡って壊さないため。
+    const allowCompletedOverwrite = includeCompleted === true;
     const mealTypes = ['breakfast', 'lunch', 'dinner'];
-    const targetSlots = mealTypes.map(mealType => {
-      const existingMeal = (meals || []).find(m => m.meal_type === mealType);
-      return {
+    const targetSlots = mealTypes
+      .map(mealType => ({
+        mealType,
+        existingMeal: (meals || []).find(m => m.meal_type === mealType),
+      }))
+      .filter(({ existingMeal }) => allowCompletedOverwrite || !existingMeal?.is_completed)
+      .map(({ mealType, existingMeal }) => ({
         date: dailyMeal.day_date,
         mealType,
         plannedMealId: existingMeal?.id || undefined,
-      };
-    });
+      }));
+
+    if (targetSlots.length === 0) {
+      return NextResponse.json({
+        success: true,
+        status: 'skipped',
+        message: '完食済みのため再生成対象がありません',
+        mealsCount: 0,
+      });
+    }
 
     // 5. リクエストを作成
     const featureFlags = await loadFeatureFlags(supabase);

--- a/src/app/api/ai/menu/weekly/cleanup/route.ts
+++ b/src/app/api/ai/menu/weekly/cleanup/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
+import { restorePlannedMealsSnapshot, extractPlannedMealsSnapshot } from '@/lib/planned-meals-snapshot';
 
 // スタックしているリクエストをクリーンアップ（5分以上前のpending/processingをfailedに）
 export async function POST() {
@@ -16,7 +17,7 @@ export async function POST() {
   // 自分のスタックしているリクエストを取得
   const { data: stuckRequests, error: fetchError } = await supabase
     .from('weekly_menu_requests')
-    .select('id, status, created_at')
+    .select('id, status, created_at, generated_data')
     .eq('user_id', user.id)
     .in('status', ['queued', 'pending', 'processing'])
     .lt('created_at', fiveMinutesAgo);
@@ -40,10 +41,30 @@ export async function POST() {
     return NextResponse.json({ error: updateError.message }, { status: 500 });
   }
 
-  return NextResponse.json({ 
-    message: 'Cleaned up stuck requests', 
+  // #1042: waitUntil 消失等で生成コールバックが実行されず stuck になったリクエストについて、
+  // 削除済み献立のスナップショットが残っていれば復元する（sweeper 経由の救済ロールバック）。
+  let restoredMeals = 0;
+  let skippedMeals = 0;
+  let failedMeals = 0;
+  for (const stuckRequest of stuckRequests) {
+    const snapshot = extractPlannedMealsSnapshot((stuckRequest as { generated_data?: unknown }).generated_data);
+    if (snapshot.length === 0) continue;
+    const restoreResult = await restorePlannedMealsSnapshot(supabase, snapshot);
+    restoredMeals += restoreResult.restored;
+    skippedMeals += restoreResult.skipped;
+    failedMeals += restoreResult.failed;
+    console.log(
+      `🔁 [stale sweeper/cleanup] Restored meals for request ${stuckRequest.id}: restored=${restoreResult.restored} skipped=${restoreResult.skipped} failed=${restoreResult.failed}`,
+    );
+  }
+
+  return NextResponse.json({
+    message: 'Cleaned up stuck requests',
     cleaned: stuckIds.length,
-    ids: stuckIds 
+    ids: stuckIds,
+    restoredMeals,
+    skippedMeals,
+    failedMeals,
   });
 }
 

--- a/src/app/api/ai/menu/weekly/pending/route.ts
+++ b/src/app/api/ai/menu/weekly/pending/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
+import { restorePlannedMealsSnapshot, extractPlannedMealsSnapshot } from '@/lib/planned-meals-snapshot';
 
 // 週間生成中のリクエストがあるか確認
 export async function GET(request: Request) {
@@ -26,7 +27,7 @@ export async function GET(request: Request) {
     // mode='weekly', mode='v4', mode='v5', mode=null のすべてを対象
     const { data: pendingRequest, error } = await supabase
       .from('weekly_menu_requests')
-      .select('id, status, mode, start_date, created_at, updated_at')
+      .select('id, status, mode, start_date, created_at, updated_at, generated_data')
       .eq('user_id', user.id)
       .or('mode.eq.weekly,mode.eq.v4,mode.eq.v5,mode.is.null')
       .in('status', ['queued', 'pending', 'processing'])
@@ -63,10 +64,24 @@ export async function GET(request: Request) {
         if (staleError) {
           console.error('Failed to mark stale weekly request as failed:', staleError);
         }
-        
+
         // プレースホルダーは使用しないので、is_generating のクリアは不要
-        
-        return NextResponse.json({ hasPending: false });
+
+        // #1042: waitUntil 消失等で生成コールバックが実行されず stale になったケースでも、
+        // 削除済み献立のスナップショットが残っていれば復元する（sweeper 経由の救済ロールバック）。
+        const snapshot = extractPlannedMealsSnapshot(pendingRequest.generated_data);
+        let restoreResult: { restored: number; skipped: number; failed: number } | null = null;
+        if (snapshot.length > 0) {
+          restoreResult = await restorePlannedMealsSnapshot(supabase, snapshot);
+          console.log(
+            `🔁 [stale sweeper/pending] Restored meals for request ${pendingRequest.id}: restored=${restoreResult.restored} skipped=${restoreResult.skipped} failed=${restoreResult.failed}`,
+          );
+        }
+
+        return NextResponse.json({
+          hasPending: false,
+          ...(restoreResult ? { restore: restoreResult } : {}),
+        });
       }
 
       if (pendingRequest.start_date && pendingRequest.start_date !== date) {

--- a/src/app/api/ai/menu/weekly/pending/route.ts
+++ b/src/app/api/ai/menu/weekly/pending/route.ts
@@ -25,9 +25,11 @@ export async function GET(request: Request) {
     // ユーザーの最新の queued / pending / processing の週間生成リクエストを確認
     // start_date に関係なく、最新のリクエストを返す（リロード時の復元を確実にするため）
     // mode='weekly', mode='v4', mode='v5', mode=null のすべてを対象
+    // #1042: 通常ポーリング（3秒間隔）では生成中に肥大化する generated_data(jsonb) を
+    // select しない。stale 判定が成立した場合のみ、下記で二次クエリして取得する。
     const { data: pendingRequest, error } = await supabase
       .from('weekly_menu_requests')
-      .select('id, status, mode, start_date, created_at, updated_at, generated_data')
+      .select('id, status, mode, start_date, created_at, updated_at')
       .eq('user_id', user.id)
       .or('mode.eq.weekly,mode.eq.v4,mode.eq.v5,mode.is.null')
       .in('status', ['queued', 'pending', 'processing'])
@@ -69,7 +71,17 @@ export async function GET(request: Request) {
 
         // #1042: waitUntil 消失等で生成コールバックが実行されず stale になったケースでも、
         // 削除済み献立のスナップショットが残っていれば復元する（sweeper 経由の救済ロールバック）。
-        const snapshot = extractPlannedMealsSnapshot(pendingRequest.generated_data);
+        // generated_data は stale 判定成立時のみここで二次クエリして取得する。
+        const { data: snapshotRow, error: snapshotError } = await supabase
+          .from('weekly_menu_requests')
+          .select('generated_data')
+          .eq('id', pendingRequest.id)
+          .eq('user_id', user.id)
+          .maybeSingle();
+        if (snapshotError) {
+          console.error('Failed to fetch generated_data for stale restore:', snapshotError);
+        }
+        const snapshot = extractPlannedMealsSnapshot(snapshotRow?.generated_data);
         let restoreResult: { restored: number; skipped: number; failed: number } | null = null;
         if (snapshot.length > 0) {
           restoreResult = await restorePlannedMealsSnapshot(supabase, snapshot);

--- a/src/app/api/ai/menu/weekly/request/route.ts
+++ b/src/app/api/ai/menu/weekly/request/route.ts
@@ -7,6 +7,7 @@ import { callGenerateMenuV5WithRetry } from '@/lib/generate-menu-v5-retry';
 import { cancelPendingMealImageJobs } from '../../../../../../lib/meal-image-jobs';
 import { createLogger } from '@/lib/db-logger';
 import { checkRateLimit, rateLimitExceededResponse } from '@/lib/rate-limit';
+import { restorePlannedMealsSnapshot, type PlannedMealSnapshotRow } from '@/lib/planned-meals-snapshot';
 
 // Vercel Proプランでは最大300秒まで延長可能
 export const maxDuration = 300;
@@ -139,6 +140,9 @@ export async function POST(request: Request) {
 
     // 2. 今日以降の日付の既存食事を削除（Edge Functionが新規INSERTするため）
     const todayStr = getTodayStr();
+    // #1042: 削除前に旧値をスナップショットしておく（生成失敗時のロールバック用）。
+    // 「先に削除→後で書き込み」を維持しつつ、失敗時に元の献立を復元できるようにする。
+    const deletedMealsSnapshot: PlannedMealSnapshotRow[] = [];
 
     for (let i = 0; i < 7; i++) {
       const dateStr = addDays(startDate, i);
@@ -154,10 +158,12 @@ export async function POST(request: Request) {
         if (existingDay) {
           const { data: existingMeals } = await supabase
             .from('planned_meals')
-            .select('id')
+            .select('*')
             .eq('daily_meal_id', existingDay.id);
 
           if (Array.isArray(existingMeals) && existingMeals.length > 0) {
+            deletedMealsSnapshot.push(...(existingMeals as PlannedMealSnapshotRow[]));
+
             await Promise.all(
               existingMeals.map((meal) =>
                 cancelPendingMealImageJobs({
@@ -179,8 +185,11 @@ export async function POST(request: Request) {
         }
       }
     }
-    
-    console.log(`📝 Cleared existing meals for week starting ${startDate}`);
+
+    console.log(
+      `📝 Cleared existing meals for week starting ${startDate}` +
+        (deletedMealsSnapshot.length > 0 ? ` (snapshot: ${deletedMealsSnapshot.length} meals)` : ''),
+    );
 
     // 3. リクエストをDBに保存（ステータス追跡用）
     const { data: requestData, error: insertError } = await supabase
@@ -192,6 +201,8 @@ export async function POST(request: Request) {
         status: 'processing',
         prompt: noteForAi || '',
         constraints,
+        // #1042: 生成失敗時に削除済み献立を復元するためのスナップショット（監査用途も兼ねる）
+        generated_data: deletedMealsSnapshot.length > 0 ? { snapshot: deletedMealsSnapshot } : null,
       })
       .select('id')
       .single();
@@ -248,10 +259,22 @@ export async function POST(request: Request) {
     }).then(async (result) => {
       if (!result.ok) {
         console.error('❌ Edge Function error:', result.errorMessage);
+        let errorMessage = result.errorMessage;
+
+        // #1042: 生成失敗時、削除済みの旧献立をスナップショットから復元する。
+        // 部分的に新しい献立が既に書き込まれているスロットは上書きしない（skip）。
+        if (deletedMealsSnapshot.length > 0) {
+          const restoreResult = await restorePlannedMealsSnapshot(supabase, deletedMealsSnapshot);
+          console.log(
+            `🔁 Restored meals after generation failure: restored=${restoreResult.restored} skipped=${restoreResult.skipped} failed=${restoreResult.failed}`,
+          );
+          errorMessage = `${result.errorMessage} (rollback: restored=${restoreResult.restored}, skipped=${restoreResult.skipped}, failed=${restoreResult.failed})`;
+        }
+
         await markWeeklyMenuRequestFailed({
           supabase,
           requestId: requestData.id,
-          errorMessage: result.errorMessage,
+          errorMessage,
         });
         return;
       }

--- a/src/app/api/ai/menu/weekly/status/route.ts
+++ b/src/app/api/ai/menu/weekly/status/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
+import { restorePlannedMealsSnapshot, extractPlannedMealsSnapshot } from '@/lib/planned-meals-snapshot';
 
 // リクエストのステータスを確認
 export async function GET(request: Request) {
@@ -20,7 +21,7 @@ export async function GET(request: Request) {
   try {
     const { data: request, error } = await supabase
       .from('weekly_menu_requests')
-      .select('id, status, error_message, updated_at, mode, start_date, target_meal_id, progress')
+      .select('id, status, error_message, updated_at, mode, start_date, target_meal_id, progress, generated_data')
       .eq('id', requestId)
       .eq('user_id', user.id)
       .maybeSingle();
@@ -53,13 +54,25 @@ export async function GET(request: Request) {
       if (staleError) {
         console.error('Failed to mark stale request as failed:', staleError);
       }
-      
+
       // プレースホルダーは使用しないので、is_generating のクリアは不要
-      
+
+      // #1042: waitUntil 消失等で生成コールバックが実行されず stale になったケースでも、
+      // 削除済み献立のスナップショットが残っていれば復元する（sweeper 経由の救済ロールバック）。
+      const snapshot = extractPlannedMealsSnapshot(request.generated_data);
+      let restoreResult: { restored: number; skipped: number; failed: number } | null = null;
+      if (snapshot.length > 0) {
+        restoreResult = await restorePlannedMealsSnapshot(supabase, snapshot);
+        console.log(
+          `🔁 [stale sweeper/status] Restored meals for request ${requestId}: restored=${restoreResult.restored} skipped=${restoreResult.skipped} failed=${restoreResult.failed}`,
+        );
+      }
+
       return NextResponse.json({
         status: 'failed',
         errorMessage: 'stale_request_timeout',
         updatedAt: new Date().toISOString(),
+        ...(restoreResult ? { restore: restoreResult } : {}),
       });
     }
 

--- a/src/app/api/ai/menu/weekly/status/route.ts
+++ b/src/app/api/ai/menu/weekly/status/route.ts
@@ -19,9 +19,11 @@ export async function GET(request: Request) {
   }
 
   try {
+    // #1042: 通常ポーリング（3秒間隔）では生成中に肥大化する generated_data(jsonb) を
+    // select しない。stale 判定が成立した場合のみ、下記で二次クエリして取得する。
     const { data: request, error } = await supabase
       .from('weekly_menu_requests')
-      .select('id, status, error_message, updated_at, mode, start_date, target_meal_id, progress, generated_data')
+      .select('id, status, error_message, updated_at, mode, start_date, target_meal_id, progress')
       .eq('id', requestId)
       .eq('user_id', user.id)
       .maybeSingle();
@@ -59,7 +61,17 @@ export async function GET(request: Request) {
 
       // #1042: waitUntil 消失等で生成コールバックが実行されず stale になったケースでも、
       // 削除済み献立のスナップショットが残っていれば復元する（sweeper 経由の救済ロールバック）。
-      const snapshot = extractPlannedMealsSnapshot(request.generated_data);
+      // generated_data は stale 判定成立時のみここで二次クエリして取得する。
+      const { data: snapshotRow, error: snapshotError } = await supabase
+        .from('weekly_menu_requests')
+        .select('generated_data')
+        .eq('id', requestId)
+        .eq('user_id', user.id)
+        .maybeSingle();
+      if (snapshotError) {
+        console.error('Failed to fetch generated_data for stale restore:', snapshotError);
+      }
+      const snapshot = extractPlannedMealsSnapshot(snapshotRow?.generated_data);
       let restoreResult: { restored: number; skipped: number; failed: number } | null = null;
       if (snapshot.length > 0) {
         restoreResult = await restorePlannedMealsSnapshot(supabase, snapshot);

--- a/src/app/api/pantry/from-photo/route.ts
+++ b/src/app/api/pantry/from-photo/route.ts
@@ -202,6 +202,9 @@ export async function POST(request: Request) {
     // 削除済みの旧データと新規データが混在した中途半端な状態を残さないため、
     // 今回新規挿入した分を削除し、退避しておいた旧データを復元する。
     if (mode === 'replace' && replaceWriteFailures > 0) {
+      let rollbackDeleteFailed = false;
+      let restoreFailed = false;
+
       if (insertedPantryItemIds.length > 0) {
         const { error: rollbackDeleteError } = await supabase
           .from('pantry_items')
@@ -209,6 +212,7 @@ export async function POST(request: Request) {
           .in('id', insertedPantryItemIds);
         if (rollbackDeleteError) {
           console.error('Failed to roll back partially inserted pantry items:', rollbackDeleteError);
+          rollbackDeleteFailed = true;
         }
       }
       if (previousPantryItems.length > 0) {
@@ -217,12 +221,22 @@ export async function POST(request: Request) {
           .insert(previousPantryItems);
         if (restoreError) {
           console.error('Failed to restore previous pantry items after partial replace failure:', restoreError);
+          restoreFailed = true;
         }
       }
 
+      // #1042: ロールバック（新規分の削除・旧データの復元）自体が失敗した場合、
+      // 「元のデータへロールバックしました」という誤ったメッセージを返してはいけない。
+      // rollbackSucceeded をレスポンスに反映し、失敗時はデータ消失の可能性を明示する。
+      const rollbackSucceeded = !rollbackDeleteFailed && !restoreFailed;
+      const message = rollbackSucceeded
+        ? 'Pantry replace が部分的に失敗したため、元のデータへロールバックしました'
+        : 'Pantry replace が部分的に失敗し、ロールバックにも失敗しました。冷蔵庫データが失われた可能性があります。サポートへ連絡してください';
+
       return NextResponse.json(
         {
-          error: 'Pantry replace が部分的に失敗したため、元のデータへロールバックしました',
+          error: message,
+          rollbackSucceeded,
           results,
         },
         { status: 500 },

--- a/src/app/api/pantry/from-photo/route.ts
+++ b/src/app/api/pantry/from-photo/route.ts
@@ -70,7 +70,21 @@ export async function POST(request: Request) {
     }
 
     // mode='replace' の場合、既存アイテムを全削除
+    // #1042: 削除前に旧値をスナップショットしておき、逐次insertが部分的に
+    // 失敗した場合は新規分をロールバックして旧データへ復元する（補償ロールバック）。
+    let previousPantryItems: Tables<'pantry_items'>[] = [];
     if (mode === 'replace') {
+      const { data: snapshotItems, error: snapshotError } = await supabase
+        .from('pantry_items')
+        .select('*')
+        .eq('user_id', user.id);
+
+      if (snapshotError) {
+        console.error('Failed to snapshot existing pantry items:', snapshotError);
+        return NextResponse.json({ error: 'Failed to prepare pantry replace' }, { status: 500 });
+      }
+      previousPantryItems = snapshotItems ?? [];
+
       const { error: deleteError } = await supabase
         .from('pantry_items')
         .delete()
@@ -89,6 +103,9 @@ export async function POST(request: Request) {
       skipped: 0,
       items: [] as Tables<'pantry_items'>[],
     };
+    // replace モードで新規挿入したID（ロールバック時の削除対象）と書き込み失敗件数
+    const insertedPantryItemIds: string[] = [];
+    let replaceWriteFailures = 0;
 
     // 各アイテムを処理
     for (const ingredient of ingredients) {
@@ -119,9 +136,11 @@ export async function POST(request: Request) {
         if (insertError) {
           console.error('Failed to insert pantry item:', insertError);
           results.skipped++;
+          replaceWriteFailures++;
         } else {
           results.created++;
           results.items.push(inserted);
+          insertedPantryItemIds.push(inserted.id);
         }
       } else {
         // append モードでは既存チェック → upsert
@@ -177,6 +196,37 @@ export async function POST(request: Request) {
           }
         }
       }
+    }
+
+    // #1042: replace モードで書き込みが部分的に失敗した場合はロールバックする。
+    // 削除済みの旧データと新規データが混在した中途半端な状態を残さないため、
+    // 今回新規挿入した分を削除し、退避しておいた旧データを復元する。
+    if (mode === 'replace' && replaceWriteFailures > 0) {
+      if (insertedPantryItemIds.length > 0) {
+        const { error: rollbackDeleteError } = await supabase
+          .from('pantry_items')
+          .delete()
+          .in('id', insertedPantryItemIds);
+        if (rollbackDeleteError) {
+          console.error('Failed to roll back partially inserted pantry items:', rollbackDeleteError);
+        }
+      }
+      if (previousPantryItems.length > 0) {
+        const { error: restoreError } = await supabase
+          .from('pantry_items')
+          .insert(previousPantryItems);
+        if (restoreError) {
+          console.error('Failed to restore previous pantry items after partial replace failure:', restoreError);
+        }
+      }
+
+      return NextResponse.json(
+        {
+          error: 'Pantry replace が部分的に失敗したため、元のデータへロールバックしました',
+          results,
+        },
+        { status: 500 },
+      );
     }
 
     // スナップショットを保存（履歴）

--- a/src/app/api/pantry/from-photo/route.ts
+++ b/src/app/api/pantry/from-photo/route.ts
@@ -227,11 +227,17 @@ export async function POST(request: Request) {
 
       // #1042: ロールバック（新規分の削除・旧データの復元）自体が失敗した場合、
       // 「元のデータへロールバックしました」という誤ったメッセージを返してはいけない。
-      // rollbackSucceeded をレスポンスに反映し、失敗時はデータ消失の可能性を明示する。
+      // rollbackSucceeded をレスポンスに反映し、失敗内容に応じてメッセージを分岐する。
+      // - restoreFailed（旧データ復元insert自体が失敗）: 旧データが失われた可能性がある
+      //   （delete が成功していれば新旧どちらも無い状態、失敗していても旧データは戻っていない）
+      // - rollbackDeleteFailed のみ（旧データ復元は成功、新規挿入分の削除だけ失敗）: 旧データは
+      //   無事だが新規挿入分が残留しており、重複している可能性がある（データ消失ではない）
       const rollbackSucceeded = !rollbackDeleteFailed && !restoreFailed;
       const message = rollbackSucceeded
         ? 'Pantry replace が部分的に失敗したため、元のデータへロールバックしました'
-        : 'Pantry replace が部分的に失敗し、ロールバックにも失敗しました。冷蔵庫データが失われた可能性があります。サポートへ連絡してください';
+        : restoreFailed
+          ? 'Pantry replace が部分的に失敗し、旧データの復元にも失敗しました。冷蔵庫データが失われた可能性があります。サポートへ連絡してください'
+          : 'Pantry replace が部分的に失敗し、新規追加分の削除ロールバックに失敗しました。旧データは復元済みのため、新規追加分と重複している可能性があります。内容をご確認ください';
 
       return NextResponse.json(
         {

--- a/src/lib/planned-meals-snapshot.ts
+++ b/src/lib/planned-meals-snapshot.ts
@@ -1,0 +1,82 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * #1042: 破壊的な献立操作 (削除→再生成) のデータ消失防止。
+ *
+ * 「先に削除→後で書き込み」型の再生成フローでは、生成処理が失敗すると
+ * 旧データが復元されないまま消失する。本モジュールは削除前に旧値を
+ * スナップショットし、失敗時に安全に復元するためのヘルパーを提供する。
+ * （設計基準: 一括書き込みは旧値スナップショット→書き込み→失敗時ロールバック）
+ */
+
+// planned_meals の 1 行分（select('*') の結果をそのまま保持する）
+export type PlannedMealSnapshotRow = Record<string, unknown> & {
+  id: string;
+  daily_meal_id: string;
+  meal_type: string;
+};
+
+export type RestorePlannedMealsResult = {
+  restored: number;
+  skipped: number;
+  failed: number;
+};
+
+/**
+ * 削除前に退避したスナップショットから planned_meals を復元する。
+ *
+ * 復元前に同一スロット (daily_meal_id + meal_type) が既に埋まっていないかを
+ * 確認し、埋まっていればスキップする（生成処理が部分的に成功して新しい
+ * データを書き込んでいた場合に、それを上書きしないため = 他者による更新の検知）。
+ */
+export async function restorePlannedMealsSnapshot(
+  supabase: Pick<SupabaseClient, 'from'>,
+  snapshot: PlannedMealSnapshotRow[],
+): Promise<RestorePlannedMealsResult> {
+  let restored = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const row of snapshot) {
+    if (!row?.daily_meal_id || !row?.meal_type) {
+      failed++;
+      continue;
+    }
+
+    const { data: occupied, error: lookupError } = await supabase
+      .from('planned_meals')
+      .select('id')
+      .eq('daily_meal_id', row.daily_meal_id)
+      .eq('meal_type', row.meal_type)
+      .maybeSingle();
+
+    if (lookupError) {
+      console.error(
+        `[restorePlannedMealsSnapshot] lookup failed for ${row.daily_meal_id}/${row.meal_type}:`,
+        lookupError.message,
+      );
+      failed++;
+      continue;
+    }
+
+    if (occupied) {
+      // 他の書き込み（部分的に成功した生成結果など）が既にこのスロットを
+      // 埋めている。旧データで上書きしない。
+      skipped++;
+      continue;
+    }
+
+    const { error: insertError } = await supabase.from('planned_meals').insert(row);
+    if (insertError) {
+      console.error(
+        `[restorePlannedMealsSnapshot] restore insert failed for planned_meal ${row.id}:`,
+        insertError.message,
+      );
+      failed++;
+      continue;
+    }
+    restored++;
+  }
+
+  return { restored, skipped, failed };
+}

--- a/src/lib/planned-meals-snapshot.ts
+++ b/src/lib/planned-meals-snapshot.ts
@@ -80,3 +80,26 @@ export async function restorePlannedMealsSnapshot(
 
   return { restored, skipped, failed };
 }
+
+/**
+ * weekly_menu_requests.generated_data (jsonb, request/route.ts が
+ * `{ snapshot: PlannedMealSnapshotRow[] }` の形で保存) から復元用スナップショットを
+ * 安全に取り出す。
+ *
+ * #1042: 生成が waitUntil 消失等で止まり stale sweeper (status/pending/cleanup)
+ * が status='failed' にするだけで終わっていたケースの救済に使う。
+ * 想定外の形（null / 他フィールドのみ等）の場合は空配列を返す。
+ */
+export function extractPlannedMealsSnapshot(generatedData: unknown): PlannedMealSnapshotRow[] {
+  if (!generatedData || typeof generatedData !== 'object') return [];
+  const snapshot = (generatedData as Record<string, unknown>).snapshot;
+  if (!Array.isArray(snapshot)) return [];
+  return snapshot.filter(
+    (row): row is PlannedMealSnapshotRow =>
+      !!row &&
+      typeof row === 'object' &&
+      typeof (row as Record<string, unknown>).id === 'string' &&
+      typeof (row as Record<string, unknown>).daily_meal_id === 'string' &&
+      typeof (row as Record<string, unknown>).meal_type === 'string',
+  );
+}


### PR DESCRIPTION
## 概要
破壊的な献立操作(削除→再生成・一括置換)でのデータ消失を防止(#1042、code-only 部分=F1a-03/F1a-14)。

## 修正内容
- **snapshot→rollback 構造**: weekly/request・day/regenerate・save-meal・pantry/from-photo の破壊的操作を「旧値スナップショット → 書き込み → 失敗時ロールバック」に(一括書き込みの設計基準どおり)。部分失敗で中途半端な消失を残さない。
- **sweeper の復元漏れ解消**: 生成が waitUntil 消失等で止まった場合に stale sweeper(status/pending/cleanup の3箇所)が status='failed' にするだけで旧献立が消えたままだった問題を、`restorePlannedMealsSnapshot`(generated_data.snapshot、occupied は skip)で復元するよう修正。
- **ロールバック結果の正直な報告**: pantry replace で復元自体が失敗した場合に「ロールバックしました」と偽って返していた問題を `rollbackSucceeded` + メッセージ分岐に(復元失敗=データ喪失の可能性 / 削除ロールバック失敗=重複の可能性、を区別)。
- **性能配慮**: 3秒ポーリングの status/pending API は通常時 `generated_data`(肥大 jsonb)を select せず、stale 成立時のみ二次クエリで取得。

## スコープ外(migration=#1064 後・報告のみ)
- F1a-15 `replace_pantry_items` / F1a-17 `swap_planned_meal_order` の RPC 化(DB トランザクション本筋)。check-then-act の極小レース窓は RPC 化で解消予定。

## 検証
- 失敗注入テスト(書き込み途中失敗→旧値復元)、sweeper 復元3ケース×3、メッセージ分岐、非 stale 時に generated_data を select しないこと、を含むテスト群全 PASS。tsc/eslint クリーン。ベースライン比較で退行ゼロ。
- 2モデル敵対レビュー(Sonnet5+Fable)**double-PASS ×3回**(本修正 → 誤メッセージ/復元漏れ修正 → 性能退行修正)。
