### PR TITLE
fix(super-admin): 機能フラグ API の no-op を解消し実データで動作させる (#1029)

### DIFF
--- a/src/__tests__/lib/super-admin/evaluate-flag.test.ts
+++ b/src/__tests__/lib/super-admin/evaluate-flag.test.ts
@@ -1,0 +1,188 @@
+/**
+ * src/__tests__/lib/super-admin/evaluate-flag.test.ts
+ *
+ * #1029: feature flags API が no-op でフラグ機構全体が無効化されていた問題の修正。
+ * evaluateFlag (DB I/O を含まない純粋関数) が percentage/plan/role/org ロールアウト
+ * および constraints を実際に判定することを検証する。
+ */
+import { describe, it, expect } from 'vitest';
+import { evaluateFlag, type FeatureFlagRecord, type UserFlagContext } from '@/lib/super-admin/evaluate-flag';
+
+function makeFlag(overrides: Partial<FeatureFlagRecord> = {}): FeatureFlagRecord {
+  return {
+    key: 'test_flag',
+    enabled: true,
+    rollout_strategy: null,
+    constraints: null,
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides: Partial<UserFlagContext> = {}): UserFlagContext {
+  return {
+    userId: 'user-1',
+    planKey: 'free',
+    roles: ['user'],
+    organizationId: null,
+    accountCreatedAt: null,
+    ...overrides,
+  };
+}
+
+describe('evaluateFlag — 基本', () => {
+  it('flag が存在しない (null) 場合は無効 (fail-closed)', () => {
+    expect(evaluateFlag(null, makeCtx())).toBe(false);
+  });
+
+  it('enabled=false は rollout_strategy に関わらず常に無効', () => {
+    const flag = makeFlag({ enabled: false, rollout_strategy: { type: 'all' } });
+    expect(evaluateFlag(flag, makeCtx())).toBe(false);
+  });
+
+  it('enabled=true かつ rollout_strategy=null は全ユーザーで有効', () => {
+    const flag = makeFlag({ enabled: true, rollout_strategy: null });
+    expect(evaluateFlag(flag, makeCtx())).toBe(true);
+  });
+
+  it("rollout_strategy.type='all' は全ユーザーで有効", () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'all' } });
+    expect(evaluateFlag(flag, makeCtx())).toBe(true);
+  });
+});
+
+describe('evaluateFlag — percentage ロールアウト', () => {
+  it('value=0 は常に無効', () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'percentage', value: 0 } });
+    for (let i = 0; i < 50; i++) {
+      expect(evaluateFlag(flag, makeCtx({ userId: `user-${i}` }))).toBe(false);
+    }
+  });
+
+  it('value=100 は常に有効', () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'percentage', value: 100 } });
+    for (let i = 0; i < 50; i++) {
+      expect(evaluateFlag(flag, makeCtx({ userId: `user-${i}` }))).toBe(true);
+    }
+  });
+
+  it('同一ユーザー・同一フラグへの判定は決定的 (何度呼んでも同じ結果)', () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'percentage', value: 42 } });
+    const ctx = makeCtx({ userId: 'stable-user' });
+    const first = evaluateFlag(flag, ctx);
+    for (let i = 0; i < 10; i++) {
+      expect(evaluateFlag(flag, ctx)).toBe(first);
+    }
+  });
+
+  it('value を増やすと有効判定はモノトニックに増える (percentage を上げても既存の有効ユーザーは無効化されない)', () => {
+    const userIds = Array.from({ length: 200 }, (_, i) => `user-${i}`);
+    const enabledAt = (value: number) => {
+      const flag = makeFlag({ rollout_strategy: { type: 'percentage', value } });
+      return new Set(userIds.filter((id) => evaluateFlag(flag, makeCtx({ userId: id }))));
+    };
+
+    const at10 = enabledAt(10);
+    const at50 = enabledAt(50);
+    const at90 = enabledAt(90);
+
+    for (const id of at10) expect(at50.has(id)).toBe(true);
+    for (const id of at50) expect(at90.has(id)).toBe(true);
+  });
+
+  it('十分なユーザー数では実測有効率が指定 % に近い値になる (統計的検証)', () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'percentage', value: 25 } });
+    const userIds = Array.from({ length: 2000 }, (_, i) => `stat-user-${i}`);
+    const enabledCount = userIds.filter((id) => evaluateFlag(flag, makeCtx({ userId: id }))).length;
+    const ratio = enabledCount / userIds.length;
+    expect(ratio).toBeGreaterThan(0.2);
+    expect(ratio).toBeLessThan(0.3);
+  });
+});
+
+describe('evaluateFlag — plan ロールアウト', () => {
+  it('ユーザーの planKey が rollout.plans に含まれれば有効', () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'plan', plans: ['pro', 'family_pro'] } });
+    expect(evaluateFlag(flag, makeCtx({ planKey: 'pro' }))).toBe(true);
+  });
+
+  it('ユーザーの planKey が rollout.plans に含まれなければ無効', () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'plan', plans: ['pro', 'family_pro'] } });
+    expect(evaluateFlag(flag, makeCtx({ planKey: 'free' }))).toBe(false);
+  });
+
+  it('planKey が未設定 (null) の場合は無効', () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'plan', plans: ['pro'] } });
+    expect(evaluateFlag(flag, makeCtx({ planKey: null }))).toBe(false);
+  });
+});
+
+describe('evaluateFlag — role ロールアウト', () => {
+  it('ユーザーの roles のいずれかが rollout.roles に含まれれば有効', () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'role', roles: ['admin', 'super_admin'] } });
+    expect(evaluateFlag(flag, makeCtx({ roles: ['user', 'admin'] }))).toBe(true);
+  });
+
+  it('ユーザーの roles が rollout.roles と重複しなければ無効', () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'role', roles: ['admin', 'super_admin'] } });
+    expect(evaluateFlag(flag, makeCtx({ roles: ['user'] }))).toBe(false);
+  });
+
+  it('roles が未設定 (undefined) の場合は無効', () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'role', roles: ['admin'] } });
+    expect(evaluateFlag(flag, makeCtx({ roles: undefined }))).toBe(false);
+  });
+});
+
+describe('evaluateFlag — org ロールアウト', () => {
+  it('ユーザーの organizationId が rollout.org_ids に含まれれば有効', () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'org', org_ids: ['org-1', 'org-2'] } });
+    expect(evaluateFlag(flag, makeCtx({ organizationId: 'org-1' }))).toBe(true);
+  });
+
+  it('organizationId が null の場合は無効', () => {
+    const flag = makeFlag({ rollout_strategy: { type: 'org', org_ids: ['org-1'] } });
+    expect(evaluateFlag(flag, makeCtx({ organizationId: null }))).toBe(false);
+  });
+});
+
+describe('evaluateFlag — constraints', () => {
+  it('min_user_age_days 未満のアカウントは無効', () => {
+    const flag = makeFlag({ constraints: { min_user_age_days: 30 } });
+    const recentAccount = new Date(Date.now() - 10 * 86_400_000).toISOString();
+    expect(evaluateFlag(flag, makeCtx({ accountCreatedAt: recentAccount }))).toBe(false);
+  });
+
+  it('min_user_age_days 以上のアカウントは有効', () => {
+    const flag = makeFlag({ constraints: { min_user_age_days: 30 } });
+    const oldAccount = new Date(Date.now() - 60 * 86_400_000).toISOString();
+    expect(evaluateFlag(flag, makeCtx({ accountCreatedAt: oldAccount }))).toBe(true);
+  });
+
+  it('exclude_plans に含まれる plan は無効', () => {
+    const flag = makeFlag({ constraints: { exclude_plans: ['free'] } });
+    expect(evaluateFlag(flag, makeCtx({ planKey: 'free' }))).toBe(false);
+  });
+
+  it('include_plans が指定されている場合、含まれない plan は無効', () => {
+    const flag = makeFlag({ constraints: { include_plans: ['pro'] } });
+    expect(evaluateFlag(flag, makeCtx({ planKey: 'free' }))).toBe(false);
+    expect(evaluateFlag(flag, makeCtx({ planKey: 'pro' }))).toBe(true);
+  });
+
+  it('include_roles が指定されている場合、含まれない role は無効', () => {
+    const flag = makeFlag({ constraints: { include_roles: ['admin'] } });
+    expect(evaluateFlag(flag, makeCtx({ roles: ['user'] }))).toBe(false);
+    expect(evaluateFlag(flag, makeCtx({ roles: ['user', 'admin'] }))).toBe(true);
+  });
+
+  it('constraints と rollout_strategy の両方を満たす必要がある (AND 条件)', () => {
+    const flag = makeFlag({
+      constraints: { exclude_plans: ['free'] },
+      rollout_strategy: { type: 'percentage', value: 100 },
+    });
+    // constraints で弾かれる
+    expect(evaluateFlag(flag, makeCtx({ planKey: 'free' }))).toBe(false);
+    // constraints は通るが rollout 100% なので有効
+    expect(evaluateFlag(flag, makeCtx({ planKey: 'pro' }))).toBe(true);
+  });
+});

