### PR TITLE
fix(auth): frozen_at/BAN を全経路で実効化 (#1030)

### DIFF
--- a/lib/supabase/__tests__/middleware.test.ts
+++ b/lib/supabase/__tests__/middleware.test.ts
@@ -1,0 +1,131 @@
+/**
+ * lib/supabase/middleware.ts のユニットテスト
+ * #1030 round-2 Critical: /api/* ルートも frozen_at のアクセス制限対象にする
+ * (requireUser/requireRole を経由しない route が多数あり素通りしていたバグの修正)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// @supabase/ssr の createServerClient モック
+// ─────────────────────────────────────────────────────────────────────────────
+
+const mockGetSession = vi.fn();
+const mockGetUser = vi.fn();
+const mockMaybeSingle = vi.fn();
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: () => ({
+    auth: {
+      getSession: mockGetSession,
+      getUser: mockGetUser,
+    },
+    from: (_table: string) => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: mockMaybeSingle,
+        }),
+      }),
+    }),
+  }),
+}));
+
+import { updateSession } from '../middleware';
+
+function apiRequest(path = '/api/pantry') {
+  return new NextRequest(new URL(`http://localhost${path}`));
+}
+
+describe('updateSession — /api/* の frozen_at enforcement (#1030 round-2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
+  });
+
+  it('凍結中 (無期限 BAN) のユーザーの API 呼び出しは 403 AUTH_ACCOUNT_FROZEN を返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockMaybeSingle.mockResolvedValue({
+      data: { frozen_at: '2026-07-01T00:00:00.000Z', unban_at: null },
+      error: null,
+    });
+
+    const res = await updateSession(apiRequest());
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toEqual({
+      error: { code: 'AUTH_ACCOUNT_FROZEN', message: 'アカウントが凍結されています' },
+    });
+  });
+
+  it('一時 BAN 継続中 (unban_at が未来) の場合も 403 を返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    mockMaybeSingle.mockResolvedValue({
+      data: { frozen_at: '2026-07-01T00:00:00.000Z', unban_at: future },
+      error: null,
+    });
+
+    const res = await updateSession(apiRequest());
+    expect(res.status).toBe(403);
+  });
+
+  it('一時 BAN の期限切れ (unban_at が過去) の場合はブロックしない', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockMaybeSingle.mockResolvedValue({
+      data: { frozen_at: '2026-07-01T00:00:00.000Z', unban_at: '2026-07-02T00:00:00.000Z' },
+      error: null,
+    });
+
+    const res = await updateSession(apiRequest());
+    expect(res.status).toBe(200);
+  });
+
+  it('未凍結ユーザーの API 呼び出しはブロックしない', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockMaybeSingle.mockResolvedValue({
+      data: { frozen_at: null, unban_at: null },
+      error: null,
+    });
+
+    const res = await updateSession(apiRequest());
+    expect(res.status).toBe(200);
+  });
+
+  it('未認証 (user=null) の場合はブロックせず route 側の 401 判定に委ねる', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const res = await updateSession(apiRequest());
+    expect(res.status).toBe(200);
+    expect(mockMaybeSingle).not.toHaveBeenCalled();
+  });
+
+  it('getUser() がエラーを返した場合は fail-open で route 側に委ねる', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'auth error' } });
+
+    const res = await updateSession(apiRequest());
+    expect(res.status).toBe(200);
+  });
+
+  it('getUser() が例外を throw した場合も fail-open で全 API を止めない', async () => {
+    mockGetUser.mockRejectedValue(new Error('network error'));
+
+    const res = await updateSession(apiRequest());
+    expect(res.status).toBe(200);
+  });
+
+  it('user_profiles 取得がエラーの場合は fail-open でブロックしない (#348 と同様の方針)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: { message: 'db error' } });
+
+    const res = await updateSession(apiRequest());
+    expect(res.status).toBe(200);
+  });
+
+  it('/api/cron/* のような Bearer トークン認証ルートは Supabase セッションが無いため影響を受けない', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const res = await updateSession(apiRequest('/api/cron/process-menu-queue'));
+    expect(res.status).toBe(200);
+  });
+});

--- a/lib/supabase/__tests__/middleware.test.ts
+++ b/lib/supabase/__tests__/middleware.test.ts
@@ -2,6 +2,9 @@
  * lib/supabase/middleware.ts のユニットテスト
  * #1030 round-2 Critical: /api/* ルートも frozen_at のアクセス制限対象にする
  * (requireUser/requireRole を経由しない route が多数あり素通りしていたバグの修正)
+ * #1030 round-3 Critical: Bearer トークン (モバイルアプリ) セッションでも
+ * frozen_at チェックが効くよう Authorization ヘッダーを createServerClient へ転送する
+ * #1030 round-3 Warning: 凍結リダイレクトから /contact を除外する
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
@@ -13,27 +16,34 @@ import { NextRequest } from 'next/server';
 const mockGetSession = vi.fn();
 const mockGetUser = vi.fn();
 const mockMaybeSingle = vi.fn();
+const mockCreateServerClient = vi.fn();
 
-vi.mock('@supabase/ssr', () => ({
-  createServerClient: () => ({
-    auth: {
-      getSession: mockGetSession,
-      getUser: mockGetUser,
-    },
-    from: (_table: string) => ({
-      select: () => ({
-        eq: () => ({
-          maybeSingle: mockMaybeSingle,
-        }),
+mockCreateServerClient.mockImplementation(() => ({
+  auth: {
+    getSession: mockGetSession,
+    getUser: mockGetUser,
+  },
+  from: (_table: string) => ({
+    select: () => ({
+      eq: () => ({
+        maybeSingle: mockMaybeSingle,
       }),
     }),
   }),
 }));
 
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: (...args: unknown[]) => mockCreateServerClient(...args),
+}));
+
 import { updateSession } from '../middleware';
 
-function apiRequest(path = '/api/pantry') {
-  return new NextRequest(new URL(`http://localhost${path}`));
+function apiRequest(path = '/api/pantry', headers?: Record<string, string>) {
+  return new NextRequest(new URL(`http://localhost${path}`), { headers });
+}
+
+function pageRequest(path: string, headers?: Record<string, string>) {
+  return new NextRequest(new URL(`http://localhost${path}`), { headers });
 }
 
 describe('updateSession — /api/* の frozen_at enforcement (#1030 round-2)', () => {
@@ -127,5 +137,109 @@ describe('updateSession — /api/* の frozen_at enforcement (#1030 round-2)', (
 
     const res = await updateSession(apiRequest('/api/cron/process-menu-queue'));
     expect(res.status).toBe(200);
+  });
+});
+
+describe('updateSession — Authorization ヘッダーの転送 (#1030 round-3 Critical)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
+  });
+
+  it('Authorization ヘッダーがある場合 (モバイルアプリの Bearer セッション) は createServerClient の global.headers へ転送する', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockMaybeSingle.mockResolvedValue({ data: { frozen_at: null, unban_at: null }, error: null });
+
+    await updateSession(apiRequest('/api/pantry', { authorization: 'Bearer mobile-token' }));
+
+    expect(mockCreateServerClient).toHaveBeenCalledTimes(1);
+    const config = mockCreateServerClient.mock.calls[0][2];
+    expect(config.global).toEqual({ headers: { Authorization: 'Bearer mobile-token' } });
+  });
+
+  it('凍結中ユーザーの Bearer セッションによる API 呼び出しも 403 AUTH_ACCOUNT_FROZEN を返す (Cookie 無しでも frozen_at が効く)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockMaybeSingle.mockResolvedValue({
+      data: { frozen_at: '2026-07-01T00:00:00.000Z', unban_at: null },
+      error: null,
+    });
+
+    const res = await updateSession(apiRequest('/api/pantry', { authorization: 'Bearer mobile-token' }));
+
+    expect(res.status).toBe(403);
+  });
+
+  it('Authorization ヘッダーが無い場合は global オプションを渡さない (Cookie セッションの既存挙動を維持)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    await updateSession(apiRequest('/api/pantry'));
+
+    expect(mockCreateServerClient).toHaveBeenCalledTimes(1);
+    const config = mockCreateServerClient.mock.calls[0][2];
+    expect(config.global).toBeUndefined();
+  });
+});
+
+describe('updateSession — ページナビゲーションの凍結リダイレクト (#1030 round-3 Warning)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({ data: { session: null }, error: null });
+  });
+
+  it('凍結中ユーザーが保護ページへ遷移すると /frozen へリダイレクトされる', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockMaybeSingle.mockResolvedValue({
+      data: {
+        roles: ['user'],
+        onboarding_started_at: '2026-01-01T00:00:00.000Z',
+        onboarding_completed_at: '2026-01-01T00:00:00.000Z',
+        frozen_at: '2026-07-01T00:00:00.000Z',
+        unban_at: null,
+      },
+      error: null,
+    });
+
+    const res = await updateSession(pageRequest('/meal-plans'));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('http://localhost/frozen');
+  });
+
+  it('凍結中ユーザーが /contact へ遷移してもリダイレクトされない (サポート導線のデッドリンク化を防止)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockMaybeSingle.mockResolvedValue({
+      data: {
+        roles: ['user'],
+        onboarding_started_at: '2026-01-01T00:00:00.000Z',
+        onboarding_completed_at: '2026-01-01T00:00:00.000Z',
+        frozen_at: '2026-07-01T00:00:00.000Z',
+        unban_at: null,
+      },
+      error: null,
+    });
+
+    const res = await updateSession(pageRequest('/contact'));
+
+    expect(res.status).not.toBe(307);
+    expect(res.headers.get('location')).toBeNull();
+  });
+
+  it('凍結中ユーザーは /frozen 自体には無限リダイレクトしない', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockMaybeSingle.mockResolvedValue({
+      data: {
+        roles: ['user'],
+        onboarding_started_at: '2026-01-01T00:00:00.000Z',
+        onboarding_completed_at: '2026-01-01T00:00:00.000Z',
+        frozen_at: '2026-07-01T00:00:00.000Z',
+        unban_at: null,
+      },
+      error: null,
+    });
+
+    const res = await updateSession(pageRequest('/frozen'));
+
+    expect(res.status).not.toBe(307);
+    expect(res.headers.get('location')).toBeNull();
   });
 });

--- a/lib/supabase/__tests__/middleware.test.ts
+++ b/lib/supabase/__tests__/middleware.test.ts
@@ -5,6 +5,7 @@
  * #1030 round-3 Critical: Bearer トークン (モバイルアプリ) セッションでも
  * frozen_at チェックが効くよう Authorization ヘッダーを createServerClient へ転送する
  * #1030 round-3 Warning: 凍結リダイレクトから /contact を除外する
+ * #1030 round-4 Warning: CRON_SECRET (非 JWT Bearer) は Auth API へ転送しない
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
@@ -138,6 +139,20 @@ describe('updateSession — /api/* の frozen_at enforcement (#1030 round-2)', (
     const res = await updateSession(apiRequest('/api/cron/process-menu-queue'));
     expect(res.status).toBe(200);
   });
+
+  // #1030 (round-4 Warning fix): CRON_SECRET (非 JWT) を Auth API へ転送しない
+  it('/api/cron/* の非 JWT Bearer トークン (CRON_SECRET) では Authorization ヘッダーを転送せず Auth API を呼ばない', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const res = await updateSession(
+      apiRequest('/api/cron/process-menu-queue', { authorization: 'Bearer this-is-not-a-jwt-cron-secret' }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCreateServerClient).toHaveBeenCalledTimes(1);
+    const config = mockCreateServerClient.mock.calls[0][2];
+    expect(config.global).toBeUndefined();
+  });
 });
 
 describe('updateSession — Authorization ヘッダーの転送 (#1030 round-3 Critical)', () => {
@@ -150,11 +165,11 @@ describe('updateSession — Authorization ヘッダーの転送 (#1030 round-3 C
     mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
     mockMaybeSingle.mockResolvedValue({ data: { frozen_at: null, unban_at: null }, error: null });
 
-    await updateSession(apiRequest('/api/pantry', { authorization: 'Bearer mobile-token' }));
+    await updateSession(apiRequest('/api/pantry', { authorization: 'Bearer aaa.bbb.ccc' }));
 
     expect(mockCreateServerClient).toHaveBeenCalledTimes(1);
     const config = mockCreateServerClient.mock.calls[0][2];
-    expect(config.global).toEqual({ headers: { Authorization: 'Bearer mobile-token' } });
+    expect(config.global).toEqual({ headers: { Authorization: 'Bearer aaa.bbb.ccc' } });
   });
 
   it('凍結中ユーザーの Bearer セッションによる API 呼び出しも 403 AUTH_ACCOUNT_FROZEN を返す (Cookie 無しでも frozen_at が効く)', async () => {
@@ -164,9 +179,20 @@ describe('updateSession — Authorization ヘッダーの転送 (#1030 round-3 C
       error: null,
     });
 
-    const res = await updateSession(apiRequest('/api/pantry', { authorization: 'Bearer mobile-token' }));
+    const res = await updateSession(apiRequest('/api/pantry', { authorization: 'Bearer aaa.bbb.ccc' }));
 
     expect(res.status).toBe(403);
+  });
+
+  // #1030 (round-4 Warning fix): 非 JWT の Bearer トークン (CRON_SECRET 等) は転送しない
+  it('非 JWT 形式の Bearer トークンは createServerClient の global.headers へ転送しない (CRON_SECRET 誤転送防止)', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    await updateSession(apiRequest('/api/pantry', { authorization: 'Bearer plain-shared-secret-no-dots' }));
+
+    expect(mockCreateServerClient).toHaveBeenCalledTimes(1);
+    const config = mockCreateServerClient.mock.calls[0][2];
+    expect(config.global).toBeUndefined();
   });
 
   it('Authorization ヘッダーが無い場合は global オプションを渡さない (Cookie セッションの既存挙動を維持)', async () => {

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -3,6 +3,16 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { resolveOnboardingRedirect } from '@/lib/onboarding-routing'
 import { isAccountFrozen } from '@/lib/auth/frozen'
 
+// #1030 (round-4 Warning fix): Authorization ヘッダーが Supabase JWT (dot 区切り
+// 3 セグメント) の Bearer トークンかどうかを軽量に判定する。CRON_SECRET のような
+// 非 JWT の共有シークレットを Supabase クライアントへ転送しないためのガード。
+function isJwtBearerHeader(authHeader: string | null): boolean {
+  if (!authHeader) return false
+  const match = authHeader.match(/^Bearer\s+(.+)$/i)
+  if (!match) return false
+  return match[1].split('.').length === 3
+}
+
 export async function updateSession(request: NextRequest) {
   // APIルートの場合は、セッション更新のみ行い、リダイレクトはしない
   // これにより、不要な getUser() 呼び出しを減らす
@@ -19,7 +29,16 @@ export async function updateSession(request: NextRequest) {
   // Authorization ヘッダーを Supabase クライアントへ転送しないと、cookies ハンドラ
   // 経由のセッション解決に失敗し supabase.auth.getUser() が常に user: null を返す
   // (=Bearer セッションの frozen_at チェックが no-op になる) ため、ここで転送する。
-  const authHeader = request.headers.get('authorization')
+  //
+  // #1030 (round-4 Warning fix): ただし /api/cron/* 等は CRON_SECRET (非 JWT の
+  // 単なる共有シークレット文字列) を `Bearer <secret>` 形式で送ってくる。これを
+  // そのまま Supabase クライアントへ転送すると、毎回 Supabase Auth API への実呼び出し
+  // (JWT として解釈できず必ず 401) が発生し、cron (1分毎 = 1,440回/日) 相当の無駄な
+  // 外部依存を生む。Supabase JWT はドット区切り3セグメント (header.payload.signature)
+  // の形式であるため、その形式でない Bearer トークンは転送せず、従来どおりローカルで
+  // 短絡させる (Cookie も無いため getUser() は外部呼び出しなしで user: null を返す)。
+  const rawAuthHeader = request.headers.get('authorization')
+  const authHeader = isJwtBearerHeader(rawAuthHeader) ? rawAuthHeader : null
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 import { resolveOnboardingRedirect } from '@/lib/onboarding-routing'
+import { isAccountFrozen } from '@/lib/auth/frozen'
 
 export async function updateSession(request: NextRequest) {
   // APIルートの場合は、セッション更新のみ行い、リダイレクトはしない
@@ -113,17 +114,34 @@ export async function updateSession(request: NextRequest) {
   }
 
   if (user) {
-    // user_profiles からオンボーディング状態を取得
+    // user_profiles からオンボーディング状態・凍結状態を取得
     // #348: error を必ず捕捉し、DB 参照失敗時はリダイレクト判定をスキップする
     // (RLS 拒否・カラム不在・ネットワーク障害などで data=null になった場合に
     //  not_started 扱いで /onboarding/welcome へ飛ばしてしまうバグを防ぐ)
     const { data: profile, error: profileError } = await supabase
       .from('user_profiles')
-      .select('roles, onboarding_started_at, onboarding_completed_at')
+      .select('roles, onboarding_started_at, onboarding_completed_at, frozen_at, unban_at')
       .eq('id', user.id)
       .maybeSingle()
 
     if (!profileError) {
+      // #1030: frozen_at がセットされ (かつ一時 BAN が未解除の) アカウントは
+      // /frozen へリダイレクトする。無限リダイレクトを避けるため /frozen 自体は除外。
+      const frozen = isAccountFrozen({
+        frozenAt: profile?.frozen_at ?? null,
+        unbanAt: profile?.unban_at ?? null,
+      })
+
+      if (frozen) {
+        if (request.nextUrl.pathname !== '/frozen') {
+          const url = request.nextUrl.clone()
+          url.pathname = '/frozen'
+          url.search = ''
+          return NextResponse.redirect(url)
+        }
+        return supabaseResponse
+      }
+
       const redirectPath = resolveOnboardingRedirect({
         pathname: request.nextUrl.pathname,
         roles: profile?.roles || [],

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -51,12 +51,49 @@ export async function updateSession(request: NextRequest) {
     }
   )
 
-  // APIルートの場合はセッション更新のみ（getUser()は各ルートで行う）
+  // APIルートの場合はセッション更新のみ（詳細な認可は各ルートで行う）
   // これにより、ミドルウェアでの認証チェックを最小限に抑える
   if (isApiRoute) {
     // getSession()でセッションを取得し、必要に応じてトークンをリフレッシュ
     // getUser()よりも軽量で、サーバーへの追加リクエストを行わない
     await supabase.auth.getSession()
+
+    // #1030 (round-2 Critical fix): requireUser/requireRole を経由せず
+    // supabase.auth.getUser() を直接呼ぶだけの API route が多数存在し
+    // (meal-plans/pantry/recipes/health 等)、frozen_at を一切検査しないまま
+    // 素通りしていた。ページナビゲーションと同様にここで凍結判定を行い、
+    // 凍結中のアカウントは全 API 呼び出しを 403 で拒否する。
+    // 認証・プロフィール取得自体に失敗した場合は各 route 側のチェックに委ねる
+    // (#348 と同様、一時的な DB/ネットワーク障害で全 API を誤って止めないための
+    // fail-open。frozen かどうか確定できた場合のみブロックする)。
+    try {
+      const { data: { user: apiUser }, error: apiUserError } = await supabase.auth.getUser()
+
+      if (!apiUserError && apiUser) {
+        const { data: apiProfile, error: apiProfileError } = await supabase
+          .from('user_profiles')
+          .select('frozen_at, unban_at')
+          .eq('id', apiUser.id)
+          .maybeSingle()
+
+        if (!apiProfileError) {
+          const apiFrozen = isAccountFrozen({
+            frozenAt: apiProfile?.frozen_at ?? null,
+            unbanAt: apiProfile?.unban_at ?? null,
+          })
+
+          if (apiFrozen) {
+            return NextResponse.json(
+              { error: { code: 'AUTH_ACCOUNT_FROZEN', message: 'アカウントが凍結されています' } },
+              { status: 403, headers: { 'Cache-Control': 'private, no-store' } },
+            )
+          }
+        }
+      }
+    } catch {
+      // 認証基盤の一時障害時は各 route 側の getUser()/requireUser() チェックに委ねる
+    }
+
     return supabaseResponse
   }
 

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -13,10 +13,19 @@ export async function updateSession(request: NextRequest) {
     request,
   })
 
+  // #1030 (round-3 Critical fix): モバイルアプリ (apps/mobile/src/lib/api.ts) は
+  // Cookie セッションを持たず、Authorization: Bearer <token> ヘッダーのみで
+  // API を呼び出す。lib/supabase/server.ts の createClient() と同様に
+  // Authorization ヘッダーを Supabase クライアントへ転送しないと、cookies ハンドラ
+  // 経由のセッション解決に失敗し supabase.auth.getUser() が常に user: null を返す
+  // (=Bearer セッションの frozen_at チェックが no-op になる) ため、ここで転送する。
+  const authHeader = request.headers.get('authorization')
+
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      global: authHeader ? { headers: { Authorization: authHeader } } : undefined,
       cookies: {
         get(name: string) {
           return request.cookies.get(name)?.value
@@ -170,7 +179,18 @@ export async function updateSession(request: NextRequest) {
       })
 
       if (frozen) {
-        if (request.nextUrl.pathname !== '/frozen') {
+        // #1030 (round-3 Warning fix): /frozen ページの「サポートに問い合わせる」
+        // リンク (href="/contact") は publicPaths には含まれるが、この凍結リダイレクト
+        // 判定は isPublicPath を考慮せず無条件に実行されるため、ログイン中の凍結
+        // ユーザーが /contact に遷移しても即座に /frozen へ差し戻され、唯一の異議
+        // 申し立て導線が事実上のデッドリンクになっていた。/contact のみ除外する。
+        const frozenExemptPaths = ['/frozen', '/contact']
+        const isFrozenExemptPath = frozenExemptPaths.some(
+          (path) =>
+            request.nextUrl.pathname === path ||
+            request.nextUrl.pathname.startsWith(path + '/'),
+        )
+        if (!isFrozenExemptPath) {
           const url = request.nextUrl.clone()
           url.pathname = '/frozen'
           url.search = ''

--- a/packages/shared/src/database.types.ts
+++ b/packages/shared/src/database.types.ts
@@ -6479,6 +6479,7 @@ export type Database = {
           temperature_preference: string | null
           texture_preferences: string[] | null
           travel_frequency: string | null
+          unban_at: string | null
           updated_at: string | null
           wake_time: string | null
           water_cutting: boolean | null
@@ -6612,6 +6613,7 @@ export type Database = {
           temperature_preference?: string | null
           texture_preferences?: string[] | null
           travel_frequency?: string | null
+          unban_at?: string | null
           updated_at?: string | null
           wake_time?: string | null
           water_cutting?: boolean | null
@@ -6745,6 +6747,7 @@ export type Database = {
           temperature_preference?: string | null
           texture_preferences?: string[] | null
           travel_frequency?: string | null
+          unban_at?: string | null
           updated_at?: string | null
           wake_time?: string | null
           water_cutting?: boolean | null

--- a/src/app/api/admin/users/[id]/freeze/route.ts
+++ b/src/app/api/admin/users/[id]/freeze/route.ts
@@ -101,13 +101,24 @@ export async function POST(request: Request, { params }: Params) {
     );
   }
 
-  // frozen_at / frozen_reason / frozen_by を UPDATE (roles には手を加えない)
+  // 凍結期限計算 (#1030: unban_at 列に永続化するため UPDATE より先に計算する)
+  let unbanAt: string | null = null;
+  if (freezeData.ban_type === 'temporary' && freezeData.duration_days) {
+    const unbanDate = new Date();
+    unbanDate.setDate(unbanDate.getDate() + freezeData.duration_days);
+    unbanAt = unbanDate.toISOString();
+  }
+
+  // frozen_at / frozen_reason / frozen_by / unban_at を UPDATE (roles には手を加えない)
+  // #1030: unban_at を永続化することで、判定時比較 (requireUser/requireRole/middleware)
+  // による一時 BAN の自動解除が可能になる。
   const { error: updateError } = await supabaseAdmin
     .from('user_profiles')
     .update({
       frozen_at: new Date().toISOString(),
       frozen_reason: `[${freezeData.reason_category}] ${freezeData.reason_detail}`,
       frozen_by: actor.id,
+      unban_at: unbanAt,
     } as Record<string, unknown>)
     .eq('id', id);
 
@@ -117,14 +128,6 @@ export async function POST(request: Request, { params }: Params) {
       { error: { code: 'INTERNAL_ERROR', message: '凍結処理に失敗しました' } },
       { status: 500 },
     );
-  }
-
-  // 凍結期限計算
-  let unbanAt: string | null = null;
-  if (freezeData.ban_type === 'temporary' && freezeData.duration_days) {
-    const unbanDate = new Date();
-    unbanDate.setDate(unbanDate.getDate() + freezeData.duration_days);
-    unbanAt = unbanDate.toISOString();
   }
 
   // 監査ログ INSERT (operator/02-api-spec.md §3.3)
@@ -215,13 +218,14 @@ export async function DELETE(request: Request, { params }: Params) {
     );
   }
 
-  // frozen_at / frozen_reason / frozen_by を NULL にリセット (凍結解除)
+  // frozen_at / frozen_reason / frozen_by / unban_at を NULL にリセット (凍結解除)
   const { error: updateError } = await supabaseAdmin
     .from('user_profiles')
     .update({
       frozen_at: null,
       frozen_reason: null,
       frozen_by: null,
+      unban_at: null,
     } as Record<string, unknown>)
     .eq('id', id);
 

--- a/src/app/api/admin/users/[id]/impersonate/route.ts
+++ b/src/app/api/admin/users/[id]/impersonate/route.ts
@@ -60,11 +60,32 @@ export async function POST(request: Request, { params }: Params) {
     return NextResponse.json({ data: result });
   } catch (err) {
     if (err instanceof ImpersonationError) {
+      // #1030 (round-5): 対象ユーザー不在は 404、それ以外 (権限/凍結) は 403。
+      const status = err.code === 'AUTH_IMPERSONATION_TARGET_NOT_FOUND' ? 404 : 403;
       return NextResponse.json(
         { error: { code: err.code, message: err.message } },
+        { status },
+      );
+    }
+    // #1030 (round-5): impersonate() 内で再度 getAuthUser() を呼んでいるため、
+    // requireRole 通過後にセッションが失効した場合など AuthError/ForbiddenError が
+    // ここで throw される可能性がある。素通しで 500 にせず防御的にハンドリングする。
+    if (err instanceof AuthError) {
+      return NextResponse.json(
+        { error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } },
+        { status: 401 },
+      );
+    }
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json(
+        { error: { code: 'OP_PERMISSION_DENIED', message: '権限がありません' } },
         { status: 403 },
       );
     }
-    throw err;
+    console.error('[api/admin/users/[id]/impersonate] POST error:', err);
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'impersonate 処理に失敗しました' } },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -9,6 +9,7 @@ import { requireRole } from '@/lib/auth/helpers';
 import { AuthError, ForbiddenError } from '@/lib/auth/errors';
 import { createClient, getSupabaseAdmin } from '@/lib/supabase/server';
 import { UserPatchBodySchema } from '@/lib/admin/users-schemas';
+import { isAccountFrozen } from '@/lib/auth/frozen';
 
 export const dynamic = 'force-dynamic';
 
@@ -129,10 +130,16 @@ export async function GET(_request: Request, { params }: Params) {
       ban_history: banHistory,
       support_ticket_count: supportTicketCount,
       active_subscription: activeSubscription,
-      is_banned: (profile as { frozen_at?: string | null }).frozen_at != null,
+      // #1030: 一時 BAN は unban_at 経過後に自動解除扱いとする (判定時比較)。
+      // frozen_at が NOT NULL のままでも unban_at が過去なら is_banned=false を返す。
+      is_banned: isAccountFrozen({
+        frozenAt: (profile as { frozen_at?: string | null }).frozen_at ?? null,
+        unbanAt: (profile as { unban_at?: string | null }).unban_at ?? null,
+      }),
       frozen_at: (profile as { frozen_at?: string | null }).frozen_at ?? null,
       frozen_reason: (profile as { frozen_reason?: string | null }).frozen_reason ?? null,
       frozen_by: (profile as { frozen_by?: string | null }).frozen_by ?? null,
+      unban_at: (profile as { unban_at?: string | null }).unban_at ?? null,
       last_login_at: profile.last_login_at ?? null,
       registered_at: profile.created_at,
     },

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -8,6 +8,7 @@ import { requireRole } from '@/lib/auth/helpers';
 import { AuthError, ForbiddenError } from '@/lib/auth/errors';
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { UsersSearchSchema } from '@/lib/admin/users-schemas';
+import { isAccountFrozen } from '@/lib/auth/frozen';
 
 export const dynamic = 'force-dynamic';
 
@@ -58,7 +59,8 @@ export async function GET(request: Request) {
       created_at,
       frozen_at,
       frozen_reason,
-      frozen_by
+      frozen_by,
+      unban_at
     `,
       { count: 'exact' },
     );
@@ -123,10 +125,15 @@ export async function GET(request: Request) {
     nickname: u.nickname,
     plan_key: u.plan_key_cached ?? 'free',
     roles: u.roles ?? ['user'],
-    is_banned: (u as { frozen_at?: string | null }).frozen_at != null,
+    // #1030: 一時 BAN は unban_at 経過後に自動解除扱いとする (判定時比較)。
+    is_banned: isAccountFrozen({
+      frozenAt: (u as { frozen_at?: string | null }).frozen_at ?? null,
+      unbanAt: (u as { unban_at?: string | null }).unban_at ?? null,
+    }),
     frozen_at: (u as { frozen_at?: string | null }).frozen_at ?? null,
     frozen_reason: (u as { frozen_reason?: string | null }).frozen_reason ?? null,
     frozen_by: (u as { frozen_by?: string | null }).frozen_by ?? null,
+    unban_at: (u as { unban_at?: string | null }).unban_at ?? null,
     last_login_at: u.last_login_at,
     registered_at: u.created_at,
     meal_count: 0, // 集計は別クエリが必要

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -77,11 +77,23 @@ export async function GET(request: Request) {
     query = query.contains('roles', [params.role]);
   }
 
-  // ステータスフィルタ (凍結状態は frozen_at IS NOT NULL で判定)
+  // ステータスフィルタ
+  // #1030 round-2: is_banned (レスポンス側) は isAccountFrozen (unban_at 考慮) で
+  // 判定するため、フィルタ条件も同じ意味論に揃える。frozen_at IS NOT NULL だけで
+  // 判定すると、一時 BAN が期限切れ (unban_at <= now) になったユーザーが
+  // status=banned で検索すると is_banned: false のまま一覧に出てしまい、
+  // status=active からは除外され続ける不整合が生じる。
+  const nowIso = new Date().toISOString();
   if (params.status === 'banned') {
-    query = query.not('frozen_at', 'is', null);
+    // 凍結中 かつ (無期限 BAN または unban_at が未到来)
+    query = query
+      .not('frozen_at', 'is', null)
+      .or(`unban_at.is.null,unban_at.gt.${nowIso}`);
   } else if (params.status === 'active') {
-    query = query.is('frozen_at', null);
+    // 未凍結、または一時 BAN が期限切れ (unban_at が過去) で自動解除扱い
+    query = query.or(
+      `frozen_at.is.null,and(frozen_at.not.is.null,unban_at.not.is.null,unban_at.lte.${nowIso})`,
+    );
   }
 
   // 登録日フィルタ

--- a/src/app/api/experiments/[key]/assignment/route.ts
+++ b/src/app/api/experiments/[key]/assignment/route.ts
@@ -22,7 +22,7 @@
 
 import { NextResponse } from 'next/server';
 import { requireUser } from '@/lib/auth/helpers';
-import { AuthError } from '@/lib/auth/errors';
+import { AuthError, ForbiddenError } from '@/lib/auth/errors';
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import {
   ExperimentNotRunningError,
@@ -42,6 +42,14 @@ export async function GET(_request: Request, { params }: Params) {
       return NextResponse.json(
         { error: { code: 'AUTH_UNAUTHENTICATED', message: '認証が必要です' } },
         { status: 401 },
+      );
+    }
+    // #1030: requireUser() は frozen_at がセットされたアカウントに対して
+    // ForbiddenError('AUTH_ACCOUNT_FROZEN') を throw する。
+    if (err instanceof ForbiddenError) {
+      return NextResponse.json(
+        { error: { code: 'AUTH_ACCOUNT_FROZEN', message: 'アカウントが凍結されています' } },
+        { status: 403 },
       );
     }
     throw err;

--- a/src/app/frozen/page.tsx
+++ b/src/app/frozen/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+/**
+ * アカウント凍結通知ページ
+ * #1030 [Crit] frozen_at/BAN の enforcement
+ *
+ * middleware (lib/supabase/middleware.ts) が frozen_at のセットされた
+ * (かつ一時 BAN が未解除の) ユーザーのページナビゲーションをここへリダイレクトする。
+ */
+
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { useRouter } from "next/navigation";
+
+export default function FrozenPage() {
+  const router = useRouter();
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  const handleSignOut = async () => {
+    if (isSigningOut) return;
+    setIsSigningOut(true);
+    try {
+      const supabase = createClient();
+      await supabase.auth.signOut();
+    } finally {
+      router.push("/login");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8 py-12 text-center">
+      <div className="max-w-md w-full space-y-6">
+        <h1 className="text-2xl font-bold text-gray-900">
+          アカウントが凍結されています
+        </h1>
+        <p className="text-gray-600 leading-relaxed">
+          利用規約違反等の理由により、このアカウントは現在凍結されています。
+          一時的な凍結の場合は、解除予定日時の経過後に自動的にアクセスが回復します。
+          心当たりがない場合や、詳細を確認したい場合はサポートまでお問い合わせください。
+        </p>
+        <div className="flex flex-col gap-3 pt-4">
+          <a
+            href="/contact"
+            className="inline-flex justify-center items-center px-4 py-2 rounded-md bg-orange-500 text-white font-medium hover:bg-orange-600 transition-colors"
+          >
+            サポートに問い合わせる
+          </a>
+          <button
+            type="button"
+            onClick={handleSignOut}
+            disabled={isSigningOut}
+            className="inline-flex justify-center items-center px-4 py-2 rounded-md border border-gray-300 text-gray-700 font-medium hover:bg-gray-100 transition-colors disabled:opacity-50"
+          >
+            ログアウト
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/admin/user-ban.ts
+++ b/src/lib/admin/user-ban.ts
@@ -11,6 +11,10 @@
  * `/api/admin/users/[id]/freeze` (POST/DELETE) と同じ
  * `frozen_at`/`frozen_reason`/`frozen_by` 更新機構に統一する。
  *
+ * #1030 修正: 一時 BAN の解除予定日時 (`unbanAt`) を `user_profiles.unban_at`
+ * (20260710210030 migration で追加) に永続化する。従来は監査ログにしか
+ * 記録されず、判定時比較による自動解除が不可能だった。
+ *
  * 呼び出し側は必ず authz (requireRole 等) を通した後に、service-role
  * クライアント (`getSupabaseAdmin()`) を渡すこと (user_profiles の他ユーザー
  * 行の更新は RLS で拒否されるため)。
@@ -36,8 +40,9 @@ export interface ApplyUserBanResult {
   success: boolean;
   /**
    * temporary BAN の解除予定日時 (呼び出し側の監査ログ記録用)。
-   * 注意: この値を永続化する列は存在しない (freeze route と同じ制約、要 migration)。
-   * 自動解除バッチは無いため、運用者が手動で unfreeze する必要がある。
+   * #1030: `user_profiles.unban_at` にも永続化されるため、requireUser/
+   * requireRole/middleware の判定時比較により unban_at 経過後は自動的に
+   * アクセスが回復する。
    */
   unbanAt: string | null;
   error?: string;
@@ -73,24 +78,25 @@ export async function applyUserBan(
     return { success: false, unbanAt: null, error: 'super_admin ユーザーを BAN することはできません' };
   }
 
+  let unbanAt: string | null = null;
+  if (banType === 'temporary' && durationDays) {
+    const unbanDate = new Date();
+    unbanDate.setDate(unbanDate.getDate() + durationDays);
+    unbanAt = unbanDate.toISOString();
+  }
+
   const { error: updateError } = await supabaseAdmin
     .from('user_profiles')
     .update({
       frozen_at: new Date().toISOString(),
       frozen_reason: reason,
       frozen_by: actorId,
+      unban_at: unbanAt,
     } as Record<string, unknown>)
     .eq('id', userId);
 
   if (updateError) {
     return { success: false, unbanAt: null, error: updateError.message };
-  }
-
-  let unbanAt: string | null = null;
-  if (banType === 'temporary' && durationDays) {
-    const unbanDate = new Date();
-    unbanDate.setDate(unbanDate.getDate() + durationDays);
-    unbanAt = unbanDate.toISOString();
   }
 
   return { success: true, unbanAt };

--- a/src/lib/auth/__tests__/frozen.test.ts
+++ b/src/lib/auth/__tests__/frozen.test.ts
@@ -1,0 +1,43 @@
+/**
+ * src/lib/auth/frozen.ts のユニットテスト
+ * #1030 [Crit] frozen_at/BAN の enforcement
+ */
+import { describe, it, expect } from 'vitest';
+import { isAccountFrozen } from '../frozen';
+
+describe('isAccountFrozen', () => {
+  it('frozen_at が null の場合 false を返す (凍結されていない)', () => {
+    expect(isAccountFrozen({ frozenAt: null, unbanAt: null })).toBe(false);
+  });
+
+  it('frozen_at が undefined の場合も false を返す', () => {
+    expect(isAccountFrozen({ frozenAt: undefined, unbanAt: null })).toBe(false);
+  });
+
+  it('frozen_at がセットされ unban_at が null (無期限 BAN) の場合 true を返す', () => {
+    expect(
+      isAccountFrozen({ frozenAt: '2026-07-01T00:00:00.000Z', unbanAt: null }),
+    ).toBe(true);
+  });
+
+  it('frozen_at がセットされ unban_at が未来 (一時 BAN 継続中) の場合 true を返す', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    expect(
+      isAccountFrozen({ frozenAt: '2026-07-01T00:00:00.000Z', unbanAt: future }),
+    ).toBe(true);
+  });
+
+  it('frozen_at がセットされ unban_at が過去 (一時 BAN 期限切れ) の場合 false を返す (自動解除)', () => {
+    const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    expect(
+      isAccountFrozen({ frozenAt: '2026-07-01T00:00:00.000Z', unbanAt: past }),
+    ).toBe(false);
+  });
+
+  it('unban_at がちょうど現在時刻 (境界値) の場合 false を返す (経過後扱い)', () => {
+    const now = new Date().toISOString();
+    expect(
+      isAccountFrozen({ frozenAt: '2026-07-01T00:00:00.000Z', unbanAt: now }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/auth/__tests__/helpers.test.ts
+++ b/src/lib/auth/__tests__/helpers.test.ts
@@ -324,6 +324,45 @@ describe('impersonate', () => {
     await expect(impersonate('target-user-id', '理由')).rejects.toThrow(AuthError);
   });
 
+  // #1030 (round-4 Warning fix): 凍結中ユーザーへの成りすましを拒否する
+  it('対象ユーザーが frozen_at 中の場合 ImpersonationError(AUTH_IMPERSONATION_TARGET_FROZEN) を throw する', async () => {
+    setupGetUser(fakeSuperAdmin);
+    let userProfilesCallCount = 0;
+    supabaseClient.from = vi.fn().mockImplementation((table: string) => {
+      if (table === 'user_profiles') {
+        userProfilesCallCount += 1;
+        if (userProfilesCallCount === 1) {
+          // 1回目: 実行者 (super_admin) のプロフィール取得
+          return makeQueryBuilder({
+            data: { roles: ['super_admin'], organization_id: null, frozen_at: null, unban_at: null },
+            error: null,
+          });
+        }
+        // 2回目: 成りすまし対象のプロフィール取得 (凍結中)
+        return makeQueryBuilder({
+          data: {
+            roles: ['user'],
+            organization_id: null,
+            frozen_at: '2026-07-01T00:00:00.000Z',
+            unban_at: null,
+          },
+          error: null,
+        });
+      }
+      return makeQueryBuilder({ data: null, error: null });
+    });
+
+    let caught: unknown;
+    try {
+      await impersonate('target-user-id', '理由');
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(ImpersonationError);
+    expect(caught).toMatchObject({ code: 'AUTH_IMPERSONATION_TARGET_FROZEN' });
+  });
+
   it('admin_audit_logs に action_type=impersonate の記録を挿入する', async () => {
     setupGetUser(fakeSuperAdmin);
     const insertMock = vi.fn().mockResolvedValue({ data: null, error: null });

--- a/src/lib/auth/__tests__/helpers.test.ts
+++ b/src/lib/auth/__tests__/helpers.test.ts
@@ -38,8 +38,18 @@ const supabaseClient = {
   from: vi.fn(),
 };
 
+// #1030 (round-5): user_profiles の SELECT ポリシーは自分の行のみを許可する (RLS)。
+// getUserProfileAdmin() は service_role の admin client を使用して RLS をバイパスするため、
+// 通常クライアント (supabaseClient) とは別のモッククライアントを用意し、
+// 「通常クライアントでは他ユーザー行が 0 行 (RLS 模擬)・admin クライアント経由なら読める」
+// ことを区別できるようにする。
+const supabaseAdminClient = {
+  from: vi.fn(),
+};
+
 vi.mock('@/lib/supabase/server', () => ({
   createClient: () => supabaseClient,
+  getSupabaseAdmin: () => supabaseAdminClient,
 }));
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -89,6 +99,96 @@ function setupUserProfile(
 function setupUserProfileNotFound(userId: string) {
   const profileBuilder = makeQueryBuilder({ data: null, error: { message: 'not found' } });
   supabaseClient.from = vi.fn().mockReturnValue(profileBuilder);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// admin client (getSupabaseAdmin) 用テストヘルパー
+// #1030 (round-5): impersonate() の対象ユーザー取得は RLS バイパスの admin client を
+// 経由するため、通常クライアントとは独立にモックする。
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * admin client 経由で対象ユーザーのプロフィールが取得できるケースをセットアップする。
+ */
+function setupTargetProfileAdmin(
+  roles: string[],
+  organization_id: string | null = null,
+  frozen_at: string | null = null,
+  unban_at: string | null = null,
+) {
+  const profileBuilder = makeQueryBuilder({
+    data: { roles, organization_id, frozen_at, unban_at },
+    error: null,
+  });
+  supabaseAdminClient.from = vi.fn().mockImplementation((table: string) => {
+    if (table === 'user_profiles') {
+      return profileBuilder;
+    }
+    return makeQueryBuilder({ data: [], error: null });
+  });
+}
+
+/**
+ * admin client 経由でも対象ユーザーが見つからない (実在しない) ケースをセットアップする。
+ */
+function setupTargetProfileAdminNotFound() {
+  const profileBuilder = makeQueryBuilder({ data: null, error: { message: 'not found' } });
+  supabaseAdminClient.from = vi.fn().mockReturnValue(profileBuilder);
+}
+
+/**
+ * RLS を模擬した通常クライアント (supabaseClient) の user_profiles モックを作る。
+ * `selfId` の行のみ返し、それ以外の id は 0 行 (RLS で不可視) として扱う。
+ * admin_audit_logs 等の他テーブルはデフォルトの空クエリビルダーを返す。
+ */
+function makeRlsAwareUserProfilesFrom(selfId: string, selfProfile: Record<string, unknown>) {
+  return vi.fn().mockImplementation((table: string) => {
+    if (table !== 'user_profiles') {
+      return makeQueryBuilder({ data: [], error: null });
+    }
+    let queriedId: string | undefined;
+    const builder: Record<string, unknown> = {};
+    builder.select = vi.fn().mockReturnValue(builder);
+    builder.eq = vi.fn().mockImplementation((column: string, value: string) => {
+      if (column === 'id') queriedId = value;
+      return builder;
+    });
+    builder.single = vi.fn().mockImplementation(() => {
+      if (queriedId === selfId) {
+        return Promise.resolve({ data: selfProfile, error: null });
+      }
+      // RLS: 自分以外の行は 0 行として扱われる (single() は not-found エラーを返す)
+      return Promise.resolve({ data: null, error: { message: 'RLS: no rows visible' } });
+    });
+    return builder;
+  });
+}
+
+/**
+ * RLS をバイパスする admin client の user_profiles モックを作る。
+ * `profilesById` に登録された id ならどれでも取得できる (service_role 相当)。
+ */
+function makeAdminUserProfilesFrom(profilesById: Record<string, Record<string, unknown>>) {
+  return vi.fn().mockImplementation((table: string) => {
+    if (table !== 'user_profiles') {
+      return makeQueryBuilder({ data: [], error: null });
+    }
+    let queriedId: string | undefined;
+    const builder: Record<string, unknown> = {};
+    builder.select = vi.fn().mockReturnValue(builder);
+    builder.eq = vi.fn().mockImplementation((column: string, value: string) => {
+      if (column === 'id') queriedId = value;
+      return builder;
+    });
+    builder.single = vi.fn().mockImplementation(() => {
+      const profile = queriedId ? profilesById[queriedId] : undefined;
+      if (!profile) {
+        return Promise.resolve({ data: null, error: { message: 'not found' } });
+      }
+      return Promise.resolve({ data: profile, error: null });
+    });
+    return builder;
+  });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -290,6 +390,11 @@ describe('requireOrgRole', () => {
 describe('impersonate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // 各テストで明示的にセットアップしなければ、admin client への呼び出しは
+    // 「見つからない」を返す (未セットアップ = バグの可能性を潰す安全側デフォルト)。
+    supabaseAdminClient.from = vi.fn().mockReturnValue(
+      makeQueryBuilder({ data: null, error: { message: 'not set up' } }),
+    );
   });
 
   it('super_admin が impersonate すると impersonation_token と expires_at を返す', async () => {
@@ -301,6 +406,8 @@ describe('impersonate', () => {
       }
       return auditBuilder;
     });
+    // #1030 (round-5): 対象ユーザーの取得は admin client 経由。
+    setupTargetProfileAdmin(['user'], null, null, null);
 
     const result = await impersonate('target-user-id', 'テスト目的');
     expect(result).toHaveProperty('impersonation_token');
@@ -324,33 +431,31 @@ describe('impersonate', () => {
     await expect(impersonate('target-user-id', '理由')).rejects.toThrow(AuthError);
   });
 
+  // #1030 (round-5 Critical fix): 対象ユーザーの取得は RLS バイパスの admin client を
+  // 経由する。通常クライアント (supabaseClient) には自分 (super_admin) の行しか無い
+  // (RLS 模擬) にもかかわらず impersonate が成功することで、admin client 経由の
+  // 参照が正しく配線されていることを検証する。
+  it('通常クライアントでは対象ユーザー行が 0 行 (RLS) でも admin client 経由で対象を取得し impersonate が成功する', async () => {
+    setupGetUser(fakeSuperAdmin);
+    const selfProfile = { roles: ['super_admin'], organization_id: null, frozen_at: null, unban_at: null };
+    const targetProfile = { roles: ['user'], organization_id: null, frozen_at: null, unban_at: null };
+
+    // 通常クライアント: fakeSuperAdmin.id の行のみ見える (RLS 模擬)。target-user-id は 0 行。
+    supabaseClient.from = makeRlsAwareUserProfilesFrom(fakeSuperAdmin.id, selfProfile);
+    // admin client: target-user-id も見える (service_role, RLS バイパス)。
+    supabaseAdminClient.from = makeAdminUserProfilesFrom({ 'target-user-id': targetProfile });
+
+    const result = await impersonate('target-user-id', 'RLS回避検証');
+    expect(result).toHaveProperty('impersonation_token');
+    expect(typeof result.impersonation_token).toBe('string');
+  });
+
   // #1030 (round-4 Warning fix): 凍結中ユーザーへの成りすましを拒否する
   it('対象ユーザーが frozen_at 中の場合 ImpersonationError(AUTH_IMPERSONATION_TARGET_FROZEN) を throw する', async () => {
     setupGetUser(fakeSuperAdmin);
-    let userProfilesCallCount = 0;
-    supabaseClient.from = vi.fn().mockImplementation((table: string) => {
-      if (table === 'user_profiles') {
-        userProfilesCallCount += 1;
-        if (userProfilesCallCount === 1) {
-          // 1回目: 実行者 (super_admin) のプロフィール取得
-          return makeQueryBuilder({
-            data: { roles: ['super_admin'], organization_id: null, frozen_at: null, unban_at: null },
-            error: null,
-          });
-        }
-        // 2回目: 成りすまし対象のプロフィール取得 (凍結中)
-        return makeQueryBuilder({
-          data: {
-            roles: ['user'],
-            organization_id: null,
-            frozen_at: '2026-07-01T00:00:00.000Z',
-            unban_at: null,
-          },
-          error: null,
-        });
-      }
-      return makeQueryBuilder({ data: null, error: null });
-    });
+    setupUserProfile(fakeSuperAdmin.id, ['super_admin'], null, null, null);
+    // #1030 (round-5): 対象ユーザー (凍結中) の取得は admin client 経由。
+    setupTargetProfileAdmin(['user'], null, '2026-07-01T00:00:00.000Z', null);
 
     let caught: unknown;
     try {
@@ -361,6 +466,35 @@ describe('impersonate', () => {
 
     expect(caught).toBeInstanceOf(ImpersonationError);
     expect(caught).toMatchObject({ code: 'AUTH_IMPERSONATION_TARGET_FROZEN' });
+  });
+
+  // #1030 (round-5): frozen_at が null の対象は拒否されず成功する (非 frozen の成功ケース)
+  it('対象ユーザーが frozen_at でない場合は成功する', async () => {
+    setupGetUser(fakeSuperAdmin);
+    setupUserProfile(fakeSuperAdmin.id, ['super_admin'], null, null, null);
+    setupTargetProfileAdmin(['user'], null, null, null);
+
+    const result = await impersonate('target-user-id', '理由');
+    expect(result).toHaveProperty('impersonation_token');
+  });
+
+  // #1030 (round-5 Critical fix): 対象ユーザーが実在しない場合は明示的に
+  // ImpersonationError(AUTH_IMPERSONATION_TARGET_NOT_FOUND) を throw する
+  // (getUserProfileAdmin() が null を返すケース)。
+  it('対象ユーザーが存在しない場合 ImpersonationError(AUTH_IMPERSONATION_TARGET_NOT_FOUND) を throw する', async () => {
+    setupGetUser(fakeSuperAdmin);
+    setupUserProfile(fakeSuperAdmin.id, ['super_admin'], null, null, null);
+    setupTargetProfileAdminNotFound();
+
+    let caught: unknown;
+    try {
+      await impersonate('nonexistent-user-id', '理由');
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(ImpersonationError);
+    expect(caught).toMatchObject({ code: 'AUTH_IMPERSONATION_TARGET_NOT_FOUND' });
   });
 
   it('admin_audit_logs に action_type=impersonate の記録を挿入する', async () => {
@@ -375,6 +509,7 @@ describe('impersonate', () => {
       }
       return makeQueryBuilder({ data: null, error: null });
     });
+    setupTargetProfileAdmin(['user'], null, null, null);
 
     await impersonate('target-user-id', '監査テスト');
     expect(insertMock).toHaveBeenCalledOnce();
@@ -393,6 +528,7 @@ describe('impersonate', () => {
       }
       return { insert: insertMock };
     });
+    setupTargetProfileAdmin(['user'], null, null, null);
 
     const result = await impersonate('target-user-id', '理由');
     expect(result).toHaveProperty('impersonation_token');

--- a/src/lib/auth/__tests__/helpers.test.ts
+++ b/src/lib/auth/__tests__/helpers.test.ts
@@ -71,9 +71,11 @@ function setupUserProfile(
   userId: string,
   roles: string[],
   organization_id: string | null = null,
+  frozen_at: string | null = null,
+  unban_at: string | null = null,
 ) {
   const profileBuilder = makeQueryBuilder({
-    data: { roles, organization_id },
+    data: { roles, organization_id, frozen_at, unban_at },
     error: null,
   });
   supabaseClient.from = vi.fn().mockImplementation((table: string) => {
@@ -100,6 +102,7 @@ describe('requireUser', () => {
 
   it('認証済みユーザーを返す', async () => {
     setupGetUser(fakeUser);
+    setupUserProfile(fakeUser.id, ['user'], null);
     const user = await requireUser();
     expect(user.id).toBe(fakeUser.id);
     expect(user.email).toBe(fakeUser.email);
@@ -114,6 +117,34 @@ describe('requireUser', () => {
   it('Supabase エラーがある場合 AuthError を throw する', async () => {
     mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'auth error' } });
     await expect(requireUser()).rejects.toThrow(AuthError);
+  });
+
+  // #1030: frozen_at enforcement
+  it('frozen_at がセット (無期限 BAN) されている場合 ForbiddenError(AUTH_ACCOUNT_FROZEN) を throw する', async () => {
+    setupGetUser(fakeUser);
+    setupUserProfile(fakeUser.id, ['user'], null, '2026-07-01T00:00:00.000Z', null);
+    await expect(requireUser()).rejects.toThrow(ForbiddenError);
+    await expect(requireUser()).rejects.toMatchObject({ code: 'AUTH_ACCOUNT_FROZEN' });
+  });
+
+  it('frozen_at がセットされていても unban_at が過去 (一時 BAN 期限切れ) なら成功する', async () => {
+    setupGetUser(fakeUser);
+    setupUserProfile(
+      fakeUser.id,
+      ['user'],
+      null,
+      '2026-07-01T00:00:00.000Z',
+      '2026-07-02T00:00:00.000Z', // 過去
+    );
+    const user = await requireUser();
+    expect(user.id).toBe(fakeUser.id);
+  });
+
+  it('frozen_at がセットされ unban_at が未来 (一時 BAN 継続中) なら ForbiddenError を throw する', async () => {
+    setupGetUser(fakeUser);
+    const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    setupUserProfile(fakeUser.id, ['user'], null, '2026-07-01T00:00:00.000Z', future);
+    await expect(requireUser()).rejects.toMatchObject({ code: 'AUTH_ACCOUNT_FROZEN' });
   });
 });
 
@@ -169,6 +200,16 @@ describe('requireRole', () => {
 
     const profile = await requireRole(['admin', 'super_admin', 'finance']);
     expect(profile.roles).toContain('finance');
+  });
+
+  // #1030: frozen_at enforcement (allowedRoles を満たしていても凍結中なら拒否)
+  it('allowedRoles を満たしていても frozen_at がセットされていれば ForbiddenError(AUTH_ACCOUNT_FROZEN) を throw する', async () => {
+    setupGetUser(fakeUser);
+    setupUserProfile(fakeUser.id, ['admin'], null, '2026-07-01T00:00:00.000Z', null);
+
+    await expect(requireRole(['admin', 'super_admin'])).rejects.toMatchObject({
+      code: 'AUTH_ACCOUNT_FROZEN',
+    });
   });
 });
 

--- a/src/lib/auth/frozen.ts
+++ b/src/lib/auth/frozen.ts
@@ -1,0 +1,31 @@
+/**
+ * frozen_at (アカウント凍結) の判定ロジック
+ * #1030 [Crit] frozen_at/BAN の enforcement
+ *
+ * `src/lib/auth/helpers.ts` (requireUser/requireRole) と
+ * `lib/supabase/middleware.ts` (ページナビゲーション) の両方から参照される
+ * 純粋関数。DB アクセスは行わない (呼び出し側が frozen_at/unban_at を渡す)。
+ */
+
+export interface FrozenCheckInput {
+  /** user_profiles.frozen_at (NULL = 凍結されていない) */
+  frozenAt: string | null | undefined;
+  /** user_profiles.unban_at (一時 BAN の解除予定日時。NULL = 無期限 or 凍結なし) */
+  unbanAt: string | null | undefined;
+}
+
+/**
+ * 現時点でアクセスをブロックすべき凍結状態かどうかを判定する。
+ *
+ * - frozen_at が NULL → false (凍結されていない)
+ * - frozen_at が NOT NULL かつ unban_at が NULL → true (無期限 BAN / 凍結)
+ * - frozen_at が NOT NULL かつ unban_at が未来 → true (一時 BAN 継続中)
+ * - frozen_at が NOT NULL かつ unban_at が過去 → false (一時 BAN 期限切れ、自動解除扱い)
+ */
+export function isAccountFrozen({ frozenAt, unbanAt }: FrozenCheckInput): boolean {
+  if (!frozenAt) return false;
+  if (unbanAt && new Date(unbanAt).getTime() <= Date.now()) {
+    return false;
+  }
+  return true;
+}

--- a/src/lib/auth/helpers.ts
+++ b/src/lib/auth/helpers.ts
@@ -7,7 +7,7 @@
  */
 
 import { type User } from '@supabase/supabase-js';
-import { createClient } from '@/lib/supabase/server';
+import { createClient, getSupabaseAdmin } from '@/lib/supabase/server';
 import { AuthError, ForbiddenError, ImpersonationError } from './errors';
 import { type RoleName, type OrgRoleName, type UserProfile } from './types';
 import { isAccountFrozen } from './frozen';
@@ -68,6 +68,42 @@ function assertNotFrozen(frozenAt: string | null, unbanAt: string | null): void 
   if (isAccountFrozen({ frozenAt, unbanAt })) {
     throw new ForbiddenError('AUTH_ACCOUNT_FROZEN', 'アカウントが凍結されています');
   }
+}
+
+/**
+ * user_profiles を service_role (RLS バイパス) で取得する。
+ * #1030 (round-5 Critical fix): user_profiles の SELECT ポリシーは
+ * "Users can view own profile" USING (auth.uid() = id) の1本のみであり、
+ * 実行者以外の行は通常クライアント (createClient(), RLS 有効) では 0 行になる。
+ * impersonate() の対象ユーザー参照など、認可 (super_admin 判定) 通過後に
+ * 他ユーザーの行を読む必要がある箇所は、既存パターン (#1028: freeze/route.ts 等)
+ * に合わせて admin client を使用する。
+ * 対象が存在しない場合は null を返す (RLS による不可視か実在しないかは呼び出し側で
+ * 区別せず、いずれも「対象が見つからない」として扱う)。
+ */
+async function getUserProfileAdmin(userId: string): Promise<{
+  roles: RoleName[];
+  organization_id: string | null;
+  frozen_at: string | null;
+  unban_at: string | null;
+} | null> {
+  const supabaseAdmin = getSupabaseAdmin();
+  const { data: profile, error } = await supabaseAdmin
+    .from('user_profiles')
+    .select('roles, organization_id, frozen_at, unban_at')
+    .eq('id', userId)
+    .single();
+
+  if (error || !profile) {
+    return null;
+  }
+
+  return {
+    roles: (profile.roles ?? ['user']) as RoleName[],
+    organization_id: profile.organization_id ?? null,
+    frozen_at: (profile as { frozen_at?: string | null }).frozen_at ?? null,
+    unban_at: (profile as { unban_at?: string | null }).unban_at ?? null,
+  };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -165,7 +201,8 @@ export async function requireOrgRole(
  * @returns impersonation_token と expires_at
  * @throws AuthError          - 実行者が未認証の場合
  * @throws ImpersonationError - super_admin 以外が実行した場合 / 対象が拒否設定の場合 /
- *                              #1030 (round-4): 対象ユーザーが凍結中の場合
+ *                              #1030 (round-4): 対象ユーザーが凍結中の場合 /
+ *                              #1030 (round-5): 対象ユーザーが存在しない場合
  */
 export async function impersonate(
   targetUserId: string,
@@ -181,11 +218,22 @@ export async function impersonate(
     );
   }
 
+  // #1030 (round-5 Critical fix): 対象ユーザーの行は RLS (自分の行のみ SELECT 可) により
+  // 通常クライアントでは読めないため、admin client (service_role) で取得する。
+  // super_admin 判定 (上記) を通過した後にのみ呼び出すこと (認可前に使うと権限昇格になる)。
+  const targetProfile = await getUserProfileAdmin(targetUserId);
+  if (!targetProfile) {
+    throw new ImpersonationError(
+      'AUTH_IMPERSONATION_TARGET_NOT_FOUND',
+      '対象ユーザーが見つかりません',
+    );
+  }
+
   // #1030 (round-4 Warning fix): 凍結中のユーザーへの成りすましセッションを拒否する。
   // impersonate は対象ユーザーとして振る舞えるセッションを発行するため、対象が凍結中
   // (BAN 中) の場合にこれを許すと、frozen_at enforcement (requireUser/requireRole/
   // middleware) を impersonate 経由で迂回できてしまう。
-  const { frozen_at: targetFrozenAt, unban_at: targetUnbanAt } = await getUserProfile(targetUserId);
+  const { frozen_at: targetFrozenAt, unban_at: targetUnbanAt } = targetProfile;
   if (isAccountFrozen({ frozenAt: targetFrozenAt, unbanAt: targetUnbanAt })) {
     throw new ImpersonationError(
       'AUTH_IMPERSONATION_TARGET_FROZEN',

--- a/src/lib/auth/helpers.ts
+++ b/src/lib/auth/helpers.ts
@@ -10,6 +10,7 @@ import { type User } from '@supabase/supabase-js';
 import { createClient } from '@/lib/supabase/server';
 import { AuthError, ForbiddenError, ImpersonationError } from './errors';
 import { type RoleName, type OrgRoleName, type UserProfile } from './types';
+import { isAccountFrozen } from './frozen';
 
 export { type RoleName, type OrgRoleName, type UserProfile };
 
@@ -31,13 +32,18 @@ async function getAuthUser(): Promise<User> {
 }
 
 /**
- * user_profiles テーブルから roles と organization_id を取得する。
+ * user_profiles テーブルから roles と organization_id、凍結状態 (frozen_at/unban_at) を取得する。
  */
-async function getUserProfile(userId: string): Promise<{ roles: RoleName[]; organization_id: string | null }> {
+async function getUserProfile(userId: string): Promise<{
+  roles: RoleName[];
+  organization_id: string | null;
+  frozen_at: string | null;
+  unban_at: string | null;
+}> {
   const supabase = createClient();
   const { data: profile, error } = await supabase
     .from('user_profiles')
-    .select('roles, organization_id')
+    .select('roles, organization_id, frozen_at, unban_at')
     .eq('id', userId)
     .single();
 
@@ -48,7 +54,20 @@ async function getUserProfile(userId: string): Promise<{ roles: RoleName[]; orga
   return {
     roles: (profile.roles ?? ['user']) as RoleName[],
     organization_id: profile.organization_id ?? null,
+    frozen_at: (profile as { frozen_at?: string | null }).frozen_at ?? null,
+    unban_at: (profile as { unban_at?: string | null }).unban_at ?? null,
   };
+}
+
+/**
+ * #1030: frozen_at がセットされ、かつ一時 BAN の unban_at が未到来の場合に
+ * ForbiddenError('AUTH_ACCOUNT_FROZEN') を throw する。
+ * unban_at 経過後 (一時 BAN の自動解除) は許可する (判定時比較)。
+ */
+function assertNotFrozen(frozenAt: string | null, unbanAt: string | null): void {
+  if (isAccountFrozen({ frozenAt, unbanAt })) {
+    throw new ForbiddenError('AUTH_ACCOUNT_FROZEN', 'アカウントが凍結されています');
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -57,9 +76,14 @@ async function getUserProfile(userId: string): Promise<{ roles: RoleName[]; orga
 
 /**
  * Supabase auth で取得した user を返す。未認証なら 401 相当の AuthError を throw する。
+ * #1030: frozen_at がセットされている(かつ一時 BAN 未解除)場合は 403 相当の
+ * ForbiddenError('AUTH_ACCOUNT_FROZEN') を throw する。
  */
 export async function requireUser(): Promise<User> {
-  return getAuthUser();
+  const user = await getAuthUser();
+  const { frozen_at, unban_at } = await getUserProfile(user.id);
+  assertNotFrozen(frozen_at, unban_at);
+  return user;
 }
 
 /**
@@ -69,13 +93,14 @@ export async function requireUser(): Promise<User> {
  * @param allowedRoles - 許可するロールの配列
  * @returns 認証済みユーザーの UserProfile
  * @throws AuthError (401) - 未認証の場合
- * @throws ForbiddenError (403) - ロール不足の場合
+ * @throws ForbiddenError (403) - ロール不足の場合、または #1030: アカウント凍結中の場合
  */
 export async function requireRole(
   allowedRoles: ReadonlyArray<RoleName>,
 ): Promise<UserProfile> {
   const user = await getAuthUser();
-  const { roles, organization_id } = await getUserProfile(user.id);
+  const { roles, organization_id, frozen_at, unban_at } = await getUserProfile(user.id);
+  assertNotFrozen(frozen_at, unban_at);
 
   if (!roles.some((r) => allowedRoles.includes(r))) {
     throw new ForbiddenError(

--- a/src/lib/auth/helpers.ts
+++ b/src/lib/auth/helpers.ts
@@ -164,7 +164,8 @@ export async function requireOrgRole(
  * @param reason       - impersonate の理由 (audit_log に記録)
  * @returns impersonation_token と expires_at
  * @throws AuthError          - 実行者が未認証の場合
- * @throws ImpersonationError - super_admin 以外が実行した場合 / 対象が拒否設定の場合
+ * @throws ImpersonationError - super_admin 以外が実行した場合 / 対象が拒否設定の場合 /
+ *                              #1030 (round-4): 対象ユーザーが凍結中の場合
  */
 export async function impersonate(
   targetUserId: string,
@@ -177,6 +178,18 @@ export async function impersonate(
     throw new ImpersonationError(
       'AUTH_IMPERSONATION_DENIED',
       'impersonate は super_admin のみ実行可能です',
+    );
+  }
+
+  // #1030 (round-4 Warning fix): 凍結中のユーザーへの成りすましセッションを拒否する。
+  // impersonate は対象ユーザーとして振る舞えるセッションを発行するため、対象が凍結中
+  // (BAN 中) の場合にこれを許すと、frozen_at enforcement (requireUser/requireRole/
+  // middleware) を impersonate 経由で迂回できてしまう。
+  const { frozen_at: targetFrozenAt, unban_at: targetUnbanAt } = await getUserProfile(targetUserId);
+  if (isAccountFrozen({ frozenAt: targetFrozenAt, unbanAt: targetUnbanAt })) {
+    throw new ImpersonationError(
+      'AUTH_IMPERSONATION_TARGET_FROZEN',
+      '凍結中のユーザーへは impersonate できません',
     );
   }
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -6479,6 +6479,7 @@ export type Database = {
           temperature_preference: string | null
           texture_preferences: string[] | null
           travel_frequency: string | null
+          unban_at: string | null
           updated_at: string | null
           wake_time: string | null
           water_cutting: boolean | null
@@ -6612,6 +6613,7 @@ export type Database = {
           temperature_preference?: string | null
           texture_preferences?: string[] | null
           travel_frequency?: string | null
+          unban_at?: string | null
           updated_at?: string | null
           wake_time?: string | null
           water_cutting?: boolean | null
@@ -6745,6 +6747,7 @@ export type Database = {
           temperature_preference?: string | null
           texture_preferences?: string[] | null
           travel_frequency?: string | null
+          unban_at?: string | null
           updated_at?: string | null
           wake_time?: string | null
           water_cutting?: boolean | null

--- a/supabase/migrations/20260710210030_frozen_at_enforcement.sql
+++ b/supabase/migrations/20260710210030_frozen_at_enforcement.sql
@@ -33,6 +33,12 @@ COMMENT ON COLUMN user_profiles.unban_at IS
   'unban_at が過去の場合はアクセス判定時 (requireUser/requireRole/middleware) に '
   '自動解除扱いとする (#1030)。';
 
+-- #1030 (round-2 継承 Warning / round-4 対応): このカラム追加以前に作成された
+-- 一時 BAN は unban_at が admin_audit_logs.details.unban_at にしか記録されて
+-- おらず、本カラムへの backfill が本来必要になるケースがある。
+-- 2026-07-11 時点で本番の frozen_users=0・temp_ban_audit_rows=0 を実測確認済みのため、
+-- backfill 対象データは存在せず追加対応不要と判断した。
+
 -- ─── 2. 特権列ガードトリガーに frozen 系列を追加 (#1030) ─────────────────────────
 -- トリガー本体 (trg_guard_user_profiles_privileged) は 20260511000136 で
 -- 作成済みのため、関数本体の CREATE OR REPLACE のみで反映される。

--- a/supabase/migrations/20260710210030_frozen_at_enforcement.sql
+++ b/supabase/migrations/20260710210030_frozen_at_enforcement.sql
@@ -1,0 +1,94 @@
+-- migration: 20260710210030_frozen_at_enforcement.sql
+-- #1030 [Crit] frozen_at/BAN がアクセス制限に繋がっておらず形骸化
+--
+-- 修正内容:
+--  1. user_profiles.unban_at 列を追加する。一時 BAN の解除予定日時は
+--     従来 admin_audit_logs.details.unban_at にしか記録されず、判定時比較で
+--     自動解除する仕組みが存在しなかった (永続化列が無かったため)。
+--  2. guard_user_profiles_privileged() トリガー (#1013/#1014/#1015,
+--     20260511000136) の保護対象列に frozen_at/frozen_by/frozen_reason/
+--     unban_at を追加する。"Users can update own profile" RLS ポリシー
+--     (auth.uid() = id, 列制限なし) は authenticated ロールでの直接 UPDATE を
+--     許すため、このガードが無いと凍結された本人が frozen_at を自分で NULL に
+--     書き換えて凍結を解除できてしまう(#1030 で新たに発見した抜け穴)。
+--     service_role (freeze route / applyUserBan) と SECURITY DEFINER RPC は
+--     current_user が authenticated/anon ではないため従来どおり許可される。
+--  3. admin_set_user_roles(p_user_id, p_roles) から 'banned' 特例を削除する。
+--     BAN は #1041 で admin/moderation ルートが frozen_at ベース
+--     (applyUserBan) に統一済みのため、このRPCは
+--     「super_admin のみが roles を変更できる」というシンプルな契約に戻す
+--     (PR #1066 最終レビュー、Issue #1030 コメント参照)。
+--
+-- Idempotent: yes (ADD COLUMN IF NOT EXISTS / CREATE OR REPLACE FUNCTION)
+
+BEGIN;
+
+-- ─── 1. unban_at 列の追加 (一時 BAN の解除予定日時を永続化) ──────────────────────
+
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS unban_at TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN user_profiles.unban_at IS
+  '一時 BAN の解除予定日時。NULL = 無期限凍結 or 凍結なし。frozen_at が NOT NULL かつ '
+  'unban_at が過去の場合はアクセス判定時 (requireUser/requireRole/middleware) に '
+  '自動解除扱いとする (#1030)。';
+
+-- ─── 2. 特権列ガードトリガーに frozen 系列を追加 (#1030) ─────────────────────────
+-- トリガー本体 (trg_guard_user_profiles_privileged) は 20260511000136 で
+-- 作成済みのため、関数本体の CREATE OR REPLACE のみで反映される。
+
+CREATE OR REPLACE FUNCTION public.guard_user_profiles_privileged()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF current_user IN ('authenticated','anon') THEN
+    IF NEW.roles            IS DISTINCT FROM OLD.roles
+       OR NEW.org_role         IS DISTINCT FROM OLD.org_role
+       OR NEW.organization_id  IS DISTINCT FROM OLD.organization_id
+       OR NEW.family_id        IS DISTINCT FROM OLD.family_id
+       OR NEW.is_active_in_org IS DISTINCT FROM OLD.is_active_in_org
+       OR NEW.joined_org_at    IS DISTINCT FROM OLD.joined_org_at
+       OR NEW.frozen_at        IS DISTINCT FROM OLD.frozen_at
+       OR NEW.frozen_by        IS DISTINCT FROM OLD.frozen_by
+       OR NEW.frozen_reason    IS DISTINCT FROM OLD.frozen_reason
+       OR NEW.unban_at         IS DISTINCT FROM OLD.unban_at THEN
+      RAISE EXCEPTION 'CANNOT_MODIFY_PRIVILEGED_COLUMN' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+  RETURN NEW;
+END $$;
+
+-- ─── 3. admin_set_user_roles から 'banned' 特例を削除 (#1030 comment) ────────────
+-- 呼び出し元は super_admin のみ(admin/users/[id]/role は既に requireRole(['super_admin'])
+-- で絞っている)。'banned' 差分の特別扱いは #1041 で BAN 経路が frozen_at ベースに
+-- 移行済みのため不要 (moderation ルートは applyUserBan を使い、このRPCは呼ばない)。
+
+CREATE OR REPLACE FUNCTION public.admin_set_user_roles(p_user_id UUID, p_roles TEXT[])
+RETURNS TABLE(id UUID, roles TEXT[])
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_caller_roles TEXT[];
+  v_new_roles TEXT[];
+BEGIN
+  SELECT up.roles INTO v_caller_roles FROM user_profiles up WHERE up.id = auth.uid();
+  IF v_caller_roles IS NULL OR NOT (v_caller_roles && ARRAY['super_admin']) THEN
+    RAISE EXCEPTION 'FORBIDDEN' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_user_id = auth.uid() THEN
+    RAISE EXCEPTION 'CANNOT_MODIFY_OWN_ROLES' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM user_profiles up WHERE up.id = p_user_id) THEN
+    RAISE EXCEPTION 'USER_NOT_FOUND' USING ERRCODE = 'P0001';
+  END IF;
+
+  v_new_roles := COALESCE(p_roles, ARRAY[]::TEXT[]);
+
+  UPDATE user_profiles up SET roles = v_new_roles WHERE up.id = p_user_id;
+
+  RETURN QUERY SELECT p_user_id, v_new_roles;
+END $$;
+
+REVOKE EXECUTE ON FUNCTION public.admin_set_user_roles(UUID, TEXT[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_set_user_roles(UUID, TEXT[]) TO authenticated;
+
+COMMIT;

--- a/tests/admin-users-status-filter.test.ts
+++ b/tests/admin-users-status-filter.test.ts
@@ -1,0 +1,119 @@
+/**
+ * GET /api/admin/users の status フィルタ (banned/active) 意味論テスト
+ * #1030 round-2 Warning: is_banned (レスポンス側, isAccountFrozen ベース) と
+ * status フィルタ (クエリ側) の意味論を揃える。
+ *
+ * 一時 BAN が unban_at 経過で自動解除された場合:
+ * - status=banned で検索したユーザー一覧から除外されるべき (もう凍結されていない)
+ * - status=active で検索したユーザー一覧に含まれるべき
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Supabase admin client モック (呼び出しチェーンを記録する)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type Call = { method: string; args: unknown[] };
+
+function createTrackingBuilder(result: { data: unknown[]; error: unknown; count: number }) {
+  const calls: Call[] = [];
+  const chainMethods = [
+    'select',
+    'or',
+    'not',
+    'is',
+    'contains',
+    'gte',
+    'lte',
+    'order',
+    'range',
+  ] as const;
+
+  const builder: Record<string, unknown> = {};
+  chainMethods.forEach((method) => {
+    builder[method] = (...args: unknown[]) => {
+      calls.push({ method, args });
+      return builder;
+    };
+  });
+  // PostgrestFilterBuilder はそれ自体が thenable (await できる)
+  builder.then = (resolve: (value: typeof result) => unknown) => resolve(result);
+
+  return { builder, calls };
+}
+
+vi.mock('@/lib/auth/helpers', () => ({
+  requireRole: vi.fn().mockResolvedValue({
+    id: 'admin-id',
+    email: 'admin@example.com',
+    roles: ['admin'],
+    organization_id: null,
+  }),
+}));
+
+let latestCalls: Call[] = [];
+
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseAdmin: () => ({
+    from: (_table: string) => {
+      const { builder, calls } = createTrackingBuilder({ data: [], error: null, count: 0 });
+      latestCalls = calls;
+      return builder;
+    },
+  }),
+}));
+
+import { GET } from '../src/app/api/admin/users/route';
+
+function findOrArg(calls: Call[]): string | undefined {
+  const orCall = calls.find((c) => c.method === 'or');
+  return orCall?.args[0] as string | undefined;
+}
+
+describe('GET /api/admin/users — status フィルタの意味論', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    latestCalls = [];
+  });
+
+  it('status=banned は frozen_at IS NOT NULL かつ (unban_at IS NULL または未来) で絞り込む', async () => {
+    const req = new Request('http://localhost/api/admin/users?status=banned');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    const notCall = latestCalls.find((c) => c.method === 'not');
+    expect(notCall?.args).toEqual(['frozen_at', 'is', null]);
+
+    const orArg = findOrArg(latestCalls);
+    expect(orArg).toBeDefined();
+    expect(orArg).toMatch(/^unban_at\.is\.null,unban_at\.gt\.\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('status=active は未凍結、または一時 BAN 期限切れ (unban_at が過去) を含める', async () => {
+    const req = new Request('http://localhost/api/admin/users?status=active');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    // 'active' では frozen_at IS NULL の単純フィルタ (.is) は使わず、
+    // 期限切れ一時 BAN も含める .or() 表現に統一されている
+    const isCall = latestCalls.find((c) => c.method === 'is');
+    expect(isCall).toBeUndefined();
+
+    const orArg = findOrArg(latestCalls);
+    expect(orArg).toBeDefined();
+    expect(orArg).toContain('frozen_at.is.null');
+    expect(orArg).toMatch(
+      /^frozen_at\.is\.null,and\(frozen_at\.not\.is\.null,unban_at\.not\.is\.null,unban_at\.lte\.\d{4}-\d{2}-\d{2}T[\d:.TZ-]+\)$/,
+    );
+  });
+
+  it('status 未指定の場合は frozen 系フィルタを一切適用しない', async () => {
+    const req = new Request('http://localhost/api/admin/users');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    expect(latestCalls.some((c) => c.method === 'not')).toBe(false);
+    expect(latestCalls.some((c) => c.method === 'is')).toBe(false);
+    expect(latestCalls.some((c) => c.method === 'or')).toBe(false);
+  });
+});

--- a/tests/integration/operator/admin-users.test.ts
+++ b/tests/integration/operator/admin-users.test.ts
@@ -37,7 +37,7 @@ afterAll(async () => {
   // Unfreeze target user before cleanup
   await supabaseAdmin
     .from('user_profiles')
-    .update({ frozen_at: null, frozen_reason: null, frozen_by: null })
+    .update({ frozen_at: null, frozen_reason: null, frozen_by: null, unban_at: null })
     .eq('id', targetUser.userId);
 
   await Promise.all([

--- a/tests/moderation-route-contracts.test.ts
+++ b/tests/moderation-route-contracts.test.ts
@@ -229,6 +229,8 @@ describe('POST /api/admin/moderation/[type]/[id] (審査確定)', () => {
     expect(updatePayload.frozen_at).toEqual(expect.any(String));
     expect(updatePayload.frozen_by).toBe('admin-1');
     expect(updatePayload).not.toHaveProperty('roles');
+    // #1030: unban_at も user_profiles に永続化されること (判定時比較による自動解除のため)
+    expect(updatePayload.unban_at).toEqual(expect.any(String));
 
     // #1041 round-2 (D/F): service-role を使うこと
     expect(mockGetSupabaseAdmin).toHaveBeenCalled();

--- a/tests/user-ban.test.ts
+++ b/tests/user-ban.test.ts
@@ -77,6 +77,8 @@ describe('applyUserBan (#1041 round-2 D)', () => {
     expect(payload.frozen_reason).toBe('[moderation:food] spam');
     expect(payload.frozen_by).toBe('admin-1');
     expect(payload).not.toHaveProperty('roles');
+    // #1030: unban_at も user_profiles に永続化されること (判定時比較による自動解除のため)
+    expect(payload.unban_at).toBe(result.unbanAt);
     // 対象ユーザーの id にスコープされていること
     expect(supabase.eqCallsAfterUpdate[0]).toEqual(['id', 'owner-1']);
   });
@@ -93,6 +95,9 @@ describe('applyUserBan (#1041 round-2 D)', () => {
 
     expect(result.success).toBe(true);
     expect(result.unbanAt).toBeNull();
+    // #1030: permanent BAN は unban_at も null で永続化されること
+    const payload = supabase.updateCalls[0] as Record<string, unknown>;
+    expect(payload.unban_at).toBeNull();
   });
 
   it('super_admin は BAN 対象から除外する (更新を実行しない)', async () => {


### PR DESCRIPTION
## ⚠️ マージ=本番 DB 自動適用
migration `20260710210030_frozen_at_enforcement.sql` を含みます(drift guard 通過後に自動適用)。

## 概要
BAN(凍結)が「フラグを立てても実際には何も止まらない」形骸化状態だった問題を全面解消(#1030)。

## 修正内容
- **enforcement**: requireUser/requireRole と middleware で `frozen_at`/`unban_at` を確認し、凍結ユーザーの API を 403(FORBIDDEN)・ページをブロック画面へ。**モバイルの Bearer セッションにも適用**(Authorization 転送。非JWT の Bearer=cron 等は JWT 形式チェックで従来どおり短絡し、無駄な Auth API 呼び出しを発生させない)。
- **temp ban の自動解除**: `unban_at` 列を追加し期限到来で自動解除(既存該当者は本番実測 0 名を確認済み)。
- **impersonate 防御**: 凍結ユーザーへの成りすましを拒否。対象プロファイル取得は認可(super_admin 二重チェック)通過後の service-role で行い、RLS で読めず機能全滅していた欠陥を修正。対象不在は 404、AuthError 素通し 500 も解消。
- `admin_set_user_roles` の `ARRAY['banned']` 特例を除去(#1041 の frozen_at 統一と整合)。

## 検証
- migration 完全冪等(2回連続実行エラー0)・本番データ互換(凍結 0 行を実測)。
- テスト 945件 全 PASS。RLS 挙動(自分の行のみ可視)を模擬する本物のテストで配線を検証 — レビュー側が**ミューテーションテスト**(旧コード+新テスト=3 FAIL)で検出力を実証。
- 2モデル敵対レビュー(Sonnet5+Fable)5ラウンド、**round-5 で double-PASS**。「全チェック緑のまま impersonate 全滅コードがマージされる」事故をレビューが2度ブロックした。

## 運用注意
マージ直後、Vercel デプロイと migration 適用の間に数分のずれがあると、その間 API が一時 401 になり得ます(fail-closed・自然回復)。