### PR TITLE
fix(handson-tour): complete_handson_tour の badges列名誤り/anon暗黙EXECUTE残存を修正 (#1027 round-2)

### DIFF
--- a/packages/shared/src/database.types.ts
+++ b/packages/shared/src/database.types.ts
@@ -7330,7 +7330,7 @@ export type Database = {
       }
       cleanup_handson_tour_sandbox_rows: { Args: never; Returns: Json }
       cleanup_old_logs: { Args: never; Returns: undefined }
-      complete_handson_tour: { Args: { p_user_id: string }; Returns: Json }
+      complete_handson_tour: { Args: never; Returns: Json }
       create_family_group: {
         Args: { p_name: string; p_plan_key?: string }
         Returns: {

--- a/src/app/api/handson-tour/complete/route.ts
+++ b/src/app/api/handson-tour/complete/route.ts
@@ -49,7 +49,7 @@ export async function POST() {
     }
 
     const { data: result, error: rpcError } = await supabase
-      .rpc('complete_handson_tour', { p_user_id: user.id });
+      .rpc('complete_handson_tour');
 
     if (rpcError) {
       console.error('complete_handson_tour RPC error:', rpcError);

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -7330,7 +7330,7 @@ export type Database = {
       }
       cleanup_handson_tour_sandbox_rows: { Args: never; Returns: Json }
       cleanup_old_logs: { Args: never; Returns: undefined }
-      complete_handson_tour: { Args: { p_user_id: string }; Returns: Json }
+      complete_handson_tour: { Args: never; Returns: Json }
       create_family_group: {
         Args: { p_name: string; p_plan_key?: string }
         Returns: {

--- a/supabase/migrations/20260710210027_fix_complete_handson_tour_grant.sql
+++ b/supabase/migrations/20260710210027_fix_complete_handson_tour_grant.sql
@@ -1,0 +1,98 @@
+-- =====================================================
+-- Migration: fix_complete_handson_tour_grant
+-- Source: Issue #1027 [Crit] complete_handson_tour の GRANT 欠落でツアー完走不能
+--
+-- 不具合:
+--   旧シグネチャ complete_handson_tour(p_user_id uuid) は
+--   `REVOKE ... FROM anon, authenticated` + `GRANT ... TO service_role` のみで、
+--   route.ts (src/app/api/handson-tour/complete/route.ts) はユーザーセッションで
+--   RPC を呼ぶため permission denied → 500 (ツアー卒業不能)。
+--   仮に authenticated に EXECUTE が付与されていた場合は p_user_id を任意に渡せるため、
+--   他人のツアーを完了させバッジを付与できる無認証書き込み穴にもなり得ていた。
+--
+-- 修正方針 (兄弟関数 user_has_non_sandbox_activity / 20260510120000 と同方式):
+--   - 引数を廃止し、関数内部で auth.uid() を参照して「自分のツアー」しか完了できないよう強制。
+--   - SECURITY DEFINER は維持する: user_badges には自己 INSERT を許可する RLS ポリシーが
+--     存在しない (SELECT ポリシーのみ) ため、SECURITY INVOKER に変更すると
+--     badge 付与の INSERT が RLS に弾かれて機能が壊れる。DEFINER + auth.uid() 強制の
+--     組み合わせで「安全かつ動作する」両立を取る。
+--   - REVOKE EXECUTE FROM PUBLIC で暗黙付与を明示的に外し、authenticated にのみ GRANT。
+--
+-- Idempotent: yes (DROP FUNCTION IF EXISTS → CREATE OR REPLACE、REVOKE/GRANT は何度実行してもエラー0)
+-- =====================================================
+
+BEGIN;
+
+-- 旧シグネチャ (uuid 引数版) を drop。2回目以降の実行では既に存在しないため no-op。
+DROP FUNCTION IF EXISTS complete_handson_tour(uuid);
+
+CREATE OR REPLACE FUNCTION complete_handson_tour()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_existing_completed_at timestamptz;
+  v_completed_at timestamptz;
+  v_was_already boolean;
+  v_badge_id uuid;
+  v_badge_name text;
+  v_badge_icon_url text;
+  v_badge_obtained_at timestamptz;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'unauthorized';
+  END IF;
+
+  -- UPDATE 前に既存値を取得 (already_completed 判定のため)
+  SELECT handson_tour_completed_at INTO v_existing_completed_at
+  FROM user_profiles WHERE id = v_user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'profile_not_found';
+  END IF;
+
+  v_was_already := (v_existing_completed_at IS NOT NULL);
+
+  UPDATE user_profiles
+  SET handson_tour_completed_at = COALESCE(handson_tour_completed_at, now())
+  WHERE id = v_user_id
+  RETURNING handson_tour_completed_at INTO v_completed_at;
+
+  SELECT id, name, icon_url INTO v_badge_id, v_badge_name, v_badge_icon_url
+  FROM badges WHERE code = 'tutorial_complete';
+
+  IF v_badge_id IS NULL THEN
+    RAISE EXCEPTION 'badge_not_found';
+  END IF;
+
+  INSERT INTO user_badges (user_id, badge_id, obtained_at)
+  VALUES (v_user_id, v_badge_id, now())
+  ON CONFLICT (user_id, badge_id) DO NOTHING;
+
+  SELECT obtained_at INTO v_badge_obtained_at
+  FROM user_badges WHERE user_id = v_user_id AND badge_id = v_badge_id;
+
+  RETURN jsonb_build_object(
+    'completed_at', v_completed_at,
+    'badge_awarded', jsonb_build_object(
+      'code', 'tutorial_complete',
+      'name', v_badge_name,
+      'obtained_at', v_badge_obtained_at,
+      'icon_url', v_badge_icon_url
+    ),
+    'already_completed', v_was_already
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION complete_handson_tour() IS
+  'family/09 卒業処理: profile UPDATE + tutorial_complete バッジ INSERT を atomic に実行。#1027 修正: 引数を廃止し auth.uid() を内部参照 (他人のツアーを完了させる書き込み穴を防止)、authenticated に EXECUTE を明示的に GRANT (卒業不能バグを解消)。';
+
+REVOKE EXECUTE ON FUNCTION complete_handson_tour() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION complete_handson_tour() TO authenticated;
+GRANT EXECUTE ON FUNCTION complete_handson_tour() TO service_role;
+
+COMMIT;

--- a/supabase/migrations/20260710210027_fix_complete_handson_tour_grant.sql
+++ b/supabase/migrations/20260710210027_fix_complete_handson_tour_grant.sql
@@ -18,6 +18,17 @@
 --     組み合わせで「安全かつ動作する」両立を取る。
 --   - REVOKE EXECUTE FROM PUBLIC で暗黙付与を明示的に外し、authenticated にのみ GRANT。
 --
+-- round-2 修正 (2モデル敵対レビュー指摘):
+--   - [Critical] badges テーブルの実列は icon であり icon_url ではない (旧関数から
+--     継承していたバグ)。authenticated で RPC 実行すると
+--     `ERROR: column "icon_url" does not exist` で UPDATE ごとロールバックし
+--     500 症状が残存していた。SELECT 対象列を icon に修正 (JSON レスポンスの
+--     キー名 icon_url は zod 契約のため維持)。
+--   - [Warning] 本番は `ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+--     GRANT ALL ON FUNCTIONS TO anon` があり、CREATE 時に anon へ EXECUTE が
+--     暗黙付与される。REVOKE FROM PUBLIC だけでは剥がれないため、
+--     REVOKE EXECUTE ... FROM anon を明示追加。
+--
 -- Idempotent: yes (DROP FUNCTION IF EXISTS → CREATE OR REPLACE、REVOKE/GRANT は何度実行してもエラー0)
 -- =====================================================
 
@@ -61,7 +72,10 @@ BEGIN
   WHERE id = v_user_id
   RETURNING handson_tour_completed_at INTO v_completed_at;
 
-  SELECT id, name, icon_url INTO v_badge_id, v_badge_name, v_badge_icon_url
+  -- badges テーブルの列は icon (icon_url ではない。#1027 round-2 実測で判明:
+  -- 旧関数から継承していた誤り。JSON レスポンスキーは icon_url を維持する
+  -- (src/lib/handson-tour/schemas.ts の zod 契約に合わせる)。
+  SELECT id, name, icon INTO v_badge_id, v_badge_name, v_badge_icon_url
   FROM badges WHERE code = 'tutorial_complete';
 
   IF v_badge_id IS NULL THEN
@@ -89,9 +103,15 @@ END;
 $$;
 
 COMMENT ON FUNCTION complete_handson_tour() IS
-  'family/09 卒業処理: profile UPDATE + tutorial_complete バッジ INSERT を atomic に実行。#1027 修正: 引数を廃止し auth.uid() を内部参照 (他人のツアーを完了させる書き込み穴を防止)、authenticated に EXECUTE を明示的に GRANT (卒業不能バグを解消)。';
+  'family/09 卒業処理: profile UPDATE + tutorial_complete バッジ INSERT を atomic に実行。#1027 修正: 引数を廃止し auth.uid() を内部参照 (他人のツアーを完了させる書き込み穴を防止)、authenticated に EXECUTE を明示的に GRANT (卒業不能バグを解消)。round-2: badges.icon_url→icon 列名修正、anon への default privilege 由来の暗黙 EXECUTE を明示 REVOKE。';
 
+-- 本番は `ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+-- GRANT ALL ON FUNCTIONS TO anon` が設定されているため、CREATE 時に anon へ
+-- EXECUTE が暗黙付与される。REVOKE FROM PUBLIC だけではこの明示的な anon
+-- 付与は剥がれない (#1027 round-2 実測で確認)。anon を named role として
+-- 明示的に REVOKE することで実質的に無効化する。
 REVOKE EXECUTE ON FUNCTION complete_handson_tour() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION complete_handson_tour() FROM anon;
 GRANT EXECUTE ON FUNCTION complete_handson_tour() TO authenticated;
 GRANT EXECUTE ON FUNCTION complete_handson_tour() TO service_role;
 

--- a/tests/integration/handson-tour/rpc-complete-handson-tour.test.ts
+++ b/tests/integration/handson-tour/rpc-complete-handson-tour.test.ts
@@ -1,16 +1,21 @@
 /**
- * Integration test: RPC complete_handson_tour(uuid)
+ * Integration test: RPC complete_handson_tour()
+ *
+ * #1027 修正: 引数 (p_user_id) を廃止し auth.uid() を内部参照する方式に変更。
+ * そのため本テストは service_role ではなく、テストユーザー自身のセッション
+ * (authenticated ロール) で RPC を呼び出す。
  *
  * Test patterns:
- *   1. profile UPDATE + badge INSERT が atomic に実行される
+ *   1. profile UPDATE + badge INSERT が atomic に実行される (自分のセッションで呼び出し)
  *   2. already_completed 判定 (2回目呼び出しで already_completed=true)
- *   3. profile_not_found — 存在しない UUID でエラー
+ *   3. anon (セッションなし) からの呼び出しは permission エラー
  *
  * Requires: SUPABASE_INTEGRATION_TEST=1
- * Note: service_role キー必須 (RPC は service_role のみ EXECUTE 権限)
  */
 
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { describe, it, expect, afterEach } from 'vitest';
+import ws from 'ws';
 import {
   shouldRunIntegration,
   createTestUser,
@@ -19,8 +24,28 @@ import {
   type TestUser,
 } from '../helpers/supabase';
 
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+
+/** JWT 付き認証済みクライアントを返す (authenticated ロール、auth.uid() が自分の id になる) */
+function authedClient(accessToken: string): SupabaseClient {
+  return createClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    realtime: { transport: ws as unknown as typeof WebSocket },
+    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+}
+
+/** anon ロール (セッションなし) クライアント */
+function anonSessionlessClient(): SupabaseClient {
+  return createClient(url, anonKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+    realtime: { transport: ws as unknown as typeof WebSocket },
+  });
+}
+
 describe.skipIf(!shouldRunIntegration())(
-  'RPC complete_handson_tour(uuid) (integration)',
+  'RPC complete_handson_tour() (integration)',
   () => {
     let user: TestUser;
 
@@ -30,11 +55,10 @@ describe.skipIf(!shouldRunIntegration())(
 
     it('1. profile UPDATE + badge INSERT が atomic に実行される', async () => {
       user = await createTestUser({ onboardingCompleted: true });
-      const client = adminClient();
+      const client = authedClient(user.accessToken);
+      const admin = adminClient();
 
-      const { data: rawData, error } = await client.rpc('complete_handson_tour', {
-        p_user_id: user.id,
-      });
+      const { data: rawData, error } = await client.rpc('complete_handson_tour');
       const data = rawData as Record<string, unknown>;
 
       expect(error).toBeNull();
@@ -46,8 +70,8 @@ describe.skipIf(!shouldRunIntegration())(
       expect(badge.code).toBe('tutorial_complete');
       expect(badge.obtained_at).toBeTruthy();
 
-      // Verify profile was actually updated in DB
-      const { data: profile } = await client
+      // Verify profile was actually updated in DB (service_role で確認)
+      const { data: profile } = await admin
         .from('user_profiles')
         .select('handson_tour_completed_at')
         .eq('id', user.id)
@@ -55,14 +79,14 @@ describe.skipIf(!shouldRunIntegration())(
       expect(profile?.handson_tour_completed_at).toBeTruthy();
 
       // Verify badge row was inserted
-      const { data: badgeRow } = await client
+      const { data: badgeRow } = await admin
         .from('badges')
         .select('id')
         .eq('code', 'tutorial_complete')
         .single();
       expect(badgeRow).toBeDefined();
 
-      const { data: userBadge } = await client
+      const { data: userBadge } = await admin
         .from('user_badges')
         .select('obtained_at')
         .eq('user_id', user.id)
@@ -73,15 +97,13 @@ describe.skipIf(!shouldRunIntegration())(
 
     it('2. already_completed 判定 — 2回目呼び出しで already_completed=true', async () => {
       user = await createTestUser({ onboardingCompleted: true });
-      const client = adminClient();
+      const client = authedClient(user.accessToken);
 
       // First call
-      await client.rpc('complete_handson_tour', { p_user_id: user.id });
+      await client.rpc('complete_handson_tour');
 
       // Second call
-      const { data: rawData2, error } = await client.rpc('complete_handson_tour', {
-        p_user_id: user.id,
-      });
+      const { data: rawData2, error } = await client.rpc('complete_handson_tour');
       const data2 = rawData2 as Record<string, unknown>;
       expect(error).toBeNull();
       expect(data2.already_completed).toBe(true);
@@ -90,16 +112,12 @@ describe.skipIf(!shouldRunIntegration())(
       expect(data2.completed_at).toBeTruthy();
     });
 
-    it('3. profile_not_found — 存在しない UUID でエラー', async () => {
-      const client = adminClient();
-      const fakeUuid = '00000000-0000-0000-0000-000000000001';
+    it('3. anon (セッションなし) からの呼び出しは permission エラー', async () => {
+      const client = anonSessionlessClient();
 
-      const { data, error } = await client.rpc('complete_handson_tour', {
-        p_user_id: fakeUuid,
-      });
+      const { error } = await client.rpc('complete_handson_tour');
 
       expect(error).toBeDefined();
-      expect(error!.message).toContain('profile_not_found');
     });
   },
 );

--- a/tests/integration/handson-tour/rpc-complete-handson-tour.test.ts
+++ b/tests/integration/handson-tour/rpc-complete-handson-tour.test.ts
@@ -69,6 +69,10 @@ describe.skipIf(!shouldRunIntegration())(
       const badge = data.badge_awarded as Record<string, unknown>;
       expect(badge.code).toBe('tutorial_complete');
       expect(badge.obtained_at).toBeTruthy();
+      // #1027 round-2: badges.icon_url は実在しない列 (実列は icon) だったため
+      // RPC 内の SELECT が column-not-exist で常時失敗していた。icon_url キー自体は
+      // 維持しつつ、値が string か null であること (SELECT が例外なく完走したこと) を検証する。
+      expect(badge.icon_url === null || typeof badge.icon_url === 'string').toBe(true);
 
       // Verify profile was actually updated in DB (service_role で確認)
       const { data: profile } = await admin
@@ -112,12 +116,19 @@ describe.skipIf(!shouldRunIntegration())(
       expect(data2.completed_at).toBeTruthy();
     });
 
-    it('3. anon (セッションなし) からの呼び出しは permission エラー', async () => {
+    it('3. anon (セッションなし) からの呼び出しは permission エラー (EXECUTE 権限自体が無い)', async () => {
       const client = anonSessionlessClient();
 
       const { error } = await client.rpc('complete_handson_tour');
 
+      // #1027 round-2: anon には REVOKE EXECUTE ... FROM anon を明示しているため
+      // 「関数内部の auth.uid() IS NULL チェック (unauthorized 例外)」ではなく
+      // Postgres レベルの EXECUTE 権限拒否 (permission denied) になるはず。
+      // 前者と後者を区別できないと、anon への default privilege 由来の暗黙
+      // EXECUTE 残存 (#1027 round-2 Warning) を検出できない。
       expect(error).toBeDefined();
+      expect(error?.message).toMatch(/permission denied/i);
+      expect(error?.message).not.toMatch(/unauthorized/i);
     });
   },
 );


### PR DESCRIPTION
## ⚠️ マージ=本番 DB 自動適用
#1064 解消により通常 migration フローが復活しています。**この PR をマージすると deploy workflow が migration を本番に自動適用します**(drift guard 通過後)。

## 概要
complete_handson_tour の GRANT 欠落(authenticated が実行不可でツアー完了が常時失敗)を修正(#1027)

## 検証
- migration は完全冪等(ローカル PostgreSQL 16 で2回連続実行エラー0を実測)・既存本番データ互換(prod_public.sql 突合)・タイムスタンプ規約 20260710210
01027 系。
- 2モデル敵対レビュー(Sonnet5 + Fable)**double-PASS**(レビュー側も独立にローカル PG16 で RLS/RPC 挙動を実測)。
- 詳細は commit message を参照。