--- a/src/app/api/super-admin/flags/[key]/route.ts
+++ b/src/app/api/super-admin/flags/[key]/route.ts
@@ -26,6 +26,27 @@ export async function PATCH(request: NextRequest, { params }: Params) {
       );
     }
 
+    // #1029: feature_flags テーブルを実 UPDATE する (以前は監査ログを INSERT するだけで
+    // enabled/rollout_strategy/constraints を永続化していなかった)
+    const updateData: Record<string, unknown> = { ...parsed.data, updated_at: new Date().toISOString() };
+
+    const { data: updated, error } = await supabase
+      .from('feature_flags')
+      .update(updateData)
+      .eq('key', flagKey)
+      .select('key, description, enabled, rollout_strategy, constraints, updated_at')
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return NextResponse.json(
+          { error: { code: 'OP_FEATURE_FLAG_NOT_FOUND', message: '指定されたフラグが見つかりません' } },
+          { status: 404 },
+        );
+      }
+      return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message: error.message } }, { status: 500 });
+    }
+
     // 監査ログ
     await supabase.from('admin_audit_logs').insert({
       actor_id: user.id,
@@ -35,9 +56,7 @@ export async function PATCH(request: NextRequest, { params }: Params) {
       severity: 'info',
     });
 
-    return NextResponse.json({
-      data: { key: flagKey, ...parsed.data, updated_at: new Date().toISOString() },
-    });
+    return NextResponse.json({ data: updated });
   } catch (err) {
     if (err instanceof AuthError) {
       return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: err.message } }, { status: 401 });
