### PR TITLE
fix(health): 健康・設定UXを修正 (#1051)

### DIFF
--- a/src/app/(main)/health/blood-tests/page.tsx
+++ b/src/app/(main)/health/blood-tests/page.tsx
@@ -8,7 +8,7 @@ import {
   Calendar, TrendingUp, TrendingDown, Minus,
 } from "lucide-react";
 import {
-  BLOOD_METRIC_DEFS, evaluateStatus, formatRangeText, getRangeForSex,
+  BLOOD_METRIC_DEFS, evaluateStatus, formatRangeText, getRangeForSex, getStatusLabel,
   type BiologicalSex,
 } from "@/lib/health-blood-test-reference";
 
@@ -153,14 +153,16 @@ export default function BloodTestsPage() {
             <Droplet size={48} className="mx-auto mb-4" style={{ color: colors.textMuted }} />
             <p className="font-medium mb-2" style={{ color: colors.text }}>血液検査結果がありません</p>
             <p className="text-sm" style={{ color: colors.textMuted }}>
-              カメラで健診結果を撮影すると自動で記録されます
+              健診結果をカメラで撮影すると自動で記録されます
             </p>
+            {/* #1051 UX3-02: 血液検査の記録は健診アップロード導線でしか作れないため、
+                誤って食事スキャン(/meals/new)に誘導していたのを修正する */}
             <Link
-              href="/meals/new"
+              href="/health/checkups/new"
               className="inline-flex items-center gap-2 mt-4 px-5 py-2 rounded-xl text-sm font-medium text-white"
               style={{ backgroundColor: colors.accent }}
             >
-              写真で記録する
+              健診結果を記録する
             </Link>
           </div>
         </div>
@@ -226,24 +228,32 @@ export default function BloodTestsPage() {
                           const def = BLOOD_METRIC_DEFS[key];
                           const status = evaluateStatus(key, value, sex);
                           const isAbnormal = status === "high" || status === "low";
+                          // #1051 UX3-07: 基準ぎりぎりも一律の異常扱いにせず「注意」として区別する
+                          const isWarning = status === "warning_high" || status === "warning_low";
+                          const statusColor = isAbnormal ? colors.error : isWarning ? colors.warning : colors.text;
+                          const statusLabel = getStatusLabel(status);
                           const rangeText = formatRangeText(getRangeForSex(key, sex));
                           return (
                             <div
                               key={key}
                               className="p-3 rounded-xl"
-                              style={{ backgroundColor: isAbnormal ? colors.errorLight : colors.bg }}
+                              style={{ backgroundColor: isAbnormal ? colors.errorLight : isWarning ? colors.warningLight : colors.bg }}
                             >
                               <p className="text-xs mb-1" style={{ color: colors.textMuted }}>{def.label}</p>
-                              <div className="flex items-center gap-1.5">
+                              <div className="flex items-center gap-1.5 flex-wrap">
                                 <p
                                   className="font-bold text-base"
-                                  style={{ color: isAbnormal ? colors.error : colors.text }}
+                                  style={{ color: statusColor }}
                                 >
                                   {String(value)}
                                   <span className="text-xs font-normal ml-1" style={{ color: colors.textMuted }}>{def.unit}</span>
                                 </p>
-                                {isAbnormal && (
-                                  <span className="w-2 h-2 rounded-full" style={{ backgroundColor: colors.error }} />
+                                {/* #1051 UX3-07: 色ドットだけでなくテキストラベルも併記する */}
+                                {statusLabel && (
+                                  <span className="flex items-center gap-1">
+                                    <span className="w-2 h-2 rounded-full" style={{ backgroundColor: statusColor }} />
+                                    <span className="text-[10px] font-medium" style={{ color: statusColor }}>{statusLabel}</span>
+                                  </span>
                                 )}
                               </div>
                               <p className="text-xs mt-0.5" style={{ color: colors.textMuted }}>

--- a/src/app/(main)/health/checkups/[id]/CheckupDetailClient.tsx
+++ b/src/app/(main)/health/checkups/[id]/CheckupDetailClient.tsx
@@ -6,10 +6,10 @@ import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import {
   ArrowLeft, Trash2, Activity, Heart, Droplet, AlertTriangle,
-  CheckCircle2, Sparkles, Calendar, MapPin, Loader2
+  CheckCircle2, Sparkles, Calendar, MapPin, Loader2, Scale,
 } from 'lucide-react';
 import {
-  BLOOD_METRIC_DEFS, evaluateStatus, formatRangeText, getRangeForSex,
+  ALL_METRIC_DEFS, evaluateStatus, formatRangeText, getRangeForSex, getStatusLabel,
   type BiologicalSex, type MetricStatus,
 } from '@/lib/health-blood-test-reference';
 
@@ -80,6 +80,8 @@ export default function CheckupDetailClient({ id }: Props) {
   const [checkup, setCheckup] = useState<HealthCheckup | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  // #1051 UX3-05: 削除失敗が無反応になっていたため、モーダルを保持したままエラーを表示する
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   // #1055 UX3-24: 基準値をプロフィールの性別で分岐させる
   const [sex, setSex] = useState<BiologicalSex>(null);
 
@@ -117,15 +119,21 @@ export default function CheckupDetailClient({ id }: Props) {
 
   const handleDelete = async () => {
     setDeleting(true);
+    setDeleteError(null);
     try {
       const res = await fetch(`/api/health/checkups/${id}`, {
         method: 'DELETE',
       });
       if (res.ok) {
         router.push('/health/checkups');
+        return;
       }
+      // #1051 UX3-05: 失敗時に無反応にせず、モーダルを保持したまま再試行できるようにする
+      const data = await res.json().catch(() => null);
+      setDeleteError(data?.error || '削除に失敗しました。もう一度お試しください。');
     } catch (error) {
       console.error('Failed to delete:', error);
+      setDeleteError('削除に失敗しました。もう一度お試しください。');
     }
     setDeleting(false);
   };
@@ -140,6 +148,10 @@ export default function CheckupDetailClient({ id }: Props) {
       case 'high':
       case 'low':
         return { bg: colors.errorLight, text: colors.error };
+      // #1051 UX3-07: 基準値ぎりぎりも一律の赤ではなく「注意」として区別する
+      case 'warning_high':
+      case 'warning_low':
+        return { bg: colors.warningLight, text: colors.warning };
       default:
         return { bg: colors.successLight, text: colors.success };
     }
@@ -147,12 +159,13 @@ export default function CheckupDetailClient({ id }: Props) {
 
   const renderMetricRow = (key: string, value: number | undefined) => {
     if (value === undefined) return null;
-    const def = BLOOD_METRIC_DEFS[key];
+    const def = ALL_METRIC_DEFS[key];
     if (!def) return null;
 
     const status = evaluateStatus(key, value, sex);
     const statusStyle = getStatusStyle(status);
     const rangeText = formatRangeText(getRangeForSex(key, sex));
+    const statusLabel = getStatusLabel(status);
 
     return (
       <div key={key} className="flex items-center justify-between py-2 border-b" style={{ borderColor: colors.border }}>
@@ -168,11 +181,15 @@ export default function CheckupDetailClient({ id }: Props) {
             {value}
           </span>
           <span className="text-xs" style={{ color: colors.textMuted }}>{def.unit}</span>
-          {(status === 'high' || status === 'low') && (
-            <div
-              className="w-2 h-2 rounded-full"
-              style={{ backgroundColor: statusStyle.text }}
-            />
+          {/* #1051 UX3-07: 色ドットだけでなくテキストラベルも併記する */}
+          {statusLabel && (
+            <span className="flex items-center gap-1">
+              <span
+                className="w-2 h-2 rounded-full"
+                style={{ backgroundColor: statusStyle.text }}
+              />
+              <span className="text-xs font-medium" style={{ color: statusStyle.text }}>{statusLabel}</span>
+            </span>
           )}
         </div>
       </div>
@@ -373,6 +390,18 @@ export default function CheckupDetailClient({ id }: Props) {
             </p>
           )}
 
+          {/* 身体測定 (#1051 UX3-07: 従来この画面で一切表示されていなかった) */}
+          <div className="mb-4">
+            <div className="flex items-center gap-2 mb-2">
+              <Scale size={16} style={{ color: colors.accent }} />
+              <span className="text-sm font-bold" style={{ color: colors.textLight }}>身体測定</span>
+            </div>
+            {renderMetricRow('height', checkup.height)}
+            {renderMetricRow('weight', checkup.weight)}
+            {renderMetricRow('bmi', checkup.bmi)}
+            {renderMetricRow('waist_circumference', checkup.waist_circumference)}
+          </div>
+
           {/* 血圧・代謝 */}
           <div className="mb-4">
             <div className="flex items-center gap-2 mb-2">
@@ -451,12 +480,19 @@ export default function CheckupDetailClient({ id }: Props) {
             <h3 className="text-lg font-bold mb-2" style={{ color: colors.text }}>
               記録を削除しますか？
             </h3>
-            <p className="text-sm mb-6" style={{ color: colors.textMuted }}>
+            <p className="text-sm mb-4" style={{ color: colors.textMuted }}>
               この操作は取り消せません。
             </p>
+            {/* #1051 UX3-05: 削除失敗を無反応にせず、モーダルを保持したままエラーを表示する */}
+            {deleteError && (
+              <div className="flex items-start gap-2 p-3 mb-4 rounded-lg" style={{ backgroundColor: colors.errorLight }}>
+                <AlertTriangle size={16} className="flex-shrink-0 mt-0.5" style={{ color: colors.error }} />
+                <p className="text-sm" style={{ color: colors.error }}>{deleteError}</p>
+              </div>
+            )}
             <div className="flex gap-3">
               <button
-                onClick={() => setShowDeleteConfirm(false)}
+                onClick={() => { setShowDeleteConfirm(false); setDeleteError(null); }}
                 className="flex-1 py-3 rounded-full font-bold"
                 style={{ backgroundColor: colors.bg, color: colors.text }}
               >

--- a/src/app/(main)/health/graphs/page.tsx
+++ b/src/app/(main)/health/graphs/page.tsx
@@ -22,6 +22,7 @@ const colors = {
   success: '#4CAF50',
   successLight: '#E8F5E9',
   error: '#F44336',
+  errorLight: '#FFEBEE',
   purple: '#7C4DFF',
   purpleLight: '#EDE7F6',
   blue: '#2196F3',
@@ -398,14 +399,39 @@ export default function HealthGraphsPage() {
     );
   };
 
-  const metricConfig = {
-    weight: { icon: Scale, label: '体重', unit: 'kg', color: colors.accent },
-    body_fat: { icon: Scale, label: '体脂肪率', unit: '%', color: colors.purple },
-    bp: { icon: Heart, label: '血圧', unit: 'mmHg', color: colors.error },
-    sleep: { icon: Moon, label: '睡眠', unit: '時間', color: colors.blue },
+  // #1051 UX3-08: 「減少=緑/増加=赤」の固定意味付けは指標によって意味が逆になる
+  // (例: 睡眠時間の減少は改善ではない)。指標ごとに「良い方向」を持たせる。
+  // 体重のみ目標体重との大小関係で動的に決まるため null にし、後段の getChangeSentiment で判定する。
+  const metricConfig: Record<Metric, { icon: typeof Scale; label: string; unit: string; color: string; goodDirection: 'up' | 'down' | null }> = {
+    weight: { icon: Scale, label: '体重', unit: 'kg', color: colors.accent, goodDirection: null },
+    body_fat: { icon: Scale, label: '体脂肪率', unit: '%', color: colors.purple, goodDirection: 'down' },
+    bp: { icon: Heart, label: '血圧', unit: 'mmHg', color: colors.error, goodDirection: 'down' },
+    sleep: { icon: Moon, label: '睡眠', unit: '時間', color: colors.blue, goodDirection: 'up' },
   };
 
   const currentMetric = metricConfig[metric];
+
+  // #1051 UX3-08: 体重は目標体重が分かっている場合のみ、目標に近づく方向を「良い」とする。
+  // 目標未設定時は判定できないため中立表示にする(誤った「改善/悪化」を主張しない)。
+  const getChangeSentiment = (): 'good' | 'bad' | 'neutral' => {
+    if (change === null || change === 0) return 'neutral';
+    let goodDirection = metricConfig[metric].goodDirection;
+    if (metric === 'weight') {
+      const currentValue = graphData.filter(d => d.value !== null).slice(-1)[0]?.value;
+      goodDirection = (targetWeight != null && currentValue != null && currentValue !== targetWeight)
+        ? (currentValue > targetWeight ? 'down' : 'up')
+        : null;
+    }
+    if (goodDirection == null) return 'neutral';
+    const actualDirection: 'up' | 'down' = change > 0 ? 'up' : 'down';
+    return actualDirection === goodDirection ? 'good' : 'bad';
+  };
+  const changeSentiment = getChangeSentiment();
+  const changeColor = changeSentiment === 'good'
+    ? colors.success
+    : changeSentiment === 'bad'
+      ? colors.error
+      : colors.textMuted;
 
   return (
     <div className="min-h-screen pb-24" style={{ backgroundColor: colors.bg }}>
@@ -487,20 +513,20 @@ export default function HealthGraphsPage() {
               </div>
             </div>
             {change !== null && (
-              <div 
+              <div
                 className="flex items-center gap-1 px-3 py-1 rounded-full"
-                style={{ 
-                  backgroundColor: change < 0 ? colors.successLight : change > 0 ? '#FFEBEE' : colors.bg,
+                style={{
+                  backgroundColor: changeSentiment === 'good' ? colors.successLight : changeSentiment === 'bad' ? colors.errorLight : colors.bg,
                 }}
               >
                 {change < 0 ? (
-                  <TrendingDown size={16} style={{ color: colors.success }} />
+                  <TrendingDown size={16} style={{ color: changeColor }} />
                 ) : change > 0 ? (
-                  <TrendingUp size={16} style={{ color: colors.error }} />
+                  <TrendingUp size={16} style={{ color: changeColor }} />
                 ) : null}
-                <span 
+                <span
                   className="text-sm font-medium"
-                  style={{ color: change < 0 ? colors.success : change > 0 ? colors.error : colors.textMuted }}
+                  style={{ color: changeColor }}
                 >
                   {change > 0 ? '+' : ''}{change} {currentMetric.unit}
                 </span>
@@ -595,8 +621,10 @@ export default function HealthGraphsPage() {
                 <p className="font-medium" style={{ color: colors.success }}>
                   目標体重: {targetWeight}kg
                 </p>
+                {/* #1051 UX3-08: 「あと」に符号付きの差分をそのまま出すと増量目標で
+                    負の値になり意味が伝わらないため、絶対値+「目標まで」に統一する */}
                 <p className="text-sm" style={{ color: colors.success }}>
-                  あと {((graphData.filter(d => d.value !== null).slice(-1)[0]?.value || 0) - targetWeight).toFixed(1)}kg
+                  目標まであと {Math.abs((graphData.filter(d => d.value !== null).slice(-1)[0]?.value || 0) - targetWeight).toFixed(1)}kg
                 </p>
               </div>
             </div>

--- a/src/app/(main)/health/page.tsx
+++ b/src/app/(main)/health/page.tsx
@@ -7,7 +7,7 @@ import { createClient } from "@/lib/supabase/client";
 import {
   Scale, Heart, Moon, Droplets, Activity, TrendingUp, TrendingDown,
   Target, Flame, Calendar, ChevronRight, Plus, Camera, Sparkles,
-  Award, Clock, Smile, Frown, Meh, AlertTriangle, CheckCircle2
+  Award, Clock, Smile, Frown, Meh, AlertTriangle, CheckCircle2, Settings
 } from 'lucide-react';
 import { getGoalTypeLabel } from "@/lib/health-goal-types";
 
@@ -81,6 +81,8 @@ export default function HealthDashboardPage() {
   const [quickSleep, setQuickSleep] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  // #1051 UX3-05: クイック記録の保存失敗が無反応だったため、モーダルを保持したまま表示する
+  const [quickSaveError, setQuickSaveError] = useState<string | null>(null);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [selectedDateRecord, setSelectedDateRecord] = useState<HealthRecord | null>(null);
   const [loadingSelectedDate, setLoadingSelectedDate] = useState(false);
@@ -159,6 +161,7 @@ export default function HealthDashboardPage() {
     }
 
     setSaving(true);
+    setQuickSaveError(null);
     try {
       const res = await fetch('/api/health/records/quick', {
         method: 'POST',
@@ -177,12 +180,19 @@ export default function HealthDashboardPage() {
         setMessage(data.message);
         setShowQuickRecord(false);
         void fetchData(); // 再取得
-        
+
         // メッセージを3秒後に消す
         setTimeout(() => setMessage(null), 5000);
+        setSaving(false);
+        return;
       }
+
+      // #1051 UX3-05: 失敗時に無反応にせず、モーダルを保持したまま再試行できるようにする
+      const data = await res.json().catch(() => null);
+      setQuickSaveError(data?.error || '記録に失敗しました。もう一度お試しください。');
     } catch (error) {
       console.error('Failed to save:', error);
+      setQuickSaveError('記録に失敗しました。もう一度お試しください。');
     }
     setSaving(false);
   };
@@ -193,6 +203,26 @@ export default function HealthDashboardPage() {
   };
 
   const weightChange = getWeightChange();
+
+  // #1051 UX3-08: 「減少=緑/増加=赤」の固定意味付けは増量目標だと意味が逆になるため、
+  // 目標体重が分かる場合は目標に近づく方向を「良い」とする。目標が無ければ判定しない(中立表示)。
+  const weightGoal = goals.find((g) => g.goal_type === 'weight') ?? null;
+  const getWeightChangeSentiment = (): 'good' | 'bad' | 'neutral' => {
+    if (weightChange === null || weightChange === 0) return 'neutral';
+    if (!weightGoal || todayRecord?.weight == null) return 'neutral';
+    const target = weightGoal.target_value;
+    const current = todayRecord.weight;
+    if (current === target) return 'neutral';
+    const goodDirection: 'up' | 'down' = current > target ? 'down' : 'up';
+    const actualDirection: 'up' | 'down' = weightChange > 0 ? 'up' : 'down';
+    return actualDirection === goodDirection ? 'good' : 'bad';
+  };
+  const weightChangeSentiment = getWeightChangeSentiment();
+  const weightChangeColor = weightChangeSentiment === 'good'
+    ? colors.success
+    : weightChangeSentiment === 'bad'
+      ? colors.error
+      : colors.textMuted;
 
   // 週間カレンダーを生成
   const getWeekDays = () => {
@@ -228,11 +258,22 @@ export default function HealthDashboardPage() {
   return (
     <div className="min-h-screen pb-24" style={{ backgroundColor: colors.bg }}>
       {/* ヘッダー */}
-      <div className="px-4 pt-6 pb-4">
-        <h1 className="text-2xl font-bold" style={{ color: colors.text }}>健康記録</h1>
-        <p className="text-sm mt-1" style={{ color: colors.textMuted }}>
-          毎日の記録があなたの健康を支えます
-        </p>
+      <div className="px-4 pt-6 pb-4 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold" style={{ color: colors.text }}>健康記録</h1>
+          <p className="text-sm mt-1" style={{ color: colors.textMuted }}>
+            毎日の記録があなたの健康を支えます
+          </p>
+        </div>
+        {/* #1051 UX3-03: 記録設定(通知設定含む)への導線がURL直打ちでしか無かったため追加 */}
+        <Link
+          href="/health/settings"
+          aria-label="記録設定"
+          className="p-2 -mr-2 -mt-1 rounded-full"
+          style={{ color: colors.textMuted }}
+        >
+          <Settings size={22} />
+        </Link>
       </div>
 
       {/* 成功メッセージ */}
@@ -257,6 +298,17 @@ export default function HealthDashboardPage() {
 
       {/* 連続記録カード */}
       <div className="px-4 mb-4">
+        {/* #1051 UX3-03: 連続記録詳細(/health/streaks)への導線が無くURL直打ちでしか開けなかった */}
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="font-semibold" style={{ color: colors.text }}>連続記録</h3>
+          <Link
+            href="/health/streaks"
+            className="text-sm flex items-center gap-1"
+            style={{ color: colors.accent }}
+          >
+            詳細を見る <ChevronRight size={16} />
+          </Link>
+        </div>
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -420,7 +472,7 @@ export default function HealthDashboardPage() {
         {!todayRecord ? (
           <motion.button
             whileTap={{ scale: 0.98 }}
-            onClick={() => setShowQuickRecord(true)}
+            onClick={() => { setQuickSaveError(null); setShowQuickRecord(true); }}
             className="w-full p-4 rounded-2xl flex items-center justify-between"
             style={{ 
               backgroundColor: colors.card,
@@ -480,13 +532,13 @@ export default function HealthDashboardPage() {
                 {weightChange !== null && (
                   <div className="flex items-center justify-center gap-1 mt-1">
                     {weightChange < 0 ? (
-                      <TrendingDown size={12} style={{ color: colors.success }} />
+                      <TrendingDown size={12} style={{ color: weightChangeColor }} />
                     ) : weightChange > 0 ? (
-                      <TrendingUp size={12} style={{ color: colors.error }} />
+                      <TrendingUp size={12} style={{ color: weightChangeColor }} />
                     ) : null}
-                    <span 
+                    <span
                       className="text-xs"
-                      style={{ color: weightChange < 0 ? colors.success : weightChange > 0 ? colors.error : colors.textMuted }}
+                      style={{ color: weightChangeColor }}
                     >
                       {weightChange > 0 ? '+' : ''}{weightChange}
                     </span>
@@ -685,6 +737,67 @@ export default function HealthDashboardPage() {
               <p className="text-xs" style={{ color: colors.textMuted }}>目標を管理</p>
             </motion.div>
           </Link>
+
+          {/* #1051 UX3-03: 血液検査/AI分析/チャレンジへの導線が無くURL直打ちでしか開けなかった */}
+          <Link href="/health/blood-tests">
+            <motion.div
+              whileTap={{ scale: 0.98 }}
+              className="p-4 rounded-xl"
+              style={{
+                backgroundColor: colors.card,
+                boxShadow: '0 2px 8px rgba(0,0,0,0.06)'
+              }}
+            >
+              <div
+                className="w-10 h-10 rounded-lg flex items-center justify-center mb-2"
+                style={{ backgroundColor: colors.errorLight }}
+              >
+                <Droplets size={20} style={{ color: colors.error }} />
+              </div>
+              <p className="font-medium text-sm" style={{ color: colors.text }}>血液検査</p>
+              <p className="text-xs" style={{ color: colors.textMuted }}>検査結果を確認</p>
+            </motion.div>
+          </Link>
+
+          <Link href="/health/insights">
+            <motion.div
+              whileTap={{ scale: 0.98 }}
+              className="p-4 rounded-xl"
+              style={{
+                backgroundColor: colors.card,
+                boxShadow: '0 2px 8px rgba(0,0,0,0.06)'
+              }}
+            >
+              <div
+                className="w-10 h-10 rounded-lg flex items-center justify-center mb-2"
+                style={{ backgroundColor: colors.purpleLight }}
+              >
+                <Sparkles size={20} style={{ color: colors.purple }} />
+              </div>
+              <p className="font-medium text-sm" style={{ color: colors.text }}>AI分析</p>
+              <p className="text-xs" style={{ color: colors.textMuted }}>気づきを確認</p>
+            </motion.div>
+          </Link>
+
+          <Link href="/health/challenges">
+            <motion.div
+              whileTap={{ scale: 0.98 }}
+              className="p-4 rounded-xl"
+              style={{
+                backgroundColor: colors.card,
+                boxShadow: '0 2px 8px rgba(0,0,0,0.06)'
+              }}
+            >
+              <div
+                className="w-10 h-10 rounded-lg flex items-center justify-center mb-2"
+                style={{ backgroundColor: colors.warningLight }}
+              >
+                <Award size={20} style={{ color: colors.streak }} />
+              </div>
+              <p className="font-medium text-sm" style={{ color: colors.text }}>チャレンジ</p>
+              <p className="text-xs" style={{ color: colors.textMuted }}>達成に挑戦</p>
+            </motion.div>
+          </Link>
         </div>
       </div>
 
@@ -738,7 +851,7 @@ export default function HealthDashboardPage() {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             className="fixed inset-0 bg-black/50 z-[60] flex items-end"
-            onClick={() => setShowQuickRecord(false)}
+            onClick={() => { setShowQuickRecord(false); setQuickSaveError(null); }}
           >
             <motion.div
               initial={{ y: '100%' }}
@@ -754,6 +867,14 @@ export default function HealthDashboardPage() {
               <h2 className="text-xl font-bold mb-6" style={{ color: colors.text }}>
                 今日の記録
               </h2>
+
+              {/* #1051 UX3-05: 保存失敗を無反応にせず、入力を保持したままエラーを表示する */}
+              {quickSaveError && (
+                <div className="flex items-start gap-2 p-3 mb-4 rounded-lg" style={{ backgroundColor: colors.errorLight }}>
+                  <AlertTriangle size={16} className="flex-shrink-0 mt-0.5" style={{ color: colors.error }} />
+                  <p className="text-sm" style={{ color: colors.error }}>{quickSaveError}</p>
+                </div>
+              )}
 
               {/* 体重入力 */}
               <div className="mb-6">

--- a/src/app/(main)/health/record/page.tsx
+++ b/src/app/(main)/health/record/page.tsx
@@ -8,7 +8,7 @@ import { createClient } from "@/lib/supabase/client";
 import {
   Scale, Heart, Moon, Droplets, Activity, Thermometer,
   ArrowLeft, Save, ChevronDown, ChevronUp, Smile, Frown, Meh,
-  Footprints, Brain, Sparkles, AlertCircle
+  Footprints, Brain, Sparkles, AlertCircle, AlertTriangle
 } from 'lucide-react';
 
 const colors = {
@@ -51,6 +51,25 @@ interface FormData {
   daily_note: string;
 }
 
+const initialFormData: FormData = {
+  weight: '',
+  body_fat_percentage: '',
+  systolic_bp: '',
+  diastolic_bp: '',
+  heart_rate: '',
+  body_temp: '',
+  sleep_hours: '',
+  sleep_quality: null,
+  water_intake: '',
+  step_count: '',
+  bowel_movement: '',
+  overall_condition: null,
+  mood_score: null,
+  energy_level: null,
+  stress_level: null,
+  daily_note: '',
+};
+
 export default function HealthRecordPage() {
   const router = useRouter();
   const [loading, setLoading] = useState(true);
@@ -64,25 +83,15 @@ export default function HealthRecordPage() {
   
   const today = todayLocal();
   const [recordDate, setRecordDate] = useState(today);
-  
-  const [formData, setFormData] = useState<FormData>({
-    weight: '',
-    body_fat_percentage: '',
-    systolic_bp: '',
-    diastolic_bp: '',
-    heart_rate: '',
-    body_temp: '',
-    sleep_hours: '',
-    sleep_quality: null,
-    water_intake: '',
-    step_count: '',
-    bowel_movement: '',
-    overall_condition: null,
-    mood_score: null,
-    energy_level: null,
-    stress_level: null,
-    daily_note: '',
-  });
+  // #1051 UX3-04: 日付切替の確認・「未保存の変更」判定のため、最後に読み込んだ
+  // (=保存済みとみなせる) フォーム内容を別途保持する
+  const [loadedFormData, setLoadedFormData] = useState<FormData>(initialFormData);
+  const [pendingDate, setPendingDate] = useState<string | null>(null);
+  const [showDateConfirm, setShowDateConfirm] = useState(false);
+  // #1051 UX3-05: 保存失敗を無反応にせず、入力を保持したままエラーを表示する
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const [formData, setFormData] = useState<FormData>(initialFormData);
 
   const fetchRecord = useCallback(async () => {
     setLoading(true);
@@ -90,26 +99,33 @@ export default function HealthRecordPage() {
       const res = await fetch(`/api/health/records/${recordDate}`);
       if (res.ok) {
         const data = await res.json();
-        if (data.record) {
-          setFormData({
-            weight: data.record.weight?.toString() || '',
-            body_fat_percentage: data.record.body_fat_percentage?.toString() || '',
-            systolic_bp: data.record.systolic_bp?.toString() || '',
-            diastolic_bp: data.record.diastolic_bp?.toString() || '',
-            heart_rate: data.record.heart_rate?.toString() || '',
-            body_temp: data.record.body_temp?.toString() || '',
-            sleep_hours: data.record.sleep_hours?.toString() || '',
-            sleep_quality: data.record.sleep_quality || null,
-            water_intake: data.record.water_intake?.toString() || '',
-            step_count: data.record.step_count?.toString() || '',
-            bowel_movement: data.record.bowel_movement?.toString() || '',
-            overall_condition: data.record.overall_condition || null,
-            mood_score: data.record.mood_score || null,
-            energy_level: data.record.energy_level || null,
-            stress_level: data.record.stress_level || null,
-            daily_note: data.record.daily_note || '',
-          });
-        }
+        // #1051 UX3-04: その日の記録が無い場合にフォームをリセットせず、
+        // 前に選択していた日の値が残ったまま「記録する」を押すと別日に誤保存されていた。
+        const nextFormData: FormData = data.record
+          ? {
+              weight: data.record.weight?.toString() || '',
+              body_fat_percentage: data.record.body_fat_percentage?.toString() || '',
+              systolic_bp: data.record.systolic_bp?.toString() || '',
+              diastolic_bp: data.record.diastolic_bp?.toString() || '',
+              heart_rate: data.record.heart_rate?.toString() || '',
+              body_temp: data.record.body_temp?.toString() || '',
+              sleep_hours: data.record.sleep_hours?.toString() || '',
+              sleep_quality: data.record.sleep_quality || null,
+              water_intake: data.record.water_intake?.toString() || '',
+              step_count: data.record.step_count?.toString() || '',
+              bowel_movement: data.record.bowel_movement?.toString() || '',
+              overall_condition: data.record.overall_condition || null,
+              mood_score: data.record.mood_score || null,
+              energy_level: data.record.energy_level || null,
+              stress_level: data.record.stress_level || null,
+              daily_note: data.record.daily_note || '',
+            }
+          : { ...initialFormData };
+        setFormData(nextFormData);
+        setLoadedFormData(nextFormData);
+      } else {
+        setFormData({ ...initialFormData });
+        setLoadedFormData({ ...initialFormData });
       }
     } catch (error) {
       console.error('Failed to fetch record:', error);
@@ -121,8 +137,33 @@ export default function HealthRecordPage() {
     void fetchRecord();
   }, [fetchRecord]);
 
+  // #1051 UX3-04: 日付を切り替える前に未保存の変更がないか確認する
+  const hasUnsavedChanges = () => JSON.stringify(formData) !== JSON.stringify(loadedFormData);
+
+  const handleDateInputChange = (nextDate: string) => {
+    if (nextDate === recordDate) return;
+    if (hasUnsavedChanges()) {
+      setPendingDate(nextDate);
+      setShowDateConfirm(true);
+      return;
+    }
+    setRecordDate(nextDate);
+  };
+
+  const confirmDateChange = () => {
+    if (pendingDate) setRecordDate(pendingDate);
+    setPendingDate(null);
+    setShowDateConfirm(false);
+  };
+
+  const cancelDateChange = () => {
+    setPendingDate(null);
+    setShowDateConfirm(false);
+  };
+
   const handleSave = async () => {
     setSaving(true);
+    setSaveError(null);
     try {
       const payload: Record<string, any> = {
         record_date: recordDate,
@@ -154,9 +195,15 @@ export default function HealthRecordPage() {
 
       if (res.ok) {
         router.push('/health');
+        return;
       }
+
+      // #1051 UX3-05: 失敗時に無反応にせず、入力を保持したまま再試行できるようにする
+      const data = await res.json().catch(() => null);
+      setSaveError(data?.error || '保存に失敗しました。もう一度お試しください。');
     } catch (error) {
       console.error('Failed to save:', error);
+      setSaveError('保存に失敗しました。もう一度お試しください。');
     }
     setSaving(false);
   };
@@ -221,16 +268,61 @@ export default function HealthRecordPage() {
         <input
           type="date"
           value={recordDate}
-          onChange={(e) => setRecordDate(e.target.value)}
+          onChange={(e) => handleDateInputChange(e.target.value)}
           max={today}
           className="w-full p-3 rounded-xl font-medium"
-          style={{ 
+          style={{
             backgroundColor: colors.card,
             color: colors.text,
             border: `1px solid ${colors.border}`,
           }}
         />
       </div>
+
+      {/* #1051 UX3-05: 保存失敗を無反応にせず表示する */}
+      {saveError && (
+        <div className="px-4 mb-4">
+          <div className="flex items-start gap-2 p-3 rounded-lg" style={{ backgroundColor: colors.errorLight }}>
+            <AlertTriangle size={16} className="flex-shrink-0 mt-0.5" style={{ color: colors.error }} />
+            <p className="text-sm" style={{ color: colors.error }}>{saveError}</p>
+          </div>
+        </div>
+      )}
+
+      {/* #1051 UX3-04: 未保存の変更がある状態で日付を切り替えようとした時の確認モーダル */}
+      {showDateConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+          <motion.div
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            className="w-full max-w-sm p-6 rounded-2xl"
+            style={{ backgroundColor: colors.card }}
+          >
+            <h3 className="text-lg font-bold mb-2" style={{ color: colors.text }}>
+              入力内容が保存されていません
+            </h3>
+            <p className="text-sm mb-6" style={{ color: colors.textMuted }}>
+              日付を変更すると、この日の未保存の入力内容は失われます。移動しますか？
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={cancelDateChange}
+                className="flex-1 py-3 rounded-full font-bold"
+                style={{ backgroundColor: colors.bg, color: colors.text }}
+              >
+                入力に戻る
+              </button>
+              <button
+                onClick={confirmDateChange}
+                className="flex-1 py-3 rounded-full font-bold text-white"
+                style={{ backgroundColor: colors.error }}
+              >
+                移動する
+              </button>
+            </div>
+          </motion.div>
+        </div>
+      )}
 
       {/* 体組成セクション */}
       <div className="px-4 mb-4">

--- a/src/app/(main)/health/record/quick/page.tsx
+++ b/src/app/(main)/health/record/quick/page.tsx
@@ -1,12 +1,10 @@
-/* eslint-disable @next/next/no-img-element */
 "use client";
 
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import {
-  Camera, ArrowLeft, Scale, Sparkles, CheckCircle2,
-  Upload, X, Loader2
+  ArrowLeft, Scale, CheckCircle2, AlertTriangle,
 } from 'lucide-react';
 import { todayLocal } from '@/lib/date-utils';
 
@@ -20,6 +18,10 @@ const colors = {
   accentLight: '#FDF0ED',
   success: '#4CAF50',
   successLight: '#E8F5E9',
+  warning: '#FF9800',
+  warningLight: '#FFF3E0',
+  error: '#F44336',
+  errorLight: '#FFEBEE',
   purple: '#7C4DFF',
   purpleLight: '#EDE7F6',
   blue: '#2196F3',
@@ -29,64 +31,29 @@ const colors = {
 
 export default function QuickRecordPage() {
   const router = useRouter();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  
-  const [mode, setMode] = useState<'select' | 'camera' | 'manual'>('select');
-  const [photoPreview, setPhotoPreview] = useState<string | null>(null);
-  const [analyzing, setAnalyzing] = useState(false);
-  const [detectedWeight, setDetectedWeight] = useState<string>('');
+
+  // #1051 UX3-01: 「写真で記録」は AI 読み取り API が未実装で、常にダミー値
+  // (65.2kg) を「読み取り結果」として提示していた。API実装まではモードを
+  // 無効化し「準備中」表示にする。手入力のみを実際の記録経路とする。
+  const [mode, setMode] = useState<'select' | 'manual'>('select');
   const [manualWeight, setManualWeight] = useState<string>('');
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
-
-  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    // プレビュー表示
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      setPhotoPreview(e.target?.result as string);
-    };
-    reader.readAsDataURL(file);
-
-    setMode('camera');
-    setAnalyzing(true);
-
-    // AIで体重を読み取り（TODO: Edge Function実装後に有効化）
-    try {
-      // const formData = new FormData();
-      // formData.append('file', file);
-      // const res = await fetch('/api/health/records/photo', {
-      //   method: 'POST',
-      //   body: formData,
-      // });
-      // if (res.ok) {
-      //   const data = await res.json();
-      //   setDetectedWeight(data.weight?.toString() || '');
-      // }
-      
-      // 仮実装：3秒後にダミーデータ
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      setDetectedWeight('65.2');
-    } catch (error) {
-      console.error('Failed to analyze photo:', error);
-    }
-    setAnalyzing(false);
-  };
+  // #1051 UX3-05: 保存失敗時に無反応だったため、エラーを表示し入力を保持する
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const handleSave = async () => {
-    const weight = mode === 'camera' ? detectedWeight : manualWeight;
-    if (!weight) return;
+    if (!manualWeight) return;
 
     setSaving(true);
+    setSaveError(null);
     try {
       const res = await fetch('/api/health/records/quick', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          weight: parseFloat(weight),
+          weight: parseFloat(manualWeight),
           record_date: todayLocal(),
         }),
       });
@@ -95,25 +62,21 @@ export default function QuickRecordPage() {
         const data = await res.json();
         setMessage(data.message);
         setSuccess(true);
-        
+
         // 2秒後にダッシュボードへ
         setTimeout(() => {
           router.push('/health');
         }, 2000);
+        return;
       }
+
+      const data = await res.json().catch(() => null);
+      setSaveError(data?.error || '記録に失敗しました。もう一度お試しください。');
     } catch (error) {
       console.error('Failed to save:', error);
+      setSaveError('記録に失敗しました。もう一度お試しください。');
     }
     setSaving(false);
-  };
-
-  const resetPhoto = () => {
-    setPhotoPreview(null);
-    setDetectedWeight('');
-    setMode('select');
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
   };
 
   // 成功画面
@@ -167,46 +130,51 @@ export default function QuickRecordPage() {
               記録方法を選んでください
             </p>
 
-            {/* 写真で記録 */}
-            <motion.button
-              whileTap={{ scale: 0.98 }}
-              onClick={() => fileInputRef.current?.click()}
-              className="w-full p-6 rounded-2xl text-left"
-              style={{ 
+            {/* 写真で記録 (#1051 UX3-01: AI読み取り未実装のため準備中表示。ダミー値は出さない) */}
+            <div
+              aria-disabled="true"
+              className="w-full p-6 rounded-2xl text-left opacity-60 cursor-not-allowed"
+              style={{
                 backgroundColor: colors.card,
                 boxShadow: '0 2px 8px rgba(0,0,0,0.06)'
               }}
             >
               <div className="flex items-center gap-4">
-                <div 
+                <div
                   className="w-16 h-16 rounded-xl flex items-center justify-center"
                   style={{ backgroundColor: colors.blueLight }}
                 >
-                  <Camera size={32} style={{ color: colors.blue }} />
+                  <Scale size={32} style={{ color: colors.blue }} />
                 </div>
                 <div>
-                  <p className="font-bold text-lg" style={{ color: colors.text }}>
+                  <p className="font-bold text-lg flex items-center gap-2" style={{ color: colors.text }}>
                     📸 写真で記録
+                    <span
+                      className="text-xs font-normal px-2 py-0.5 rounded-full"
+                      style={{ backgroundColor: colors.border, color: colors.textMuted }}
+                    >
+                      準備中
+                    </span>
                   </p>
                   <p className="text-sm mt-1" style={{ color: colors.textMuted }}>
-                    体重計の画面を撮影するだけ
+                    AIによる自動読み取りは準備中です。手入力をご利用ください
                   </p>
                 </div>
               </div>
-            </motion.button>
+            </div>
 
             {/* 手入力 */}
             <motion.button
               whileTap={{ scale: 0.98 }}
               onClick={() => setMode('manual')}
               className="w-full p-6 rounded-2xl text-left"
-              style={{ 
+              style={{
                 backgroundColor: colors.card,
                 boxShadow: '0 2px 8px rgba(0,0,0,0.06)'
               }}
             >
               <div className="flex items-center gap-4">
-                <div 
+                <div
                   className="w-16 h-16 rounded-xl flex items-center justify-center"
                   style={{ backgroundColor: colors.accentLight }}
                 >
@@ -222,107 +190,6 @@ export default function QuickRecordPage() {
                 </div>
               </div>
             </motion.button>
-
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              capture="environment"
-              onChange={handleFileSelect}
-              className="hidden"
-            />
-          </motion.div>
-        )}
-
-        {/* 写真モード */}
-        {mode === 'camera' && (
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="space-y-4"
-          >
-            {/* 写真プレビュー */}
-            <div className="relative">
-              {photoPreview && (
-                <img
-                  src={photoPreview}
-                  alt="体重計"
-                  className="w-full rounded-2xl"
-                />
-              )}
-              <button
-                onClick={resetPhoto}
-                className="absolute top-2 right-2 p-2 rounded-full bg-black/50"
-              >
-                <X size={20} color="white" />
-              </button>
-            </div>
-
-            {/* 解析中 */}
-            {analyzing && (
-              <div 
-                className="p-6 rounded-2xl text-center"
-                style={{ backgroundColor: colors.card }}
-              >
-                <Loader2 size={32} className="animate-spin mx-auto mb-3" style={{ color: colors.accent }} />
-                <p className="font-medium" style={{ color: colors.text }}>
-                  AIが体重を読み取り中...
-                </p>
-              </div>
-            )}
-
-            {/* 読み取り結果 */}
-            {!analyzing && detectedWeight && (
-              <div 
-                className="p-6 rounded-2xl"
-                style={{ backgroundColor: colors.card }}
-              >
-                <div className="flex items-center gap-2 mb-4">
-                  <Sparkles size={20} style={{ color: colors.accent }} />
-                  <span className="font-medium" style={{ color: colors.text }}>
-                    読み取り結果
-                  </span>
-                </div>
-                <div className="text-center">
-                  <input
-                    type="number"
-                    step="0.1"
-                    value={detectedWeight}
-                    onChange={(e) => setDetectedWeight(e.target.value)}
-                    className="text-5xl font-bold text-center w-full bg-transparent"
-                    style={{ color: colors.text }}
-                  />
-                  <span className="text-2xl" style={{ color: colors.textMuted }}>kg</span>
-                </div>
-                <p className="text-center text-sm mt-2" style={{ color: colors.textMuted }}>
-                  数値が違う場合はタップして修正できます
-                </p>
-              </div>
-            )}
-
-            {/* 保存ボタン */}
-            {!analyzing && detectedWeight && (
-              <motion.button
-                whileTap={{ scale: 0.98 }}
-                onClick={handleSave}
-                disabled={saving}
-                className="w-full py-4 rounded-xl font-bold text-white"
-                style={{ backgroundColor: colors.accent }}
-              >
-                {saving ? '保存中...' : 'この体重で記録する'}
-              </motion.button>
-            )}
-
-            {/* 撮り直し */}
-            {!analyzing && (
-              <button
-                onClick={resetPhoto}
-                className="w-full py-3 text-center"
-                style={{ color: colors.accent }}
-              >
-                撮り直す
-              </button>
-            )}
           </motion.div>
         )}
 
@@ -333,7 +200,7 @@ export default function QuickRecordPage() {
             animate={{ opacity: 1, y: 0 }}
             className="space-y-6"
           >
-            <div 
+            <div
               className="p-6 rounded-2xl"
               style={{ backgroundColor: colors.card }}
             >
@@ -367,7 +234,7 @@ export default function QuickRecordPage() {
                     setManualWeight(newValue.toFixed(1));
                   }}
                   className="py-3 rounded-xl font-medium"
-                  style={{ 
+                  style={{
                     backgroundColor: colors.bg,
                     color: colors.textLight,
                   }}
@@ -376,6 +243,14 @@ export default function QuickRecordPage() {
                 </motion.button>
               ))}
             </div>
+
+            {/* #1051 UX3-05: 保存失敗を無反応にせず、入力を保持したままエラーを表示する */}
+            {saveError && (
+              <div className="flex items-start gap-2 p-3 rounded-lg" style={{ backgroundColor: colors.errorLight }}>
+                <AlertTriangle size={16} className="flex-shrink-0 mt-0.5" style={{ color: colors.error }} />
+                <p className="text-sm" style={{ color: colors.error }}>{saveError}</p>
+              </div>
+            )}
 
             {/* 保存ボタン */}
             <motion.button
@@ -390,7 +265,7 @@ export default function QuickRecordPage() {
 
             {/* 戻る */}
             <button
-              onClick={() => setMode('select')}
+              onClick={() => { setMode('select'); setSaveError(null); }}
               className="w-full py-3 text-center"
               style={{ color: colors.accent }}
             >

--- a/src/lib/health-blood-test-reference.ts
+++ b/src/lib/health-blood-test-reference.ts
@@ -42,6 +42,25 @@ export const BLOOD_METRIC_DEFS: Record<string, MetricDef> = {
   uric_acid: { label: '尿酸', unit: 'mg/dL', male: { low: 3.7, high: 7.8 }, female: { low: 2.6, high: 5.5 } },
 };
 
+/**
+ * 身体測定値の基準値 (#1051 UX3-07)。
+ * 健診詳細画面で身長/体重/BMI/腹囲が一切表示されておらず、異常判定の基準も無かった。
+ * BMI・腹囲は特定健診(メタボ)基準を目安に採用。身長・体重は個人差が大きく単一の
+ * 異常基準を持たないため、範囲を持たせず参考値なしの表示専用項目として扱う
+ * (evaluateStatus は low/high 未設定のため常に 'normal' を返し、色による誤誘導をしない)。
+ */
+export const BODY_METRIC_DEFS: Record<string, MetricDef> = {
+  height: { label: '身長', unit: 'cm', male: {}, female: {} },
+  weight: { label: '体重', unit: 'kg', male: {}, female: {} },
+  bmi: { label: 'BMI', unit: '', male: { low: 18.5, high: 25 }, female: { low: 18.5, high: 25 } },
+  waist_circumference: { label: '腹囲', unit: 'cm', male: { high: 85 }, female: { high: 90 } },
+};
+
+// evaluateStatus/getRangeForSex/getMetricLabel/getMetricUnit は血液検査値・身体測定値の
+// 両方を単一ソースから引けるようにこちらを参照する。checkups詳細画面では身体測定の
+// ラベル・単位取得にも使うためエクスポートする。
+export const ALL_METRIC_DEFS: Record<string, MetricDef> = { ...BLOOD_METRIC_DEFS, ...BODY_METRIC_DEFS };
+
 export type MetricKey = keyof typeof BLOOD_METRIC_DEFS;
 
 function normalizeSex(sex: BiologicalSex): 'male' | 'female' | null {
@@ -68,7 +87,7 @@ function combinedRange(def: MetricDef): SexRange {
 }
 
 export function getRangeForSex(key: string, sex?: BiologicalSex): SexRange | null {
-  const def = BLOOD_METRIC_DEFS[key];
+  const def = ALL_METRIC_DEFS[key];
   if (!def) return null;
   const normalized = normalizeSex(sex);
   if (normalized === 'male') return def.male;
@@ -84,21 +103,47 @@ export function formatRangeText(range: SexRange | null): string {
   return '-';
 }
 
-export type MetricStatus = 'normal' | 'low' | 'high' | 'unknown';
+// #1051 UX3-07: 基準値ちょうどの線で急に「異常」と赤表示するのではなく、
+// 境界に近い(±10%)場合は「注意(やや高め/やや低め)」として区別する。
+const WARNING_BAND_RATIO = 0.1;
+
+export type MetricStatus = 'normal' | 'low' | 'high' | 'warning_low' | 'warning_high' | 'unknown';
 
 export function evaluateStatus(key: string, value: number | null | undefined, sex?: BiologicalSex): MetricStatus {
   if (value == null) return 'unknown';
   const range = getRangeForSex(key, sex);
   if (!range) return 'unknown';
-  if (range.high != null && value > range.high) return 'high';
-  if (range.low != null && value < range.low) return 'low';
+  if (range.high != null) {
+    if (value > range.high) return 'high';
+    if (value >= range.high * (1 - WARNING_BAND_RATIO)) return 'warning_high';
+  }
+  if (range.low != null) {
+    if (value < range.low) return 'low';
+    if (value <= range.low * (1 + WARNING_BAND_RATIO)) return 'warning_low';
+  }
   return 'normal';
 }
 
 export function getMetricLabel(key: string): string | null {
-  return BLOOD_METRIC_DEFS[key]?.label ?? null;
+  return ALL_METRIC_DEFS[key]?.label ?? null;
 }
 
 export function getMetricUnit(key: string): string | null {
-  return BLOOD_METRIC_DEFS[key]?.unit ?? null;
+  return ALL_METRIC_DEFS[key]?.unit ?? null;
+}
+
+// #1051 UX3-07: 色(赤/オレンジのドット)だけに頼らず、状態をテキストでも示す。
+export function getStatusLabel(status: MetricStatus): string | null {
+  switch (status) {
+    case 'high':
+      return '基準超';
+    case 'low':
+      return '基準未満';
+    case 'warning_high':
+      return 'やや高め';
+    case 'warning_low':
+      return 'やや低め';
+    default:
+      return null;
+  }
 }


### PR DESCRIPTION
## 概要
健康・設定領域の「動くが体験を壊す/誤情報を与える」重大 UX を修正する。健康アプリの信頼性に直結する誤誘導・ダミー値・無反応・逆メッセージを解消した。

## 主な変更
- 写真の AI 体重読み取りが常にダミー値(65.2kg)を返す実装だったため、API 実装まで「準備中」表示にしダミー値の自動セットを廃止 (UX3-01)
- 血液検査の空状態 CTA を食事スキャンから健診アップロード(`/health/checkups/new`)へ修正。健康ダッシュボードに血液検査/AI分析/連続記録詳細/チャレンジ/記録設定への導線を追加 (UX3-02/03)
- 詳細記録の日付切替で前日フォーム値が残留し別日に誤保存される問題を修正(記録の無い日は空フォーム、未保存変更は切替前に確認)。保存/削除失敗の無反応にインラインエラー表示を追加し入力を保持 (UX3-04/05)
- 健診詳細に身体測定(身長/体重/BMI/腹囲)セクションを追加。基準値境界±10%を「注意」区別し、色ドットにテキストラベルを併記 (UX3-07)
- 「減少=緑/増加=赤」の固定色分けを、指標ごとの良い方向・目標体重との大小で判定するよう修正(目標未設定時は中立) (UX3-08)

補足: UX3-06(家族共有トグルの501隠蔽)は `settings/membership` 配下で #1079(mobile draft PR)競合により変更禁止のため対象外(報告のみ)

## 検証(2モデル敵対レビュー double-PASS 済・tsc/eslint/vitest 緑)
- Sonnet 5 + Fable の 2モデル敵対レビューで double-PASS 済み
- `npx tsc --noEmit` / 対象ファイル eslint エラーなし、`vitest run` 緑(既存回帰なし)

Closes #1051
