### PR TITLE
fix(membership): メンバーシップ RPC の未登録エラーコードを網羅登録し 500 化を解消 (#1062)

### DIFF
--- a/src/lib/errors/membership-errors.ts
+++ b/src/lib/errors/membership-errors.ts
@@ -10,6 +10,12 @@ export enum MembershipErrorCode {
   OWNER_CANNOT_LEAVE = 'OWNER_CANNOT_LEAVE',
   INSUFFICIENT_PERMISSION = 'INSUFFICIENT_PERMISSION',
   USER_NOT_IN_ORG = 'USER_NOT_IN_ORG',
+  // #1062: 未登録だった org 系 RAISE EXCEPTION コード
+  NOT_ORG_ADMIN = 'NOT_ORG_ADMIN',
+  NOT_ORG_OWNER = 'NOT_ORG_OWNER',
+  IS_ORG_OWNER = 'IS_ORG_OWNER',
+  CANNOT_REMOVE_OWNER = 'CANNOT_REMOVE_OWNER',
+  TARGET_NOT_IN_ORG = 'TARGET_NOT_IN_ORG',
   // family
   FAMILY_NOT_FOUND = 'FAMILY_NOT_FOUND',
   NOT_IN_FAMILY = 'NOT_IN_FAMILY',
@@ -19,6 +25,11 @@ export enum MembershipErrorCode {
   USER_NOT_IN_FAMILY = 'USER_NOT_IN_FAMILY',
   NOT_FAMILY_ADULT = 'NOT_FAMILY_ADULT',
   MEMBER_LIMIT_EXCEEDED = 'MEMBER_LIMIT_EXCEEDED',
+  // #1062: 未登録だった family 系 RAISE EXCEPTION コード
+  MEMBER_NOT_FOUND = 'MEMBER_NOT_FOUND',
+  IS_FAMILY_REPRESENTATIVE = 'IS_FAMILY_REPRESENTATIVE',
+  NOT_FAMILY_REPRESENTATIVE = 'NOT_FAMILY_REPRESENTATIVE',
+  CANNOT_TRANSFER_TO_CHILD = 'CANNOT_TRANSFER_TO_CHILD',
   // invite
   INVITE_NOT_FOUND = 'INVITE_NOT_FOUND',
   INVITE_EXPIRED = 'INVITE_EXPIRED',
@@ -29,6 +40,10 @@ export enum MembershipErrorCode {
   // transfer
   TRANSFER_NOT_FOUND = 'TRANSFER_NOT_FOUND',
   TRANSFER_NOT_PENDING = 'TRANSFER_NOT_PENDING',
+  // #1062: propose/accept_*_transfer RPC (org/family 共通, ownership_transfer_proposals 経由)
+  // が実際に RAISE するコード。TRANSFER_NOT_FOUND/TRANSFER_NOT_PENDING とは別の文字列。
+  TRANSFER_PROPOSAL_NOT_FOUND = 'TRANSFER_PROPOSAL_NOT_FOUND',
+  TRANSFER_PROPOSAL_EXPIRED = 'TRANSFER_PROPOSAL_EXPIRED',
   // misc
   NOT_AUTHENTICATED = 'NOT_AUTHENTICATED',
   RATE_LIMITED = 'RATE_LIMITED',
@@ -44,6 +59,11 @@ export const ErrorStatusMap: Record<MembershipErrorCode, number> = {
   [MembershipErrorCode.OWNER_CANNOT_LEAVE]: 409,
   [MembershipErrorCode.INSUFFICIENT_PERMISSION]: 403,
   [MembershipErrorCode.USER_NOT_IN_ORG]: 404,
+  [MembershipErrorCode.NOT_ORG_ADMIN]: 403,
+  [MembershipErrorCode.NOT_ORG_OWNER]: 403,
+  [MembershipErrorCode.IS_ORG_OWNER]: 409,
+  [MembershipErrorCode.CANNOT_REMOVE_OWNER]: 409,
+  [MembershipErrorCode.TARGET_NOT_IN_ORG]: 404,
   [MembershipErrorCode.FAMILY_NOT_FOUND]: 404,
   [MembershipErrorCode.NOT_IN_FAMILY]: 403,
   [MembershipErrorCode.ALREADY_IN_FAMILY]: 409,
@@ -52,6 +72,10 @@ export const ErrorStatusMap: Record<MembershipErrorCode, number> = {
   [MembershipErrorCode.USER_NOT_IN_FAMILY]: 404,
   [MembershipErrorCode.NOT_FAMILY_ADULT]: 403,
   [MembershipErrorCode.MEMBER_LIMIT_EXCEEDED]: 409,
+  [MembershipErrorCode.MEMBER_NOT_FOUND]: 404,
+  [MembershipErrorCode.IS_FAMILY_REPRESENTATIVE]: 409,
+  [MembershipErrorCode.NOT_FAMILY_REPRESENTATIVE]: 403,
+  [MembershipErrorCode.CANNOT_TRANSFER_TO_CHILD]: 409,
   [MembershipErrorCode.INVITE_NOT_FOUND]: 404,
   [MembershipErrorCode.INVITE_EXPIRED]: 410,
   [MembershipErrorCode.INVITE_ALREADY_USED]: 409,
@@ -60,6 +84,8 @@ export const ErrorStatusMap: Record<MembershipErrorCode, number> = {
   [MembershipErrorCode.INVITE_EMAIL_MISMATCH]: 403,
   [MembershipErrorCode.TRANSFER_NOT_FOUND]: 404,
   [MembershipErrorCode.TRANSFER_NOT_PENDING]: 409,
+  [MembershipErrorCode.TRANSFER_PROPOSAL_NOT_FOUND]: 404,
+  [MembershipErrorCode.TRANSFER_PROPOSAL_EXPIRED]: 410,
   [MembershipErrorCode.NOT_AUTHENTICATED]: 401,
   [MembershipErrorCode.RATE_LIMITED]: 429,
   [MembershipErrorCode.RPC_FAILED]: 500,

--- a/supabase/migrations/20260710210062_promote_child_to_user_sso_guard.sql
+++ b/supabase/migrations/20260710210062_promote_child_to_user_sso_guard.sql
@@ -1,0 +1,53 @@
+-- #1062: promote_child_to_user の email lookup を堅牢化 (Suggestion-1)
+-- 20260511000135 で追加された p_email → auth.users 解決の SELECT に、SSO 併用時の
+-- 非決定性回避として is_sso_user = false / deleted_at IS NULL の条件を追加する。
+-- 現状はアプリが hard-delete + 非 SSO 運用のため実害はないが、将来の保険として対応する。
+-- 関数シグネチャ(p_member_id UUID, p_email TEXT)・認可順序(認可を email 解決より先に行う)は不変。
+CREATE OR REPLACE FUNCTION public.promote_child_to_user(p_member_id UUID, p_email TEXT)
+RETURNS family_members
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_caller_role family_role_enum;
+  v_member family_members;
+  v_user_id UUID;
+BEGIN
+  -- 1) 認可を先に（元関数の順序を維持）
+  SELECT * INTO v_member FROM family_members WHERE id = p_member_id;
+  SELECT role INTO v_caller_role FROM family_members
+    WHERE family_id = v_member.family_id AND user_id = auth.uid() AND status = 'active';
+  IF v_caller_role IS NULL OR v_caller_role NOT IN ('representative','adult') THEN
+    RAISE EXCEPTION 'NOT_FAMILY_ADULT' USING ERRCODE = 'P0001';
+  END IF;
+  IF v_member.user_id IS NOT NULL THEN
+    RAISE EXCEPTION 'ALREADY_PROMOTED' USING ERRCODE = 'P0001';
+  END IF;
+
+  -- 2) 認可後に email → 既存 auth ユーザーを解決
+  -- #1062: SSO ユーザー/削除済みユーザーは対象外とし、email 重複時の非決定的な
+  -- マッチ (LIMIT 1 がどの行を返すか不定) を避ける。
+  SELECT id INTO v_user_id FROM auth.users
+    WHERE lower(email) = lower(p_email)
+      AND is_sso_user = false
+      AND deleted_at IS NULL
+    LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'USER_NOT_FOUND' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM family_members WHERE user_id = v_user_id AND status = 'active') THEN
+    RAISE EXCEPTION 'ALREADY_IN_FAMILY' USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE family_members SET user_id = v_user_id, child_profile = NULL, role = 'adult' WHERE id = p_member_id
+    RETURNING * INTO v_member;
+  UPDATE user_profiles SET family_id = v_member.family_id WHERE id = v_user_id;
+
+  INSERT INTO membership_audit (scope, scope_id, action, actor_id, target_user_id, metadata)
+  VALUES ('family', v_member.family_id, 'child_promoted', auth.uid(), v_user_id,
+          jsonb_build_object('member_id', p_member_id, 'email', lower(p_email)));
+
+  RETURN v_member;
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.promote_child_to_user(UUID, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.promote_child_to_user(UUID, TEXT) TO authenticated;

--- a/tests/membership-errors.test.ts
+++ b/tests/membership-errors.test.ts
@@ -39,4 +39,43 @@ describe("mapPgErrorToHttp", () => {
     expect(mapPgErrorToHttp("ALREADY_IN_ORG").code).toBe(MembershipErrorCode.ALREADY_IN_ORG);
     expect(mapPgErrorToHttp("something INVITE_EXPIRED").code).toBe(MembershipErrorCode.INVITE_EXPIRED);
   });
+
+  // #1062: propose/accept 系 RPC で実際に RAISE される、これまで未登録だったコードの回帰テスト。
+  it("#1062: accept_*_transfer 系の TRANSFER_PROPOSAL_NOT_FOUND が 404 で検出され、TRANSFER_NOT_FOUND に化けない", () => {
+    const result = mapPgErrorToHttp("ERROR: TRANSFER_PROPOSAL_NOT_FOUND");
+    expect(result.code).toBe(MembershipErrorCode.TRANSFER_PROPOSAL_NOT_FOUND);
+    expect(result.status).toBe(404);
+  });
+
+  it("#1062: TRANSFER_PROPOSAL_EXPIRED が 410 で検出され、TRANSFER_NOT_PENDING に化けない", () => {
+    const result = mapPgErrorToHttp("ERROR: TRANSFER_PROPOSAL_EXPIRED");
+    expect(result.code).toBe(MembershipErrorCode.TRANSFER_PROPOSAL_EXPIRED);
+    expect(result.status).toBe(410);
+  });
+
+  it("#1062: propose_family_representative_transfer 系のコードが 500/UNKNOWN に化けない", () => {
+    expect(mapPgErrorToHttp("ERROR: NOT_FAMILY_REPRESENTATIVE").code).toBe(
+      MembershipErrorCode.NOT_FAMILY_REPRESENTATIVE,
+    );
+    expect(mapPgErrorToHttp("ERROR: NOT_FAMILY_REPRESENTATIVE").status).toBe(403);
+    expect(mapPgErrorToHttp("ERROR: MEMBER_NOT_FOUND").code).toBe(MembershipErrorCode.MEMBER_NOT_FOUND);
+    expect(mapPgErrorToHttp("ERROR: MEMBER_NOT_FOUND").status).toBe(404);
+    expect(mapPgErrorToHttp("ERROR: CANNOT_TRANSFER_TO_CHILD").code).toBe(
+      MembershipErrorCode.CANNOT_TRANSFER_TO_CHILD,
+    );
+    expect(mapPgErrorToHttp("ERROR: CANNOT_TRANSFER_TO_CHILD").status).toBe(409);
+  });
+
+  it("#1062: remove_org_member/propose_org_owner_transfer 系のコードが 500/UNKNOWN に化けない", () => {
+    expect(mapPgErrorToHttp("ERROR: CANNOT_REMOVE_OWNER").code).toBe(
+      MembershipErrorCode.CANNOT_REMOVE_OWNER,
+    );
+    expect(mapPgErrorToHttp("ERROR: CANNOT_REMOVE_OWNER").status).toBe(409);
+    expect(mapPgErrorToHttp("ERROR: NOT_ORG_OWNER").code).toBe(MembershipErrorCode.NOT_ORG_OWNER);
+    expect(mapPgErrorToHttp("ERROR: NOT_ORG_OWNER").status).toBe(403);
+    expect(mapPgErrorToHttp("ERROR: TARGET_NOT_IN_ORG").code).toBe(MembershipErrorCode.TARGET_NOT_IN_ORG);
+    expect(mapPgErrorToHttp("ERROR: TARGET_NOT_IN_ORG").status).toBe(404);
+    // TARGET_NOT_IN_ORG に NOT_IN_ORG (既存コード) が部分一致で誤爆しないことも確認
+    expect(mapPgErrorToHttp("ERROR: TARGET_NOT_IN_ORG").code).not.toBe(MembershipErrorCode.NOT_IN_ORG);
+  });
 });


### PR DESCRIPTION
## ⚠️ マージ=本番 DB 自動適用
#1064 解消により通常 migration フローが復活しています。**この PR をマージすると deploy workflow が migration を本番に自動適用します**(drift guard 通過後)。

## 概要
メンバーシップ RPC の未登録エラーコードを整備しクライアントが正しく分類できるように(#1062)

## 検証
- migration は完全冪等(ローカル PostgreSQL 16 で2回連続実行エラー0を実測)・既存本番データ互換(prod_public.sql 突合)・タイムスタンプ規約 20260710210
01062 系。
- 2モデル敵対レビュー(Sonnet5 + Fable)**double-PASS**(レビュー側も独立にローカル PG16 で RLS/RPC 挙動を実測)。
- 詳細は commit message を参照。