@@ -72,6 +91,18 @@ export async function DELETE(_request: NextRequest, { params }: Params) {
         },
         { status: 409 },
       );
+    }
+
+    // #1029: feature_flags テーブルから実 DELETE する (以前は監査ログを INSERT するだけで
+    // 実データを一切削除していなかった)。未登録キー (feature_flags に行が無い) の DELETE は
+    // 0 行 affected でもエラーにせず成功として扱う (既存の orphan キー削除フローと整合)。
+    const { error: deleteError } = await supabase
+      .from('feature_flags')
+      .delete()
+      .eq('key', flagKey);
+
+    if (deleteError) {
+      return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message: deleteError.message } }, { status: 500 });
     }
 
     // 監査ログ

--- a/src/app/api/super-admin/flags/route.ts
+++ b/src/app/api/super-admin/flags/route.ts
@@ -14,46 +14,32 @@ export async function GET() {
     const user = await requireRole(['super_admin']);
     const supabase = await createClient();
 
+    // #1029: feature_flags テーブルから実データを取得する (以前は feature_packages.feature_flags
+    // 配列から flags を合成し enabled:true をハードコードして返していた no-op 実装だった)
     const { data, error } = await supabase
-      .from('feature_packages')
-      .select('id, package_key, display_name, feature_flags, status, display_order, created_at, updated_at')
-      .eq('status', 'active')
-      .order('display_order', { ascending: true });
+      .from('feature_flags')
+      .select('key, description, enabled, rollout_strategy, constraints, updated_at')
+      .order('created_at', { ascending: true });
 
     if (error) {
       return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message: error.message } }, { status: 500 });
     }
 
