### PR TITLE
fix(nutrition): 栄養計算の正確性を修正 (#1046)

### DIFF
--- a/packages/shared/src/nutrition-constants.ts
+++ b/packages/shared/src/nutrition-constants.ts
@@ -13,6 +13,11 @@ export interface NutrientDefinition {
   decimals: number;      // 小数点以下桁数
   category: 'basic' | 'mineral' | 'vitamin' | 'fat'; // カテゴリ
   description?: string;  // 説明
+  // #1046 UX3-20: 塩分・コレステロール等「控えめに」が推奨される上限系(DG/UL)栄養素か。
+  // true の場合、レーダーチャートの「平均達成率」計算からは除外する
+  // （過剰摂取が平均を押し上げて見かけ上スコアが良く見えてしまうのを防ぐ）。
+  // 個別の過剰摂取警告(達成率そのものの表示)には引き続き使用される。
+  isUpperLimit?: boolean;
 }
 
 // 栄養素定義マスター
@@ -26,7 +31,7 @@ export const NUTRIENT_DEFINITIONS: NutrientDefinition[] = [
   { key: 'sugarG', label: '糖質', unit: 'g', dri: 250, decimals: 1, category: 'basic', description: '即効性のあるエネルギー' },
 
   // === ミネラル ===
-  { key: 'sodiumG', label: '塩分', unit: 'g', dri: 7.5, decimals: 1, category: 'mineral', description: '目標量（控えめに）' },
+  { key: 'sodiumG', label: '塩分', unit: 'g', dri: 7.5, decimals: 1, category: 'mineral', description: '目標量（控えめに）', isUpperLimit: true },
   { key: 'potassiumMg', label: 'カリウム', unit: 'mg', dri: 2500, decimals: 0, category: 'mineral', description: '血圧調整・むくみ防止' },
   { key: 'calciumMg', label: 'カルシウム', unit: 'mg', dri: 700, decimals: 0, category: 'mineral', description: '骨・歯の形成' },
   { key: 'magnesiumMg', label: 'マグネシウム', unit: 'mg', dri: 340, decimals: 0, category: 'mineral', description: '酵素反応の補助' },
@@ -48,8 +53,8 @@ export const NUTRIENT_DEFINITIONS: NutrientDefinition[] = [
   { key: 'folicAcidUg', label: '葉酸', unit: 'µg', dri: 240, decimals: 0, category: 'vitamin', description: '細胞分裂・胎児発育' },
 
   // === 脂質詳細 ===
-  { key: 'saturatedFatG', label: '飽和脂肪酸', unit: 'g', dri: 16, decimals: 1, category: 'fat', description: '摂りすぎ注意' },
-  { key: 'cholesterolMg', label: 'コレステロール', unit: 'mg', dri: 300, decimals: 0, category: 'fat', description: '細胞膜・ホルモン材料' },
+  { key: 'saturatedFatG', label: '飽和脂肪酸', unit: 'g', dri: 16, decimals: 1, category: 'fat', description: '摂りすぎ注意', isUpperLimit: true },
+  { key: 'cholesterolMg', label: 'コレステロール', unit: 'mg', dri: 300, decimals: 0, category: 'fat', description: '細胞膜・ホルモン材料', isUpperLimit: true },
 ];
 
 // キーからNutrientDefinitionを取得

--- a/src/app/api/health/goals/[id]/route.ts
+++ b/src/app/api/health/goals/[id]/route.ts
@@ -1,23 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { sanitizeHealthGoalUpdate } from '@/lib/health-payloads';
-
-// #1046 F2-12: Math.abs で符号を潰すと「目標から遠ざかる」変化でも進捗が増えてしまう
-// （例: 80→85kgで目標70kgなのに進捗50%）。target - start の符号を方向として掛け、
-// 目標方向へ進んだ分だけを進捗としてカウントする。0除算はガードし、逆行時は0%にクランプする。
-export function calculateGoalProgressPercentage(
-  startValue: number,
-  targetValue: number,
-  currentValue: number,
-  fallback: number,
-): number {
-  const totalChange = targetValue - startValue;
-  if (totalChange === 0) return fallback;
-
-  const direction = Math.sign(totalChange);
-  const currentChange = (currentValue - startValue) * direction;
-  return Math.min(100, Math.max(0, (currentChange / Math.abs(totalChange)) * 100));
-}
+import { calculateGoalProgressPercentage } from '@/lib/health-goal-progress';
 
 // 目標の取得
 export async function GET(

--- a/src/app/api/health/goals/[id]/route.ts
+++ b/src/app/api/health/goals/[id]/route.ts
@@ -2,6 +2,23 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { sanitizeHealthGoalUpdate } from '@/lib/health-payloads';
 
+// #1046 F2-12: Math.abs で符号を潰すと「目標から遠ざかる」変化でも進捗が増えてしまう
+// （例: 80→85kgで目標70kgなのに進捗50%）。target - start の符号を方向として掛け、
+// 目標方向へ進んだ分だけを進捗としてカウントする。0除算はガードし、逆行時は0%にクランプする。
+export function calculateGoalProgressPercentage(
+  startValue: number,
+  targetValue: number,
+  currentValue: number,
+  fallback: number,
+): number {
+  const totalChange = targetValue - startValue;
+  if (totalChange === 0) return fallback;
+
+  const direction = Math.sign(totalChange);
+  const currentChange = (currentValue - startValue) * direction;
+  return Math.min(100, Math.max(0, (currentChange / Math.abs(totalChange)) * 100));
+}
+
 // 目標の取得
 export async function GET(
   request: NextRequest,
@@ -82,11 +99,12 @@ export async function PUT(
 
   let progressPercentage = existing.progress_percentage;
   if (currentValue !== null && existing.start_value !== null && targetValue !== null) {
-    const totalChange = Math.abs(targetValue - existing.start_value);
-    const currentChange = Math.abs(currentValue - existing.start_value);
-    if (totalChange > 0) {
-      progressPercentage = Math.min(100, (currentChange / totalChange) * 100);
-    }
+    progressPercentage = calculateGoalProgressPercentage(
+      existing.start_value,
+      targetValue,
+      currentValue,
+      progressPercentage,
+    );
   }
 
   // マイルストーン達成チェック

--- a/src/app/api/health/goals/route.ts
+++ b/src/app/api/health/goals/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { sanitizeHealthGoalUpdate } from '@/lib/health-payloads';
+import { calculateGoalProgressPercentage } from '@/lib/health-goal-progress';
 
 // 目標一覧の取得
 export async function GET(request: NextRequest) {
@@ -88,13 +89,12 @@ export async function POST(request: NextRequest) {
     startValue = profile?.body_fat_percentage;
   }
 
-  // 進捗率を計算
+  // 進捗率を計算（新規作成時は current_value = start_value のため常に0%になるが、
+  // #1046 round-2 Suggestion: PUT側と同じ calculateGoalProgressPercentage を使い
+  // 重複ロジック・死んだ分岐を解消する）
   let progressPercentage = 0;
   if (startValue !== null) {
-    const totalChange = Math.abs(targetValue - startValue);
-    if (totalChange > 0) {
-      progressPercentage = 0;
-    }
+    progressPercentage = calculateGoalProgressPercentage(startValue, targetValue, startValue, 0);
   }
 
   const { data, error } = await supabase

--- a/src/components/NutritionRadarChart.tsx
+++ b/src/components/NutritionRadarChart.tsx
@@ -55,6 +55,51 @@ const DISPLAY_CAP = 200;
 // Component
 // ============================================
 
+export interface NutritionRadarChartDatum {
+  nutrient: string;
+  value: number;
+  fullValue: number;
+  actualValue: number;
+  unit: string;
+  dri: number;
+  // UX3-20: 塩分・コレステロール等の上限系（DG/UL）栄養素かどうか
+  isUpperLimit: boolean;
+}
+
+// レーダーチャート用のデータを生成（純粋関数として切り出し、ユニットテスト可能にする）
+export function buildNutritionRadarChartData(
+  nutrients: string[],
+  nutrition: Record<string, number>
+): NutritionRadarChartDatum[] {
+  return nutrients.map(key => {
+    const def = getNutrientDefinition(key);
+    const value = nutrition[key] ?? 0;
+    const percentage = calculateDriPercentage(key, value);
+
+    return {
+      nutrient: def?.label ?? key,
+      value: Math.min(percentage, 150), // 150%でキャップ（表示上）
+      fullValue: percentage,
+      actualValue: value,
+      unit: def?.unit ?? '',
+      dri: def?.dri ?? 0,
+      isUpperLimit: def?.isUpperLimit ?? false,
+    };
+  });
+}
+
+// 全体の達成率（平均）を計算する純粋関数
+// UX3-20: 塩分・コレステロールのような「控えめに」が推奨される上限系栄養素は、
+// 過剰摂取するほど達成率(%)が上振れするため、そのまま平均に含めると
+// 摂りすぎているのに平均達成率が上がって見える逆転現象が起きる。
+// レーダー自体には引き続き表示しつつ、平均達成率の算出からは除外する。
+export function calculateAverageAchievementPercentage(chartData: NutritionRadarChartDatum[]): number {
+  const targetData = chartData.filter(d => !d.isUpperLimit);
+  if (targetData.length === 0) return 0;
+  const total = targetData.reduce((sum, d) => sum + d.fullValue, 0);
+  return Math.round(total / targetData.length);
+}
+
 export function NutritionRadarChart({
   nutrition,
   selectedNutrients,
@@ -65,30 +110,15 @@ export function NutritionRadarChart({
   // 表示する栄養素（ユーザー設定 or デフォルト）
   const nutrients = selectedNutrients?.length ? selectedNutrients : DEFAULT_RADAR_NUTRIENTS;
 
-  // レーダーチャート用のデータを生成
-  const chartData = useMemo(() => {
-    return nutrients.map(key => {
-      const def = getNutrientDefinition(key);
-      const value = nutrition[key] ?? 0;
-      const percentage = calculateDriPercentage(key, value);
-      
-      return {
-        nutrient: def?.label ?? key,
-        value: Math.min(percentage, 150), // 150%でキャップ（表示上）
-        fullValue: percentage,
-        actualValue: value,
-        unit: def?.unit ?? '',
-        dri: def?.dri ?? 0,
-      };
-    });
-  }, [nutrients, nutrition]);
+  const chartData = useMemo(
+    () => buildNutritionRadarChartData(nutrients, nutrition),
+    [nutrients, nutrition]
+  );
 
-  // 全体の達成率（平均）
-  const averagePercentage = useMemo(() => {
-    if (chartData.length === 0) return 0;
-    const total = chartData.reduce((sum, d) => sum + d.fullValue, 0);
-    return Math.round(total / chartData.length);
-  }, [chartData]);
+  const averagePercentage = useMemo(
+    () => calculateAverageAchievementPercentage(chartData),
+    [chartData]
+  );
 
   // 表示用の達成率（DISPLAY_CAP で上限ガード）— Bug-21
   const displayPercentage = Math.min(averagePercentage, DISPLAY_CAP);

--- a/src/lib/health-goal-progress.ts
+++ b/src/lib/health-goal-progress.ts
@@ -1,0 +1,22 @@
+// #1046 F2-12: Math.abs で符号を潰すと「目標から遠ざかる」変化でも進捗が増えてしまう
+// （例: 80→85kgで目標70kgなのに進捗50%）。target - start の符号を方向として掛け、
+// 目標方向へ進んだ分だけを進捗としてカウントする。0除算はガードし、逆行時は0%にクランプする。
+//
+// #1046 round-2 Critical: App Router の route.ts (src/app/api/health/goals/[id]/route.ts)
+// から value export すると、Next.js の NextTypesPlugin が route entry の export を
+// HTTP メソッド+config 系に限定する型チェックで next build を落とす
+// （"Property 'calculateGoalProgressPercentage' is incompatible with index signature"）。
+// route.ts からは export せず、この共有ライブラリに切り出して import する。
+export function calculateGoalProgressPercentage(
+  startValue: number,
+  targetValue: number,
+  currentValue: number,
+  fallback: number,
+): number {
+  const totalChange = targetValue - startValue;
+  if (totalChange === 0) return fallback;
+
+  const direction = Math.sign(totalChange);
+  const currentChange = (currentValue - startValue) * direction;
+  return Math.min(100, Math.max(0, (currentChange / Math.abs(totalChange)) * 100));
+}

--- a/src/lib/health-payloads.ts
+++ b/src/lib/health-payloads.ts
@@ -361,18 +361,22 @@ export function sanitizeHealthRecordPayload(
       if (value !== undefined) data[field] = value;
     }
 
+    // #1046 F2-13: sleep_quality/overall_condition/mood_score/energy_level/stress_level は
+    // 記録画面(renderScoreButtons, 1-5の絵文字5段階)・AI相談プロンプト(x/5表記)が
+    // いずれも1-5スケールで運用されているが、サニタイザだけmax=10のままだったため、
+    // UI上ありえない6-10の値もAPIレベルでは通過してしまっていた。実態のUI(1-5)に統一する。
     const integerFieldOpts: Record<string, { min?: number; max?: number; label?: string }> = {
       systolic_bp: { min: 30, max: 300, label: '収縮期血圧 (mmHg)' },
       diastolic_bp: { min: 20, max: 200, label: '拡張期血圧 (mmHg)' },
       heart_rate: { min: 20, max: 300, label: '心拍数 (bpm)' },
-      sleep_quality: { min: 1, max: 10, label: '睡眠の質 (1-10)' },
+      sleep_quality: { min: 1, max: 5, label: '睡眠の質 (1-5)' },
       water_intake: { min: 0, max: 10000, label: '水分摂取量 (mL)' },
       step_count: { min: 0, max: 100000, label: '歩数' },
       bowel_movement: { min: 0, max: 20, label: '排便回数' },
-      overall_condition: { min: 1, max: 10, label: '全体的な体調 (1-10)' },
-      mood_score: { min: 1, max: 10, label: '気分スコア (1-10)' },
-      energy_level: { min: 1, max: 10, label: 'エネルギーレベル (1-10)' },
-      stress_level: { min: 1, max: 10, label: 'ストレスレベル (1-10)' },
+      overall_condition: { min: 1, max: 5, label: '全体的な体調 (1-5)' },
+      mood_score: { min: 1, max: 5, label: '気分スコア (1-5)' },
+      energy_level: { min: 1, max: 5, label: 'エネルギーレベル (1-5)' },
+      stress_level: { min: 1, max: 5, label: 'ストレスレベル (1-5)' },
     };
     const integerFields = [
       'systolic_bp',

--- a/supabase/functions/_shared/nutrition-calculator-v2.ts
+++ b/supabase/functions/_shared/nutrition-calculator-v2.ts
@@ -51,6 +51,9 @@ export interface DishNutrition {
   role: string
   ingredients: IngredientNutrition[]
   totals: NutritionTotals
+  // #1046 F5-12: totals は表示用に丸め済み。複数料理を合算する側は
+  // 丸め済み値を再度足し合わせて誤差を累積させないよう、この生値(未丸め)を使うこと。
+  rawTotals: NutritionTotals
 }
 
 export interface IngredientNutrition {
@@ -275,7 +278,10 @@ export function calculateDishNutrition(
     name: dishName,
     role: dishRole,
     ingredients,
+    // totals は表示用に丸めるが、rawTotals は未丸めのまま保持し、
+    // 複数料理の合算(calculateMealNutrition 等)で二重丸めが発生しないようにする(#1046 F5-12)。
     totals: roundNutrition(totals),
+    rawTotals: totals,
   }
 }
 
@@ -284,13 +290,16 @@ export function calculateDishNutrition(
 // ============================================
 
 export function calculateMealNutrition(dishes: DishNutrition[]): MealNutrition {
-  let totals = initNutritionTotals()
+  // #1046 F5-12: 既に丸め済みの dish.totals を合算して再度丸めると
+  // 品数が多いほど微量栄養素の誤差が累積する。未丸めの rawTotals を合算し、
+  // 最終出力(食事単位)でのみ丸める。
+  let rawTotals = initNutritionTotals()
   let matchedCount = 0
   let totalIngredients = 0
 
   for (const dish of dishes) {
-    totals = sumNutrition(totals, dish.totals)
-    
+    rawTotals = sumNutrition(rawTotals, dish.rawTotals ?? dish.totals)
+
     for (const ingredient of dish.ingredients) {
       totalIngredients++
       if (ingredient.matchedId) {
@@ -301,7 +310,7 @@ export function calculateMealNutrition(dishes: DishNutrition[]): MealNutrition {
 
   return {
     dishes,
-    totals: roundNutrition(totals),
+    totals: roundNutrition(rawTotals),
     matchedCount,
     totalIngredients,
     matchRate: totalIngredients > 0 ? matchedCount / totalIngredients : 0,

--- a/supabase/functions/_shared/nutrition-calculator.ts
+++ b/supabase/functions/_shared/nutrition-calculator.ts
@@ -292,8 +292,16 @@ export const INGREDIENT_ALIASES: Record<string, string[]> = {
 };
 
 // 栄養値を加算するヘルパー関数
+// #1046 F5-11: 廃棄率(discard_rate_percent)を可食部補正として適用する。
+// v2(nutrition-calculator-v2.ts の calculateIngredientNutrition)と同じ計算式に揃え、
+// 皮付き野菜・骨付き肉等で栄養が過大計上されるv1/v2間の不一致を解消する。
 export function addNutritionFromMatch(totals: NutritionTotals, matched: any, amount_g: number) {
-  const factor = amount_g / 100.0;
+  const discardRateRaw = typeof matched?.discard_rate_percent === 'string'
+    ? parseFloat(matched.discard_rate_percent)
+    : matched?.discard_rate_percent;
+  const discardRate = Number.isFinite(discardRateRaw) ? discardRateRaw : 0;
+  const effectiveAmount_g = amount_g * (1 - discardRate / 100);
+  const factor = effectiveAmount_g / 100.0;
   const add = (key: keyof NutritionTotals, v: number | string | null | undefined) => {
     // DBからの値は文字列の場合があるので、parseFloatで変換
     const num = typeof v === 'string' ? parseFloat(v) : v;
@@ -505,8 +513,9 @@ export async function embedTexts(texts: string[], dimensions = DATASET_EMBEDDING
 
 // DBに実際に存在するカラムのみを選択
 // 存在しないカラム: sugar_g, saturated_fat_g, monounsaturated_fat_g, polyunsaturated_fat_g
+// #1046 F5-11: discard_rate_percent（廃棄率）を選択に含め、可食部補正をv2と揃える
 const INGREDIENT_SELECT = `
-  id, name, name_norm,
+  id, name, name_norm, discard_rate_percent,
   calories_kcal, protein_g, fat_g, carbs_g, fiber_g, salt_eq_g,
   potassium_mg, calcium_mg, phosphorus_mg, magnesium_mg, iron_mg, zinc_mg, iodine_ug,
   cholesterol_mg,

--- a/supabase/functions/_shared/nutrition-pipeline.ts
+++ b/supabase/functions/_shared/nutrition-pipeline.ts
@@ -450,8 +450,10 @@ function normalizeDishForNutrition(dish: GeminiDish): GeminiDish {
   }
 }
 
-function scaleNutritionTotals(totals: NutritionTotals, factor: number): NutritionTotals {
-  return roundNutrition({
+// #1046 F5-12: 丸め済みの totals ではなく未丸めの rawTotals を係数倍し、
+// totals はその結果を最後に1回だけ丸めて算出する（丸め→倍率→丸めの二重丸めを避ける）。
+export function scaleNutritionTotalsRaw(totals: NutritionTotals, factor: number): NutritionTotals {
+  return {
     calories_kcal: totals.calories_kcal * factor,
     protein_g: totals.protein_g * factor,
     fat_g: totals.fat_g * factor,
@@ -480,10 +482,10 @@ function scaleNutritionTotals(totals: NutritionTotals, factor: number): Nutritio
     biotin_ug: totals.biotin_ug * factor,
     vitamin_c_mg: totals.vitamin_c_mg * factor,
     salt_eq_g: totals.salt_eq_g * factor,
-  })
+  }
 }
 
-function applyDishNutritionCalibration(
+export function applyDishNutritionCalibration(
   dish: GeminiDish,
   dishNutrition: DishNutrition,
 ): { dishNutrition: DishNutrition; factor: number } {
@@ -522,10 +524,13 @@ function applyDishNutritionCalibration(
     caloriesAfter: Math.round(dishNutrition.totals.calories_kcal * factor),
   })
 
+  const scaledRaw = scaleNutritionTotalsRaw(dishNutrition.rawTotals ?? dishNutrition.totals, factor)
+
   return {
     dishNutrition: {
       ...dishNutrition,
-      totals: scaleNutritionTotals(dishNutrition.totals, factor),
+      totals: roundNutrition(scaledRaw),
+      rawTotals: scaledRaw,
     },
     factor,
   }
@@ -538,8 +543,9 @@ function shouldUseEstimatedNutrition(dish: GeminiDish): boolean {
   return confidence === 'medium' && ['soup', 'rice', 'salad'].includes(dish.role)
 }
 
-function totalsFromEstimatedNutrition(estimate: MealNutritionEstimate): NutritionTotals {
-  return roundNutrition({
+// #1046 F5-12: 丸めは行わず生値のまま返す。呼び出し側(rawTotals)が未丸めを保持できるようにする。
+export function totalsFromEstimatedNutritionRaw(estimate: MealNutritionEstimate): NutritionTotals {
+  return {
     ...initNutritionTotals(),
     calories_kcal: estimate.calories_kcal,
     protein_g: estimate.protein_g,
@@ -548,27 +554,30 @@ function totalsFromEstimatedNutrition(estimate: MealNutritionEstimate): Nutritio
     fiber_g: estimate.fiber_g,
     salt_eq_g: estimate.salt_eq_g,
     sodium_mg: estimate.salt_eq_g * 393.4,
-  })
+  }
 }
 
-function overlayEstimatedTopLineNutrition(
+export function overlayEstimatedTopLineNutrition(
   dishNutrition: DishNutrition,
   estimate: MealNutritionEstimate,
 ): DishNutrition {
-  const estimatedTotals = totalsFromEstimatedNutrition(estimate)
+  const estimatedTotals = totalsFromEstimatedNutritionRaw(estimate)
+  const baseRaw = dishNutrition.rawTotals ?? dishNutrition.totals
+  const rawTotals: NutritionTotals = {
+    ...baseRaw,
+    calories_kcal: estimatedTotals.calories_kcal,
+    protein_g: estimatedTotals.protein_g,
+    fat_g: estimatedTotals.fat_g,
+    carbs_g: estimatedTotals.carbs_g,
+    fiber_g: estimatedTotals.fiber_g,
+    sodium_mg: estimatedTotals.sodium_mg,
+    salt_eq_g: estimatedTotals.salt_eq_g,
+  }
 
   return {
     ...dishNutrition,
-    totals: roundNutrition({
-      ...dishNutrition.totals,
-      calories_kcal: estimatedTotals.calories_kcal,
-      protein_g: estimatedTotals.protein_g,
-      fat_g: estimatedTotals.fat_g,
-      carbs_g: estimatedTotals.carbs_g,
-      fiber_g: estimatedTotals.fiber_g,
-      sodium_mg: estimatedTotals.sodium_mg,
-      salt_eq_g: estimatedTotals.salt_eq_g,
-    }),
+    totals: roundNutrition(rawTotals),
+    rawTotals,
   }
 }
 
@@ -921,6 +930,8 @@ export async function analyzeWithEvidence(
         analyzedDish,
         stats,
         totals: dishNutrition.totals,
+        // #1046 F5-12: 食事全体の合算は丸め済み totals ではなく rawTotals を使う
+        rawTotals: dishNutrition.rawTotals,
         matchedIngredients,
         ingredientMatchingMs: dishIngredientMatchingMs,
         nutritionCalculationMs: dishNutritionCalculationMs,
@@ -950,34 +961,37 @@ export async function analyzeWithEvidence(
     llmFallbackConfidence = mergeFallbackConfidence(llmFallbackConfidence, processed.llmConfidence)
     allMatchedIngredients.push(...processed.matchedIngredients)
 
-    mealTotals.calories_kcal += processed.totals.calories_kcal
-    mealTotals.protein_g += processed.totals.protein_g
-    mealTotals.fat_g += processed.totals.fat_g
-    mealTotals.carbs_g += processed.totals.carbs_g
-    mealTotals.fiber_g += processed.totals.fiber_g
-    mealTotals.sodium_mg += processed.totals.sodium_mg
-    mealTotals.potassium_mg += processed.totals.potassium_mg
-    mealTotals.calcium_mg += processed.totals.calcium_mg
-    mealTotals.magnesium_mg += processed.totals.magnesium_mg
-    mealTotals.phosphorus_mg += processed.totals.phosphorus_mg
-    mealTotals.iron_mg += processed.totals.iron_mg
-    mealTotals.zinc_mg += processed.totals.zinc_mg
-    mealTotals.iodine_ug += processed.totals.iodine_ug
-    mealTotals.cholesterol_mg += processed.totals.cholesterol_mg
-    mealTotals.vitamin_a_ug += processed.totals.vitamin_a_ug
-    mealTotals.vitamin_d_ug += processed.totals.vitamin_d_ug
-    mealTotals.vitamin_e_mg += processed.totals.vitamin_e_mg
-    mealTotals.vitamin_k_ug += processed.totals.vitamin_k_ug
-    mealTotals.vitamin_b1_mg += processed.totals.vitamin_b1_mg
-    mealTotals.vitamin_b2_mg += processed.totals.vitamin_b2_mg
-    mealTotals.niacin_mg += processed.totals.niacin_mg
-    mealTotals.vitamin_b6_mg += processed.totals.vitamin_b6_mg
-    mealTotals.vitamin_b12_ug += processed.totals.vitamin_b12_ug
-    mealTotals.folic_acid_ug += processed.totals.folic_acid_ug
-    mealTotals.pantothenic_acid_mg += processed.totals.pantothenic_acid_mg
-    mealTotals.biotin_ug += processed.totals.biotin_ug
-    mealTotals.vitamin_c_mg += processed.totals.vitamin_c_mg
-    mealTotals.salt_eq_g += processed.totals.salt_eq_g
+    // #1046 F5-12: 丸め済みの processed.totals ではなく未丸めの rawTotals を合算し、
+    // 二重丸めによる誤差累積を避ける（最終丸めは下の roundNutrition(mealTotals) で1回のみ）。
+    const dishRaw = processed.rawTotals ?? processed.totals
+    mealTotals.calories_kcal += dishRaw.calories_kcal
+    mealTotals.protein_g += dishRaw.protein_g
+    mealTotals.fat_g += dishRaw.fat_g
+    mealTotals.carbs_g += dishRaw.carbs_g
+    mealTotals.fiber_g += dishRaw.fiber_g
+    mealTotals.sodium_mg += dishRaw.sodium_mg
+    mealTotals.potassium_mg += dishRaw.potassium_mg
+    mealTotals.calcium_mg += dishRaw.calcium_mg
+    mealTotals.magnesium_mg += dishRaw.magnesium_mg
+    mealTotals.phosphorus_mg += dishRaw.phosphorus_mg
+    mealTotals.iron_mg += dishRaw.iron_mg
+    mealTotals.zinc_mg += dishRaw.zinc_mg
+    mealTotals.iodine_ug += dishRaw.iodine_ug
+    mealTotals.cholesterol_mg += dishRaw.cholesterol_mg
+    mealTotals.vitamin_a_ug += dishRaw.vitamin_a_ug
+    mealTotals.vitamin_d_ug += dishRaw.vitamin_d_ug
+    mealTotals.vitamin_e_mg += dishRaw.vitamin_e_mg
+    mealTotals.vitamin_k_ug += dishRaw.vitamin_k_ug
+    mealTotals.vitamin_b1_mg += dishRaw.vitamin_b1_mg
+    mealTotals.vitamin_b2_mg += dishRaw.vitamin_b2_mg
+    mealTotals.niacin_mg += dishRaw.niacin_mg
+    mealTotals.vitamin_b6_mg += dishRaw.vitamin_b6_mg
+    mealTotals.vitamin_b12_ug += dishRaw.vitamin_b12_ug
+    mealTotals.folic_acid_ug += dishRaw.folic_acid_ug
+    mealTotals.pantothenic_acid_mg += dishRaw.pantothenic_acid_mg
+    mealTotals.biotin_ug += dishRaw.biotin_ug
+    mealTotals.vitamin_c_mg += dishRaw.vitamin_c_mg
+    mealTotals.salt_eq_g += dishRaw.salt_eq_g
   }
 
   mealTotals = roundNutrition(mealTotals)

--- a/supabase/functions/_shared/shopping-list-aggregation.ts
+++ b/supabase/functions/_shared/shopping-list-aggregation.ts
@@ -1,0 +1,44 @@
+/**
+ * 買い物リストの材料名寄せ合算（#1046 F5-13）
+ *
+ * 同名材料の出現(複数の食事・複数の日にまたがる)を、名前だけをキーに amount_g で
+ * 確定合算する。従来は regenerate-shopping-list-v2 内で `${name}|${amountStr}` を
+ * キーにしていたため、同じ材料でも日によって分量(g)が異なると別エントリになり、
+ * 合算(200g+300g→500g)を LLM のプロンプト任せにしていた（結果不一致の原因）。
+ * ここで g換算できる材料の合計gramを確定させ、LLMには表記整形のみを依頼する。
+ *
+ * Deno固有の import/実行(Deno.serve等)を含めず、Node(vitest)からも直接
+ * import してユニットテストできるようにするため、edge function 本体
+ * (index.ts) とは切り離して _shared 配下に置く。
+ */
+
+export interface InputIngredient {
+  name: string;
+  amount?: string | null;
+  count: number;
+}
+
+export function aggregateIngredientOccurrences(
+  occurrences: Array<{ name: string; amount_g: number }>
+): InputIngredient[] {
+  const aggregates = new Map<string, { name: string; totalAmountG: number; count: number }>();
+
+  for (const occurrence of occurrences) {
+    const name = occurrence.name?.trim();
+    if (!name) continue;
+
+    const existing = aggregates.get(name);
+    if (existing) {
+      existing.totalAmountG += occurrence.amount_g;
+      existing.count += 1;
+    } else {
+      aggregates.set(name, { name, totalAmountG: occurrence.amount_g, count: 1 });
+    }
+  }
+
+  return Array.from(aggregates.values()).map((agg) => ({
+    name: agg.name,
+    amount: agg.totalAmountG > 0 ? `${Math.round(agg.totalAmountG)}g` : null,
+    count: agg.count,
+  }));
+}

--- a/supabase/functions/regenerate-shopping-list-v2/index.ts
+++ b/supabase/functions/regenerate-shopping-list-v2/index.ts
@@ -131,10 +131,17 @@ async function markFailed(
 // ============================================
 
 function buildPrompt(ingredients: InputIngredient[]): string {
+  // #1046 round-2 Warning: InputIngredient.count は「この材料が何回の食事出現から
+  // 合算されたか」という集計用の内部カウントであり、amount（確定合算済みの総量）に
+  // 掛け合わせる係数ではない。しかしJSONをそのまま渡すとLLMが amount×count と
+  // 誤読し購入量を水増しする恐れがあるため、count はLLM入力から除去し
+  // name/amount のみを渡す（count はプロンプト生成に不要）。
+  const promptIngredients = ingredients.map(({ name, amount }) => ({ name, amount }));
+
   return `あなたは買い物リストの最適化AIです。スーパーで買い物しやすいリストを作成します。
 
-以下の材料リストを整理してください：
-${JSON.stringify(ingredients, null, 2)}
+以下の材料リストを整理してください（amountは既に合算済みの確定総量です。掛け算や倍量は不要です）：
+${JSON.stringify(promptIngredients, null, 2)}
 
 【タスク1: 表記ゆれの統一】
 同じ材料の異なる表記を統一してマージ

--- a/supabase/functions/regenerate-shopping-list-v2/index.ts
+++ b/supabase/functions/regenerate-shopping-list-v2/index.ts
@@ -13,6 +13,7 @@ import { getFastLLMApiKey, getFastLLMChatCompletionsUrl, getFastLLMModel } from 
 import { withOpenAIUsageContext, generateExecutionId } from "../_shared/llm-usage.ts";
 import { createLogger } from "../_shared/db-logger.ts";
 import { requireAuth } from "../_shared/auth.ts";
+import { aggregateIngredientOccurrences, InputIngredient } from "../_shared/shopping-list-aggregation.ts";
 
 // ============================================
 // CORS
@@ -38,12 +39,7 @@ function withCors(res: Response): Response {
 // ============================================
 // 型定義
 // ============================================
-
-interface InputIngredient {
-  name: string;
-  amount?: string | null;
-  count: number;
-}
+// InputIngredient は _shared/shopping-list-aggregation.ts からimport（#1046 F5-13）
 
 interface QuantityVariant {
   display: string;
@@ -429,7 +425,10 @@ async function processRegeneration(
     if (mealsError) throw mealsError;
 
     // 材料を抽出（人数倍率適用）
-    const ingredientsMap = new Map<string, InputIngredient>();
+    // #1046 F5-13: 各出現を { name, amount_g } のフラットな配列として集め、
+    // 名前だけをキーに amount_g を確定合算(aggregateIngredientOccurrences)する。
+    // 合算(200g+300g→500g)を LLM のプロンプト任せにしない。
+    const ingredientOccurrences: Array<{ name: string; amount_g: number }> = [];
     let totalMeals = 0; // 食事数（人数ではなく食事の回数）
 
     (dailyMeals || []).forEach((dailyMeal: any) => {
@@ -446,54 +445,22 @@ async function processRegeneration(
         if (servings === 0) return;
 
         totalMeals += 1; // 食事数をカウント（人数ではない）
-        
+
         if (meal.dishes && Array.isArray(meal.dishes)) {
           meal.dishes.forEach((dish: any) => {
             if (dish.ingredients && Array.isArray(dish.ingredients)) {
               dish.ingredients.forEach((ing: any) => {
                 const parsed = parseIngredientAmount(ing);
-                if (!parsed) return;
-                
-                const { name, amount_g } = parsed;
-                const scaledAmount = amount_g * servings;
-                const amountStr = scaledAmount > 0 ? `${Math.round(scaledAmount)}g` : null;
-
-                if (name) {
-                  const key = `${name}|${amountStr || ""}`;
-                  const existing = ingredientsMap.get(key);
-                  if (existing) {
-                    existing.count++;
-                  } else {
-                    ingredientsMap.set(key, {
-                      name: name.trim(),
-                      amount: amountStr,
-                      count: 1,
-                    });
-                  }
-                }
+                if (!parsed || !parsed.name) return;
+                ingredientOccurrences.push({ name: parsed.name, amount_g: parsed.amount_g * servings });
               });
             }
           });
         } else if (meal.ingredients && Array.isArray(meal.ingredients)) {
           meal.ingredients.forEach((ingredient: string) => {
             const parsed = parseIngredientAmount(ingredient);
-            if (!parsed) return;
-            
-            const { name, amount_g } = parsed;
-            const scaledAmount = amount_g * servings;
-            const amountStr = scaledAmount > 0 ? `${Math.round(scaledAmount)}g` : null;
-            const key = `${name}|${amountStr || ""}`;
-            
-            const existing = ingredientsMap.get(key);
-            if (existing) {
-              existing.count++;
-            } else {
-              ingredientsMap.set(key, {
-                name: name.trim(),
-                amount: amountStr,
-                count: 1,
-              });
-            }
+            if (!parsed || !parsed.name) return;
+            ingredientOccurrences.push({ name: parsed.name, amount_g: parsed.amount_g * servings });
           });
         }
       });
@@ -501,7 +468,7 @@ async function processRegeneration(
 
     console.log(`Total meals calculated: ${totalMeals}`);
 
-    const rawIngredients = Array.from(ingredientsMap.values());
+    const rawIngredients = aggregateIngredientOccurrences(ingredientOccurrences);
 
     // 既存のアクティブな買い物リストをアーカイブ
     await supabase

--- a/tests/health-goal-progress-direction.test.ts
+++ b/tests/health-goal-progress-direction.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { calculateGoalProgressPercentage } from '../src/app/api/health/goals/[id]/route';
+
+// #1046 F2-12: 進捗率が変化の「方向」を無視する問題の回帰テスト。
+// Math.abs で符号を潰すと、目標から遠ざかっても進捗が増えてしまっていた
+// (例: start=80kg, target=70kg なのに current=85kg で進捗50%になっていた)。
+describe('calculateGoalProgressPercentage', () => {
+  it('returns 0% when moving away from a weight-loss goal (80 -> 85, target 70)', () => {
+    // 修正前は Math.abs(85-80)/Math.abs(70-80) = 5/10 = 50% になっていた
+    const result = calculateGoalProgressPercentage(80, 70, 85, 0);
+    expect(result).toBe(0);
+  });
+
+  it('returns 50% for halfway progress toward a weight-loss goal (80 -> 75, target 70)', () => {
+    const result = calculateGoalProgressPercentage(80, 70, 75, 0);
+    expect(result).toBe(50);
+  });
+
+  it('clamps to 100% when the value overshoots past the weight-loss target (80 -> 60, target 70)', () => {
+    const result = calculateGoalProgressPercentage(80, 70, 60, 0);
+    expect(result).toBe(100);
+  });
+
+  it('works symmetrically for a weight-gain goal (60 -> 65, target 70)', () => {
+    const result = calculateGoalProgressPercentage(60, 70, 65, 0);
+    expect(result).toBe(50);
+  });
+
+  it('returns 0% when moving away from a weight-gain goal (60 -> 55, target 70)', () => {
+    const result = calculateGoalProgressPercentage(60, 70, 55, 0);
+    expect(result).toBe(0);
+  });
+
+  it('guards against division by zero when start equals target, returning the fallback', () => {
+    const result = calculateGoalProgressPercentage(70, 70, 65, 42);
+    expect(result).toBe(42);
+  });
+
+  it('returns exactly 100% at the target value', () => {
+    expect(calculateGoalProgressPercentage(80, 70, 70, 0)).toBe(100);
+  });
+
+  it('returns exactly 0% at the start value', () => {
+    expect(calculateGoalProgressPercentage(80, 70, 80, 0)).toBe(0);
+  });
+});

--- a/tests/health-goal-progress-direction.test.ts
+++ b/tests/health-goal-progress-direction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { calculateGoalProgressPercentage } from '../src/app/api/health/goals/[id]/route';
+import { calculateGoalProgressPercentage } from '../src/lib/health-goal-progress';
 
 // #1046 F2-12: 進捗率が変化の「方向」を無視する問題の回帰テスト。
 // Math.abs で符号を潰すと、目標から遠ざかっても進捗が増えてしまっていた

--- a/tests/health-payloads.test.ts
+++ b/tests/health-payloads.test.ts
@@ -115,6 +115,26 @@ describe('health payload sanitizers', () => {
     expect(sanitizeHealthRecordPayload({ systolic_bp: 500 }).errors.length).toBeGreaterThan(0);
     expect(sanitizeHealthRecordPayload({ systolic_bp: 10 }).errors.length).toBeGreaterThan(0);
   });
+
+  // #1046 F2-13: mood/sleep_quality等のスコア系は記録画面(renderScoreButtons、
+  // 1-5の絵文字5段階)・AI相談プロンプト(x/5表記)がいずれも1-5スケールで運用されているが、
+  // サニタイザだけmax=10のままだったため、UI上ありえない6-10の値も通過してしまっていた。
+  it('rejects out-of-range 1-5 scale score fields (mood_score:8 must be 400)', () => {
+    expect(sanitizeHealthRecordPayload({ mood_score: 8 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizeHealthRecordPayload({ sleep_quality: 8 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizeHealthRecordPayload({ overall_condition: 8 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizeHealthRecordPayload({ energy_level: 8 }).errors.length).toBeGreaterThan(0);
+    expect(sanitizeHealthRecordPayload({ stress_level: 8 }).errors.length).toBeGreaterThan(0);
+  });
+
+  it('accepts the 1-5 scale boundary values and rejects 0/6', () => {
+    for (const field of ['mood_score', 'sleep_quality', 'overall_condition', 'energy_level', 'stress_level']) {
+      expect(sanitizeHealthRecordPayload({ [field]: 1 }).errors).toEqual([]);
+      expect(sanitizeHealthRecordPayload({ [field]: 5 }).errors).toEqual([]);
+      expect(sanitizeHealthRecordPayload({ [field]: 0 }).errors.length).toBeGreaterThan(0);
+      expect(sanitizeHealthRecordPayload({ [field]: 6 }).errors.length).toBeGreaterThan(0);
+    }
+  });
 });
 
 describe('RECORD_DATE_PATTERN', () => {

--- a/tests/nutrition-calculator-accuracy.test.ts
+++ b/tests/nutrition-calculator-accuracy.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import { addNutritionFromMatch, emptyNutrition } from "../supabase/functions/_shared/nutrition-calculator.ts";
+import {
+  calculateDishNutrition,
+  calculateIngredientNutrition,
+  calculateMealNutrition,
+  initNutritionTotals,
+  roundNutrition,
+  sumNutrition,
+  DishNutrition,
+} from "../supabase/functions/_shared/nutrition-calculator-v2.ts";
+import type { IngredientMatchResult, MatchedIngredientData } from "../supabase/functions/_shared/ingredient-matcher.ts";
+
+function makeMatched(overrides: Partial<MatchedIngredientData>): MatchedIngredientData {
+  return {
+    id: "id-1",
+    name: "test-ingredient",
+    name_norm: "test-ingredient",
+    calories_kcal: null,
+    protein_g: null,
+    fat_g: null,
+    carbs_g: null,
+    fiber_g: null,
+    sodium_mg: null,
+    potassium_mg: null,
+    calcium_mg: null,
+    magnesium_mg: null,
+    phosphorus_mg: null,
+    iron_mg: null,
+    zinc_mg: null,
+    iodine_ug: null,
+    cholesterol_mg: null,
+    vitamin_a_ug: null,
+    vitamin_d_ug: null,
+    vitamin_e_alpha_mg: null,
+    vitamin_k_ug: null,
+    vitamin_b1_mg: null,
+    vitamin_b2_mg: null,
+    niacin_mg: null,
+    vitamin_b6_mg: null,
+    vitamin_b12_ug: null,
+    folic_acid_ug: null,
+    pantothenic_acid_mg: null,
+    biotin_ug: null,
+    vitamin_c_mg: null,
+    salt_eq_g: null,
+    discard_rate_percent: null,
+    similarity: 1,
+    ...overrides,
+  };
+}
+
+// #1046 F5-11: nutrition-calculator.ts(v1) が discard_rate_percent(廃棄率)を無視し、
+// v2(discard_rate_percent 適用)と結果が食い違っていた問題の回帰テスト。
+// 受入基準: 「廃棄率20%の食材でv1/v2が同一値」
+describe("#1046 F5-11: discard rate parity between v1 and v2", () => {
+  const matched = makeMatched({
+    calories_kcal: 50,
+    protein_g: 5,
+    fat_g: 2,
+    carbs_g: 10,
+    fiber_g: 1,
+    potassium_mg: 200,
+    calcium_mg: 20,
+    phosphorus_mg: 30,
+    magnesium_mg: 10,
+    iron_mg: 1,
+    zinc_mg: 0.5,
+    iodine_ug: 5,
+    cholesterol_mg: 4,
+    vitamin_a_ug: 100,
+    vitamin_b1_mg: 0.1,
+    vitamin_b2_mg: 0.2,
+    vitamin_b6_mg: 0.3,
+    vitamin_b12_ug: 0.4,
+    vitamin_c_mg: 10,
+    vitamin_d_ug: 0.6,
+    vitamin_e_alpha_mg: 1,
+    vitamin_k_ug: 5,
+    folic_acid_ug: 20,
+    discard_rate_percent: 20, // 廃棄率20%
+  });
+  const amount_g = 200;
+
+  it("v1 addNutritionFromMatch applies the discard rate (effective amount = 160g, factor 1.6)", () => {
+    const totals = emptyNutrition();
+    addNutritionFromMatch(totals, matched, amount_g);
+
+    // 200g * (1 - 20/100) = 160g -> factor = 1.6
+    expect(totals.calories_kcal).toBeCloseTo(50 * 1.6, 5);
+    expect(totals.protein_g).toBeCloseTo(5 * 1.6, 5);
+    expect(totals.potassium_mg).toBeCloseTo(200 * 1.6, 5);
+  });
+
+  it("v1 and v2 produce identical values for the same 20%-discard ingredient", () => {
+    const v1Totals = emptyNutrition();
+    addNutritionFromMatch(v1Totals, matched, amount_g);
+
+    const matchResult: IngredientMatchResult = {
+      input: { name: "test-ingredient", amount_g },
+      matched,
+      confidence: "high",
+      matchMethod: "exact_map",
+    };
+    const v2Ingredient = calculateIngredientNutrition(matchResult);
+
+    // v1/v2 で共通に計算しているフィールドはすべて一致するはず
+    expect(v2Ingredient.nutrition.calories_kcal).toBeCloseTo(v1Totals.calories_kcal, 5);
+    expect(v2Ingredient.nutrition.protein_g).toBeCloseTo(v1Totals.protein_g, 5);
+    expect(v2Ingredient.nutrition.fat_g).toBeCloseTo(v1Totals.fat_g, 5);
+    expect(v2Ingredient.nutrition.carbs_g).toBeCloseTo(v1Totals.carbs_g, 5);
+    expect(v2Ingredient.nutrition.fiber_g).toBeCloseTo(v1Totals.fiber_g, 5);
+    expect(v2Ingredient.nutrition.potassium_mg).toBeCloseTo(v1Totals.potassium_mg, 5);
+    expect(v2Ingredient.nutrition.calcium_mg).toBeCloseTo(v1Totals.calcium_mg, 5);
+    expect(v2Ingredient.nutrition.phosphorus_mg).toBeCloseTo(v1Totals.phosphorus_mg, 5);
+    expect(v2Ingredient.nutrition.magnesium_mg).toBeCloseTo(v1Totals.magnesium_mg, 5);
+    expect(v2Ingredient.nutrition.iron_mg).toBeCloseTo(v1Totals.iron_mg, 5);
+    expect(v2Ingredient.nutrition.zinc_mg).toBeCloseTo(v1Totals.zinc_mg, 5);
+    expect(v2Ingredient.nutrition.iodine_ug).toBeCloseTo(v1Totals.iodine_ug, 5);
+    expect(v2Ingredient.nutrition.cholesterol_mg).toBeCloseTo(v1Totals.cholesterol_mg, 5);
+    expect(v2Ingredient.nutrition.vitamin_a_ug).toBeCloseTo(v1Totals.vitamin_a_ug, 5);
+    expect(v2Ingredient.nutrition.vitamin_b1_mg).toBeCloseTo(v1Totals.vitamin_b1_mg, 5);
+    expect(v2Ingredient.nutrition.vitamin_b2_mg).toBeCloseTo(v1Totals.vitamin_b2_mg, 5);
+    expect(v2Ingredient.nutrition.vitamin_b6_mg).toBeCloseTo(v1Totals.vitamin_b6_mg, 5);
+    expect(v2Ingredient.nutrition.vitamin_b12_ug).toBeCloseTo(v1Totals.vitamin_b12_ug, 5);
+    expect(v2Ingredient.nutrition.vitamin_c_mg).toBeCloseTo(v1Totals.vitamin_c_mg, 5);
+    expect(v2Ingredient.nutrition.vitamin_d_ug).toBeCloseTo(v1Totals.vitamin_d_ug, 5);
+    expect(v2Ingredient.nutrition.vitamin_e_mg).toBeCloseTo(v1Totals.vitamin_e_mg, 5);
+    expect(v2Ingredient.nutrition.vitamin_k_ug).toBeCloseTo(v1Totals.vitamin_k_ug, 5);
+    expect(v2Ingredient.nutrition.folic_acid_ug).toBeCloseTo(v1Totals.folic_acid_ug, 5);
+  });
+
+  it("v1 treats a missing discard_rate_percent as 0% (no correction)", () => {
+    const noDiscard = makeMatched({ calories_kcal: 50, discard_rate_percent: null });
+    const totals = emptyNutrition();
+    addNutritionFromMatch(totals, noDiscard, 200);
+    expect(totals.calories_kcal).toBeCloseTo(100, 5); // 50 * 200/100, no correction
+  });
+
+  it("v1 parses a string-typed discard_rate_percent (Postgrest numeric column quirk)", () => {
+    const stringDiscount = makeMatched({ calories_kcal: 50, discard_rate_percent: "20" as unknown as number });
+    const totals = emptyNutrition();
+    addNutritionFromMatch(totals, stringDiscount, 200);
+    expect(totals.calories_kcal).toBeCloseTo(50 * 1.6, 5);
+  });
+});
+
+// #1046 F5-12: calculateDishNutrition が丸めた値を calculateMealNutrition が
+// 再度合算・丸めしていた二重丸め問題の回帰テスト。
+// 受入基準: 「10品合成テストで生値合算→最終丸めと一致」
+describe("#1046 F5-12: no double rounding when aggregating multiple dishes", () => {
+  it("meal totals match raw-sum-then-round-once across 10 dishes (not round-then-sum-then-round)", () => {
+    // 100gあたり vitamin_b1_mg=1.2mg の食材を 2g 使う 1皿 -> raw = 0.024mg
+    const matched = makeMatched({ vitamin_b1_mg: 1.2 });
+    const matchResult: IngredientMatchResult = {
+      input: { name: "test", amount_g: 2 },
+      matched,
+      confidence: "high",
+      matchMethod: "exact_map",
+    };
+
+    const dishes: DishNutrition[] = Array.from({ length: 10 }, (_, i) =>
+      calculateDishNutrition(`dish-${i}`, "side", [matchResult])
+    );
+
+    // 各皿の丸め済み totals は round2(0.024) = 0.02 になる(二重丸めバグの温床)
+    expect(dishes[0].totals.vitamin_b1_mg).toBe(0.02);
+    // 生値(rawTotals)は丸められていない
+    expect(dishes[0].rawTotals.vitamin_b1_mg).toBeCloseTo(0.024, 5);
+
+    const meal = calculateMealNutrition(dishes);
+
+    // 正しい計算: raw合算 10*0.024=0.24 -> 最終丸め1回 = 0.24
+    expect(meal.totals.vitamin_b1_mg).toBe(0.24);
+
+    // 誤ったロジック(丸め済みtotalsを合算)だと 10*0.02=0.20 になり、
+    // 正しい値(0.24)とズレることを明示的に確認する
+    const doubleRoundedSum = dishes.reduce((sum, d) => sum + d.totals.vitamin_b1_mg, 0);
+    expect(doubleRoundedSum).toBeCloseTo(0.2, 5);
+    expect(meal.totals.vitamin_b1_mg).not.toBeCloseTo(doubleRoundedSum, 5);
+  });
+
+  it("matches manually summing rawTotals and rounding once (contract check)", () => {
+    const matched = makeMatched({ zinc_mg: 0.37 });
+    const matchResult: IngredientMatchResult = {
+      input: { name: "test", amount_g: 33 },
+      matched,
+      confidence: "high",
+      matchMethod: "exact_map",
+    };
+    const dishes: DishNutrition[] = Array.from({ length: 7 }, (_, i) =>
+      calculateDishNutrition(`dish-${i}`, "side", [matchResult])
+    );
+
+    const expectedRaw = dishes.reduce(
+      (sum, d) => sumNutrition(sum, d.rawTotals),
+      initNutritionTotals()
+    );
+    const expectedRounded = roundNutrition(expectedRaw);
+
+    const meal = calculateMealNutrition(dishes);
+    expect(meal.totals.zinc_mg).toBe(expectedRounded.zinc_mg);
+  });
+});

--- a/tests/nutrition-radar-chart-average.test.ts
+++ b/tests/nutrition-radar-chart-average.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildNutritionRadarChartData,
+  calculateAverageAchievementPercentage,
+} from "../src/components/NutritionRadarChart";
+
+// #1046 UX3-20: 塩分・コレステロール等の上限系(DG/UL)栄養素の過剰摂取が
+// 「平均達成率」を押し上げてはいけない。
+
+describe("NutritionRadarChart average achievement rate (UX3-20)", () => {
+  it("excludes upper-limit nutrients (sodium) from the average even when over-consumed", () => {
+    // proteinG は dri=60 で ちょうど100%、sodiumG は dri=7.5 で 300%(過剰摂取)
+    const nutrition = { proteinG: 60, sodiumG: 22.5 };
+    const chartData = buildNutritionRadarChartData(["proteinG", "sodiumG"], nutrition);
+    const average = calculateAverageAchievementPercentage(chartData);
+
+    // sodiumG(上限系)を含めれば (100+300)/2=200% になってしまうが、
+    // 上限系を除外した場合は proteinG のみの 100% になるはず
+    expect(average).toBe(100);
+  });
+
+  it("does not raise the average as an upper-limit nutrient's excess grows", () => {
+    const base = buildNutritionRadarChartData(["proteinG", "sodiumG"], { proteinG: 60, sodiumG: 7.5 });
+    const overConsumed = buildNutritionRadarChartData(["proteinG", "sodiumG"], { proteinG: 60, sodiumG: 45 });
+
+    const averageBase = calculateAverageAchievementPercentage(base);
+    const averageOverConsumed = calculateAverageAchievementPercentage(overConsumed);
+
+    expect(averageBase).toBe(100);
+    expect(averageOverConsumed).toBe(100);
+  });
+
+  it("still averages normal (non upper-limit) nutrients as before", () => {
+    // caloriesKcal dri=2000 -> 50%, proteinG dri=60 -> 100%
+    const chartData = buildNutritionRadarChartData(["caloriesKcal", "proteinG"], {
+      caloriesKcal: 1000,
+      proteinG: 60,
+    });
+    const average = calculateAverageAchievementPercentage(chartData);
+    expect(average).toBe(75);
+  });
+
+  it("returns 0 when only upper-limit nutrients are selected", () => {
+    const chartData = buildNutritionRadarChartData(["sodiumG", "cholesterolMg"], {
+      sodiumG: 30,
+      cholesterolMg: 900,
+    });
+    const average = calculateAverageAchievementPercentage(chartData);
+    expect(average).toBe(0);
+  });
+
+  it("marks sodium/saturatedFat/cholesterol as isUpperLimit and other nutrients as not", () => {
+    const chartData = buildNutritionRadarChartData(
+      ["sodiumG", "saturatedFatG", "cholesterolMg", "proteinG", "fiberG"],
+      {}
+    );
+    const flags = Object.fromEntries(chartData.map((d, i) => [
+      ["sodiumG", "saturatedFatG", "cholesterolMg", "proteinG", "fiberG"][i],
+      d.isUpperLimit,
+    ]));
+
+    expect(flags.sodiumG).toBe(true);
+    expect(flags.saturatedFatG).toBe(true);
+    expect(flags.cholesterolMg).toBe(true);
+    expect(flags.proteinG).toBe(false);
+    expect(flags.fiberG).toBe(false);
+  });
+});

--- a/tests/regenerate-shopping-list-quantity-aggregation.test.ts
+++ b/tests/regenerate-shopping-list-quantity-aggregation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { aggregateIngredientOccurrences } from "../supabase/functions/_shared/shopping-list-aggregation.ts";
+
+// #1046 F5-13: 同名材料の分量合算は関数側で確定させ、LLMのプロンプト任せにしない。
+
+describe("aggregateIngredientOccurrences", () => {
+  it("sums grams for the same ingredient across multiple occurrences", () => {
+    // 受入基準: 「玉ねぎ100g×3」で出力が300g
+    const result = aggregateIngredientOccurrences([
+      { name: "玉ねぎ", amount_g: 100 },
+      { name: "玉ねぎ", amount_g: 100 },
+      { name: "玉ねぎ", amount_g: 100 },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ name: "玉ねぎ", amount: "300g", count: 3 });
+  });
+
+  it("sums differing gram amounts for the same ingredient (200g + 300g -> 500g)", () => {
+    const result = aggregateIngredientOccurrences([
+      { name: "にんじん", amount_g: 200 },
+      { name: "にんじん", amount_g: 300 },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ name: "にんじん", amount: "500g", count: 2 });
+  });
+
+  it("keeps different ingredient names as separate entries", () => {
+    const result = aggregateIngredientOccurrences([
+      { name: "玉ねぎ", amount_g: 100 },
+      { name: "にんじん", amount_g: 50 },
+    ]);
+
+    expect(result).toHaveLength(2);
+    const names = result.map((r) => r.name).sort();
+    expect(names).toEqual(["にんじん", "玉ねぎ"]);
+  });
+
+  it("keeps amount null for zero/unknown-amount ingredients (e.g. 適量) without treating them as 0g", () => {
+    const result = aggregateIngredientOccurrences([
+      { name: "塩", amount_g: 0 },
+      { name: "塩", amount_g: 0 },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ name: "塩", amount: null, count: 2 });
+  });
+
+  it("trims whitespace and drops empty names", () => {
+    const result = aggregateIngredientOccurrences([
+      { name: "  玉ねぎ  ", amount_g: 100 },
+      { name: "   ", amount_g: 50 },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("玉ねぎ");
+  });
+});


### PR DESCRIPTION
## 概要
栄養計算・目標評価の中核数値の正確性を修正する。廃棄率無視・二重丸め・買い物数量のLLM丸投げ・進捗方向の無視・mood/sleep_qualityのスケール混在に対応した。

## 主な変更
- 廃棄率補正: v1 `nutrition-calculator.ts` に `discard_rate_percent` 可食部補正を追加し v2 と結果を一致させた (F5-11、当該v1経路は現状未使用)
- 二重丸め解消: dish 単位で丸めた値を再合算していた処理を、未丸めの `rawTotals` で合算し最終(食事/日)単位のみ丸めるよう修正 (F5-12)
- 買い物リスト数量: g で表せる材料は関数側で確定合算し、LLM 入力から `count` を除去して表記整形のみ依頼(水増し防止) (F5-13)
- 健康目標の進捗率: 変化の方向 `sign(target - start)` を考慮し 0-100 にクランプ、0除算ガードを追加 (F2-12)。進捗計算ロジックを `src/lib/health-goal-progress.ts` に切り出し、route entry からの value export による `next build` 型チェック失敗も解消
- mood/sleep_quality を UI 実態の 1-5 スケールに統一 (fail-closed、F2-13)

補足:
- Edge Function (`regenerate-shopping-list-v2`) の変更はマージで auto-deploy される
- UX3-20(mobile `RadarChart` の平均達成率)は `apps/mobile` 変更禁止(#1079 競合)のため報告のみ

## 検証(2モデル敵対レビュー double-PASS 済・tsc/eslint/vitest 緑)
- Sonnet 5 + Fable の 2モデル敵対レビューで double-PASS 済み
- `npx tsc --noEmit` / 対象ファイル eslint エラーなし
- `vitest run` 全112ファイル998テスト PASS(既存回帰なし)、`next build` の型チェック段階通過を確認

Closes #1046
