### PR TITLE
ci(migrations): #1064 Phase1 実行機構(repair/apply)と drift guard 修正

### DIFF
--- a/.github/workflows/deploy-supabase-migrations.yml
+++ b/.github/workflows/deploy-supabase-migrations.yml
@@ -1,5 +1,18 @@
 name: Deploy Supabase Migrations
 
+# --- 運用モデル変更の明記 (#1064 Phase 1, round-2 監査 #5 対応) ---
+# drift guard のパーサー修正 (下記 "Detect migration drift" ステップ) により、
+# 今後このワークフローは「新規に追加された migration ファイル (=まだ本番台帳に
+# 存在しない local-only な version)」を常に正しくドリフトとして検出し、exit 1 で
+# 後続の "Apply migrations" ステップをブロックするようになる。
+#
+# これは意図的な仕様変更である: Phase 1 以降、migration の本番適用は
+# `migration-apply.yml` (workflow_dispatch, dry-run + environment 承認ゲート付き)
+# 経由に一本化する。この push トリガ workflow による自動 apply は今後実質的に
+# 常にドリフト検出で停止するため、通常運用では発火しない (意図的な無効化)。
+# 本ワークフローの役割は「db lint + drift 検出によるガード/レポート」のみとなり、
+# 実際の本番適用ロールは持たない。
+# (Phase 2 の squash で drift-free な定常状態に到達した後、運用モデルを再検討する)
 on:
   push:
     branches:
@@ -67,19 +80,19 @@ jobs:
           drift = []
           for raw_line in lines:
               line = raw_line.rstrip("\n")
-              # supabase CLI の pretty 出力は `|Local|Remote|Time (UTC)|` 形式で
-              # 各行が "|" で始まり "|" で終わる。先頭/末尾のちょうど1個だけを
-              # 取り除いてから分割しないと、空セル(local-only/remote-only 行)の
-              # 位置がずれて誤検知・見逃しの原因になる。
-              if not (line.startswith("|") and line.endswith("|")):
+              # supabase CLI の実際の出力は先頭に空白パディングがあり、行頭/行末に
+              # "|" は付かない ` 20260101000000 | 20260101000000 | 2026-01-01 00:00:00 `
+              # 形式(表示用の余白付き `|` 区切り)。旧パーサーは `line.startswith("|")`
+              # 前提で全行スキップ=偽陰性になっていたため、単純に "|" を含む行を列分割する
+              # 方式に変更する(#1064 実データ migration_list.txt で検証済み)。
+              if "|" not in line:
                   continue
-              inner = line[1:-1]
-              cols = [c.strip() for c in inner.split("|")]
+              cols = [c.strip() for c in line.split("|")]
               if len(cols) < 2:
                   continue
               local, remote = cols[0], cols[1]
-              # ヘッダー行・区切り行 (LOCAL/REMOTE 文字列や ---- ) は除外し、
-              # migration バージョン (数値) の行のみを対象にする
+              # ヘッダー行("Local"/"Remote"等)・区切り線("----")は数値正規表現に
+              # マッチしないため自然に除外され、migration バージョン(数値)の行のみ残る
               if not (re.fullmatch(r"[0-9]*", local) and re.fullmatch(r"[0-9]*", remote)):
                   continue
               if local == "" and remote == "":