-    // feature_packages の feature_flags 配列から flags を正規化して返す
-    const flagMap = new Map<string, {
-      key: string;
-      description: string;
-      enabled: boolean;
-      rollout_strategy: Record<string, unknown> | null;
-      constraints: Record<string, unknown> | null;
-      active_user_count: number;
-      updated_at: string;
-    }>();
-
-    for (const pkg of (data ?? [])) {
-      for (const flagKey of (pkg.feature_flags ?? [])) {
-        if (!flagMap.has(flagKey)) {
-          flagMap.set(flagKey, {
-            key: flagKey,
-            description: `${pkg.display_name} に含まれるフラグ`,
-            enabled: true,
-            rollout_strategy: null,
-            constraints: null,
-            active_user_count: 0,
-            updated_at: pkg.updated_at,
-          });
-        }
-      }
-    }
+    const flags = (data ?? []).map((flag) => ({
+      key: flag.key,
+      description: flag.description ?? '',
+      enabled: flag.enabled,
+      rollout_strategy: flag.rollout_strategy,
+      constraints: flag.constraints,
+      // TODO: 実ユーザー数の算出はスコープ外 (#1029)。rollout/constraints を
+      // user_profiles に対して実際に集計する仕組みは別 Issue で対応する。
+      active_user_count: 0,
+      updated_at: flag.updated_at,
+    }));
 
     return NextResponse.json({
-      data: Array.from(flagMap.values()),
-      meta: { total: flagMap.size, page: 1, per_page: flagMap.size },
+      data: flags,
+      meta: { total: flags.length, page: 1, per_page: flags.length },
     });
   } catch (err) {
     if (err instanceof AuthError) {
@@ -83,38 +69,51 @@ export async function POST(request: NextRequest) {
 
     const { key, description, enabled, rollout_strategy, constraints } = parsed.data;
 
-    // feature_packages に新しいフラグキーを追加 (basic パッケージへ append)
-    const { data: basicPkg, error: pkgError } = await supabase
+    // #1029: feature_flags テーブルへ実体を作成する (以前は feature_packages.feature_flags
+    // 配列にキーを append するだけで、enabled/rollout_strategy/constraints を保持する
+    // 場所が無かった)
+    const { data: created, error: insertError } = await supabase
+      .from('feature_flags')
+      .insert({
+        key,
+        description: description ?? null,
+        enabled,
+        rollout_strategy: rollout_strategy ?? null,
+        constraints: constraints ?? null,
+        created_by: user.id,
+      })
+      .select('key, description, enabled, rollout_strategy, constraints, created_at')
+      .single();
+
+    if (insertError) {
+      if (insertError.code === '23505') {
+        return NextResponse.json(
+          { error: { code: 'OP_FEATURE_FLAG_IN_USE', message: 'このキーは既に使用されています' } },
+          { status: 409 },
+        );
+      }
+      return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message: insertError.message } }, { status: 500 });
+    }
+
+    // feature_packages に新しいフラグキーを追加 (basic パッケージへ append)。
+    // feature_packages.feature_flags は「パッケージが含むフラグキー一覧」であり、
+    // DELETE の in-use チェック (このキーをどのパッケージが使用中か) に用いる。
+    // 'basic' パッケージが存在しない環境でもフラグ本体の作成自体は成立させるため、
+    // ここでの失敗は致命的エラーにしない (best-effort)。
+    const { data: basicPkg } = await supabase
       .from('feature_packages')
       .select('id, feature_flags')
       .eq('package_key', 'basic')
       .single();
 
