### PR TITLE
fix(db): #1020追撃 認証必須DEFINER関数25本からanon EXECUTEを剥奪

### DIFF
--- a/supabase/migrations/20260711130000_revoke_anon_execute_definer_rpcs.sql
+++ b/supabase/migrations/20260711130000_revoke_anon_execute_definer_rpcs.sql
@@ -1,0 +1,197 @@
+-- migration: 20260711130000_revoke_anon_execute_definer_rpcs.sql
+-- #1020 追撃: SECURITY DEFINER RPC の REVOKE FROM PUBLIC 漏れ是正 (anon 個別 GRANT 分)
+--
+-- 背景:
+--   Supabase は下記の default privilege を既定で設定しているため、新規関数は
+--   PUBLIC からの EXECUTE を明示的に REVOKE しても、anon/authenticated/service_role
+--   への「ロール個別 GRANT」は default privilege 経由で別途自動的に付与されており、
+--   REVOKE ... FROM PUBLIC だけでは剥奪されない:
+--     ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+--       GRANT ALL ON FUNCTIONS TO anon, authenticated, service_role;
+--
+--   #1020 の実査で、以下 30 個の SECURITY DEFINER 関数が「REVOKE FROM PUBLIC」のみで
+--   「REVOKE FROM anon」を欠いており、anon (未認証) からの個別 EXECUTE GRANT が
+--   残存している疑いが判明した。本 migration は防御多層化として、各関数本体に
+--   既にある auth.uid() ガード(認可)に加え、grant レベルでも anon を締める。
+--
+-- ⚠️ 除外した 3 関数 (招待プレビュー/詳細取得系。anon から正当に呼ばれるため温存):
+--   - get_invite_details    : src/app/invite/[token]/page.tsx が未ログイン状態
+--                              (auth.getUser() 判定より前) で直接 supabase.rpc() 呼び出し。
+--                              定義元 20260511000133_membership_remaining_rpcs.sql の
+--                              コメントに「認証不要: anon + authenticated」と明記され、
+--                              GRANT EXECUTE ... TO anon, authenticated 済み。
+--   - preview_org_invite    : 定義元 20260511000127_invite_token_rpc_only.sql で
+--   - preview_family_invite   「token を持つユーザが招待詳細を確認するために使用」する
+--                              専用 RPC として設計され、GRANT EXECUTE ... TO anon,
+--                              authenticated 済み。現行フロントエンドからの呼び出しは
+--                              確認できなかったが(get_invite_details に統合された可能性)、
+--                              anon 前提で設計された RPC を誤って締めて招待プレビュー導線を
+--                              壊すリスクを避けるため、fail-safe で温存する。
+--
+-- 対象 27 関数の判定根拠 (個別精査):
+--   - 全関数、本体内で auth.uid() が NULL (＝未認証/anon) の場合に必ず例外を送出する
+--     か、権限判定用の SELECT が auth.uid() に一致する行を見つけられず NULL 判定で
+--     弾かれる実装になっており(fail-closed)、anon から呼んでも成功しない。
+--   - is_inactive_user / can_view_user_meals / organizations_owner_id_unchanged は
+--     ヘルパー/RLS 補助関数で、src 側から直接 rpc() 呼び出しされている箇所は無い
+--     (grep 実査済み)。organizations_owner_id_unchanged は RLS の WITH CHECK 内で
+--     呼ばれるが、関数内部で呼び出し元 (auth.uid()) が対象組織の owner/admin である
+--     ことを確認しており、anon (auth.uid() IS NULL) から直接 RPC 経由で呼んでも
+--     常に false を返すのみで情報漏洩がない。can_view_user_meals も同様に
+--     auth.uid() = p_target_user_id 等の比較のみで anon には常に false。
+--   - トリガー専用関数 (AFTER/BEFORE トリガーから暗黙に呼ばれるもの) はこの 27 関数の
+--     中には無い(全て RPC として明示的に public に公開されている)ため、除外判断は
+--     不要と判断した。
+--
+-- 冪等性:
+--   各関数を to_regprocedure(...) で存在確認してから REVOKE するため、対象環境に
+--   当該シグネチャの関数が存在しない場合は安全な no-op となる。REVOKE 自体も
+--   対象ロールへの GRANT が既に無い状態で再実行してもエラーにならないため、
+--   本 migration は 2 回連続実行してもエラー 0 で完了する。
+
+DO $$
+BEGIN
+  -- 1. accept_family_invite(text, boolean, boolean, boolean)
+  IF to_regprocedure('public.accept_family_invite(text, boolean, boolean, boolean)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.accept_family_invite(text, boolean, boolean, boolean) FROM PUBLIC, anon;
+  END IF;
+
+  -- 2. accept_family_representative_transfer(uuid)
+  IF to_regprocedure('public.accept_family_representative_transfer(uuid)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.accept_family_representative_transfer(uuid) FROM PUBLIC, anon;
+  END IF;
+
+  -- 3. accept_org_owner_transfer(uuid)
+  IF to_regprocedure('public.accept_org_owner_transfer(uuid)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.accept_org_owner_transfer(uuid) FROM PUBLIC, anon;
+  END IF;
+
+  -- 4. add_family_child(uuid, text, jsonb)
+  IF to_regprocedure('public.add_family_child(uuid, text, jsonb)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.add_family_child(uuid, text, jsonb) FROM PUBLIC, anon;
+  END IF;
+
+  -- 5. admin_set_user_roles(uuid, text[])
+  IF to_regprocedure('public.admin_set_user_roles(uuid, text[])') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.admin_set_user_roles(uuid, text[]) FROM PUBLIC, anon;
+  END IF;
+
+  -- 6. can_view_user_meals(uuid)
+  IF to_regprocedure('public.can_view_user_meals(uuid)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.can_view_user_meals(uuid) FROM PUBLIC, anon;
+  END IF;
+
+  -- 7. create_family_group(text, text)
+  IF to_regprocedure('public.create_family_group(text, text)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.create_family_group(text, text) FROM PUBLIC, anon;
+  END IF;
+
+  -- 8. create_family_invite(uuid, text, text)
+  IF to_regprocedure('public.create_family_invite(uuid, text, text)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.create_family_invite(uuid, text, text) FROM PUBLIC, anon;
+  END IF;
+
+  -- 9. is_inactive_user(uuid)
+  IF to_regprocedure('public.is_inactive_user(uuid)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.is_inactive_user(uuid) FROM PUBLIC, anon;
+  END IF;
+
+  -- 10. leave_family()
+  IF to_regprocedure('public.leave_family()') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.leave_family() FROM PUBLIC, anon;
+  END IF;
+
+  -- 11. leave_org()
+  IF to_regprocedure('public.leave_org()') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.leave_org() FROM PUBLIC, anon;
+  END IF;
+
+  -- 12. list_families_with_inactive_representative()
+  IF to_regprocedure('public.list_families_with_inactive_representative()') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.list_families_with_inactive_representative() FROM PUBLIC, anon;
+  END IF;
+
+  -- 13. list_orgs_with_inactive_owner()
+  IF to_regprocedure('public.list_orgs_with_inactive_owner()') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.list_orgs_with_inactive_owner() FROM PUBLIC, anon;
+  END IF;
+
+  -- 14. operator_force_dissolve_family(uuid, text)
+  IF to_regprocedure('public.operator_force_dissolve_family(uuid, text)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.operator_force_dissolve_family(uuid, text) FROM PUBLIC, anon;
+  END IF;
+
+  -- 15. operator_force_dissolve_org(uuid, text)
+  IF to_regprocedure('public.operator_force_dissolve_org(uuid, text)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.operator_force_dissolve_org(uuid, text) FROM PUBLIC, anon;
+  END IF;
+
+  -- 16. operator_force_owner_transfer(uuid, uuid, text)
+  IF to_regprocedure('public.operator_force_owner_transfer(uuid, uuid, text)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.operator_force_owner_transfer(uuid, uuid, text) FROM PUBLIC, anon;
+  END IF;
+
+  -- 17. operator_force_representative_transfer(uuid, uuid, text)
+  IF to_regprocedure('public.operator_force_representative_transfer(uuid, uuid, text)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.operator_force_representative_transfer(uuid, uuid, text) FROM PUBLIC, anon;
+  END IF;
+
+  -- 18. organizations_owner_id_unchanged(uuid, uuid)
+  IF to_regprocedure('public.organizations_owner_id_unchanged(uuid, uuid)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.organizations_owner_id_unchanged(uuid, uuid) FROM PUBLIC, anon;
+  END IF;
+
+  -- 19. paste_meal_to_family(uuid, uuid[])
+  IF to_regprocedure('public.paste_meal_to_family(uuid, uuid[])') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.paste_meal_to_family(uuid, uuid[]) FROM PUBLIC, anon;
+  END IF;
+
+  -- 20. promote_child_to_user(uuid, text)  ※旧シグネチャ (uuid, uuid) は
+  --     20260710210062/20260511000135 で DROP FUNCTION 済みのため現行は (uuid, text) のみ
+  IF to_regprocedure('public.promote_child_to_user(uuid, text)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.promote_child_to_user(uuid, text) FROM PUBLIC, anon;
+  END IF;
+
+  -- 21. propose_family_representative_transfer(uuid, uuid)
+  IF to_regprocedure('public.propose_family_representative_transfer(uuid, uuid)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.propose_family_representative_transfer(uuid, uuid) FROM PUBLIC, anon;
+  END IF;
+
+  -- 22. propose_org_owner_transfer(uuid, uuid)
+  IF to_regprocedure('public.propose_org_owner_transfer(uuid, uuid)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.propose_org_owner_transfer(uuid, uuid) FROM PUBLIC, anon;
+  END IF;
+
+  -- 23. remove_family_member(uuid, uuid)
+  IF to_regprocedure('public.remove_family_member(uuid, uuid)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.remove_family_member(uuid, uuid) FROM PUBLIC, anon;
+  END IF;
+
+  -- 24. remove_org_member(uuid, uuid)
+  IF to_regprocedure('public.remove_org_member(uuid, uuid)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.remove_org_member(uuid, uuid) FROM PUBLIC, anon;
+  END IF;
+
+  -- 25. revoke_family_invite(uuid)
+  IF to_regprocedure('public.revoke_family_invite(uuid)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.revoke_family_invite(uuid) FROM PUBLIC, anon;
+  END IF;
+
+  -- 26. revoke_org_invite(uuid)
+  IF to_regprocedure('public.revoke_org_invite(uuid)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.revoke_org_invite(uuid) FROM PUBLIC, anon;
+  END IF;
+
+  -- 27. update_my_share_settings(boolean, boolean, boolean)
+  IF to_regprocedure('public.update_my_share_settings(boolean, boolean, boolean)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.update_my_share_settings(boolean, boolean, boolean) FROM PUBLIC, anon;
+  END IF;
+END $$;
+
+-- ────────────────────────────────────────────────────────────
+-- 除外 (温存) 3 関数: anon への意図的な GRANT はそのまま維持する。
+-- 下記は「触らない」ことの明示であり、実行される DDL は無い(コメントのみ)。
+--   - get_invite_details(text)
+--   - preview_org_invite(text)
+--   - preview_family_invite(text)
+-- ────────────────────────────────────────────────────────────

--- a/supabase/migrations/20260711130000_revoke_anon_execute_definer_rpcs.sql
+++ b/supabase/migrations/20260711130000_revoke_anon_execute_definer_rpcs.sql
@@ -14,7 +14,9 @@
 --   残存している疑いが判明した。本 migration は防御多層化として、各関数本体に
 --   既にある auth.uid() ガード(認可)に加え、grant レベルでも anon を締める。
 --
--- ⚠️ 除外した 3 関数 (招待プレビュー/詳細取得系。anon から正当に呼ばれるため温存):
+-- ⚠️ 除外した 5 関数 (anon からの EXECUTE 保持が必須。REVOKE 対象から外す):
+--
+--   [招待プレビュー/詳細取得系。anon から正当に呼ばれるため温存]
 --   - get_invite_details    : src/app/invite/[token]/page.tsx が未ログイン状態
 --                              (auth.getUser() 判定より前) で直接 supabase.rpc() 呼び出し。
 --                              定義元 20260511000133_membership_remaining_rpcs.sql の
@@ -28,18 +30,37 @@
 --                              anon 前提で設計された RPC を誤って締めて招待プレビュー導線を
 --                              壊すリスクを避けるため、fail-safe で温存する。
 --
--- 対象 27 関数の判定根拠 (個別精査):
+--   [RLS ポリシー述語ヘルパー。anon 到達可能テーブル(meals SELECT / organizations
+--    UPDATE)の RLS ポリシー述語で使われるため、ポリシー評価時に anon が EXECUTE を
+--    保持する必要がある。本体は auth.uid() で fail-closed のため剥奪の利得は無く
+--    破壊リスクのみ]
+--   - can_view_user_meals(uuid) : meals_select_owner_or_family ポリシー
+--       (meals の唯一の SELECT USING 述語、定義元 20260511000120) から呼ばれる。
+--       meals テーブルは Supabase 既定のテーブル権限で anon にも SELECT が許可されて
+--       おり、RLS ポリシー評価の過程で anon セッションとしてこの関数が実行される。
+--       EXECUTE を剥奪すると述語の実行自体が失敗し、anon の GET /rest/v1/meals は
+--       「空配列(0 件)」から「permission denied for function can_view_user_meals」
+--       に退行する(PG16 実測済み)。関数本体は auth.uid() = p_target_user_id 等の
+--       比較のみで fail-closed のため、EXECUTE を保持しても anon への情報漏洩は無い。
+--   - organizations_owner_id_unchanged(uuid, uuid) : organizations_update_admin の
+--       WITH CHECK 述語(定義元 20260710210014)から呼ばれる。organizations テーブルは
+--       20260508160000(52 行目)で GRANT ALL ON TABLE organizations TO anon が明示
+--       されており、anon からの UPDATE 自体はテーブル権限上許可されている。EXECUTE を
+--       剥奪すると WITH CHECK 述語の実行が失敗し、anon の UPDATE は
+--       「no-op(UPDATE 0 件)」から「permission denied for function
+--       organizations_owner_id_unchanged」に退行する(PG16 実測済み)。関数本体は
+--       呼び出し元が対象組織の owner/admin であることを auth.uid() で確認する
+--       fail-closed 実装のため、EXECUTE を保持しても anon への書き込み許可が
+--       生まれるわけではない。
+--
+-- 対象 25 関数の判定根拠 (個別精査):
 --   - 全関数、本体内で auth.uid() が NULL (＝未認証/anon) の場合に必ず例外を送出する
 --     か、権限判定用の SELECT が auth.uid() に一致する行を見つけられず NULL 判定で
 --     弾かれる実装になっており(fail-closed)、anon から呼んでも成功しない。
---   - is_inactive_user / can_view_user_meals / organizations_owner_id_unchanged は
---     ヘルパー/RLS 補助関数で、src 側から直接 rpc() 呼び出しされている箇所は無い
---     (grep 実査済み)。organizations_owner_id_unchanged は RLS の WITH CHECK 内で
---     呼ばれるが、関数内部で呼び出し元 (auth.uid()) が対象組織の owner/admin である
---     ことを確認しており、anon (auth.uid() IS NULL) から直接 RPC 経由で呼んでも
---     常に false を返すのみで情報漏洩がない。can_view_user_meals も同様に
---     auth.uid() = p_target_user_id 等の比較のみで anon には常に false。
---   - トリガー専用関数 (AFTER/BEFORE トリガーから暗黙に呼ばれるもの) はこの 27 関数の
+--   - is_inactive_user は上記 2 関数と異なり、いずれの RLS ポリシー述語からも呼ばれて
+--     おらず(grep 実査済み)、src 側から直接 rpc() 呼び出しされている箇所も無いヘルパー
+--     関数のため、EXECUTE を剥奪してもクエリ経路への影響は無い。
+--   - トリガー専用関数 (AFTER/BEFORE トリガーから暗黙に呼ばれるもの) はこの 25 関数の
 --     中には無い(全て RPC として明示的に public に公開されている)ため、除外判断は
 --     不要と判断した。
 --
@@ -76,122 +97,115 @@ BEGIN
     REVOKE EXECUTE ON FUNCTION public.admin_set_user_roles(uuid, text[]) FROM PUBLIC, anon;
   END IF;
 
-  -- 6. can_view_user_meals(uuid)
-  IF to_regprocedure('public.can_view_user_meals(uuid)') IS NOT NULL THEN
-    REVOKE EXECUTE ON FUNCTION public.can_view_user_meals(uuid) FROM PUBLIC, anon;
-  END IF;
-
-  -- 7. create_family_group(text, text)
+  -- 6. create_family_group(text, text)
   IF to_regprocedure('public.create_family_group(text, text)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.create_family_group(text, text) FROM PUBLIC, anon;
   END IF;
 
-  -- 8. create_family_invite(uuid, text, text)
+  -- 7. create_family_invite(uuid, text, text)
   IF to_regprocedure('public.create_family_invite(uuid, text, text)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.create_family_invite(uuid, text, text) FROM PUBLIC, anon;
   END IF;
 
-  -- 9. is_inactive_user(uuid)
+  -- 8. is_inactive_user(uuid)
   IF to_regprocedure('public.is_inactive_user(uuid)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.is_inactive_user(uuid) FROM PUBLIC, anon;
   END IF;
 
-  -- 10. leave_family()
+  -- 9. leave_family()
   IF to_regprocedure('public.leave_family()') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.leave_family() FROM PUBLIC, anon;
   END IF;
 
-  -- 11. leave_org()
+  -- 10. leave_org()
   IF to_regprocedure('public.leave_org()') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.leave_org() FROM PUBLIC, anon;
   END IF;
 
-  -- 12. list_families_with_inactive_representative()
+  -- 11. list_families_with_inactive_representative()
   IF to_regprocedure('public.list_families_with_inactive_representative()') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.list_families_with_inactive_representative() FROM PUBLIC, anon;
   END IF;
 
-  -- 13. list_orgs_with_inactive_owner()
+  -- 12. list_orgs_with_inactive_owner()
   IF to_regprocedure('public.list_orgs_with_inactive_owner()') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.list_orgs_with_inactive_owner() FROM PUBLIC, anon;
   END IF;
 
-  -- 14. operator_force_dissolve_family(uuid, text)
+  -- 13. operator_force_dissolve_family(uuid, text)
   IF to_regprocedure('public.operator_force_dissolve_family(uuid, text)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.operator_force_dissolve_family(uuid, text) FROM PUBLIC, anon;
   END IF;
 
-  -- 15. operator_force_dissolve_org(uuid, text)
+  -- 14. operator_force_dissolve_org(uuid, text)
   IF to_regprocedure('public.operator_force_dissolve_org(uuid, text)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.operator_force_dissolve_org(uuid, text) FROM PUBLIC, anon;
   END IF;
 
-  -- 16. operator_force_owner_transfer(uuid, uuid, text)
+  -- 15. operator_force_owner_transfer(uuid, uuid, text)
   IF to_regprocedure('public.operator_force_owner_transfer(uuid, uuid, text)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.operator_force_owner_transfer(uuid, uuid, text) FROM PUBLIC, anon;
   END IF;
 
-  -- 17. operator_force_representative_transfer(uuid, uuid, text)
+  -- 16. operator_force_representative_transfer(uuid, uuid, text)
   IF to_regprocedure('public.operator_force_representative_transfer(uuid, uuid, text)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.operator_force_representative_transfer(uuid, uuid, text) FROM PUBLIC, anon;
   END IF;
 
-  -- 18. organizations_owner_id_unchanged(uuid, uuid)
-  IF to_regprocedure('public.organizations_owner_id_unchanged(uuid, uuid)') IS NOT NULL THEN
-    REVOKE EXECUTE ON FUNCTION public.organizations_owner_id_unchanged(uuid, uuid) FROM PUBLIC, anon;
-  END IF;
-
-  -- 19. paste_meal_to_family(uuid, uuid[])
+  -- 17. paste_meal_to_family(uuid, uuid[])
   IF to_regprocedure('public.paste_meal_to_family(uuid, uuid[])') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.paste_meal_to_family(uuid, uuid[]) FROM PUBLIC, anon;
   END IF;
 
-  -- 20. promote_child_to_user(uuid, text)  ※旧シグネチャ (uuid, uuid) は
+  -- 18. promote_child_to_user(uuid, text)  ※旧シグネチャ (uuid, uuid) は
   --     20260710210062/20260511000135 で DROP FUNCTION 済みのため現行は (uuid, text) のみ
   IF to_regprocedure('public.promote_child_to_user(uuid, text)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.promote_child_to_user(uuid, text) FROM PUBLIC, anon;
   END IF;
 
-  -- 21. propose_family_representative_transfer(uuid, uuid)
+  -- 19. propose_family_representative_transfer(uuid, uuid)
   IF to_regprocedure('public.propose_family_representative_transfer(uuid, uuid)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.propose_family_representative_transfer(uuid, uuid) FROM PUBLIC, anon;
   END IF;
 
-  -- 22. propose_org_owner_transfer(uuid, uuid)
+  -- 20. propose_org_owner_transfer(uuid, uuid)
   IF to_regprocedure('public.propose_org_owner_transfer(uuid, uuid)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.propose_org_owner_transfer(uuid, uuid) FROM PUBLIC, anon;
   END IF;
 
-  -- 23. remove_family_member(uuid, uuid)
+  -- 21. remove_family_member(uuid, uuid)
   IF to_regprocedure('public.remove_family_member(uuid, uuid)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.remove_family_member(uuid, uuid) FROM PUBLIC, anon;
   END IF;
 
-  -- 24. remove_org_member(uuid, uuid)
+  -- 22. remove_org_member(uuid, uuid)
   IF to_regprocedure('public.remove_org_member(uuid, uuid)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.remove_org_member(uuid, uuid) FROM PUBLIC, anon;
   END IF;
 
-  -- 25. revoke_family_invite(uuid)
+  -- 23. revoke_family_invite(uuid)
   IF to_regprocedure('public.revoke_family_invite(uuid)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.revoke_family_invite(uuid) FROM PUBLIC, anon;
   END IF;
 
-  -- 26. revoke_org_invite(uuid)
+  -- 24. revoke_org_invite(uuid)
   IF to_regprocedure('public.revoke_org_invite(uuid)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.revoke_org_invite(uuid) FROM PUBLIC, anon;
   END IF;
 
-  -- 27. update_my_share_settings(boolean, boolean, boolean)
+  -- 25. update_my_share_settings(boolean, boolean, boolean)
   IF to_regprocedure('public.update_my_share_settings(boolean, boolean, boolean)') IS NOT NULL THEN
     REVOKE EXECUTE ON FUNCTION public.update_my_share_settings(boolean, boolean, boolean) FROM PUBLIC, anon;
   END IF;
 END $$;
 
 -- ────────────────────────────────────────────────────────────
--- 除外 (温存) 3 関数: anon への意図的な GRANT はそのまま維持する。
+-- 除外 (温存) 5 関数: anon への意図的な EXECUTE 保持はそのまま維持する。
 -- 下記は「触らない」ことの明示であり、実行される DDL は無い(コメントのみ)。
---   - get_invite_details(text)
---   - preview_org_invite(text)
---   - preview_family_invite(text)
+-- 理由の詳細はファイル冒頭の「除外した 5 関数」セクションを参照。
+--   - get_invite_details(text)                          [招待プレビュー/詳細取得系]
+--   - preview_org_invite(text)                          [招待プレビュー/詳細取得系]
+--   - preview_family_invite(text)                       [招待プレビュー/詳細取得系]
+--   - can_view_user_meals(uuid)                         [RLS ポリシー述語ヘルパー]
+--   - organizations_owner_id_unchanged(uuid, uuid)      [RLS ポリシー述語ヘルパー]
 -- ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 概要

#1020 実査で、SECURITY DEFINER 関数群が `REVOKE FROM PUBLIC` のみで `FROM anon` を欠き、Supabase 既定の anon 個別 EXECUTE GRANT が残存していることが判明。本 PR は**認証必須の25関数**から anon EXECUTE を剥奪(多層防御。本体は既に `auth.uid()` で fail-closed のため利得は限定的だが grant レベルでも締める)。migration `20260711130000_revoke_anon_execute_definer_rpcs.sql`。

## 温存した5関数

招待プレビュー系3本(`get_invite_details` / `preview_org_invite` / `preview_family_invite`、未ログイン招待導線で anon 実行あり)+ RLS ポリシー述語ヘルパー2本(`can_view_user_meals` = meals SELECT / `organizations_owner_id_unchanged` = organizations UPDATE WITH CHECK)。後者2本は anon EXECUTE を剥奪するとポリシー評価が `permission denied for function` で落ち anon クエリを破壊するため温存(2モデルレビューで PG16 実測)。

## 検証

2モデル敵対レビューが初版(27本剥奪)の破壊を検出→2本除外(25本)に修正して double-PASS。PG16 で 25→anon剥奪・5→anon温存・冪等2回・authenticated/service_role 温存・meals/organizations の anon クエリ正常を実測。

## ⚠️ マージ順序

**PR #1108(#1100、migration `20260711120000`)を先にマージ**してから本 PR(`20260711130000`)をマージすること。逆順だと本 migration の低いタイムスタンプが台帳最大を下回り deploy guard がブロックする。

## マージ後

deploy workflow が本番自動適用。

関連: #1020(名指し分は PR #1091 で解消済み・本 PR は残存 anon GRANT への追撃)/ 監査トラッカー #1012