--- a/.github/workflows/migration-apply.yml
+++ b/.github/workflows/migration-apply.yml
@@ -1,0 +1,222 @@
+name: Migration Apply (#1064 Phase 1, drift guard 無し)
+
+# migration-repair.yml で台帳を repair 済み (000136 と 20260710090000 の2本のみ
+# local-only) であることを前提に、その2本だけを db push --include-all で本番へ
+# 実適用する専用 workflow。drift guard は意図的に通さない (local-only 2本を push
+# するのが目的なので、guard を通すと exit 1 でブロックされてしまう = Critical-2 対応)。
+#
+# dry_run job で "適用対象が2本のみ" であることを機械的アサーション + 人手確認の
+# 両方で担保してから出力し、apply job は GitHub Environment (production-db) の
+# required reviewers 承認を経てから、直前に同アサーションを再実行してから push する
+# (round-2 監査 #3 対応: repair 未完了/部分失敗状態での apply 単独 dispatch 暴発を防止)。
+#
+# 【前提 (最終監査残課題 対応)】この workflow が checkout する ref は、PR-M
+# (forward-ref 修正 + draft migration 4本追加) がマージ済みであることを前提とする。
+# 未マージのまま dispatch した場合、`db push --include-all --dry-run` の適用対象が
+# 期待の2本 (20260511000136 / 20260710090000) 未満になり、下記の
+# "Assert apply target is exactly the expected 2 versions" が found<2 で
+# 正しく exit 1 して停止する (機械的に安全側に倒れる)。
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: '実行確認。文字列 "APPLY" を入力した場合のみ実行される'
+        required: true
+        type: string
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  SUPABASE_PROJECT_ID: flmeolcfutuwwbjmzyoz
+
+jobs:
+  dry_run:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.confirm == 'APPLY' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Guard - confirm input must be APPLY
+        run: |
+          if [ "${{ github.event.inputs.confirm }}" != "APPLY" ]; then
+            echo "::error::confirm 入力が 'APPLY' ではありません。中止します。"
+            exit 1
+          fi
+
+      - name: Create artifacts directory
+        run: mkdir -p artifacts
+
+      - name: Verify Supabase CLI version
+        run: npx --yes supabase@2.62.10 --version
+
+      - name: Link Supabase project
+        run: |
+          npx --yes supabase@2.62.10 link --project-ref ${{ env.SUPABASE_PROJECT_ID }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: db push --include-all --dry-run (適用対象の事前確認)
+        run: |
+          npx --yes supabase@2.62.10 db push --linked --include-all --dry-run 2>&1 | tee artifacts/apply_dryrun.txt
+          {
+            echo "## apply_dryrun.txt (db push --include-all --dry-run)"
+            echo ""
+            echo "\`\`\`"
+            cat artifacts/apply_dryrun.txt
+            echo "\`\`\`"
+            echo ""
+            echo "**承認前に必ず確認すること**: 適用対象が \`20260511000136\` と \`20260710090000\` の"
+            echo "2本のみであること。それ以外が含まれる場合は migration-repair.yml が未完了、"
+            echo "または repair 対象リストと台帳の不一致がある可能性が高い。承認しないこと。"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      # --- 「適用対象がちょうど2本」の機械アサーション (round-2 監査 #3 対応) ---
+      # `db push --include-all --dry-run` の実出力は以下の形式であることを実測済み:
+      #   Would push these migrations:
+      #    • 20260511000136_rls_guard_privileged_columns.sql
+      #    • 20260710090000_reconcile_paired_drift.sql
+      #   Finished supabase db push.
+      # 各行末尾の "<14桁version>_....sql" を抽出し、期待する2 version の集合と
+      # 完全一致するかを検証する。想定外の migration が並んだ場合や repair 未完了で
+      # 3本以上/1本以下になっている場合は exit 1 で機械的に停止する。
+      - name: Assert apply target is exactly the expected 2 versions
+        run: |
+          python3 - <<'PY'
+          import re
+          import sys
+
+          EXPECTED = {"20260511000136", "20260710090000"}
+
+          with open("artifacts/apply_dryrun.txt", encoding="utf-8") as fh:
+              lines = fh.readlines()
+
+          found = set()
+          for raw_line in lines:
+              line = raw_line.rstrip("\n").strip()
+              m = re.search(r"(\d{14})_\S+\.sql$", line)
+              if m:
+                  found.add(m.group(1))
+
+          if found != EXPECTED:
+              print("::error::apply 対象が想定の2本 (20260511000136 / 20260710090000) と一致しません。", file=sys.stderr)
+              print(f"検出された version: {sorted(found)}", file=sys.stderr)
+              print(f"期待される version: {sorted(EXPECTED)}", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"OK: apply 対象は想定通り2本 ({sorted(found)})")
+          PY
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Upload dry-run artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-apply-dryrun
+          path: artifacts/apply_dryrun.txt
+          retention-days: 90
+
+  apply:
+    needs: dry_run
+    runs-on: ubuntu-latest
+    # required reviewers による承認ゲート。repo Settings > Environments で
+    # "production-db" environment を作成し、Required reviewers を設定しておくこと。
+    # 未設定の場合、このジョブは承認待ちにならず即実行される点に注意。
+    environment: production-db
+    if: ${{ github.event.inputs.confirm == 'APPLY' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Create artifacts directory
+        run: mkdir -p artifacts
+
+      - name: Verify Supabase CLI version
+        run: npx --yes supabase@2.62.10 --version
+
+      - name: Link Supabase project
+        run: |
+          npx --yes supabase@2.62.10 link --project-ref ${{ env.SUPABASE_PROJECT_ID }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      # dry_run job の承認からこの job の実行までに時間差があり得るため、push 直前に
+      # 同じ dry-run + アサーションを再実行する (二重化。round-2 監査 #3 対応)。
+      # dry_run job の artifact をそのまま信用せず、この job 自身で fresh に取得し直す。
+      - name: db push --include-all --dry-run (push 直前の再確認)
+        run: |
+          npx --yes supabase@2.62.10 db push --linked --include-all --dry-run 2>&1 | tee artifacts/apply_dryrun_recheck.txt
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Assert apply target is exactly the expected 2 versions (re-check before push)
+        run: |
+          python3 - <<'PY'
+          import re
+          import sys
+
+          EXPECTED = {"20260511000136", "20260710090000"}
+
+          with open("artifacts/apply_dryrun_recheck.txt", encoding="utf-8") as fh:
+              lines = fh.readlines()
+
+          found = set()
+          for raw_line in lines:
+              line = raw_line.rstrip("\n").strip()
+              m = re.search(r"(\d{14})_\S+\.sql$", line)
+              if m:
+                  found.add(m.group(1))
+
+          if found != EXPECTED:
+              print("::error::[re-check] apply 対象が想定の2本 (20260511000136 / 20260710090000) と一致しません。push を中止します。", file=sys.stderr)
+              print(f"検出された version: {sorted(found)}", file=sys.stderr)
+              print(f"期待される version: {sorted(EXPECTED)}", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"OK: push 直前の再確認でも apply 対象は想定通り2本 ({sorted(found)})")
+          PY
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      # drift guard は意図的に無し (000136 + 20260710090000 の local-only 2本を
+      # 承認済みで push するのがこの workflow の目的そのものであるため)
+      - name: db push --include-all (承認後の実適用)
+        run: |
+          npx --yes supabase@2.62.10 db push --linked --include-all
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Verify migration list after apply (完全 paired 確認用)
+        run: |
+          npx --yes supabase@2.62.10 migration list --linked | tee artifacts/migration_list_final.txt
+          {
+            echo "## migration list (apply 後・最終確認)"
+            echo ""
+            echo "\`\`\`"
+            cat artifacts/migration_list_final.txt
+            echo "\`\`\`"
+            echo ""
+            echo "期待値: 全 version が Local/Remote 完全 paired。片方のみの行が残っていれば異常。"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Upload post-apply artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-apply-final
+          path: |
+            artifacts/apply_dryrun_recheck.txt
+            artifacts/migration_list_final.txt
+          retention-days: 90

--- a/.github/workflows/migration-repair.yml
+++ b/.github/workflows/migration-repair.yml
@@ -1,0 +1,305 @@
+name: Migration Repair (#1064 Phase 1, push無し)
+
+# push は一切行わない repair 専用 workflow。台帳 (supabase_migrations.schema_migrations)
+# のステータスのみを付け替える (migration repair --status applied/reverted)。
+# applied37/reverted31 のバージョンリストは scratchpad/phase0/PHASE1-PLAN.md 由来。
+#
+# 2ジョブ構成 (round-2 監査 #2 対応): inspect (snapshot + gate, 停止) → repair
+# (environment 承認後に実行)。gate と repair の間に必ず人手承認を挟むための分割。
+# 特に 20260708005642 は「revert 前に中身確認が必須」の唯一の未確認 version。
+#
+# --- ロールバック手順 (round-2 監査 #4 対応 / 最終監査残課題 修正) ---
+# repair が途中失敗した場合 (例: applied37 の途中でエラー) は、台帳が中途半端な
+# 状態になり得る。ロールバックは以下の手順で行う:
+#   1. inspect job の artifact "migration-repair-pre" から ledger_snapshot.sql
+#      (repair 実行前の supabase_migrations.schema_migrations 全件、単一マルチ行
+#      INSERT 形式) を取得する。このダンプは schema_migrations テーブル単体に
+#      限定されており、同スキーマ内の他テーブル (supabase_migrations.seed_files 等)
+#      の行は含まれない (下記 Snapshot ステップ参照)。
+#   2. ledger_snapshot.sql は INSERT 文であり、そのまま現在の (repair 途中状態の)
+#      schema_migrations に流すと version が PK 衝突を起こして INSERT が全文失敗する。
+#      必ず先に `TRUNCATE supabase_migrations.schema_migrations;` で全行を空にしてから
+#      ledger_snapshot.sql を実行すること (`psql <接続文字列> -f ledger_snapshot.sql` 等)。
+#      ダンプが schema_migrations 単体に限定されているため、この TRUNCATE 対象も
+#      schema_migrations 単体のみで過不足なく整合する (seed_files 等の他テーブルは
+#      触れないため、そちらの既存データと PK 衝突する心配は無い)。
+#   3. 復元後は `supabase migration list --linked` で repair 前の状態に戻ったことを
+#      確認する。
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: '実行確認。文字列 "REPAIR" を入力した場合のみ実行される'
+        required: true
+        type: string
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  SUPABASE_PROJECT_ID: flmeolcfutuwwbjmzyoz
+
+jobs:
+  # --- job1: 台帳全件スナップショット + SELECT ゲート (repair はしない・ここで停止) ---
+  inspect:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.confirm == 'REPAIR' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Guard - confirm input must be REPAIR
+        run: |
+          if [ "${{ github.event.inputs.confirm }}" != "REPAIR" ]; then
+            echo "::error::confirm 入力が 'REPAIR' ではありません。中止します。"
+            exit 1
+          fi
+
+      - name: Create artifacts directory
+        run: mkdir -p artifacts
+
+      - name: Verify Supabase CLI version
+        run: npx --yes supabase@2.62.10 --version
+
+      - name: Link Supabase project
+        run: |
+          npx --yes supabase@2.62.10 link --project-ref ${{ env.SUPABASE_PROJECT_ID }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      # --- 台帳全件スナップショット (監査C Warning-3 対応 / ロールバック canonical 参照) ---
+      # supabase CLI 2.62.10 には任意 SQL を実行する汎用コマンドが無いため、
+      # `db dump --data-only -s supabase_migrations` を用いて schema_migrations
+      # テーブルの全行 (version, statements, name 含む全列) をダンプする。
+      #
+      # 【最終監査残課題 修正】`-s supabase_migrations` はスキーマ単位の指定であり、
+      # 同スキーマ内に schema_migrations 以外のテーブル (実測: CLI 2.62.10 は
+      # `supabase_migrations.seed_files` テーブルを内部で作成・使用する。PK は
+      # path 列であり schema_migrations の PK (version 列) とは無関係) が存在する
+      # 場合、それらの行もダンプに含まれてしまう。ロールバック手順は
+      # `TRUNCATE supabase_migrations.schema_migrations;` のみを先行させる設計の
+      # ため、ダンプに seed_files 等の行が混入していると、それらのテーブルは
+      # TRUNCATE されないまま再 INSERT されることになり、既存行との PK 衝突で
+      # ロールバック自体が失敗し得る。そのため `-x/--exclude` (schema.table を
+      # data-only ダンプ対象から除外する既存フラグ) で schema_migrations 以外を
+      # 明示的に除外し、ダンプ対象を schema_migrations テーブル単体に限定する。
+      # (supabase_migrations スキーマに将来新しいテーブルが追加された場合は、
+      # ここの -x にも追加すること。)
+      #
+      # CLI 内部は pg_dump に `--column-inserts --rows-per-insert 100000` を渡すため、
+      # 実際の出力は「1本の複数行 INSERT」形式になる:
+      #   INSERT INTO "supabase_migrations"."schema_migrations" ("version", "statements", "name") VALUES
+      #   \t('20260708005642', '{"..."}', 'some_name'),
+      #   \t('20260508143656', '{"..."}', 'some_name2'),
+      #   ...;
+      # (ローカル pg_dump --column-inserts --rows-per-insert 100000 で実出力形式を確認済み)
+      # これは "SELECT version,name,statements FROM schema_migrations ORDER BY version"
+      # の内容を実質的に包含し、かつそのまま再投入可能なロールバック canonical 参照になる。
+      # -x により seed_files 等の他テーブルが除外されるため、ダンプファイルには
+      # schema_migrations 用の INSERT 文が1本だけ含まれる (ロールバック手順の
+      # TRUNCATE 対象と過不足なく整合する)。
+      - name: Snapshot full ledger (schema_migrations) before repair
+        run: |
+          npx --yes supabase@2.62.10 db dump --linked --data-only \
+            -s supabase_migrations \
+            -x supabase_migrations.seed_files \
+            -f artifacts/ledger_snapshot.sql
+          {
+            echo "## ledger_snapshot.sql (schema_migrations 単体スナップショット, repair 前)"
+            echo ""
+            echo "行数: $(wc -l < artifacts/ledger_snapshot.sql)"
+            echo ""
+            echo "対象テーブル: supabase_migrations.schema_migrations のみ"
+            echo "(supabase_migrations.seed_files は -x で除外済み。ロールバック時の"
+            echo "TRUNCATE 対象と過不足なく一致させるため。)"
+            echo ""
+            echo "この artifact はロールバックの canonical 参照。repair/apply 前の台帳状態を必ず保持する。"
+            echo "ロールバック手順はこのファイル冒頭のコメントを参照。"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      # --- SELECT ゲート (revert 対象のうち中身未確認の4本を repair 前に確認) ---
+      # ledger_snapshot.sql は上記の通り「1本の複数行 INSERT」形式であり、各 version は
+      # タブ字下げの継続行 `\t('VERSION', ...` として現れる (VALUES は先頭行に1回だけ)。
+      # そのため `grep -F "VALUES ('$v',"` は常に空振りする。`VALUES ` を落とし
+      # `('$v',` (先頭括弧+バージョン+カンマ) のみで一致させる。
+      - name: SELECT gate - inspect gate versions before revert
+        run: |
+          GATE_VERSIONS="20260708005642 20260508143656 20260508143738 20260510110015"
+          : > artifacts/gate_versions.txt
+          for v in $GATE_VERSIONS; do
+            if grep -F "('$v'," artifacts/ledger_snapshot.sql >> artifacts/gate_versions.txt; then
+              :
+            else
+              echo "-- NOT FOUND IN LEDGER: $v" >> artifacts/gate_versions.txt
+              # advisory annotation のみ (job は fail させない)。人手承認ゲートが本来の
+              # 砦であり、承認者が Actions UI 上でこの版数を見落とさないようにするための
+              # 可視化目的。exit 1 にはしない。
+              echo "::warning::gate version $v が台帳に見つかりません"
+            fi
+          done
+          {
+            echo "## gate_versions.txt (revert 対象のうち中身未確認 4 本の台帳内容)"
+            echo ""
+            echo '```'
+            cat artifacts/gate_versions.txt
+            echo '```'
+            echo ""
+            echo "上記が期待した version/statements/name と一致することを目視確認してから"
+            echo "repair job (environment 承認) を承認すること。特に 20260708005642 は"
+            echo "中身未確認のまま revert する唯一の version なので必ず確認する。"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "=== gate_versions.txt ==="
+          cat artifacts/gate_versions.txt
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Upload pre-repair artifacts (ledger snapshot + gate)
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-repair-pre
+          path: artifacts/
+          retention-days: 90
+
+      # inspect job はここで終了。repair は行わない。
+
+  # --- job2: repair 本体。environment 承認 (required reviewers) を経てから実行 ---
+  repair:
+    needs: inspect
+    runs-on: ubuntu-latest
+    # required reviewers による承認ゲート。repo Settings > Environments で
+    # "production-db" environment を作成し、Required reviewers を設定しておくこと。
+    # 未設定の場合、このジョブは承認待ちにならず inspect 完了後に即実行される点に注意。
+    # 承認者は inspect job の artifact (migration-repair-pre, 特に gate_versions.txt の
+    # 20260708005642 の中身) をレビューしてから承認すること。
+    environment: production-db
+    if: ${{ github.event.inputs.confirm == 'REPAIR' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Create artifacts directory
+        run: mkdir -p artifacts
+
+      - name: Verify Supabase CLI version
+        run: npx --yes supabase@2.62.10 --version
+
+      - name: Link Supabase project
+        run: |
+          npx --yes supabase@2.62.10 link --project-ref ${{ env.SUPABASE_PROJECT_ID }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      # --- repair --status applied (37本、20260511000136 は意図的に除外) ---
+      - name: Repair - mark 37 versions as applied (000136 excluded)
+        run: |
+          npx --yes supabase@2.62.10 migration repair --status applied --linked \
+            20260430280000 \
+            20260508160000 \
+            20260508180000 \
+            20260508190000 \
+            20260508210000 \
+            20260509000000 \
+            20260510120000 \
+            20260511000000 \
+            20260511000095 \
+            20260511000096 \
+            20260511000097 \
+            20260511000098 \
+            20260511000100 \
+            20260511000101 \
+            20260511000102 \
+            20260511000103 \
+            20260511000104 \
+            20260511000105 \
+            20260511000110 \
+            20260511000111 \
+            20260511000112 \
+            20260511000113 \
+            20260511000114 \
+            20260511000115 \
+            20260511000120 \
+            20260511000125 \
+            20260511000126 \
+            20260511000127 \
+            20260511000128 \
+            20260511000129 \
+            20260511000130 \
+            20260511000131 \
+            20260511000132 \
+            20260511000133 \
+            20260511000134 \
+            20260511000135 \
+            20260511000137
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      # --- repair --status reverted (31本) ---
+      - name: Repair - mark 31 versions as reverted
+        run: |
+          npx --yes supabase@2.62.10 migration repair --status reverted --linked \
+            20260508143656 \
+            20260508143738 \
+            20260510110015 \
+            20260510174540 \
+            20260510174558 \
+            20260510174701 \
+            20260510174713 \
+            20260510174801 \
+            20260510174820 \
+            20260510174848 \
+            20260510174906 \
+            20260510174925 \
+            20260510175004 \
+            20260510175058 \
+            20260510175345 \
+            20260510175416 \
+            20260510175439 \
+            20260510175456 \
+            20260510175518 \
+            20260510175621 \
+            20260510175650 \
+            20260510175721 \
+            20260510175742 \
+            20260510175800 \
+            20260510175820 \
+            20260510175844 \
+            20260510175911 \
+            20260510175925 \
+            20260510175942 \
+            20260510190623 \
+            20260708005642
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      # --- repair 後の migration list を artifact 化 ---
+      - name: Verify migration list after repair
+        run: |
+          npx --yes supabase@2.62.10 migration list --linked | tee artifacts/migration_list_after_repair.txt
+          {
+            echo "## migration list (repair 後)"
+            echo ""
+            echo "\`\`\`"
+            cat artifacts/migration_list_after_repair.txt
+            echo "\`\`\`"
+            echo ""
+            echo "期待値: 20260511000136 と 20260710090000 以外は全て paired (Local/Remote 両方に同一 version)。"
+            echo "この2本のみ local-only のまま残っていれば正常 (次段の migration-apply.yml で push する)。"
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Upload post-repair artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-repair-post
+          path: artifacts/migration_list_after_repair.txt
+          retention-days: 90


### PR DESCRIPTION
## 概要
#1064(migration ドリフト解消)Phase 1 の実行機構。**このPRは .github/workflows のみで、supabase/migrations を含まないため deploy をトリガしません**。

## 内容
- **deploy-supabase-migrations.yml**: drift guard パーサー修正(実出力の「先頭空白+` | `区切り」形式に対応)。従来は全行スキップの偽陰性で、ドリフト状態でも push 時に自動 apply が走る危険があった。修正後はドリフト検出で exit 1(実データで66行検出を確認済み)。
- **migration-repair.yml 新設**(workflow_dispatch・confirm=REPAIR): inspect(台帳全件スナップショット=schema_migrations 単体・20260708005642 等4本の SELECT gate・artifact 化)→ **production-db Environment 承認** → repair(applied 37 / reverted 31)。push は一切しない。
- **migration-apply.yml 新設**(workflow_dispatch・confirm=APPLY): dry-run で適用対象が **20260511000136 + 20260710090000 のちょうど2本**であることを機械 assert(0/1/3本等は全て fail-close)→ **production-db Environment 承認** → db push --include-all。

## 監査
3モデル監査(repair分類=PASS / SQL=PASS / workflow=PASS)+ ロールバック堅牢化(スナップショット対象を schema_migrations 単体に限定、seed_files PK 衝突回避)。apply の「ちょうど2本」assertion は 6 シナリオの fail-close を実測検証済み。

## ⚠️ dispatch 前の必須手順(堀さん)
GitHub Settings → Environments → **production-db を作成し Required reviewers に自分を設定**してください。未設定だと inspect→repair / dry-run→apply が承認待ちにならず自動実行されます(この設定が人手ゲートの本体)。