-    if (pkgError || !basicPkg) {
-      return NextResponse.json(
-        { error: { code: 'INTERNAL_ERROR', message: '機能パッケージが見つかりません' } },
-        { status: 500 },
-      );
-    }
-
-    const currentFlags: string[] = basicPkg.feature_flags ?? [];
-    if (currentFlags.includes(key)) {
-      return NextResponse.json(
-        { error: { code: 'OP_FEATURE_FLAG_IN_USE', message: 'このキーは既に使用されています' } },
-        { status: 409 },
-      );
-    }
-
-    const { error: updateError } = await supabase
-      .from('feature_packages')
-      .update({
-        feature_flags: [...currentFlags, key],
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', basicPkg.id);
-
-    if (updateError) {
-      return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message: updateError.message } }, { status: 500 });
+    if (basicPkg) {
+      const currentFlags: string[] = basicPkg.feature_flags ?? [];
+      if (!currentFlags.includes(key)) {
+        await supabase
+          .from('feature_packages')
+          .update({ feature_flags: [...currentFlags, key], updated_at: new Date().toISOString() })
+          .eq('id', basicPkg.id);
+      }
     }
 
     // 監査ログ
@@ -126,9 +125,7 @@ export async function POST(request: NextRequest) {
       severity: 'info',
     });
 
-    return NextResponse.json({
-      data: { key, description, enabled, rollout_strategy, constraints, created_at: new Date().toISOString() },
-    }, { status: 201 });
+    return NextResponse.json({ data: created }, { status: 201 });
   } catch (err) {
     if (err instanceof AuthError) {
       return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: err.message } }, { status: 401 });

--- a/src/lib/super-admin/evaluate-flag.ts
+++ b/src/lib/super-admin/evaluate-flag.ts
@@ -1,0 +1,111 @@
+/**
+ * 機能フラグ評価
+ * operator/02-api-spec.md §7 準拠
+ *
+ * feature_flags テーブル (#1029, 20260710210029_feature_flags_table.sql) に保存された
+ * enabled / rollout_strategy / constraints を、実際のユーザーコンテキストに対して判定する。
+ *
+ * evaluateFlag は DB I/O を含まない純粋関数にしてある (ユニットテストで
+ * percentage/plan/role/org の全ロールアウトパターンを検証するため)。
+ * fetchAndEvaluateFlag が DB からの読み出し (service_role 経由、RLS バイパス) を担う。
+ * feature_flags テーブルの RLS は super_admin 限定のため、一般ユーザーからのフラグ
+ * 判定は必ずこの fetchAndEvaluateFlag 経由 (service_role) で行う。
+ */
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import type { RolloutStrategy, FeatureFlagConstraints } from './flags-schemas';
+
+export interface FeatureFlagRecord {
+  key: string;
+  enabled: boolean;
+  rollout_strategy: RolloutStrategy | null;
+  constraints: FeatureFlagConstraints | null;
+}
+
+export interface UserFlagContext {
+  userId: string;
+  planKey?: string | null;
+  roles?: string[];
+  organizationId?: string | null;
+  /** アカウント作成日時 (ISO 文字列)。constraints.min_user_age_days の判定に使用 */
+  accountCreatedAt?: string | null;
+}
+
+/**
+ * 文字列を安定的に 0-99 のバケット値へ変換する (percentage rollout 用の決定的ハッシュ)。
+ * 同じ (flagKey, userId) の組は常に同じバケット値を返すため、同一ユーザーへの判定結果は
+ * enabled/value の変更が無い限り不変になる (rollout% を上げても既に対象だったユーザーは
+ * 外れない = モノトニックに増える)。
+ */
+function stableBucket(seed: string): number {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (Math.imul(hash, 31) + seed.charCodeAt(i)) >>> 0;
+  }
+  return hash % 100;
+}
+
+/**
+ * feature_flags 1 行 + ユーザーコンテキストから有効/無効を判定する純粋関数。
+ * @param flag - feature_flags テーブルの 1 行相当。存在しない (null) 場合は無効扱い (fail-closed)
+ * @param ctx - 判定対象ユーザーのコンテキスト
+ */
+export function evaluateFlag(flag: FeatureFlagRecord | null, ctx: UserFlagContext): boolean {
+  if (!flag) return false;
+  if (!flag.enabled) return false;
+
+  const constraints = flag.constraints;
+  if (constraints) {
+    if (typeof constraints.min_user_age_days === 'number' && ctx.accountCreatedAt) {
+      const ageDays = (Date.now() - new Date(ctx.accountCreatedAt).getTime()) / 86_400_000;
+      if (ageDays < constraints.min_user_age_days) return false;
+    }
+    if (constraints.exclude_plans && ctx.planKey && constraints.exclude_plans.includes(ctx.planKey)) {
+      return false;
+    }
+    if (constraints.include_plans && constraints.include_plans.length > 0) {
+      if (!ctx.planKey || !constraints.include_plans.includes(ctx.planKey)) return false;
+    }
+    if (constraints.include_roles && constraints.include_roles.length > 0) {
+      if (!(ctx.roles ?? []).some((r) => constraints.include_roles!.includes(r))) return false;
+    }
+    if (constraints.include_org_ids && constraints.include_org_ids.length > 0) {
+      if (!ctx.organizationId || !constraints.include_org_ids.includes(ctx.organizationId)) return false;
+    }
+  }
+
+  const rollout = flag.rollout_strategy;
+  if (!rollout || rollout.type === 'all') return true;
+
+  switch (rollout.type) {
+    case 'percentage': {
+      const value = rollout.value ?? 0;
+      if (value <= 0) return false;
+      if (value >= 100) return true;
+      return stableBucket(`${flag.key}:${ctx.userId}`) < value;
+    }
+    case 'plan':
+      return !!ctx.planKey && !!rollout.plans?.includes(ctx.planKey);
+    case 'role':
+      return (ctx.roles ?? []).some((r) => rollout.roles?.includes(r));
+    case 'org':
+      return !!ctx.organizationId && !!rollout.org_ids?.includes(ctx.organizationId);
+    default:
+      return false;
+  }
+}
+
+/**
+ * feature_flags テーブルから key を取得し evaluateFlag で判定する。
+ * service_role (getSupabaseAdmin) で RLS をバイパスする — feature_flags は
+ * super_admin 限定 RLS のため、一般ユーザーのセッションクライアントでは SELECT できない。
+ */
+export async function fetchAndEvaluateFlag(key: string, ctx: UserFlagContext): Promise<boolean> {
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase
+    .from('feature_flags')
+    .select('key, enabled, rollout_strategy, constraints')
+    .eq('key', key)
+    .maybeSingle();
+
+  return evaluateFlag(data as FeatureFlagRecord | null, ctx);
+}

--- a/src/lib/super-admin/flags-schemas.ts
+++ b/src/lib/super-admin/flags-schemas.ts
@@ -38,6 +38,7 @@ export const UpdateFeatureFlagSchema = z.object({
 export type CreateFeatureFlagInput = z.infer<typeof CreateFeatureFlagSchema>;
 export type UpdateFeatureFlagInput = z.infer<typeof UpdateFeatureFlagSchema>;
 export type RolloutStrategy = z.infer<typeof RolloutStrategySchema>;
+export type FeatureFlagConstraints = z.infer<typeof FeatureFlagConstraintsSchema>;
 
 export interface FeatureFlag {
   id: string;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -2440,6 +2440,42 @@ export type Database = {
           },
         ]
       }
+      feature_flags: {
+        Row: {
+          constraints: Json | null
+          created_at: string
+          created_by: string | null
+          description: string | null
+          enabled: boolean
+          id: string
+          key: string
+          rollout_strategy: Json | null
+          updated_at: string
+        }
+        Insert: {
+          constraints?: Json | null
+          created_at?: string
+          created_by?: string | null
+          description?: string | null
+          enabled?: boolean
+          id?: string
+          key: string
+          rollout_strategy?: Json | null
+          updated_at?: string
+        }
+        Update: {
+          constraints?: Json | null
+          created_at?: string
+          created_by?: string | null
+          description?: string | null
+          enabled?: boolean
+          id?: string
+          key?: string
+          rollout_strategy?: Json | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
       feature_packages: {
         Row: {
           created_at: string

--- a/supabase/migrations/20260710210029_feature_flags_table.sql
+++ b/supabase/migrations/20260710210029_feature_flags_table.sql
@@ -1,0 +1,66 @@
+-- migration: 20260710210029_feature_flags_table.sql
+-- #1029 [Crit]: super-admin の機能フラグ API が実質 no-op で、フラグ機構全体が
+-- 無効化されていた。
+--   - PATCH/DELETE はフラグ状態を保存する UPDATE/DELETE を一切持たず監査ログのみ
+--   - GET は常に enabled:true をハードコードして返す
+--   - enabled/rollout_strategy/constraints を永続化する実テーブルが存在しない
+--     (feature_packages.feature_flags は「パッケージがどのキーを含むか」の配列に
+--      過ぎず、フラグ自体の ON/OFF・ロールアウト状態を保持する場所ではない)
+--
+-- 本 migration は「フラグ定義そのもの」を保持する feature_flags テーブルを新設する。
+-- API 側 (src/app/api/super-admin/flags/**) はこのテーブルに対して実際に
+-- INSERT/UPDATE/DELETE/SELECT するよう修正し (同コミットのコード変更)、
+-- アプリ側の評価関数 evaluateFlag はここに保存された enabled/rollout_strategy/
+-- constraints を実際に判定する (src/lib/super-admin/evaluate-flag.ts)。
+--
+-- 冪等性: CREATE TABLE IF NOT EXISTS + DO $$ ... EXCEPTION WHEN duplicate_object
+-- で 2 回連続実行してもエラー 0 になる。
+
+CREATE TABLE IF NOT EXISTS public.feature_flags (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  key               VARCHAR(100) NOT NULL UNIQUE,
+  description       TEXT,
+  enabled           BOOLEAN NOT NULL DEFAULT FALSE,
+  -- { type: 'all'|'percentage'|'plan'|'role'|'org', value?, plans?, roles?, org_ids? }
+  -- NULL = rollout_strategy 未設定 (evaluateFlag は 'all' 相当として扱う)
+  rollout_strategy  JSONB,
+  -- { min_user_age_days?, exclude_plans?, include_plans?, include_roles?, include_org_ids? }
+  constraints       JSONB,
+  created_by        UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.feature_flags IS
+  '機能フラグ定義。enabled/rollout_strategy/constraints は super-admin API (PATCH) から実更新され、
+   evaluateFlag (src/lib/super-admin/evaluate-flag.ts) がユーザーコンテキストに対し実判定する。
+   feature_packages.feature_flags (VARCHAR配列) とは別概念 — そちらは「パッケージが含むフラグキー一覧」。';
+
+-- =====================================================
+-- RLS: super_admin 限定 (SELECT/INSERT/UPDATE/DELETE 全て)
+--   一般ユーザー向けのフラグ評価 (evaluateFlag) は service_role 経由
+--   (getSupabaseAdmin()) で RLS をバイパスして行う。
+-- =====================================================
+
+ALTER TABLE public.feature_flags ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'feature_flags' AND policyname = 'feature_flags_super_admin_all'
+  ) THEN
+    CREATE POLICY "feature_flags_super_admin_all" ON public.feature_flags
+      FOR ALL USING (
+        EXISTS (
+          SELECT 1 FROM user_profiles
+          WHERE id = auth.uid() AND 'super_admin' = ANY(roles)
+        )
+      )
+      WITH CHECK (
+        EXISTS (
+          SELECT 1 FROM user_profiles
+          WHERE id = auth.uid() AND 'super_admin' = ANY(roles)
+        )
+      );
+  END IF;
+END $$;

--- a/tests/integration/operator/super-admin-flags.test.ts
+++ b/tests/integration/operator/super-admin-flags.test.ts
@@ -52,6 +52,10 @@ afterAll(async () => {
     }
   }
 
+  // #1029: feature_flags テーブルの実データも掃除する (DELETE テストは 409 で
+  // ブロックされるため testFlagKey の行が残ったままになる)
+  await supabaseAdmin.from('feature_flags').delete().eq('key', testFlagKey);
+
   await Promise.all([
     cleanupAuditLogs(superAdminUser.userId),
     cleanupAuditLogs(adminUser.userId),
@@ -191,6 +195,40 @@ describe('PATCH /api/super-admin/flags/[key]', () => {
     );
     expect(res.status).toBe(400);
   });
+
+  it('404 for a flag key that does not exist in feature_flags', async () => {
+    const res = await apiCall(
+      'PATCH',
+      `/api/super-admin/flags/nonexistent_flag_${TS}`,
+      superAdminUser.jwt,
+      { enabled: true }
+    );
+    expect(res.status).toBe(404);
+    const body = res.body as { error: { code: string } };
+    expect(body.error.code).toBe('OP_FEATURE_FLAG_NOT_FOUND');
+  });
+
+  // #1029: PATCH で保存した enabled 状態が実際に永続化され、GET で読み返せることを検証する
+  // (修正前は PATCH が監査ログを INSERT するだけの no-op で、GET は enabled:true を
+  // ハードコードして返していた)
+  it('persists enabled=false — a subsequent GET reflects the PATCH', async () => {
+    const patchRes = await apiCall(
+      'PATCH',
+      `/api/super-admin/flags/${testFlagKey}`,
+      superAdminUser.jwt,
+      { enabled: false }
+    );
+    expect(patchRes.status).toBe(200);
+    const patchBody = patchRes.body as { data: { key: string; enabled: boolean } };
+    expect(patchBody.data.enabled).toBe(false);
+
+    const getRes = await apiCall('GET', '/api/super-admin/flags', superAdminUser.jwt);
+    expect(getRes.status).toBe(200);
+    const getBody = getRes.body as { data: Array<{ key: string; enabled: boolean }> };
+    const persisted = getBody.data.find((f) => f.key === testFlagKey);
+    expect(persisted).toBeDefined();
+    expect(persisted?.enabled).toBe(false);
+  });
 });
 
 // ─────────────────────────────────────────
@@ -228,14 +266,14 @@ describe('DELETE /api/super-admin/flags/[key]', () => {
   });
 
   it('200 for super_admin deleting an orphan flag key (not in any package)', async () => {
-    // The DELETE route checks feature_packages for the key — orphanFlagKey has never been inserted
+    // orphanFlagKey was never created via POST, so it has no row in feature_flags and is
+    // not referenced by any feature_packages.feature_flags array. The DELETE FROM feature_flags
+    // affects 0 rows (no error) — the route still returns 200 with deleted:true (idempotent).
     const res = await apiCall(
       'DELETE',
       `/api/super-admin/flags/${orphanFlagKey}`,
       superAdminUser.jwt
     );
-    // The route does NOT check if the flag exists; it just confirms it is not in any package
-    // and returns 200 with deleted:true
     expect(res.status).toBe(200);
     const body = res.body as { data: { key: string; deleted: boolean } };
     expect(body.data.key).toBe(orphanFlagKey);


### PR DESCRIPTION
## ⚠️ マージ=本番 DB 自動適用
#1064 解消により通常 migration フローが復活しています。**この PR をマージすると deploy workflow が migration を本番に自動適用します**(drift guard 通過後)。

## 概要
feature_flags テーブルを新設(super_admin 限定 RLS)し、no-op だった flags API を実テーブルに接続(#1029)

## 検証
- migration は完全冪等(ローカル PostgreSQL 16 で2回連続実行エラー0を実測)・既存本番データ互換(prod_public.sql 突合)・タイムスタンプ規約 20260710210
01029 系。
- 2モデル敵対レビュー(Sonnet5 + Fable)**double-PASS**(レビュー側も独立にローカル PG16 で RLS/RPC 挙動を実測)。
- 詳細は commit message を参照。
